### PR TITLE
Changing class and function names to follow the convention

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -6,14 +6,14 @@ set(
   src/Quality.cxx
   src/ObjectsManager.cxx
   src/Checker.cxx
-  src/CheckerDataProcessorFactory.cxx
+  src/CheckerFactory.cxx
   src/CheckInterface.cxx
   src/DatabaseFactory.cxx
   src/CcdbDatabase.cxx
   src/InformationService.cxx
   src/InformationServiceDump.cxx
   src/TaskRunner.cxx
-  src/TaskDataProcessorFactory.cxx
+  src/TaskRunnerFactory.cxx
   src/TaskInterface.cxx
   src/RepositoryBenchmark.cxx
   src/HistoMerger.cxx
@@ -25,11 +25,11 @@ set(
   include/QualityControl/Quality.h
   include/QualityControl/CheckInterface.h
   include/QualityControl/Checker.h
-  include/QualityControl/CheckerDataProcessorFactory.h
+  include/QualityControl/CheckerFactory.h
   include/QualityControl/DatabaseInterface.h
   include/QualityControl/CcdbDatabase.h
   include/QualityControl/TaskRunner.h
-  include/QualityControl/TaskDataProcessorFactory.h
+  include/QualityControl/TaskRunnerFactory.h
   include/QualityControl/HistoMerger.h
 )
 

--- a/Framework/include/QualityControl/Checker.h
+++ b/Framework/include/QualityControl/Checker.h
@@ -57,7 +57,7 @@ class Checker : public framework::Task
   framework::OutputSpec getOutputSpec() { return mOutputSpec; };
 
   /// \brief Unified DataDescription naming scheme for all checkers
-  static o2::header::DataDescription checkerDataDescription(const std::string taskName);
+  static o2::header::DataDescription createCheckerDataDescription(const std::string taskName);
 
  private:
   /**

--- a/Framework/include/QualityControl/CheckerFactory.h
+++ b/Framework/include/QualityControl/CheckerFactory.h
@@ -1,9 +1,9 @@
 ///
-/// \file   CheckerDataProcessorFactory.h
+/// \file   CheckerFactory.h
 /// \author Piotr Konopka
 ///
-#ifndef QC_CHECKER_DATAPROCESSORFACTORY_H
-#define QC_CHECKER_DATAPROCESSORFACTORY_H
+#ifndef QC_CHECKERFACTORY_H
+#define QC_CHECKERFACTORY_H
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -15,11 +15,11 @@ namespace checker
 {
 
 /// \brief Factory in charge of creating DataProcessorSpec of QC Checker
-class CheckerDataProcessorFactory
+class CheckerFactory
 {
  public:
-  CheckerDataProcessorFactory() = default;
-  virtual ~CheckerDataProcessorFactory() = default;
+  CheckerFactory() = default;
+  virtual ~CheckerFactory() = default;
 
   framework::DataProcessorSpec create(std::string checkerName, std::string taskName, std::string configurationSource);
 };
@@ -28,4 +28,4 @@ class CheckerDataProcessorFactory
 } // namespace quality_control
 } // namespace o2
 
-#endif // QC_CHECKER_DATAPROCESSORFACTORY_H
+#endif // QC_CHECKERFACTORY_H

--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -81,7 +81,7 @@ class TaskRunner
   void setResetAfterPublish(bool);
 
   /// \brief Unified DataDescription naming scheme for all tasks
-  static o2::header::DataDescription taskDataDescription(const std::string taskName);
+  static o2::header::DataDescription createTaskDataDescription(const std::string taskName);
 
  private:
   void populateConfig(std::string taskName);

--- a/Framework/include/QualityControl/TaskRunnerFactory.h
+++ b/Framework/include/QualityControl/TaskRunnerFactory.h
@@ -1,10 +1,10 @@
 ///
-/// \file   TaskDataProcessorFactory.h
+/// \file   TaskRunnerFactory.h
 /// \author Piotr Konopka
 ///
 
-#ifndef QC_CORE_TASKDATAPROCESSORFACTORY_H
-#define QC_CORE_TASKDATAPROCESSORFACTORY_H
+#ifndef QC_CORE_TASKFACTORY_H
+#define QC_CORE_TASKFACTORY_H
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -16,11 +16,11 @@ namespace core
 {
 
 /// \brief Factory in charge of creating DataProcessorSpec of QC task
-class TaskDataProcessorFactory
+class TaskRunnerFactory
 {
  public:
-  TaskDataProcessorFactory();
-  virtual ~TaskDataProcessorFactory();
+  TaskRunnerFactory();
+  virtual ~TaskRunnerFactory();
 
   o2::framework::DataProcessorSpec create(std::string taskName, std::string configurationSource);
 };
@@ -29,4 +29,4 @@ class TaskDataProcessorFactory
 } // namespace quality_control
 } // namespace o2
 
-#endif // QC_CORE_TASKDATAPROCESSORFACTORY_H
+#endif // QC_CORE_TASKFACTORY_H

--- a/Framework/src/Checker.cxx
+++ b/Framework/src/Checker.cxx
@@ -34,13 +34,13 @@ namespace checker
 {
 
 // TODO do we need a CheckFactory ? here it is embedded in the Checker
-// TODO maybe we could use the CheckerDataProcessorFactory
+// TODO maybe we could use the CheckerFactory
 
 Checker::Checker(std::string checkerName, std::string taskName, std::string configurationSource)
   : mCheckerName(checkerName),
     mConfigurationSource(configurationSource),
-    mInputSpec{ "mo", "QC", TaskRunner::taskDataDescription(taskName), 0 },
-    mOutputSpec{ "QC", Checker::checkerDataDescription(taskName), 0 },
+    mInputSpec{ "mo", "QC", TaskRunner::createTaskDataDescription(taskName), 0 },
+    mOutputSpec{ "QC", Checker::createCheckerDataDescription(taskName), 0 },
     mLogger(QcInfoLogger::GetInstance()),
     startFirstObject{ system_clock::time_point::min() },
     endLastObject{ system_clock::time_point::min() },
@@ -126,7 +126,7 @@ void Checker::run(framework::ProcessingContext& ctx)
   }
 }
 
-o2::header::DataDescription Checker::checkerDataDescription(const std::string taskName)
+o2::header::DataDescription Checker::createCheckerDataDescription(const std::string taskName)
 {
   o2::header::DataDescription description;
   description.runtimeInit(std::string(taskName.substr(0, o2::header::DataDescription::size - 4) + "-chk").c_str());

--- a/Framework/src/CheckerFactory.cxx
+++ b/Framework/src/CheckerFactory.cxx
@@ -1,12 +1,12 @@
 ///
-/// \file   CheckerDataProcessorFactory.cxx
+/// \file   CheckerFactory.cxx
 /// \author Piotr Konopka
 ///
 
 #include <Framework/DataProcessorSpec.h>
 
 #include "QualityControl/Checker.h"
-#include "QualityControl/CheckerDataProcessorFactory.h"
+#include "QualityControl/CheckerFactory.h"
 
 namespace o2
 {
@@ -18,8 +18,7 @@ namespace checker
 using namespace o2::framework;
 using namespace o2::quality_control::checker;
 
-DataProcessorSpec CheckerDataProcessorFactory::create(std::string checkerName, std::string taskName,
-                                                      std::string configurationSource)
+DataProcessorSpec CheckerFactory::create(std::string checkerName, std::string taskName, std::string configurationSource)
 {
   Checker qcChecker{ checkerName, taskName, configurationSource };
 

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -132,7 +132,7 @@ void TaskRunner::timerCallback(ProcessingContext& pCtx) { finishCycle(pCtx.outpu
 
 void TaskRunner::setResetAfterPublish(bool resetAfterPublish) { mResetAfterPublish = resetAfterPublish; }
 
-o2::header::DataDescription TaskRunner::taskDataDescription(const std::string taskName)
+o2::header::DataDescription TaskRunner::createTaskDataDescription(const std::string taskName)
 {
   o2::header::DataDescription description;
   description.runtimeInit(std::string(taskName.substr(0, o2::header::DataDescription::size - 3) + "-mo").c_str());
@@ -155,7 +155,7 @@ void TaskRunner::populateConfig(std::string taskName)
     mInputSpecs = framework::DataSampling::InputSpecsForPolicy(mConfigFile.get(), taskConfigTree.get<std::string>("dataSamplingPolicy"));
 
     mMonitorObjectsSpec.origin.runtimeInit("QC");
-    mMonitorObjectsSpec.description = taskDataDescription(taskName);
+    mMonitorObjectsSpec.description = createTaskDataDescription(taskName);
     mMonitorObjectsSpec.subSpec = 0;
     mMonitorObjectsSpec.lifetime = o2::framework::Lifetime::QA;
   } catch (...) { // catch already here the configuration exception and print it

--- a/Framework/src/TaskRunnerFactory.cxx
+++ b/Framework/src/TaskRunnerFactory.cxx
@@ -9,11 +9,11 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// \file   TaskDataProcessorFactory.cxx
+/// \file   TaskRunnerFactory.cxx
 /// \author Piotr Konopka
 ///
 
-#include "QualityControl/TaskDataProcessorFactory.h"
+#include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/TaskRunner.h"
 
 namespace o2
@@ -25,11 +25,11 @@ namespace core
 
 using namespace o2::framework;
 
-TaskDataProcessorFactory::TaskDataProcessorFactory() {}
+TaskRunnerFactory::TaskRunnerFactory() {}
 
-TaskDataProcessorFactory::~TaskDataProcessorFactory() {}
+TaskRunnerFactory::~TaskRunnerFactory() {}
 
-DataProcessorSpec TaskDataProcessorFactory::create(std::string taskName, std::string configurationSource)
+DataProcessorSpec TaskRunnerFactory::create(std::string taskName, std::string configurationSource)
 {
   auto qcTask = std::make_shared<TaskRunner>(taskName, configurationSource);
 

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -52,8 +52,8 @@ void customize(std::vector<ChannelConfigurationPolicy>& policies)
 #include "Framework/runDataProcessing.h"
 
 #include "QualityControl/Checker.h"
-#include "QualityControl/CheckerDataProcessorFactory.h"
-#include "QualityControl/TaskDataProcessorFactory.h"
+#include "QualityControl/CheckerFactory.h"
+#include "QualityControl/TaskRunnerFactory.h"
 
 using namespace o2::framework;
 using namespace o2::quality_control::core;
@@ -90,18 +90,18 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   // Exemplary initialization of QC Task:
   const std::string qcTaskName = "QcTask";
   const std::string qcConfigurationSource = std::string("json://") + getenv("QUALITYCONTROL_ROOT") + "/etc/basic.json";
-  TaskDataProcessorFactory taskFactory;
+  TaskRunnerFactory taskFactory;
   specs.push_back(taskFactory.create(qcTaskName, qcConfigurationSource));
 
   // Now the QC Checker
-  CheckerDataProcessorFactory checkerFactory;
+  CheckerFactory checkerFactory;
   specs.push_back(checkerFactory.create("checker_0", qcTaskName, qcConfigurationSource));
 
   // Finally the printer
   DataProcessorSpec printer{
     "printer",
     Inputs{
-      { "checked-mo", "QC", Checker::checkerDataDescription(qcTaskName), 0 }
+      { "checked-mo", "QC", Checker::createCheckerDataDescription(qcTaskName), 0 }
     },
     Outputs{},
     AlgorithmSpec{

--- a/Framework/src/runMergerTest.cxx
+++ b/Framework/src/runMergerTest.cxx
@@ -32,9 +32,9 @@ void customize(std::vector<CompletionPolicy>& policies)
 #include "Framework/runDataProcessing.h"
 
 #include "QualityControl/Checker.h"
-#include "QualityControl/CheckerDataProcessorFactory.h"
+#include "QualityControl/CheckerFactory.h"
 #include "QualityControl/HistoMerger.h"
-#include "QualityControl/TaskDataProcessorFactory.h"
+#include "QualityControl/TaskRunnerFactory.h"
 
 using namespace o2::quality_control::core;
 using namespace o2::quality_control::checker;

--- a/Framework/src/runReadout.cxx
+++ b/Framework/src/runReadout.cxx
@@ -47,8 +47,8 @@ void customize(std::vector<ChannelConfigurationPolicy>& policies)
 #include "Framework/DataSamplingReadoutAdapter.h"
 #include "Framework/runDataProcessing.h"
 #include "QualityControl/Checker.h"
-#include "QualityControl/CheckerDataProcessorFactory.h"
-#include "QualityControl/TaskDataProcessorFactory.h"
+#include "QualityControl/CheckerFactory.h"
+#include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/TaskRunner.h"
 
 using namespace o2::framework;
@@ -70,15 +70,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   const std::string qcTaskName = "daqTask";
   const std::string qcConfigurationSource =
     std::string("json:/") + getenv("QUALITYCONTROL_ROOT") + "/etc/readout.json";
-  TaskDataProcessorFactory qcFactory;
+  TaskRunnerFactory qcFactory;
   specs.push_back(qcFactory.create(qcTaskName, qcConfigurationSource));
-  CheckerDataProcessorFactory checkerFactory;
+  CheckerFactory checkerFactory;
   specs.push_back(checkerFactory.create("checker_0", qcTaskName, qcConfigurationSource));
 
   DataProcessorSpec printer{
     "printer",
     Inputs{
-      { "checked-mo", "QC", Checker::checkerDataDescription(qcTaskName), 0 }
+      { "checked-mo", "QC", Checker::createCheckerDataDescription(qcTaskName), 0 }
     },
     Outputs{},
     AlgorithmSpec{

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ accordingly.
 ```
 ...
 
-#include "QualityControl/TaskDataProcessorFactory.h"
+#include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/TaskRunner.h"
 #include "Framework/DataSampling.h"
 #include "Framework/runDataProcessing.h"
@@ -195,7 +195,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&) {
   const std::string qcConfigurationSource = std::string("file://") + getenv("QUALITYCONTROL_ROOT") + "/etc/qcTaskDplConfig.json";
   // An entry in config file which describes your QC task
   const std::string qcTaskName = "skeletonTask";
-  o2::quality_control::core::TaskDataProcessorFactory qcFactory;
+  o2::quality_control::core::TaskRunnerFactory qcFactory;
   specs.push_back(qcFactory.create(qcTaskName, qcConfigurationSource));
 
   o2::framework::DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);


### PR DESCRIPTION
The factories still have the old names of `checkers` and `tasks`, which is a bit confusing imho. The commit changes them as follows:
`CheckerDataProcessorFactory` -> `CheckerFactory`
`TaskDataProcessorFactory` -> `TaskRunnerFactory`
Also the names of static methods creating `dataDescriptions` received a `create` prefix.
