### PR TITLE
Possibility to reset task's monitor objects after publishing

### DIFF
--- a/Framework/include/QualityControl/TaskDataProcessor.h
+++ b/Framework/include/QualityControl/TaskDataProcessor.h
@@ -74,6 +74,8 @@ class TaskDataProcessor {
   const Inputs& getInputsSpecs() { return mInputSpecs; };
   const OutputSpec getOutputSpec() { return mMonitorObjectsSpec; };
 
+  void setResetAfterPublish(bool);
+
   /// \brief Unified DataDescription naming scheme for all tasks
   static o2::header::DataDescription taskDataDescription(const std::string taskName);
 
@@ -91,6 +93,7 @@ class TaskDataProcessor {
   std::shared_ptr<o2::configuration::ConfigurationInterface> mConfigFile; // used in init only
   std::shared_ptr<o2::monitoring::Monitoring> mCollector;
   TaskInterfaceDPL* mTask;
+  bool mResetAfterPublish;
   std::shared_ptr<ObjectsManager> mObjectsManager;
   std::recursive_mutex mTaskMutex; // \todo should be plain mutex, when timer callback is implemented in dpl
 

--- a/Framework/src/TaskDataProcessor.cxx
+++ b/Framework/src/TaskDataProcessor.cxx
@@ -32,7 +32,8 @@ TaskDataProcessor::TaskDataProcessor(std::string taskName, std::string configura
     mLastNumberObjects(0),
     mCycleOn(false),
     mCycleNumber(0),
-    mMonitorObjectsSpec("", "", 0)
+    mMonitorObjectsSpec("", "", 0),
+    mResetAfterPublish(false)
 {
   // setup configuration
   mConfigFile = ConfigurationFactory::getConfiguration(configurationSource);
@@ -109,6 +110,9 @@ void TaskDataProcessor::processCallback(ProcessingContext& pCtx)
 
     // temporarily here, until timer callback is implemented in dpl
     timerCallback(pCtx);
+    if (mResetAfterPublish) {
+      mTask->reset();
+    }
   }
 }
 
@@ -116,6 +120,12 @@ void TaskDataProcessor::timerCallback(ProcessingContext& pCtx)
 {
   finishCycle(pCtx.outputs());
 }
+
+void TaskDataProcessor::setResetAfterPublish(bool resetAfterPublish)
+{
+  mResetAfterPublish = resetAfterPublish;
+}
+
 
 o2::header::DataDescription TaskDataProcessor::taskDataDescription(const std::string taskName)
 {

--- a/Modules/SkeletonDPL/src/SkeletonTaskDPL.cxx
+++ b/Modules/SkeletonDPL/src/SkeletonTaskDPL.cxx
@@ -99,7 +99,10 @@ void SkeletonTaskDPL::endOfActivity(Activity &activity)
 
 void SkeletonTaskDPL::reset()
 {
-  QcInfoLogger::GetInstance() << "Reset" << AliceO2::InfoLogger::InfoLogger::endm;
+  // clean all the monitor objects here
+
+  QcInfoLogger::GetInstance() << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  mHistogram->Reset();
 }
 
 }


### PR DESCRIPTION
This will provide possibility to use mergers as "keepers" of full monitor objects, while distributed tasks would send only the updates. Of course, when there is no need for merging, tasks would keep the full MOs.