### PR TITLE
Unify include guards and namespaces comments

### DIFF
--- a/Framework/include/QualityControl/Activity.h
+++ b/Framework/include/QualityControl/Activity.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_CORE_ACTIVITY_H
-#define QUALITYCONTROL_CORE_ACTIVITY_H
+#ifndef QC_CORE_ACTIVITY_H
+#define QC_CORE_ACTIVITY_H
 
 namespace o2 {
 namespace quality_control {
@@ -35,7 +35,7 @@ class Activity
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_CORE_ACTIVITY_H
+#endif // QC_CORE_ACTIVITY_H

--- a/Framework/include/QualityControl/AlfaReceiverForTests.h
+++ b/Framework/include/QualityControl/AlfaReceiverForTests.h
@@ -3,8 +3,8 @@
 /// @author  Barthelemy von Haller
 ///
 
-#ifndef QUALITY_CONTROL_AlfaReceiverForTests_H
-#define QUALITY_CONTROL_AlfaReceiverForTests_H
+#ifndef QC_CORE_ALFARECEIVERFORTESTS_H
+#define QC_CORE_ALFARECEIVERFORTESTS_H
 
 #include <FairMQDevice.h>
 #include <TMessage.h>
@@ -35,7 +35,7 @@ class AlfaReceiverForTests : public FairMQDevice
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITY_CONTROL_AlfaReceiverForTests_H
+#endif // QC_CORE_ALFARECEIVERFORTESTS_H

--- a/Framework/include/QualityControl/CcdbDatabase.h
+++ b/Framework/include/QualityControl/CcdbDatabase.h
@@ -13,8 +13,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef PROJECT_CCDBDATABASE_H
-#define PROJECT_CCDBDATABASE_H
+#ifndef QC_REPOSITORY_CCDBDATABASE_H
+#define QC_REPOSITORY_CCDBDATABASE_H
 
 #include <ctime>
 #include <chrono>
@@ -93,4 +93,4 @@ class CcdbDatabase : public DatabaseInterface
 }
 }
 
-#endif //PROJECT_CCDBDATABASE_H
+#endif //QC_REPOSITORY_CCDBDATABASE_H

--- a/Framework/include/QualityControl/CheckInterface.h
+++ b/Framework/include/QualityControl/CheckInterface.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CHECKER_CHECKINTERFACE_H_
-#define QUALITYCONTROL_LIBS_CHECKER_CHECKINTERFACE_H_
+#ifndef QC_CHECKER_CHECKINTERFACE_H
+#define QC_CHECKER_CHECKINTERFACE_H
 
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
@@ -74,8 +74,8 @@ class CheckInterface
   ClassDef(CheckInterface, 1)
 };
 
-} /* namespace Checker */
-} /* namespace QualityControl */
+} /* namespace checker */
+} /* namespace quality_control */
 } /* namespace o2 */
 
-#endif /* QUALITYCONTROL_LIBS_CHECKER_CHECKINTERFACE_H_ */
+#endif /* QC_CHECKER_CHECKINTERFACE_H */

--- a/Framework/include/QualityControl/Checker.h
+++ b/Framework/include/QualityControl/Checker.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CHECKER_CHECKER_H_
-#define QUALITYCONTROL_LIBS_CHECKER_CHECKER_H_
+#ifndef QC_CHECKER_CHECKER_H
+#define QC_CHECKER_CHECKER_H
 
 // std & boost
 #include <chrono>
@@ -108,8 +108,8 @@ class Checker : public FairMQDevice
     AliceO2::Common::Timer timer;
 };
 
-} /* namespace Checker */
-} /* namespace QualityControl */
+} /* namespace checker */
+} /* namespace quality_control */
 } /* namespace o2 */
 
-#endif /* QUALITYCONTROL_LIBS_CHECKER_CHECKER_H_ */
+#endif /* QC_CHECKER_CHECKER_H */

--- a/Framework/include/QualityControl/CheckerConfig.h
+++ b/Framework/include/QualityControl/CheckerConfig.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_CORE_CHECKERCONFIG_H_
-#define QUALITYCONTROL_CORE_CHECKERCONFIG_H_
+#ifndef QC_CORE_CHECKERCONFIG_H
+#define QC_CORE_CHECKERCONFIG_H
 
 #include <string>
 
@@ -29,7 +29,7 @@ struct CheckerConfig
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_CORE_CHECKERCONFIG_H_
+#endif // QC_CORE_CHECKERCONFIG_H

--- a/Framework/include/QualityControl/CheckerDataProcessor.h
+++ b/Framework/include/QualityControl/CheckerDataProcessor.h
@@ -4,8 +4,8 @@
 /// \author Piotr Konopka
 ///
 
-#ifndef QUALITYCONTROL_CORE_CHECKERDATAPROCESSOR_H
-#define QUALITYCONTROL_CORE_CHECKERDATAPROCESSOR_H
+#ifndef QC_CHECKER_CHECKERDATAPROCESSOR_H
+#define QC_CHECKER_CHECKERDATAPROCESSOR_H
 
 // std & boost
 #include <chrono>
@@ -125,8 +125,8 @@ class CheckerDataProcessor : public framework::Task
     AliceO2::Common::Timer timer;
 };
 
-} /* namespace Checker */
-} /* namespace QualityControl */
+} /* namespace checker */
+} /* namespace quality_control */
 } /* namespace o2 */
 
-#endif // QUALITYCONTROL_CORE_CHECKERDATAPROCESSOR_H
+#endif // QC_CHECKER_CHECKERDATAPROCESSOR_H

--- a/Framework/include/QualityControl/CheckerDataProcessorFactory.h
+++ b/Framework/include/QualityControl/CheckerDataProcessorFactory.h
@@ -2,8 +2,8 @@
 /// \file   CheckerDataProcessorFactory.h
 /// \author Piotr Konopka
 ///
-#ifndef PROJECT_CHECKERDATAPROCESSORFACTORY_H
-#define PROJECT_CHECKERDATAPROCESSORFACTORY_H
+#ifndef QC_CHECKER_DATAPROCESSORFACTORY_H
+#define QC_CHECKER_DATAPROCESSORFACTORY_H
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -24,4 +24,4 @@ public:
 } // namespace quality_control
 } // namespace o2
 
-#endif // PROJECT_CHECKERDATAPROCESSORFACTORY_H
+#endif // QC_CHECKER_DATAPROCESSORFACTORY_H

--- a/Framework/include/QualityControl/ClientDataProvider.h
+++ b/Framework/include/QualityControl/ClientDataProvider.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_CLIENT_CLIENT_DATA_PROVIDER_H_
-#define QUALITYCONTROL_CLIENT_CLIENT_DATA_PROVIDER_H_
+#ifndef QC_CLIENT_CLIENTDATAPROVIDER_H
+#define QC_CLIENT_CLIENTDATAPROVIDER_H
 
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/DatabaseInterface.h"
@@ -40,8 +40,8 @@ class ClientDataProvider
 
 };
 
-} /* namespace Client */
-} /* namespace QualityControl */
+} /* namespace client */
+} /* namespace quality_control */
 } /* namespace o2 */
 
-#endif /* QUALITYCONTROL_CLIENT_CLIENT_DATA_PROVIDER_H_ */
+#endif /* QC_CLIENT_CLIENTDATAPROVIDER_H */

--- a/Framework/include/QualityControl/Consumer.h
+++ b/Framework/include/QualityControl/Consumer.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_CLIENT_CONSUMER_H_
-#define QUALITYCONTROL_CLIENT_CONSUMER_H_
+#ifndef QC_CLIENT_CONSUMER_H
+#define QC_CLIENT_CONSUMER_H
 
 // QC
 #include "QualityControl/ClientDataProvider.h"
@@ -35,8 +35,8 @@ class Consumer
     unsigned int mNumberCycles, mNumberObjects, mNumberTasks;
 };
 
-} /* namespace Client */
-} /* namespace QualityControl */
+} /* namespace client */
+} /* namespace quality_control */
 } /* namespace o2 */
 
-#endif /* QUALITYCONTROL_CLIENT_CONSUMER_H_ */
+#endif /* QC_CLIENT_CONSUMER_H */

--- a/Framework/include/QualityControl/DatabaseFactory.h
+++ b/Framework/include/QualityControl/DatabaseFactory.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CORE_DatabaseFactory_H_
-#define QUALITYCONTROL_LIBS_CORE_DatabaseFactory_H_
+#ifndef QC_REPOSITORY_DATABASEFACTORY_H
+#define QC_REPOSITORY_DATABASEFACTORY_H
 
 #include <memory>
 // O2
@@ -29,8 +29,8 @@ class DatabaseFactory
     static std::unique_ptr<DatabaseInterface> create(std::string name);
 };
 
-} // namespace core
-} // namespace QualityControl
+} // namespace repository
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CORE_DatabaseFactory_H_
+#endif // QC_REPOSITORY_DATABASEFACTORY_H

--- a/Framework/include/QualityControl/DatabaseInterface.h
+++ b/Framework/include/QualityControl/DatabaseInterface.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_REPOSITORY_DATABASE_INTERFACE_H_
-#define QUALITYCONTROL_REPOSITORY_DATABASE_INTERFACE_H_
+#ifndef QC_REPOSITORY_DATABASEINTERFACE_H
+#define QC_REPOSITORY_DATABASEINTERFACE_H
 
 #include "QualityControl/MonitorObject.h"
 #include <memory>
@@ -79,7 +79,7 @@ class DatabaseInterface
 };
 
 } /* namespace repository */
-} /* namespace QualityControl */
+} /* namespace quality_control */
 } /* namespace o2 */
 
-#endif /* QUALITYCONTROL_REPOSITORY_DATABASE_INTERFACE_H_ */
+#endif /* QC_REPOSITORY_DATABASEINTERFACE_H */

--- a/Framework/include/QualityControl/MonitorObject.h
+++ b/Framework/include/QualityControl/MonitorObject.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CORE_MONITOROBJECT_H_
-#define QUALITYCONTROL_LIBS_CORE_MONITOROBJECT_H_
+#ifndef QC_CORE_MONITOROBJECT_H
+#define QC_CORE_MONITOROBJECT_H
 
 // std
 #include <map>
@@ -164,7 +164,7 @@ class MonitorObject : public TObject
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CORE_MONITOROBJECT_H_
+#endif // QC_CORE_MONITOROBJECT_H

--- a/Framework/include/QualityControl/MySqlDatabase.h
+++ b/Framework/include/QualityControl/MySqlDatabase.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_REPOSITORY_MYSQL_DATABASE_H_
-#define QUALITYCONTROL_REPOSITORY_MYSQL_DATABASE_H_
+#ifndef QC_REPOSITORY_MYSQLDATABASE_H
+#define QC_REPOSITORY_MYSQLDATABASE_H
 
 #include "QualityControl/DatabaseInterface.h"
 #include "TMySQLServer.h"
@@ -70,7 +70,7 @@ class MySqlDatabase: public DatabaseInterface
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_REPOSITORY_MYSQL_DATABASE_H_
+#endif // QC_REPOSITORY_MYSQLDATABASE_H

--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_OBJECTSMANAGER_H_
-#define QUALITYCONTROL_LIBS_OBJECTSMANAGER_H_
+#ifndef QC_CORE_OBJECTMANAGER_H
+#define QC_CORE_OBJECTMANAGER_H
 
 #include <string>
 #include <boost/concept_check.hpp>
@@ -80,7 +80,7 @@ class ObjectsManager
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_OBJECTSMANAGER_H_
+#endif // QC_CORE_OBJECTMANAGER_H

--- a/Framework/include/QualityControl/QcInfoLogger.h
+++ b/Framework/include/QualityControl/QcInfoLogger.h
@@ -3,8 +3,8 @@
 /// @author  Barthelemy von Haller
 ///
 
-#ifndef QUALITY_CONTROL_QCINFOLOGGER_H
-#define QUALITY_CONTROL_QCINFOLOGGER_H
+#ifndef QC_CORE_QCINFOLOGGER_H
+#define QC_CORE_QCINFOLOGGER_H
 
 #include <iostream>
 #include <InfoLogger/InfoLogger.hxx>
@@ -54,8 +54,8 @@ class QcInfoLogger : public AliceO2::InfoLogger::InfoLogger
     QcInfoLogger(const QcInfoLogger &) = delete;
 };
 
-}
-}
-}
+} // namespace core
+} // namespace quality_control
+} // namespace o2
 
-#endif //QUALITY_CONTROL_BASICTASK_H
+#endif //QC_CORE_QCINFOLOGGER_H

--- a/Framework/include/QualityControl/Quality.h
+++ b/Framework/include/QualityControl/Quality.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_CORE_QUALITY_H_
-#define QUALITYCONTROL_CORE_QUALITY_H_
+#ifndef QC_CORE_QUALITY_H
+#define QC_CORE_QUALITY_H
 
 #include <string>
 #include <ostream>
@@ -76,7 +76,7 @@ class Quality
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_CORE_QUALITY_H_
+#endif // QC_CORE_QUALITY_H

--- a/Framework/include/QualityControl/SpyDevice.h
+++ b/Framework/include/QualityControl/SpyDevice.h
@@ -3,8 +3,8 @@
 /// @author  Barthelemy von Haller
 ///
 
-#ifndef QUALITY_CONTROL_SpyDevice_H
-#define QUALITY_CONTROL_SpyDevice_H
+#ifndef QC_GUI_SPYDEVICE_H
+#define QC_GUI_SPYDEVICE_H
 
 // ROOT
 #include <TMessage.h>
@@ -57,7 +57,7 @@ class SpyDevice: public FairMQDevice
 };
 
 } // namespace gui
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITY_CONTROL_SpyDevice_H
+#endif // QC_GUI_SPYDEVICE_H

--- a/Framework/include/QualityControl/SpyMainFrame.h
+++ b/Framework/include/QualityControl/SpyMainFrame.h
@@ -13,8 +13,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_SRC_QCSPY_H_
-#define QUALITYCONTROL_SRC_QCSPY_H_
+#ifndef QC_GUI_SPYMAINFRAME_H
+#define QC_GUI_SPYMAINFRAME_H
 
 //std
 #include <map>
@@ -99,7 +99,7 @@ class SpyMainFrame: public TGMainFrame
 };
 
 } /* namespace gui */
-} /* namespace QualityControl */
+} /* namespace quality_control */
 } /* namespace o2 */
 
-#endif /* QUALITYCONTROL_SRC_QCSPY_H_ */
+#endif /* QC_GUI_SPYMAINFRAME_H */

--- a/Framework/include/QualityControl/TaskConfig.h
+++ b/Framework/include/QualityControl/TaskConfig.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_CORE_TASKCONFIG_H_
-#define QUALITYCONTROL_CORE_TASKCONFIG_H_
+#ifndef QC_CORE_TASKCONFIG_H
+#define QC_CORE_TASKCONFIG_H
 
 #include <string>
 
@@ -28,7 +28,7 @@ struct TaskConfig
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_CORE_TASKCONFIG_H_
+#endif // QC_CORE_TASKCONFIG_H

--- a/Framework/include/QualityControl/TaskDataProcessor.h
+++ b/Framework/include/QualityControl/TaskDataProcessor.h
@@ -3,8 +3,8 @@
 /// \author Piotr Konopka
 ///
 
-#ifndef TASKDATAPROCESSOR_H
-#define TASKDATAPROCESSOR_H
+#ifndef QC_CORE_TASKDATAPROCESSOR_H
+#define QC_CORE_TASKDATAPROCESSOR_H
 
 #include <thread>
 #include <mutex>
@@ -114,8 +114,8 @@ class TaskDataProcessor {
   ba::accumulator_set<double, ba::features<ba::tag::mean, ba::tag::variance>> mPMems;
 };
 
-}
-}
-}
+} // namespace core
+} // namespace quality_control
+} // namespace o2
 
-#endif // TASKDATAPROCESSOR_H
+#endif // QC_CORE_TASKDATAPROCESSOR_H

--- a/Framework/include/QualityControl/TaskDataProcessorFactory.h
+++ b/Framework/include/QualityControl/TaskDataProcessorFactory.h
@@ -3,8 +3,8 @@
 /// \author Piotr Konopka
 ///
 
-#ifndef PROJECT_TASKDATAPROCESSORFACTORY_H
-#define PROJECT_TASKDATAPROCESSORFACTORY_H
+#ifndef QC_CORE_TASKDATAPROCESSORFACTORY_H
+#define QC_CORE_TASKDATAPROCESSORFACTORY_H
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -23,7 +23,7 @@ class TaskDataProcessorFactory
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif //PROJECT_TASKDATAPROCESSORFACTORY_H
+#endif //QC_CORE_TASKDATAPROCESSORFACTORY_H

--- a/Framework/include/QualityControl/TaskDevice.h
+++ b/Framework/include/QualityControl/TaskDevice.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_TASKDEVICE_H
-#define QUALITYCONTROL_TASKDEVICE_H
+#ifndef QC_CORE_TASKDEVICE_H
+#define QC_CORE_TASKDEVICE_H
 
 // fairroot
 #include <fairmq/FairMQDevice.h>
@@ -76,8 +76,8 @@ class TaskDevice : public FairMQDevice
     ba::accumulator_set<double, ba::features<ba::tag::mean, ba::tag::variance>> pmems;
 };
 
-}
-}
-}
+} // namespace core
+} // namespace quality_control
+} // namespace o2
 
-#endif //QUALITYCONTROL_TASKDEVICE_H
+#endif //QC_CORE_TASKDEVICE_H

--- a/Framework/include/QualityControl/TaskFactory.h
+++ b/Framework/include/QualityControl/TaskFactory.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CORE_TASKFACTORY_H_
-#define QUALITYCONTROL_LIBS_CORE_TASKFACTORY_H_
+#ifndef QC_CORE_TASKFACTORY_H
+#define QC_CORE_TASKFACTORY_H
 
 #include <iostream>
 #include <memory>
@@ -82,7 +82,7 @@ class TaskFactory
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CORE_TASKFACTORY_H_
+#endif // QC_CORE_TASKFACTORY_H

--- a/Framework/include/QualityControl/TaskInterface.h
+++ b/Framework/include/QualityControl/TaskInterface.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CORE_QCTASK_H_
-#define QUALITYCONTROL_LIBS_CORE_QCTASK_H_
+#ifndef QC_CORE_TASKINTERFACE_H
+#define QC_CORE_TASKINTERFACE_H
 
 #include <memory>
 
@@ -72,7 +72,7 @@ class TaskInterface
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CORE_QCTASK_H_
+#endif // QC_CORE_TASKINTERFACE_H

--- a/Framework/include/QualityControl/TaskInterfaceDPL.h
+++ b/Framework/include/QualityControl/TaskInterfaceDPL.h
@@ -3,8 +3,8 @@
 /// \author Piotr Konopka
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CORE_QCTASKDPL_H_
-#define QUALITYCONTROL_LIBS_CORE_QCTASKDPL_H_
+#ifndef QC_CORE_TASKINTERFACEDPL_H
+#define QC_CORE_TASKINTERFACEDPL_H
 
 #include <memory>
 // fixes problem of ''assert' not declared in this scope' in Framework/InitContext.h.
@@ -78,7 +78,7 @@ private:
 };
 
 } // namespace core
-} // namespace QualityControl
+} // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CORE_QCTASKDPL_H_
+#endif // QC_CORE_TASKINTERFACEDPL_H

--- a/Framework/include/QualityControl/Version.h.in
+++ b/Framework/include/QualityControl/Version.h.in
@@ -4,8 +4,8 @@
 /// \author  bvonhall
 ///
 
-#ifndef O2_QC_CORE_VERSION_H
-#define O2_QC_CORE_VERSION_H
+#ifndef QC_CORE_VERSION_H
+#define QC_CORE_VERSION_H
 
 #include <string>
 #include <sstream>
@@ -92,8 +92,9 @@ public:
     return version.str();
   }
 };
-}
-}
-}
 
-#endif // O2_QC_CORE_VERSION_H
+} // namespace core
+} // namespace quality_control
+} // namespace o2
+
+#endif // QC_CORE_VERSION_H

--- a/Framework/src/AlfaReceiverForTests.cxx
+++ b/Framework/src/AlfaReceiverForTests.cxx
@@ -45,6 +45,7 @@ bool AlfaReceiverForTests::HandleData(FairMQMessagePtr &msg, int /*index*/)
   // return true if want to be called again (otherwise go to IDLE state)
   return true;
 }
-}
-}
-}
+
+} // namespace core
+} // namespace quality_control
+} // namespace o2

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -464,6 +464,6 @@ void CcdbDatabase::truncateObject(std::string taskName, std::string objectName)
   }
 }
 
-}
-}
-}
+} // namespace repository
+} // namespace quality_control
+} // namespace o2

--- a/Framework/src/CheckInterface.cxx
+++ b/Framework/src/CheckInterface.cxx
@@ -45,7 +45,7 @@ bool CheckInterface::isObjectCheckable(const MonitorObject *mo)
   return false;
 }
 
-} /* namespace Checker */
+} /* namespace checker */
 } /* namespace quality_control */
 } /* namespace o2 */
 

--- a/Framework/src/Checker.cxx
+++ b/Framework/src/Checker.cxx
@@ -286,7 +286,7 @@ CheckInterface *Checker::instantiateCheck(string checkName, string className)
   return result;
 }
 
-} /* namespace Checker */
+} /* namespace checker */
 } /* namespace quality_control */
 } /* namespace o2 */
 

--- a/Framework/src/CheckerDataProcessor.cxx
+++ b/Framework/src/CheckerDataProcessor.cxx
@@ -244,6 +244,6 @@ CheckInterface* CheckerDataProcessor::getCheck(std::string checkName, std::strin
   return result;
 }
 
-} /* namespace Checker */
+} /* namespace checker */
 } /* namespace quality_control */
 } /* namespace o2 */

--- a/Framework/src/DatabaseFactory.cxx
+++ b/Framework/src/DatabaseFactory.cxx
@@ -47,6 +47,6 @@ std::unique_ptr<DatabaseInterface> DatabaseFactory::create(std::string name)
   return nullptr;
 }
 
-} // namespace core
+} // namespace repository
 } // namespace quality_control
 } // namespace o2

--- a/Framework/src/InformationService.h
+++ b/Framework/src/InformationService.h
@@ -15,8 +15,8 @@
 ///
 
 
-#ifndef PROJECT_INFORMATIONSERVICE_H
-#define PROJECT_INFORMATIONSERVICE_H
+#ifndef QC_INFORMATIONSERVICE_H
+#define QC_INFORMATIONSERVICE_H
 
 #include <InfoLogger/InfoLogger.hxx>
 #include "FairMQDevice.h"
@@ -95,4 +95,4 @@ class InformationService : public FairMQDevice
 
 };
 
-#endif //PROJECT_INFORMATIONSERVICE_H
+#endif //QC_INFORMATIONSERVICE_H

--- a/Framework/src/InformationServiceDump.h
+++ b/Framework/src/InformationServiceDump.h
@@ -15,8 +15,8 @@
 ///
 
 
-#ifndef PROJECT_INFORMATIONSERVICEDUMP_H
-#define PROJECT_INFORMATIONSERVICEDUMP_H
+#ifndef QC_INFORMATIONSERVICEDUMP_H
+#define QC_INFORMATIONSERVICEDUMP_H
 
 #include "FairMQDevice.h"
 #include <boost/asio.hpp>
@@ -45,4 +45,4 @@ class InformationServiceDump : public FairMQDevice
     bool HandleData(FairMQMessagePtr &, int);
 };
 
-#endif //PROJECT_InformationServiceDump_H
+#endif //QC_INFORMATIONSERVICEDUMP_H

--- a/Framework/src/RepositoryBenchmark.cxx
+++ b/Framework/src/RepositoryBenchmark.cxx
@@ -192,6 +192,6 @@ void RepositoryBenchmark::emptyDatabase()
   }
 }
 
-}
-}
-}
+} // namespace core
+} // namespace quality_control
+} // namespace o2

--- a/Framework/src/RepositoryBenchmark.h
+++ b/Framework/src/RepositoryBenchmark.h
@@ -13,8 +13,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef PROJECT_REPOSITORYBENCHMARK_H
-#define PROJECT_REPOSITORYBENCHMARK_H
+#ifndef QC_REPOSITORYBENCHMARK_H
+#define QC_REPOSITORYBENCHMARK_H
 
 #include <FairMQDevice.h>
 #include "QualityControl/CcdbDatabase.h"
@@ -65,8 +65,8 @@ class RepositoryBenchmark : public FairMQDevice
     std::thread *th;
 };
 
-}
-}
-}
+} // namespace core
+} // namespace quality_control
+} // namespace o2
 
-#endif //PROJECT_CCDBBENCHMARK_H
+#endif //QC_REPOSITORYBENCHMARK_H

--- a/Framework/src/SpyDevice.cxx
+++ b/Framework/src/SpyDevice.cxx
@@ -118,7 +118,7 @@ void SpyDevice::stopChannel()
   }
 }
 
-} // namespace core
+} // namespace gui
 } // namespace quality_control
 } // namespace o2
 

--- a/Framework/src/TObject2JsonBackend.h
+++ b/Framework/src/TObject2JsonBackend.h
@@ -14,8 +14,8 @@
 /// \author Adam Wegrzynek
 ///
 
-#ifndef QUALITYCONTROL_TOBJECT2JSON_BACKEND_H
-#define QUALITYCONTROL_TOBJECT2JSON_BACKEND_H
+#ifndef QC_TOBJECT2JSON_BACKEND_H
+#define QC_TOBJECT2JSON_BACKEND_H
 
 // QualityControl
 #include "QualityControl/MySqlDatabase.h"
@@ -44,4 +44,4 @@ class Backend
 } // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_TOBJECT2JSON_MYSQL_H
+#endif // QC_TOBJECT2JSON_BACKEND_H

--- a/Framework/src/TObject2JsonBackendFactory.h
+++ b/Framework/src/TObject2JsonBackendFactory.h
@@ -14,8 +14,8 @@
 /// \author Vladimir Kosmala
 ///
 
-#ifndef QUALITYCONTROL_TOBJECT2JSON_BACKEND_FACTORY_H
-#define QUALITYCONTROL_TOBJECT2JSON_BACKEND_FACTORY_H
+#ifndef QC_TOBJECT2JSON_BACKENDFACTORY_H
+#define QC_TOBJECT2JSON_BACKENDFACTORY_H
 
 #include "TObject2JsonServer.h"
 #include "TObject2JsonBackend.h"
@@ -44,4 +44,4 @@ class TObject2JsonBackendFactory
 } // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_TOBJECT2JSON_BACKEND_FACTORY_H
+#endif // QC_TOBJECT2JSON_BACKENDFACTORY_H

--- a/Framework/src/TObject2JsonCcdb.h
+++ b/Framework/src/TObject2JsonCcdb.h
@@ -14,8 +14,8 @@
 /// \author Adam Wegrzynek
 ///
 
-#ifndef QUALITYCONTROL_TOBJECT2JSON_CCDB_H
-#define QUALITYCONTROL_TOBJECT2JSON_CCDB_H
+#ifndef QC_TOBJECT2JSON_CCDB_H
+#define QC_TOBJECT2JSON_CCDB_H
 
 #include "TObject2JsonBackend.h"
 
@@ -49,4 +49,4 @@ class Ccdb final : public Backend
 } // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_TOBJECT2JSON_MYSQL_H
+#endif // QC_TOBJECT2JSON_CCDB_H

--- a/Framework/src/TObject2JsonMySql.h
+++ b/Framework/src/TObject2JsonMySql.h
@@ -14,8 +14,8 @@
 /// \author Adam Wegrzynek
 ///
 
-#ifndef QUALITYCONTROL_TOBJECT2JSON_MYSQL_H
-#define QUALITYCONTROL_TOBJECT2JSON_MYSQL_H
+#ifndef QC_TOBJECT2JSON_MYSQL_H
+#define QC_TOBJECT2JSON_MYSQL_H
 
 #include "TObject2JsonBackend.h"
 
@@ -49,4 +49,4 @@ class MySql final : public Backend
 } // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_TOBJECT2JSON_MYSQL_H
+#endif // QC_TOBJECT2JSON_MYSQL_H

--- a/Framework/src/TObject2JsonServer.h
+++ b/Framework/src/TObject2JsonServer.h
@@ -14,8 +14,8 @@
 /// \author Adam Wegrzynek
 ///
 
-#ifndef QUALITYCONTROL_TOBJECT2JSON_SERVER_H
-#define QUALITYCONTROL_TOBJECT2JSON_SERVER_H
+#ifndef QC_TOBJECT2JSON_SERVER_H
+#define QC_TOBJECT2JSON_SERVER_H
 
 // std
 #include <sstream>
@@ -57,4 +57,4 @@ class TObject2JsonServer
 } // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_TOBJECT2JSON_SERVER_H
+#endif // QC_TOBJECT2JSON_SERVER_H

--- a/Framework/src/TObject2JsonWorker.h
+++ b/Framework/src/TObject2JsonWorker.h
@@ -13,8 +13,8 @@
 /// \author Vladimir Kosmala
 ///
 
-#ifndef QUALITYCONTROL_TOBJECT2JSON_WORKER_H
-#define QUALITYCONTROL_TOBJECT2JSON_WORKER_H
+#ifndef QC_TOBJECT2JSON_WORKER_H
+#define QC_TOBJECT2JSON_WORKER_H
 
 #include <thread>
 
@@ -75,4 +75,4 @@ class TObject2JsonWorker
 } // namespace quality_control
 } // namespace o2
 
-#endif // QUALITYCONTROL_TOBJECT2JSON_WORKER_H
+#endif // QC_TOBJECT2JSON_WORKER_H

--- a/Framework/src/TaskDataProcessor.cxx
+++ b/Framework/src/TaskDataProcessor.cxx
@@ -266,6 +266,6 @@ unsigned long TaskDataProcessor::publish(DataAllocator& outputs)
 
 void TaskDataProcessor::CustomCleanupTMessage(void* data, void* object) { delete (TMessage*)object; }
 
-}
-}
-}
+} // namespace core
+} // namespace quality_control
+} // namespace o2

--- a/Framework/src/TaskDevice.cxx
+++ b/Framework/src/TaskDevice.cxx
@@ -287,7 +287,6 @@ void TaskDevice::sendToInformationService(string objectsListString)
 
 }
 
-}
-}
-}
-
+} // namespace core
+} // namespace quality_control
+} // namespace o2

--- a/Framework/test/testMonitorObject.cxx
+++ b/Framework/test/testMonitorObject.cxx
@@ -57,6 +57,6 @@ BOOST_AUTO_TEST_CASE(mo_check)
 }
 
 
-} /* namespace ObjectsManager */
+} /* namespace core */
 } /* namespace quality_control */
 } /* namespace o2 */

--- a/Framework/test/testPublisher.cxx
+++ b/Framework/test/testPublisher.cxx
@@ -53,6 +53,6 @@ BOOST_AUTO_TEST_CASE(publisher_test)
   }
 }
 
-} /* namespace ObjectsManager */
+} /* namespace core */
 } /* namespace quality_control */
 } /* namespace o2 */

--- a/Framework/test/testQcInfoLogger.cxx
+++ b/Framework/test/testQcInfoLogger.cxx
@@ -26,6 +26,6 @@ BOOST_AUTO_TEST_CASE(qc_info_logger)
   qc1 << "test" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
-} /* namespace ObjectsManager */
+} /* namespace core */
 } /* namespace quality_control */
 } /* namespace o2 */

--- a/Framework/test/testQuality.cxx
+++ b/Framework/test/testQuality.cxx
@@ -47,6 +47,6 @@ BOOST_AUTO_TEST_CASE(quality_test)
   BOOST_CHECK(!Quality::Good.isBetterThan(Quality::Good));
 }
 
-} /* namespace ObjectsManager */
+} /* namespace core */
 } /* namespace quality_control */
 } /* namespace o2 */

--- a/Modules/Common/include/Common/MeanIsAbove.h
+++ b/Modules/Common/include/Common/MeanIsAbove.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_CHECKER_MEANISABOVE_H_
-#define QUALITYCONTROL_CHECKER_MEANISABOVE_H_
+#ifndef QC_MODULE_COMMON_MEANISABOVE_H
+#define QC_MODULE_COMMON_MEANISABOVE_H
 
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
@@ -41,8 +41,8 @@ class MeanIsAbove : public o2::quality_control::checker::CheckInterface
     ClassDefOverride(MeanIsAbove, 1)
 };
 
-} /* namespace Common */
-} /* namespace QualityControlModules */
-} /* namespace AliceO2 */
+} /* namespace common */
+} /* namespace quality_control_modules */
+} /* namespace o2 */
 
-#endif /* QUALITYCONTROL_CHECKER_MEANISABOVE_H_ */
+#endif /* QC_MODULE_COMMON_MEANISABOVE_H */

--- a/Modules/Common/include/Common/NonEmpty.h
+++ b/Modules/Common/include/Common/NonEmpty.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CHECKER_NONEMPTY_H_
-#define QUALITYCONTROL_LIBS_CHECKER_NONEMPTY_H_
+#ifndef QC_MODULE_COMMON_NONEMPTY_H
+#define QC_MODULE_COMMON_NONEMPTY_H
 
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
@@ -33,8 +33,8 @@ class NonEmpty : public o2::quality_control::checker::CheckInterface
     ClassDefOverride(NonEmpty,1);
 };
 
-} // namespace Checker
-} // namespace QualityControl
+} // namespace common
+} // namespace quality_control_modules
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CHECKER_NONEMPTY_H_
+#endif // QC_MODULE_COMMON_NONEMPTY_H

--- a/Modules/Common/src/NonEmpty.cxx
+++ b/Modules/Common/src/NonEmpty.cxx
@@ -57,7 +57,7 @@ void NonEmpty::beautify(MonitorObject *mo, Quality checkResult)
 // NOOP
 }
 
-}  // namespace Checker
-}  // namespace quality_control
+}  // namespace common
+}  // namespace quality_control_modules
 } // namespace o2
 

--- a/Modules/Daq/include/Daq/DaqTask.h
+++ b/Modules/Daq/include/Daq/DaqTask.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QC_MODULE_EXAMPLE_EXAMPLETASK_H
-#define QC_MODULE_EXAMPLE_EXAMPLETASK_H
+#ifndef QC_MODULE_DAQ_DAQTASK_H
+#define QC_MODULE_DAQ_DAQTASK_H
 
 #include <TCanvas.h>
 #include <TPaveText.h>
@@ -52,8 +52,8 @@ class DaqTask /*final*/: public TaskInterface // todo add back the "final" when 
     TPaveText *mPaveText;
 };
 
-}
-}
-}
+} // namespace daq
+} // namespace quality_control_modules
+} // namespace o2
 
-#endif //QC_MODULE_EXAMPLE_EXAMPLETASK_H
+#endif //QC_MODULE_DAQ_DAQTASK_H

--- a/Modules/Daq/include/Daq/EverIncreasingGraph.h
+++ b/Modules/Daq/include/Daq/EverIncreasingGraph.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CHECKER_EverIncreasingGraph_H_
-#define QUALITYCONTROL_LIBS_CHECKER_EverIncreasingGraph_H_
+#ifndef QC_MODULE_DAQ_EVERINCREASINGRAPH_H
+#define QC_MODULE_DAQ_EVERINCREASINGRAPH_H
 
 #include <Common/DataBlock.h>
 
@@ -38,8 +38,8 @@ class EverIncreasingGraph : public o2::quality_control::checker::CheckInterface
     ClassDefOverride(EverIncreasingGraph,1);
 };
 
-} // namespace Example
-} // namespace QualityControl
+} // namespace daq
+} // namespace quality_control_modules
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CHECKER_EverIncreasingGraph_H_
+#endif // QC_MODULE_DAQ_EVERINCREASINGRAPH_H

--- a/Modules/Daq/src/DaqTask.cxx
+++ b/Modules/Daq/src/DaqTask.cxx
@@ -144,6 +144,6 @@ void DaqTask::reset()
   QcInfoLogger::GetInstance() << "Reset" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
-}
-}
-}
+} // namespace daq
+} // namespace quality_control_modules
+} // namespace o2

--- a/Modules/Daq/src/EverIncreasingGraph.cxx
+++ b/Modules/Daq/src/EverIncreasingGraph.cxx
@@ -82,7 +82,7 @@ void EverIncreasingGraph::beautify(MonitorObject *mo, Quality checkResult)
   g->GetListOfFunctions()->AddLast(paveText);
 }
 
-}  // namespace example
-}  // namespace quality_control
+} // namespace daq
+} // namespace quality_control_modules
 } // namespace o2
 

--- a/Modules/Example/include/Example/BenchmarkTask.h
+++ b/Modules/Example/include/Example/BenchmarkTask.h
@@ -53,8 +53,8 @@ class BenchmarkTask: public TaskInterface
 //    ClassDef(BenchmarkTask,1);
 };
 
-}
-}
-}
+} // namespace example
+} // namespace quality_control_modules
+} // namespace o2
 
 #endif //QC_MODULE_EXAMPLE_BENCHMARKTASK_H

--- a/Modules/Example/include/Example/ExampleTask.h
+++ b/Modules/Example/include/Example/ExampleTask.h
@@ -52,8 +52,8 @@ class ExampleTask /*final*/: public TaskInterface // todo add back the "final" w
     void publishHisto(int i);
 };
 
-}
-}
-}
+} // namespace example
+} // namespace quality_control_modules
+} // namespace o2
 
 #endif //QC_MODULE_EXAMPLE_EXAMPLETASK_H

--- a/Modules/Example/include/Example/FakeCheck.h
+++ b/Modules/Example/include/Example/FakeCheck.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CHECKER_FakeCheck_H_
-#define QUALITYCONTROL_LIBS_CHECKER_FakeCheck_H_
+#ifndef QC_MODULE_EXAMPLE_FAKECHECK_H
+#define QC_MODULE_EXAMPLE_FAKECHECK_H
 
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
@@ -33,8 +33,8 @@ class FakeCheck : public o2::quality_control::checker::CheckInterface
     ClassDefOverride(FakeCheck,1);
 };
 
-} // namespace Example
-} // namespace QualityControl
+} // namespace example
+} // namespace quality_control_modules
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CHECKER_FakeCheck_H_
+#endif // QC_MODULE_EXAMPLE_FAKECHECK_H

--- a/Modules/Example/src/BenchmarkTask.cxx
+++ b/Modules/Example/src/BenchmarkTask.cxx
@@ -90,6 +90,6 @@ void BenchmarkTask::reset()
   QcInfoLogger::GetInstance() << "Reset" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
-}
-}
-}
+} // namespace example
+} // namespace quality_control_modules
+} // namespace o2

--- a/Modules/Example/src/ExampleTask.cxx
+++ b/Modules/Example/src/ExampleTask.cxx
@@ -107,6 +107,6 @@ void ExampleTask::reset()
   QcInfoLogger::GetInstance() << "Reset" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
-}
-}
-}
+} // namespace example
+} // namespace quality_control_modules
+} // namespace o2

--- a/Modules/Example/src/FakeCheck.cxx
+++ b/Modules/Example/src/FakeCheck.cxx
@@ -45,7 +45,7 @@ void FakeCheck::beautify(MonitorObject *mo, Quality checkResult)
 // NOOP
 }
 
-}  // namespace example
-}  // namespace quality_control
+} // namespace example
+} // namespace quality_control_modules
 } // namespace o2
 

--- a/Modules/Skeleton/include/Skeleton/SkeletonCheck.h
+++ b/Modules/Skeleton/include/Skeleton/SkeletonCheck.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CHECKER_SkeletonCheck_H_
-#define QUALITYCONTROL_LIBS_CHECKER_SkeletonCheck_H_
+#ifndef QC_MODULE_SKELETON_SKELETONCHECK_H
+#define QC_MODULE_SKELETON_SKELETONCHECK_H
 
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
@@ -34,8 +34,8 @@ class SkeletonCheck : public o2::quality_control::checker::CheckInterface
   ClassDefOverride(SkeletonCheck, 1);
 };
 
-} // namespace Example
-} // namespace QualityControl
+} // namespace skeleton
+} // namespace quality_control_modules
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CHECKER_SkeletonCheck_H_
+#endif // QC_MODULE_SKELETON_SKELETONCHECK_H

--- a/Modules/Skeleton/include/Skeleton/SkeletonTask.h
+++ b/Modules/Skeleton/include/Skeleton/SkeletonTask.h
@@ -3,8 +3,8 @@
 /// \author Barthelemy von Haller
 ///
 
-#ifndef QC_MODULE_EXAMPLE_EXAMPLETASK_H
-#define QC_MODULE_EXAMPLE_EXAMPLETASK_H
+#ifndef QC_MODULE_SKELETON_SKELETONTASK_H
+#define QC_MODULE_SKELETON_SKELETONTASK_H
 
 #include "QualityControl/TaskInterface.h"
 
@@ -41,8 +41,8 @@ class SkeletonTask /*final*/: public TaskInterface // todo add back the "final" 
     TH1F *mHistogram;
 };
 
-}
-}
-}
+} // namespace skeleton
+} // namespace quality_control_modules
+} // namespace o2
 
-#endif //QC_MODULE_EXAMPLE_EXAMPLETASK_H
+#endif //QC_MODULE_SKELETON_SKELETONTASK_H

--- a/Modules/Skeleton/src/SkeletonCheck.cxx
+++ b/Modules/Skeleton/src/SkeletonCheck.cxx
@@ -46,6 +46,6 @@ void SkeletonCheck::beautify(MonitorObject *mo, Quality checkResult)
 }
 
 } // namespace skeleton
-} // namespace quality_control
+} // namespace quality_control_modules
 } // namespace o2
 

--- a/Modules/Skeleton/src/SkeletonTask.cxx
+++ b/Modules/Skeleton/src/SkeletonTask.cxx
@@ -65,6 +65,6 @@ void SkeletonTask::reset()
   QcInfoLogger::GetInstance() << "Reset" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
-}
-}
-}
+} // namespace skeleton
+} // namespace quality_control_modules
+} // namespace o2

--- a/Modules/SkeletonDPL/include/SkeletonDPL/SkeletonCheckDPL.h
+++ b/Modules/SkeletonDPL/include/SkeletonDPL/SkeletonCheckDPL.h
@@ -3,8 +3,8 @@
 /// \author Piotr Konopka
 ///
 
-#ifndef QUALITYCONTROL_LIBS_CHECKER_SkeletonCheckDPL_H_
-#define QUALITYCONTROL_LIBS_CHECKER_SkeletonCheckDPL_H_
+#ifndef QC_MODULE_SKELETONDPL_SKELETONCHECKDPL_H
+#define QC_MODULE_SKELETONDPL_SKELETONCHECKDPL_H
 
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
@@ -34,8 +34,8 @@ class SkeletonCheckDPL : public o2::quality_control::checker::CheckInterface
   ClassDefOverride(SkeletonCheckDPL, 1);
 };
 
-} // namespace Example
-} // namespace QualityControl
+} // namespace skeleton_dpl
+} // namespace quality_control_modules
 } // namespace o2
 
-#endif // QUALITYCONTROL_LIBS_CHECKER_SkeletonCheck_H_
+#endif // QC_MODULE_SKELETONDPL_SKELETONCHECKDPL_H

--- a/Modules/SkeletonDPL/include/SkeletonDPL/SkeletonTaskDPL.h
+++ b/Modules/SkeletonDPL/include/SkeletonDPL/SkeletonTaskDPL.h
@@ -4,8 +4,8 @@
 /// \author Piotr Konopka
 ///
 
-#ifndef QC_MODULE_EXAMPLE_EXAMPLETASKDPL_H
-#define QC_MODULE_EXAMPLE_EXAMPLETASKDPL_H
+#ifndef QC_MODULE_SKELETONDPL_SKELETONTASKDPL_H
+#define QC_MODULE_SKELETONDPL_SKELETONTASKDPL_H
 
 #include "QualityControl/TaskInterfaceDPL.h"
 
@@ -43,8 +43,8 @@ class SkeletonTaskDPL /*final*/: public TaskInterfaceDPL // todo add back the "f
     TH1F *mHistogram;
 };
 
-}
-}
-}
+} // namespace skeleton_dpl
+} // namespace quality_control_modules
+} // namespace o2
 
-#endif //QC_MODULE_EXAMPLE_EXAMPLETASKDPL_H
+#endif //QC_MODULE_SKELETONDPL_SKELETONTASKDPL_H

--- a/Modules/SkeletonDPL/src/SkeletonCheckDPL.cxx
+++ b/Modules/SkeletonDPL/src/SkeletonCheckDPL.cxx
@@ -75,6 +75,6 @@ void SkeletonCheckDPL::beautify(MonitorObject *mo, Quality checkResult)
 }
 
 } // namespace skeleton_dpl
-} // namespace quality_control
+} // namespace quality_control_modules
 } // namespace o2
 

--- a/Modules/SkeletonDPL/src/SkeletonTaskDPL.cxx
+++ b/Modules/SkeletonDPL/src/SkeletonTaskDPL.cxx
@@ -105,6 +105,6 @@ void SkeletonTaskDPL::reset()
   mHistogram->Reset();
 }
 
-}
-}
-}
+} // namespace skeleton_dpl
+} // namespace quality_control_modules
+} // namespace o2


### PR DESCRIPTION
Unifying all include guards to:
`QC_<3rd namespace uppercase>_<class name uppercase>_H`
and fixing some outdated namespace comments like:
`} // namespace QualityControl` to `} // namespace quality_control`
