### PR TITLE
Information Service 

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -74,6 +74,8 @@ set(SRCS
         src/SpyDevice.cxx
         src/SpyMainFrame.cxx
         src/CcdbDatabase.cxx
+        src/InformationService.cxx
+        src/InformationServiceDump.cxx
         )
 
 set(HEADERS # needed for the dictionary generation
@@ -130,6 +132,20 @@ O2_GENERATE_EXECUTABLE(
 O2_GENERATE_EXECUTABLE(
         EXE_NAME qcSpy
         SOURCES src/qcSpy.cxx
+        MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+        BUCKET_NAME ${BUCKET_NAME}
+)
+
+O2_GENERATE_EXECUTABLE(
+        EXE_NAME qcInfoService
+        SOURCES src/runInformationService.cxx
+        MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+        BUCKET_NAME ${BUCKET_NAME}
+)
+
+O2_GENERATE_EXECUTABLE(
+        EXE_NAME qcInfoServiceDump
+        SOURCES src/runInformationServiceDump.cxx
         MODULE_LIBRARY_NAME ${LIBRARY_NAME}
         BUCKET_NAME ${BUCKET_NAME}
 )

--- a/Framework/alfa.json
+++ b/Framework/alfa.json
@@ -24,8 +24,8 @@
                                 "type": "pub",
                                 "method": "connect",
                                 "address": "tcp://localhost:5560",
-                                "sndBufSize": 1,
-                                "rcvBufSize": 1,
+                                "sndBufSize": 10,
+                                "rcvBufSize": 10,
                                 "rateLogging": 0
                             }
                         ]
@@ -41,9 +41,9 @@
                             {
                                 "type": "pub",
                                 "method": "bind",
-                                "address": "tcp://*:5556",
-                                "sndBufSize": 100,
-                                "rcvBufSize": 100,
+                                "address": "tcp://*:5557",
+                                "sndBufSize": 1,
+                                "rcvBufSize": 1,
                                 "rateLogging": 0
                             }
                         ]
@@ -53,10 +53,10 @@
                         "sockets": [
                             {
                                 "type": "pub",
-                                "method": "bind",
+                                "method": "connect",
                                 "address": "tcp://localhost:5560",
-                                "sndBufSize": 100,
-                                "rcvBufSize": 100,
+                                "sndBufSize": 1,
+                                "rcvBufSize": 1,
                                 "rateLogging": 0
                             }
                         ]

--- a/Framework/alfa.json
+++ b/Framework/alfa.json
@@ -16,6 +16,19 @@
                                 "rateLogging": 0
                             }
                         ]
+                    },
+                    {
+                        "name": "information-service-out",
+                        "sockets": [
+                            {
+                                "type": "pub",
+                                "method": "connect",
+                                "address": "tcp://localhost:5560",
+                                "sndBufSize": 1,
+                                "rcvBufSize": 1,
+                                "rateLogging": 0
+                            }
+                        ]
                     }
                 ]
             },
@@ -29,6 +42,19 @@
                                 "type": "pub",
                                 "method": "bind",
                                 "address": "tcp://*:5556",
+                                "sndBufSize": 100,
+                                "rcvBufSize": 100,
+                                "rateLogging": 0
+                            }
+                        ]
+                    },
+                    {
+                        "name": "information-service-out",
+                        "sockets": [
+                            {
+                                "type": "pub",
+                                "method": "bind",
+                                "address": "tcp://localhost:5560",
                                 "sndBufSize": 100,
                                 "rcvBufSize": 100,
                                 "rateLogging": 0

--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -29,15 +29,10 @@ class ObjectsManager
 
   public:
     ObjectsManager(TaskConfig &taskConfig);
-
-    /// Destructor
     virtual ~ObjectsManager();
-
     void startPublishing(TObject *obj, std::string objectName = "");
-
+    // todo stoppublishing
     void setQuality(std::string objectName, Quality quality);
-    // todo stop publishing
-
     Quality getQuality(std::string objectName);
 
     /// \brief Add a check to the object defined by objectName.
@@ -70,6 +65,9 @@ class ObjectsManager
 
     iterator end()
     { return mMonitorObjects.end(); }
+
+    std::string getObjectsListString()
+    { return mObjectsList.GetString().Data(); }
 
   private:
     void UpdateIndex(const std::string &nonEmptyName) ;

--- a/Framework/include/QualityControl/TaskDevice.h
+++ b/Framework/include/QualityControl/TaskDevice.h
@@ -27,15 +27,6 @@ namespace o2 {
 namespace quality_control {
 namespace core {
 
-//class InformationServiceSender{
-//  public:
-//    InformationServiceSender();
-//    virtual ~InformationServiceSender();
-//    void send(std::string objectsListString);
-//  private:
-//    std::string lastListSent;
-//};
-
 class TaskInterface;
 
 /// \brief The device driving the execution of a QC task.

--- a/Framework/include/QualityControl/TaskDevice.h
+++ b/Framework/include/QualityControl/TaskDevice.h
@@ -27,6 +27,15 @@ namespace o2 {
 namespace quality_control {
 namespace core {
 
+//class InformationServiceSender{
+//  public:
+//    InformationServiceSender();
+//    virtual ~InformationServiceSender();
+//    void send(std::string objectsListString);
+//  private:
+//    std::string lastListSent;
+//};
+
 class TaskInterface;
 
 /// \brief The device driving the execution of a QC task.
@@ -56,6 +65,7 @@ class TaskDevice : public FairMQDevice
     void monitorCycle();
     unsigned long publish();
     static void CustomCleanupTMessage(void *data, void *object);
+    void sendToInformationService(std::string objectsListString);
 
   private:
     std::string mTaskName;
@@ -65,6 +75,8 @@ class TaskDevice : public FairMQDevice
     std::unique_ptr<AliceO2::DataSampling::SamplerInterface> mSampler;
     o2::quality_control::core::TaskInterface *mTask;
     std::shared_ptr<ObjectsManager> mObjectsManager;
+//    InformationServiceSender infoServiceSender;
+    std::string lastListSent;
 
     // stats
     int mTotalNumberObjectsPublished;

--- a/Framework/src/InformationService.cxx
+++ b/Framework/src/InformationService.cxx
@@ -1,0 +1,87 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+
+///
+/// \author bvonhall
+/// \file InformationService.cxx
+///
+
+#include "InformationService.h"
+
+#include "FairMQLogger.h"
+
+#include <string>
+#include <iostream>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+using namespace std;
+namespace pt = boost::property_tree;
+
+InformationService::InformationService()
+{
+  OnData("tasks_input", &InformationService::HandleData);
+}
+
+bool InformationService::HandleData(FairMQMessagePtr &msg, int /*index*/)
+{
+  string *receivedData = new std::string(static_cast<char *>(msg->GetData()), msg->GetSize());
+  LOG(INFO) << "Received data, processing...";
+  LOG(INFO) << "    " << *receivedData;
+
+  // parse
+  std::string taskName = receivedData->substr(0, receivedData->find(":"));
+  std::string objectsString = receivedData->substr(receivedData->find(":") + 1, receivedData->length());
+  boost::char_separator<char> sep(",");
+  typedef boost::tokenizer<boost::char_separator<char> > t_tokenizer;
+  t_tokenizer tok(objectsString, sep);
+  vector<string> objects;
+  LOG(DEBUG) << "task : " << taskName;
+  LOG(DEBUG) << "objects : " << objectsString;
+
+  // store
+  for (t_tokenizer::iterator beg = tok.begin(); beg != tok.end(); ++beg) {
+    objects.push_back(*beg);
+  }
+  mCache[taskName] = objects;
+
+  // json
+  pt::ptree task_node;
+  task_node.put("name", taskName);
+  pt::ptree objects_node;
+  for (auto &object : mCache[taskName]) {
+    pt::ptree object_node;
+    object_node.put("id", object);
+    objects_node.push_back(std::make_pair("", object_node));
+  }
+  task_node.add_child("objects", objects_node);
+  std::stringstream ss;
+  pt::json_parser::write_json(ss, task_node);
+
+  // publish
+  string* json = new std::string(ss.str());
+  FairMQMessagePtr msg2(NewMessage(const_cast<char *>(json->c_str()),
+                                   json->length(),
+                                   [](void * /*data*/, void *object) { delete static_cast<string *>(object); },
+                                   json));
+  int ret = Send(msg2, "updates_output");
+  if(ret < 0)
+  {
+    LOG(error) << "Error sending update" << endl;
+  }
+
+  return true; // keep running
+}
+
+InformationService::~InformationService()
+{
+}

--- a/Framework/src/InformationService.cxx
+++ b/Framework/src/InformationService.cxx
@@ -15,20 +15,41 @@
 ///
 
 #include "InformationService.h"
-
 #include "QualityControl/QcInfoLogger.h"
 
 using namespace std;
 typedef boost::tokenizer<boost::char_separator<char> > t_tokenizer;
 using namespace o2::quality_control::core;
 
+int timeOutIntervals = 5; // in seconds
+
 InformationService::InformationService()
+//  : mTimer(io, boost::posix_time::seconds(timeOutIntervals))
 {
-  OnData("tasks_input", &InformationService::HandleData);
-  OnData("request_data", &InformationService::requestData);
+  OnData("tasks_input", &InformationService::handleTaskInputData);
+  OnData("request_data", &InformationService::handleRequestData);
+
+//  mTimer = new boost::asio::deadline_timer(io, boost::posix_time::seconds(timeOutIntervals));
+//  mTimer->async_wait(boost::bind(&InformationService::checkTimedOut, this));
+//  std::cout << " If we see this before the callback function, we know async_wait() returns immediately.\n This confirms async_wait() is non-blocking call!\n";
+//  io.run();
 }
 
-bool InformationService::requestData(FairMQMessagePtr &request, int /*index*/)
+InformationService::~InformationService()
+{
+}
+
+//void InformationService::checkTimedOut()
+//{
+//  // todo check each agent if alive
+//  cout << "checkTimedOut" << endl;
+//
+//  // restart timer
+//  mTimer->expires_at(mTimer->expires_at() + boost::posix_time::seconds(timeOutIntervals));
+//  mTimer->async_wait(boost::bind(&InformationService::checkTimedOut, this));
+//}
+
+bool InformationService::handleRequestData(FairMQMessagePtr &request, int /*index*/)
 {
   string requestParam = string(static_cast<char *>(request->GetData()), request->GetSize());
   LOG(INFO) << "Received request from client: \"" << requestParam << "\"";
@@ -56,7 +77,7 @@ bool InformationService::requestData(FairMQMessagePtr &request, int /*index*/)
   return true; // keep running
 }
 
-bool InformationService::HandleData(FairMQMessagePtr &msg, int /*index*/)
+bool InformationService::handleTaskInputData(FairMQMessagePtr &msg, int /*index*/)
 {
   string *receivedData = new std::string(static_cast<char *>(msg->GetData()), msg->GetSize());
   LOG(INFO) << "Received data, processing...";
@@ -161,6 +182,3 @@ void InformationService::sendJson(std::string *json)
   }
 }
 
-InformationService::~InformationService()
-{
-}

--- a/Framework/src/InformationService.h
+++ b/Framework/src/InformationService.h
@@ -18,13 +18,28 @@
 #ifndef PROJECT_INFORMATIONSERVICE_H
 #define PROJECT_INFORMATIONSERVICE_H
 
+#include <InfoLogger/InfoLogger.hxx>
 #include "FairMQDevice.h"
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+namespace pt = boost::property_tree;
 
 /// \brief Collect the list of objects published by all the tasks and make it available to clients.
 ///
 /// The InformationService receives the list of objects published by each task.
-/// It keeps an up to date list and send it upon request to clients. It also publishes updates when
+/// It keeps a list of all tasks and objects and send it upon request to clients. It also publishes updates when
 /// new information comes from the tasks.
+///
+/// See InformationService.json to know the port where updates are published.
+/// See InformationService.json to know the port where to request information for all tasks (param "all") or
+/// for a specific task (param "<name_of_task>").
+///
+/// Example usage :
+///      qcInfoService -c /absolute/path/to/InformationService.json -n information_service \
+///                    --id information_service --mq-config /absolute/path/to/InformationService.json
+
 class InformationService : public FairMQDevice
 {
   public:
@@ -33,9 +48,18 @@ class InformationService : public FairMQDevice
 
   protected:
     bool HandleData(FairMQMessagePtr&, int);
+    bool requestData(FairMQMessagePtr&, int);
 
   private:
-    std::map<std::string,std::vector<std::string>> mCache;
+    std::vector<std::string> getObjects(std::string *receivedData);
+    std::string getTaskName(std::string *receivedData);
+    std::string produceJson(std::string taskName);
+    std::string produceJsonAll();
+    void sendJson(std::string *json);
+    pt::ptree buildTaskNode(std::string taskName);
+
+  private:
+    std::map<std::string,std::vector<std::string>> mCacheTasksData;
 };
 
 #endif //PROJECT_INFORMATIONSERVICE_H

--- a/Framework/src/InformationService.h
+++ b/Framework/src/InformationService.h
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+
+///
+/// \author bvonhall
+/// \file InformationService.h
+///
+
+
+#ifndef PROJECT_INFORMATIONSERVICE_H
+#define PROJECT_INFORMATIONSERVICE_H
+
+#include "FairMQDevice.h"
+
+/// \brief Collect the list of objects published by all the tasks and make it available to clients.
+///
+/// The InformationService receives the list of objects published by each task.
+/// It keeps an up to date list and send it upon request to clients. It also publishes updates when
+/// new information comes from the tasks.
+class InformationService : public FairMQDevice
+{
+  public:
+    InformationService();
+    virtual ~InformationService();
+
+  protected:
+    bool HandleData(FairMQMessagePtr&, int);
+
+  private:
+    std::map<std::string,std::vector<std::string>> mCache;
+};
+
+#endif //PROJECT_INFORMATIONSERVICE_H

--- a/Framework/src/InformationService.h
+++ b/Framework/src/InformationService.h
@@ -42,6 +42,11 @@ namespace pt = boost::property_tree;
 ///      qcInfoService -c /absolute/path/to/InformationService.json -n information_service \\
 ///                    --id information_service --mq-config /absolute/path/to/InformationService.json
 ///
+/// Format of the string coming from the tasks :
+///      `task_id:obj0,obj1,obj2`
+/// Format of the JSON output for one task or all tasks :
+///      See README
+///
 /// \todo Handle tasks dying and their removal from the cache and the publication of an update (heartbeat ?).
 /// \todo Handle tasks sending information that they are disappearing.
 
@@ -63,6 +68,7 @@ class InformationService : public FairMQDevice
     std::vector<std::string> getObjects(std::string *receivedData);
     /// Extract the task name from the string received from the tasks
     std::string getTaskName(std::string *receivedData);
+    /// Produce the JSON string for the specified task
     std::string produceJson(std::string taskName);
     /// Produce the JSON string for all tasks and objects
     std::string produceJsonAll();
@@ -70,8 +76,12 @@ class InformationService : public FairMQDevice
     void sendJson(std::string *json);
     pt::ptree buildTaskNode(std::string taskName);
     void checkTimedOut();
+    /// Compute and send the JSON using the inputString from a task
     bool handleTaskInputData(std::string inputString);
-    void readFile(std::string filePath);
+    /// Reads a file containing data in format as received from the tasks.
+    /// Store the items and use them at regular intervals to simulate tasks inputs.
+    /// Calling again this method will delete the former fake data cache.
+    void readFakeDataFile(std::string filePath);
 
   private:
     std::map<std::string,std::vector<std::string>> mCacheTasksData; /// the list of objects names for each task

--- a/Framework/src/InformationService.h
+++ b/Framework/src/InformationService.h
@@ -56,6 +56,7 @@ class InformationService : public FairMQDevice
     bool handleTaskInputData(FairMQMessagePtr&, int);
     /// Callback for the requests coming from clients
     bool handleRequestData(FairMQMessagePtr&, int);
+    void Init();
 
   private:
     /// Extract the list of objects from the string received from the tasks
@@ -68,13 +69,19 @@ class InformationService : public FairMQDevice
     /// Send the JSON string to all clients (subscribers)
     void sendJson(std::string *json);
     pt::ptree buildTaskNode(std::string taskName);
-//    void checkTimedOut();
+    void checkTimedOut();
+    bool handleTaskInputData(std::string inputString);
+    void readFile(std::string filePath);
 
   private:
     std::map<std::string,std::vector<std::string>> mCacheTasksData; /// the list of objects names for each task
-    std::map<std::string /*task name*/, int /*hash of the objects list*/> mCacheTasksObjectsHash; /// used to check whether we already have received this list of objects
-//    boost::asio::deadline_timer *mTimer; /// the asynchronous timer to check if agents have timed out
-//    boost::asio::io_service io;
+    std::map<std::string /*task name*/, size_t /*hash of the objects list*/> mCacheTasksObjectsHash; /// used to check whether we already have received this list of objects
+    boost::asio::deadline_timer *mTimer; /// the asynchronous timer to check if agents have timed out
+    std::vector<std::string> mFakeData; /// container for the fake data (if any). Each line is in a string and used in turn.
+    int mFakeDataIndex;
+    // variables for the timer
+    boost::asio::io_service io;
+    std::thread *th;
 
 };
 

--- a/Framework/src/InformationService.h
+++ b/Framework/src/InformationService.h
@@ -35,9 +35,10 @@ namespace pt = boost::property_tree;
 /// See InformationService.json to know the port where updates are published.
 /// See InformationService.json to know the port where to request information for all tasks (param "all") or
 /// for a specific task (param "<name_of_task>").
+/// See runInformationService.cxx for the steering code.
 ///
 /// Example usage :
-///      qcInfoService -c /absolute/path/to/InformationService.json -n information_service \
+///      qcInfoService -c /absolute/path/to/InformationService.json -n information_service \\
 ///                    --id information_service --mq-config /absolute/path/to/InformationService.json
 
 class InformationService : public FairMQDevice

--- a/Framework/src/InformationService.h
+++ b/Framework/src/InformationService.h
@@ -60,7 +60,8 @@ class InformationService : public FairMQDevice
     pt::ptree buildTaskNode(std::string taskName);
 
   private:
-    std::map<std::string,std::vector<std::string>> mCacheTasksData;
+    std::map<std::string,std::vector<std::string>> mCacheTasksData; /// the list of objects names for each task
+    std::map<std::string /*task name*/, int /*hash of the objects list*/> mCacheTasksObjectsHash; /// used to check whether we already have received this list of objects
 };
 
 #endif //PROJECT_INFORMATIONSERVICE_H

--- a/Framework/src/InformationServiceDump.cxx
+++ b/Framework/src/InformationServiceDump.cxx
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+
+///
+/// \author bvonhall
+/// \file InformationServiceDump.cxx
+///
+
+#include "InformationServiceDump.h"
+
+#include "FairMQLogger.h"
+
+#include <string>
+#include <iostream>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+using namespace std;
+namespace pt = boost::property_tree;
+
+InformationServiceDump::InformationServiceDump()
+{
+  OnData("info_service_input", &InformationServiceDump::HandleData);
+}
+
+bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
+{
+  string *receivedData = new std::string(static_cast<char *>(msg->GetData()), msg->GetSize());
+  LOG(INFO) << "Received data : ";
+  LOG(INFO) << "    " << *receivedData;
+
+  return true; // keep running
+}
+
+InformationServiceDump::~InformationServiceDump()
+{
+}

--- a/Framework/src/InformationServiceDump.cxx
+++ b/Framework/src/InformationServiceDump.cxx
@@ -24,12 +24,56 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 using namespace std;
 namespace pt = boost::property_tree;
 
-InformationServiceDump::InformationServiceDump()
+int requestIntervals = 5; // in seconds
+
+void InformationServiceDump::sendRequest()
+{
+  string* text = new string("asdf");
+  cout << "preparing request " << endl;
+  FairMQMessagePtr request(NewMessage(const_cast<char*>(text->c_str()), // data
+                                      text->length(), // size
+                                      [](void* /*data*/, void* object) { delete static_cast<string*>(object); }, // deletion callback
+                                      text)); // object that manages the data
+  cout << "Sending request" << endl;
+  if (Send(request, "send_request") <= 0)
+  {
+    cout << "problem sending request" << endl;
+  }
+
+  // restart timer
+  mTimer.expires_at(mTimer.expires_at() + boost::posix_time::seconds(requestIntervals));
+  mTimer.async_wait(boost::bind(&InformationServiceDump::sendRequest, this));
+}
+
+bool InformationServiceDump::ConditionalRun()
+{
+  string* text = new string("asdf");
+  cout << "preparing request " << endl;
+  FairMQMessagePtr request(NewMessage(const_cast<char*>(text->c_str()), // data
+                                      text->length(), // size
+                                      [](void* /*data*/, void* object) { delete static_cast<string*>(object); }, // deletion callback
+                                      text)); // object that manages the data
+  cout << "Sending request" << endl;
+  if (Send(request, "send_request") <= 0)
+  {
+    cout << "problem sending request" << endl;
+  }
+  this_thread::sleep_for(chrono::seconds(5));
+
+  return true;
+}
+
+InformationServiceDump::InformationServiceDump(boost::asio::io_service& io)
+  : mTimer(io, boost::posix_time::seconds(requestIntervals))
 {
   OnData("info_service_input", &InformationServiceDump::HandleData);
+
+//  mTimer.async_wait(boost::bind(&InformationServiceDump::sendRequest, this));
 }
 
 bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
@@ -37,6 +81,25 @@ bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
   string *receivedData = new std::string(static_cast<char *>(msg->GetData()), msg->GetSize());
   LOG(INFO) << "Received data : ";
   LOG(INFO) << "    " << *receivedData;
+
+  string* text = new string("asdf");
+  cout << "preparing request " << endl;
+  FairMQMessagePtr request(NewMessage(const_cast<char*>(text->c_str()), // data
+                                      text->length(), // size
+                                      [](void* /*data*/, void* object) { delete static_cast<string*>(object); }, // deletion callback
+                                      text)); // object that manages the data
+  cout << "Sending request" << endl;
+  if (Send(request, "send_request") > 0) {
+    FairMQMessagePtr reply(NewMessage());
+    if (Receive(reply, "send_request") >= 0)
+    {
+      LOG(INFO) << "Received reply from server: \"" << string(static_cast<char*>(reply->GetData()), reply->GetSize()) << "\"";
+    } else {
+      cout << "Problem receiving reply" << endl;
+    }
+  } else {
+    cout << "problem sending request" << endl;
+  }
 
   return true; // keep running
 }

--- a/Framework/src/InformationServiceDump.cxx
+++ b/Framework/src/InformationServiceDump.cxx
@@ -31,6 +31,10 @@ InformationServiceDump::InformationServiceDump()
   OnData("info_service_input", &InformationServiceDump::HandleData);
 }
 
+InformationServiceDump::~InformationServiceDump()
+{
+}
+
 bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
 {
   string *receivedData = new std::string(static_cast<char *>(msg->GetData()), msg->GetSize());
@@ -38,7 +42,7 @@ bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
   LOG(INFO) << "    " << *receivedData;
 
   string* text = new string( fConfig->GetValue<string>("request-task"));
-  cout << "preparing request for \"" << text << "\"" << endl;
+  cout << "preparing request for \"" << *text << "\"" << endl;
   FairMQMessagePtr request(NewMessage(const_cast<char*>(text->c_str()), // data
                                       text->length(), // size
                                       [](void* /*data*/, void* object) { delete static_cast<string*>(object); }, // deletion callback
@@ -57,8 +61,4 @@ bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
   }
 
   return true; // keep running
-}
-
-InformationServiceDump::~InformationServiceDump()
-{
 }

--- a/Framework/src/InformationServiceDump.cxx
+++ b/Framework/src/InformationServiceDump.cxx
@@ -21,7 +21,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h> // device->fConfig
+#include <options/FairMQProgOptions.h>
 
 using namespace std;
 namespace pt = boost::property_tree;
@@ -42,22 +42,22 @@ bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
   LOG(INFO) << "    " << *receivedData;
 
   string* text = new string( fConfig->GetValue<string>("request-task"));
-  cout << "preparing request for \"" << *text << "\"" << endl;
+  LOG(INFO) << "Preparing request for \"" << *text << "\"";
   FairMQMessagePtr request(NewMessage(const_cast<char*>(text->c_str()), // data
                                       text->length(), // size
                                       [](void* /*data*/, void* object) { delete static_cast<string*>(object); }, // deletion callback
                                       text)); // object that manages the data
-  cout << "Sending request " << endl;
+  LOG(INFO) << "Sending request ";
   if (Send(request, "send_request") > 0) {
     FairMQMessagePtr reply(NewMessage());
     if (Receive(reply, "send_request") >= 0)
     {
       LOG(INFO) << "Received reply from server: \"" << string(static_cast<char*>(reply->GetData()), reply->GetSize()) << "\"";
     } else {
-      cout << "Problem receiving reply" << endl;
+      LOG(ERROR) << "Problem receiving reply";
     }
   } else {
-    cout << "problem sending request" << endl;
+    LOG(ERROR) << "problem sending request";
   }
 
   return true; // keep running

--- a/Framework/src/InformationServiceDump.cxx
+++ b/Framework/src/InformationServiceDump.cxx
@@ -26,8 +26,7 @@
 using namespace std;
 namespace pt = boost::property_tree;
 
-InformationServiceDump::InformationServiceDump(boost::asio::io_service& io)
-  : mTimer(io, boost::posix_time::seconds(requestIntervals))
+InformationServiceDump::InformationServiceDump()
 {
   OnData("info_service_input", &InformationServiceDump::HandleData);
 }

--- a/Framework/src/InformationServiceDump.cxx
+++ b/Framework/src/InformationServiceDump.cxx
@@ -16,64 +16,20 @@
 
 #include "InformationServiceDump.h"
 
-#include "FairMQLogger.h"
-
-#include <string>
-#include <iostream>
-
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
-
 #include <boost/date_time/posix_time/posix_time.hpp>
+
+#include "FairMQLogger.h"
+#include <options/FairMQProgOptions.h> // device->fConfig
 
 using namespace std;
 namespace pt = boost::property_tree;
-
-int requestIntervals = 5; // in seconds
-
-void InformationServiceDump::sendRequest()
-{
-  string* text = new string("asdf");
-  cout << "preparing request " << endl;
-  FairMQMessagePtr request(NewMessage(const_cast<char*>(text->c_str()), // data
-                                      text->length(), // size
-                                      [](void* /*data*/, void* object) { delete static_cast<string*>(object); }, // deletion callback
-                                      text)); // object that manages the data
-  cout << "Sending request" << endl;
-  if (Send(request, "send_request") <= 0)
-  {
-    cout << "problem sending request" << endl;
-  }
-
-  // restart timer
-  mTimer.expires_at(mTimer.expires_at() + boost::posix_time::seconds(requestIntervals));
-  mTimer.async_wait(boost::bind(&InformationServiceDump::sendRequest, this));
-}
-
-bool InformationServiceDump::ConditionalRun()
-{
-  string* text = new string("asdf");
-  cout << "preparing request " << endl;
-  FairMQMessagePtr request(NewMessage(const_cast<char*>(text->c_str()), // data
-                                      text->length(), // size
-                                      [](void* /*data*/, void* object) { delete static_cast<string*>(object); }, // deletion callback
-                                      text)); // object that manages the data
-  cout << "Sending request" << endl;
-  if (Send(request, "send_request") <= 0)
-  {
-    cout << "problem sending request" << endl;
-  }
-  this_thread::sleep_for(chrono::seconds(5));
-
-  return true;
-}
 
 InformationServiceDump::InformationServiceDump(boost::asio::io_service& io)
   : mTimer(io, boost::posix_time::seconds(requestIntervals))
 {
   OnData("info_service_input", &InformationServiceDump::HandleData);
-
-//  mTimer.async_wait(boost::bind(&InformationServiceDump::sendRequest, this));
 }
 
 bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
@@ -82,13 +38,13 @@ bool InformationServiceDump::HandleData(FairMQMessagePtr &msg, int /*index*/)
   LOG(INFO) << "Received data : ";
   LOG(INFO) << "    " << *receivedData;
 
-  string* text = new string("asdf");
-  cout << "preparing request " << endl;
+  string* text = new string( fConfig->GetValue<string>("request-task"));
+  cout << "preparing request for \"" << text << "\"" << endl;
   FairMQMessagePtr request(NewMessage(const_cast<char*>(text->c_str()), // data
                                       text->length(), // size
                                       [](void* /*data*/, void* object) { delete static_cast<string*>(object); }, // deletion callback
                                       text)); // object that manages the data
-  cout << "Sending request" << endl;
+  cout << "Sending request " << endl;
   if (Send(request, "send_request") > 0) {
     FairMQMessagePtr reply(NewMessage());
     if (Receive(reply, "send_request") >= 0)

--- a/Framework/src/InformationServiceDump.h
+++ b/Framework/src/InformationServiceDump.h
@@ -42,8 +42,8 @@ class InformationServiceDump : public FairMQDevice
     virtual ~InformationServiceDump();
 
   protected:
+    /// Callback for data coming from InformationService
     bool HandleData(FairMQMessagePtr&, int);
-
 };
 
 #endif //PROJECT_InformationServiceDump_H

--- a/Framework/src/InformationServiceDump.h
+++ b/Framework/src/InformationServiceDump.h
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+
+///
+/// \author bvonhall
+/// \file InformationServiceDump.h
+///
+
+
+#ifndef PROJECT_INFORMATIONSERVICEDUMP_H
+#define PROJECT_INFORMATIONSERVICEDUMP_H
+
+#include "FairMQDevice.h"
+
+/// \brief Dump the publications received from the InformationService.
+/// Useful for checking the InformationService.
+class InformationServiceDump : public FairMQDevice
+{
+  public:
+    InformationServiceDump();
+    virtual ~InformationServiceDump();
+
+  protected:
+    bool HandleData(FairMQMessagePtr&, int);
+};
+
+#endif //PROJECT_InformationServiceDump_H

--- a/Framework/src/InformationServiceDump.h
+++ b/Framework/src/InformationServiceDump.h
@@ -30,7 +30,6 @@
 ///
 /// See runInformationServiceDump.cxx for the steering code.
 ///
-///
 /// Example usage :
 ///       qcInfoServiceDump -c /absolute/path/to/InformationService.json -n information_service_dump
 ///                         --id information_service_dump --mq-config /absolute/path/to/InformationService.json
@@ -43,7 +42,7 @@ class InformationServiceDump : public FairMQDevice
 
   protected:
     /// Callback for data coming from InformationService
-    bool HandleData(FairMQMessagePtr&, int);
+    bool HandleData(FairMQMessagePtr &, int);
 };
 
 #endif //PROJECT_InformationServiceDump_H

--- a/Framework/src/InformationServiceDump.h
+++ b/Framework/src/InformationServiceDump.h
@@ -19,17 +19,24 @@
 #define PROJECT_INFORMATIONSERVICEDUMP_H
 
 #include "FairMQDevice.h"
+#include <boost/asio.hpp>
 
 /// \brief Dump the publications received from the InformationService.
 /// Useful for checking the InformationService.
 class InformationServiceDump : public FairMQDevice
 {
   public:
-    InformationServiceDump();
+    InformationServiceDump(boost::asio::io_service& io);
     virtual ~InformationServiceDump();
 
   protected:
     bool HandleData(FairMQMessagePtr&, int);
+    void sendRequest();
+    virtual bool ConditionalRun();
+
+  private:
+    boost::asio::deadline_timer mTimer; /// the asynchronous timer to call print at regular intervals
+
 };
 
 #endif //PROJECT_InformationServiceDump_H

--- a/Framework/src/InformationServiceDump.h
+++ b/Framework/src/InformationServiceDump.h
@@ -22,7 +22,19 @@
 #include <boost/asio.hpp>
 
 /// \brief Dump the publications received from the InformationService.
+///
 /// Useful for checking the InformationService.
+/// It will receive the updates from the tasks. Upon reception , it dumps it and send a request for all or a single
+/// task data and displays the reply.
+/// To decide which task the request should target, use parameter "request-task". By default it asks for all.
+///
+/// See runInformationServiceDump.cxx for the steering code.
+///
+///
+/// Example usage :
+///       qcInfoServiceDump -c /absolute/path/to/InformationService.json -n information_service_dump
+///                         --id information_service_dump --mq-config /absolute/path/to/InformationService.json
+///                         --request-task myTask1
 class InformationServiceDump : public FairMQDevice
 {
   public:
@@ -31,8 +43,6 @@ class InformationServiceDump : public FairMQDevice
 
   protected:
     bool HandleData(FairMQMessagePtr&, int);
-    void sendRequest();
-    virtual bool ConditionalRun();
 
   private:
     boost::asio::deadline_timer mTimer; /// the asynchronous timer to call print at regular intervals

--- a/Framework/src/InformationServiceDump.h
+++ b/Framework/src/InformationServiceDump.h
@@ -38,14 +38,11 @@
 class InformationServiceDump : public FairMQDevice
 {
   public:
-    InformationServiceDump(boost::asio::io_service& io);
+    InformationServiceDump();
     virtual ~InformationServiceDump();
 
   protected:
     bool HandleData(FairMQMessagePtr&, int);
-
-  private:
-    boost::asio::deadline_timer mTimer; /// the asynchronous timer to call print at regular intervals
 
 };
 

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -36,7 +36,9 @@ void ObjectsManager::startPublishing(TObject *object, std::string objectName)
   mMonitorObjects[nonEmptyName] = newObject;
 
   //update index
-  UpdateIndex(nonEmptyName);
+  if(objectName != MonitorObject::SYSTEM_OBJECT_PUBLICATION_LIST) {
+    UpdateIndex(nonEmptyName);
+  }
 }
 
 void ObjectsManager::UpdateIndex(const string &nonEmptyName)

--- a/Framework/src/TaskDevice.cxx
+++ b/Framework/src/TaskDevice.cxx
@@ -235,8 +235,6 @@ void TaskDevice::endOfActivity()
 
 void TaskDevice::sendToInformationService(string objectsListString)
 {
-  // todo only send if a certain time has passed and also if the list has changed
-
   string* text = new std::string(mTaskName);
   *text += ":" + objectsListString;
   // todo escape names with a comma or a colon

--- a/Framework/src/runInformationService.cxx
+++ b/Framework/src/runInformationService.cxx
@@ -19,11 +19,16 @@
 
 namespace bpo = boost::program_options;
 
-void addCustomOptions(bpo::options_description& /*options*/)
+void addCustomOptions(bpo::options_description& options)
 {
+  options.add_options()
+    ("fake-data-file", bpo::value<std::string>()->default_value(""),
+     "File containing JSON to use as input (useful for tests if no tasks is running). It is used to reply to requests. It is reloaded every 10 seconds and if it changed it is published to the clients.");
 }
 
 FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
 {
-  return new InformationService();
+  InformationService *is = new InformationService();
+
+  return is;
 }

--- a/Framework/src/runInformationService.cxx
+++ b/Framework/src/runInformationService.cxx
@@ -19,14 +19,15 @@
 
 namespace bpo = boost::program_options;
 
-void addCustomOptions(bpo::options_description& options)
+void addCustomOptions(bpo::options_description &options)
 {
   options.add_options()
     ("fake-data-file", bpo::value<std::string>()->default_value(""),
-     "File containing JSON to use as input (useful for tests if no tasks is running). It is used to reply to requests. It is reloaded every 10 seconds and if it changed it is published to the clients.");
+     "File containing JSON to use as input (useful for tests if no tasks is running). It is used to reply to requests. "
+       "It is reloaded every 10 seconds and if it changed it is published to the clients.");
 }
 
-FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
+FairMQDevicePtr getDevice(const FairMQProgOptions & /*config*/)
 {
   InformationService *is = new InformationService();
 

--- a/Framework/src/runInformationService.cxx
+++ b/Framework/src/runInformationService.cxx
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+
+///
+/// \author bvonhall
+/// \file runInformationService.cxx
+///
+
+#include "runFairMQDevice.h"
+#include "InformationService.h"
+
+namespace bpo = boost::program_options;
+
+void addCustomOptions(bpo::options_description& /*options*/)
+{
+}
+
+FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
+{
+  return new InformationService();
+}

--- a/Framework/src/runInformationServiceDump.cxx
+++ b/Framework/src/runInformationServiceDump.cxx
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+
+///
+/// \author bvonhall
+/// \file InformationServiceDump.cxx
+///
+
+#include "runFairMQDevice.h"
+#include "InformationServiceDump.h"
+
+namespace bpo = boost::program_options;
+
+void addCustomOptions(bpo::options_description& /*options*/)
+{
+}
+
+FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
+{
+  return new InformationServiceDump();
+}

--- a/Framework/src/runInformationServiceDump.cxx
+++ b/Framework/src/runInformationServiceDump.cxx
@@ -25,5 +25,8 @@ void addCustomOptions(bpo::options_description& /*options*/)
 
 FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
 {
-  return new InformationServiceDump();
+  boost::asio::io_service io;
+  InformationServiceDump *isDump = new InformationServiceDump(io);
+  io.run();
+  return isDump;
 }

--- a/Framework/src/runInformationServiceDump.cxx
+++ b/Framework/src/runInformationServiceDump.cxx
@@ -19,11 +19,14 @@
 
 namespace bpo = boost::program_options;
 
-void addCustomOptions(bpo::options_description& /*options*/)
+void addCustomOptions(bpo::options_description &options)
 {
+  options.add_options()
+    ("request-task", bpo::value<std::string>()->default_value("all"),
+     "The name of the task it will request (default: all)");
 }
 
-FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
+FairMQDevicePtr getDevice(const FairMQProgOptions & /*config*/)
 {
   boost::asio::io_service io;
   InformationServiceDump *isDump = new InformationServiceDump(io);

--- a/Framework/src/runInformationServiceDump.cxx
+++ b/Framework/src/runInformationServiceDump.cxx
@@ -28,8 +28,5 @@ void addCustomOptions(bpo::options_description &options)
 
 FairMQDevicePtr getDevice(const FairMQProgOptions & /*config*/)
 {
-  boost::asio::io_service io;
-  InformationServiceDump *isDump = new InformationServiceDump(io);
-  io.run();
-  return isDump;
+  return new InformationServiceDump();
 }

--- a/InformationService.json
+++ b/InformationService.json
@@ -29,6 +29,19 @@
                 "rateLogging": 0
               }
             ]
+          },
+          {
+            "name": "request_data",
+            "sockets": [
+              {
+                "type": "rep",
+                "method": "bind",
+                "address": "tcp://*:5562",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
           }
         ]
       },
@@ -42,6 +55,19 @@
                 "type": "sub",
                 "method": "connect",
                 "address": "tcp://localhost:5561",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          },
+          {
+            "name": "send_request",
+            "sockets": [
+              {
+                "type": "req",
+                "method": "connect",
+                "address": "tcp://localhost:5562",
                 "sndBufSize": 1000,
                 "rcvBufSize": 1000,
                 "rateLogging": 0

--- a/InformationService.json
+++ b/InformationService.json
@@ -11,8 +11,8 @@
                 "type": "sub",
                 "method": "bind",
                 "address": "tcp://*:5560",
-                "sndBufSize": 1000,
-                "rcvBufSize": 1000,
+                "sndBufSize": 1,
+                "rcvBufSize": 100,
                 "rateLogging": 0
               }
             ]

--- a/InformationService.json
+++ b/InformationService.json
@@ -1,0 +1,55 @@
+{
+  "fairMQOptions": {
+    "devices": [
+      {
+        "key": "information_service",
+        "channels": [
+          {
+            "name": "tasks_input",
+            "sockets": [
+              {
+                "type": "sub",
+                "method": "bind",
+                "address": "tcp://*:5560",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          },
+          {
+            "name": "updates_output",
+            "sockets": [
+              {
+                "type": "pub",
+                "method": "bind",
+                "address": "tcp://*:5561",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "key": "information_service_dump",
+        "channels": [
+          {
+            "name": "info_service_input",
+            "sockets": [
+              {
+                "type": "sub",
+                "method": "connect",
+                "address": "tcp://localhost:5561",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Modules/Example/include/Example/ExampleTask.h
+++ b/Modules/Example/include/Example/ExampleTask.h
@@ -47,8 +47,9 @@ class ExampleTask /*final*/: public TaskInterface // todo add back the "final" w
     }
 
   private:
-
+    int mNumberCycles;
     TH1F *mHistos[25];
+    void publishHisto(int i);
 };
 
 }

--- a/README.md
+++ b/README.md
@@ -170,14 +170,78 @@ file was passed to the `qcSpy` utility.
 
 ### Information Service
 
-The information service is needed in case some GUIs need information
-about the running tasks and the objects they publish.
+The information service publishes information about the tasks currently
+running and the objects they publish. It is needed by some GUIs, or
+other clients.
 
-To run it :
+By default it will publish on port 5561 the json description of a task
+when it is updated. A client can also request on port 5562 the information
+about a specific task or about all the tasks, by passing the name of the
+task as a parameter or "all" respectively.
+
+The JSON for a task looks like :
+```
+{
+    "name": "myTask_1",
+    "objects": [
+        {
+            "id": "array-0"
+        },
+        {
+            "id": "array-1"
+        },
+        {
+            "id": "array-2"
+        },
+        {
+            "id": "array-3"
+        },
+        {
+            "id": "array-4"
+        }
+    ]
+}
+```
+
+The JSON for all tasks looks like :
+```
+{
+    "tasks": [
+        {
+            "name": "myTask_1",
+            "objects": [
+                {
+                    "id": "array-0"
+                },
+                {
+                    "id": "array-1"
+                }
+            ]
+        },
+        {
+            "name": "myTask_2",
+            "objects": [
+                {
+                    "id": "array-0"
+                },
+                {
+                    "id": "array-1"
+                }
+            ]
+        }
+    ]
+}
+```
+#### Usage
 ```
 qcInfoService -c /absolute/path/to/InformationService.json -n information_service \
               --id information_service --mq-config /absolute/path/to/InformationService.json
 ```
+
+The `qcInfoService` can provide fake data from a file. This is useful
+to test the clients. Use the option `--fake-data-file` and provide the
+absolute path to the file. The file `infoServiceFake.json` is provided
+as an example.
 
 To check what is being output by the Information Service, one can
 run the InformationServiceDump :

--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ One can also check what is stored in the database by clicking `Stop`
 and then switching to `Database` source. This will only work if a config
 file was passed to the `qcSpy` utility.
 
+### Information Service
+
+The information service is needed in case some GUIs need information
+about the running tasks and the objects they publish.
+
+To run it :
+```
+qcInfoService -c /absolute/path/to/InformationService.json -n information_service \
+              --id information_service --mq-config /absolute/path/to/InformationService.json
+```
+
+To check what is being output by the Information Service, one can
+run the InformationServiceDump :
+```
+qcInfoServiceDump -c /absolute/path/to/InformationService.json -n information_service_dump \
+                  --id information_service_dump --mq-config /absolute/path/to/InformationService.json
+                  --request-task myTask1
+```
+The last parameter can be omitted to receive information about all tasks.
+
 ## Modules development
 
 Steps to create a new module Abc
@@ -184,4 +204,4 @@ From here, fill in the methods in AbcTask.cxx, and AbcCheck.cxx if needed.
 
 In case special additional dependencies are needed, create a new bucket in QualityControlModules/cmake/QualityControlModulesDependencies.cmake.
 
- 
+

--- a/infoServiceFake.json
+++ b/infoServiceFake.json
@@ -1,0 +1,5 @@
+myTask_1:array-0,array-1,array-2,array-3,array-4,
+myTask_1:array-0,array-1,array-2,array-3,array-4,array-5,
+myTask_1:array-0,array-1,array-2,array-3,array-4,array-5,
+myTask_1:array-0,array-1,array-2,array-3,array-4,
+myTask_2:array-0,array-1,array-2,array-3,array-4,


### PR DESCRIPTION
Add an information service that collects the list of objects published by all the tasks and make it available to clients. There are 2 binaries : qcInfoService and qcInfoServiceDump. The latter is to check what is being produced by the Information Service. 

The information service can use a file as input if there are no tasks running but one wants to simulate a normal use. 
QC-57