### PR TITLE
Fix access to monitorObject in taskDPL example

### DIFF
--- a/Framework/src/TaskDPL.cxx
+++ b/Framework/src/TaskDPL.cxx
@@ -85,16 +85,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
 
         return (AlgorithmSpec::ProcessCallback) [](ProcessingContext& processingContext) mutable {
           LOG(INFO) << "checker invoked";
-//          auto mo = processingContext.inputs().get<o2::quality_control::core::MonitorObject>("aaa");
-//
-//          if (mo->getName() == "example") {
-//            auto* g = dynamic_cast<TH1F*>(mo->getObject());
-//            std::string bins = "BINS:";
-//            for (int i = 0; i < g->GetNbinsX(); i++) {
-//              bins += " " + std::to_string((int) g->GetBinContent(i));
-//            }
-//            LOG(INFO) << bins;
-//          }
+          auto mo = processingContext.inputs().get<o2::quality_control::core::MonitorObject*>("aaa").get();
+
+          if (mo->getName() == "example") {
+            auto* g = dynamic_cast<TH1F*>(mo->getObject());
+            std::string bins = "BINS:";
+            for (int i = 0; i < g->GetNbinsX(); i++) {
+              bins += " " + std::to_string((int) g->GetBinContent(i));
+            }
+            LOG(INFO) << bins;
+          }
 
         };
       }


### PR DESCRIPTION
This commit follows the API change of accessing DPL ROOT inputs.
Note, that Dispatcher will still cause segfault until https://github.com/AliceO2Group/AliceO2/pull/1229 is merged.