### PR TITLE
Use DPL state transition callbacks

### DIFF
--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -91,6 +91,13 @@ class TaskRunner
   static header::DataDescription createTaskDataDescription(const std::string& taskName);
 
  private:
+  /// \brief Callback for CallbackService::Id::Start (DPL) a.k.a. RUN transition (FairMQ)
+  void start();
+  /// \brief Callback for CallbackService::Id::Stop (DPL) a.k.a. STOP transition (FairMQ)
+  void stop();
+  /// \brief Callback for CallbackService::Id::Reset (DPL) a.k.a. RESET DEVICE transition (FairMQ)
+  void reset();
+
   void populateConfig(std::string taskName);
   void startOfActivity();
   void endOfActivity();


### PR DESCRIPTION
Initially I just wanted to move user's task loading from constructor to init callback, which would significantly speed up the topology generation time. However, it also required moving EndOfActivity from
destructor to Stop callback. So in the end I implemented all Start, Stop and Reset callbacks to fully support the state transitions.