### PR TITLE
[QC-88] Exit TaskRunner when cycles number reaches the specified maximum

### DIFF
--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -23,6 +23,7 @@
 #include "Configuration/ConfigurationFactory.h"
 #include "Framework/RawDeviceService.h"
 #include "Framework/DataSampling.h"
+#include "Framework/ControlService.h"
 #include "Monitoring/MonitoringFactory.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/TaskFactory.h"
@@ -105,6 +106,9 @@ void TaskRunner::processCallback(ProcessingContext& pCtx)
 
       mNumberBlocks = 0;
       mCycleOn = true;
+    } else {
+      // when number of cycles reaches the max => quit
+      pCtx.services().get<framework::ControlService>().readyToQuit(true);
     }
   }
   if (mCycleOn) {


### PR DESCRIPTION
Before, when task reached its maximum number of cycles, it just didn't accept any new data, but still published the latest MOs.
Now it can quit instead, which shuts down the whole topology. I am not sure if this is the best possible behaviour, but at least we have some starting point to discuss it.  