### PR TITLE
Handle disconnecting from databases internally

### DIFF
--- a/Framework/include/QualityControl/CcdbDatabase.h
+++ b/Framework/include/QualityControl/CcdbDatabase.h
@@ -53,6 +53,7 @@ class CcdbDatabase : public DatabaseInterface
 {
   public:
     CcdbDatabase();
+    ~CcdbDatabase();
 
     void connect(std::string host, std::string database, std::string username, std::string password) override;
     void connect(std::unique_ptr<ConfigurationInterface> &config) override;

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -36,6 +36,11 @@ using namespace std;
 CcdbDatabase::CcdbDatabase() : mUrl("")
 {}
 
+CcdbDatabase::~CcdbDatabase()
+{
+  disconnect();
+}
+
 void CcdbDatabase::curlInit()
 {
   curl_global_init(CURL_GLOBAL_DEFAULT);

--- a/Framework/src/Checker.cxx
+++ b/Framework/src/Checker.cxx
@@ -124,8 +124,6 @@ void Checker::createChannel(std::string type, std::string method, std::string ad
 
 Checker::~Checker()
 {
-  mDatabase->disconnect();
-
   // Monitoring
   std::chrono::duration<double> diff = endLastObject - startFirstObject;
   mCollector->send({diff.count(), "QC_checker_Time_between_first_and_last_objects_received"});

--- a/Framework/src/ClientDataProvider.cxx
+++ b/Framework/src/ClientDataProvider.cxx
@@ -22,7 +22,6 @@ ClientDataProvider::ClientDataProvider()
 
 ClientDataProvider::~ClientDataProvider()
 {
-  database->disconnect();
 }
 
 TObject* ClientDataProvider::getObject(std::string taskName, std::string objectName)


### PR DESCRIPTION
Now also CCDB (not only MySQL) disconnects from database during destruction and handling it manually is no longer required.

This should allow to safely keep database interfaces as `shared_ptr`s, which is probably unavoidable when implementing checkers as DPL devices.