### PR TITLE
[QC-114] Use a container to send all MOs at once

### DIFF
--- a/Framework/include/QualityControl/Checker.h
+++ b/Framework/include/QualityControl/Checker.h
@@ -82,7 +82,7 @@ class Checker : public framework::Task
   /**
    * \brief Send the MonitorObject on FairMQ to whoever is listening.
    */
-  void send(std::shared_ptr<MonitorObject> mo, framework::DataAllocator& allocator);
+  void send(std::unique_ptr<TObjArray>& mo, framework::DataAllocator& allocator);
 
   /**
    * \brief Load a library.

--- a/Framework/include/QualityControl/HistoMerger.h
+++ b/Framework/include/QualityControl/HistoMerger.h
@@ -56,7 +56,7 @@ class HistoMerger : public framework::Task
  private:
   // General state
   std::string mMergerName;
-  std::shared_ptr<MonitorObject> mMonitorObject;
+  TObjArray mMergedArray;
   AliceO2::Common::Timer mPublicationTimer;
 
   // DPL

--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -9,6 +9,7 @@
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/TaskConfig.h"
+#include <TObjArray.h>
 #include <TObjString.h>
 #include <boost/concept_check.hpp>
 #include <string>
@@ -53,14 +54,7 @@ class ObjectsManager
 
   TObject* getObject(std::string objectName);
 
-  typedef typename std::map<std::string, quality_control::core::MonitorObject*>::iterator iterator;
-  typedef typename std::map<std::string, quality_control::core::MonitorObject*>::const_iterator const_iterator;
-
-  const_iterator begin() const { return mMonitorObjects.begin(); }
-  const_iterator end() const { return mMonitorObjects.end(); }
-
-  iterator begin() { return mMonitorObjects.begin(); }
-  iterator end() { return mMonitorObjects.end(); }
+  TObjArray* getNonOwningArray() const { return new TObjArray(mMonitorObjects); };
 
   std::string getObjectsListString() { return mObjectsList.GetString().Data(); }
 
@@ -68,7 +62,7 @@ class ObjectsManager
   void UpdateIndex(const std::string& nonEmptyName);
 
  private:
-  std::map<std::string /*object name*/, quality_control::core::MonitorObject* /* object */> mMonitorObjects;
+  TObjArray mMonitorObjects;
   std::string mTaskName;
   // todo make it a vector of string when support added
   TObjString mObjectsList; // the list of objects we publish. (comma separated)

--- a/Framework/src/Checker.cxx
+++ b/Framework/src/Checker.cxx
@@ -14,6 +14,7 @@
 #include <Common/Exceptions.h>
 #include <Configuration/ConfigurationFactory.h>
 #include <Framework/DataRefUtils.h>
+#include <TMap.h>
 // QC
 #include "QualityControl/DatabaseFactory.h"
 #include "QualityControl/TaskRunner.h"
@@ -101,10 +102,12 @@ void Checker::run(framework::ProcessingContext& ctx)
     startFirstObject = system_clock::now();
   }
 
-  for (auto&& input : ctx.inputs()) {
-    // will that work properly with shmem?
-    std::shared_ptr<MonitorObject> mo{ std::move(framework::DataRefUtils::as<MonitorObject>(input)) };
+  std::shared_ptr<TObjArray> moArray{ std::move(framework::DataRefUtils::as<TObjArray>(*ctx.inputs().begin())) };
+  moArray->SetOwner(false);
 
+  for (const auto& to : *moArray) {
+    std::shared_ptr<MonitorObject> mo{dynamic_cast<MonitorObject*>(to)};
+    moArray->RemoveFirst();
     if (mo) {
       check(mo);
       store(mo);

--- a/Framework/src/Checker.cxx
+++ b/Framework/src/Checker.cxx
@@ -104,6 +104,8 @@ void Checker::run(framework::ProcessingContext& ctx)
 
   std::shared_ptr<TObjArray> moArray{ std::move(framework::DataRefUtils::as<TObjArray>(*ctx.inputs().begin())) };
   moArray->SetOwner(false);
+  auto checkedMoArray = std::make_unique<TObjArray>();
+  checkedMoArray->SetOwner();
 
   for (const auto& to : *moArray) {
     std::shared_ptr<MonitorObject> mo{dynamic_cast<MonitorObject*>(to)};
@@ -111,12 +113,14 @@ void Checker::run(framework::ProcessingContext& ctx)
     if (mo) {
       check(mo);
       store(mo);
-      send(mo, ctx.outputs());
       mTotalNumberHistosReceived++;
+      checkedMoArray->Add(new MonitorObject(*mo));
     } else {
       mLogger << "the mo is null" << AliceO2::InfoLogger::InfoLogger::endm;
     }
   }
+
+  send(checkedMoArray, ctx.outputs());
 
   // monitoring
   endLastObject = system_clock::now();
@@ -172,13 +176,12 @@ void Checker::store(std::shared_ptr<MonitorObject> mo)
   }
 }
 
-void Checker::send(std::shared_ptr<MonitorObject> mo, framework::DataAllocator& allocator)
+void Checker::send(std::unique_ptr<TObjArray>& moArray, framework::DataAllocator& allocator)
 {
-  mLogger << "Sending \"" << mo->getName() << "\"" << AliceO2::InfoLogger::InfoLogger::endm;
-
-  // todo: consider adopting
-  allocator.snapshot<MonitorObject>(
-    framework::Output{ mOutputSpec.origin, mOutputSpec.description, mOutputSpec.subSpec, mOutputSpec.lifetime }, *mo);
+  mLogger << "Sending Monitor Object array with " << moArray->GetEntries() << " objects inside." << AliceO2::InfoLogger::InfoLogger::endm;
+  
+  allocator.adopt(
+    framework::Output{ mOutputSpec.origin, mOutputSpec.description, mOutputSpec.subSpec, mOutputSpec.lifetime }, moArray.release());
 }
 
 void Checker::loadLibrary(const std::string libraryName)

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -31,14 +31,11 @@ namespace core
 ObjectsManager::ObjectsManager(TaskConfig& taskConfig) : mTaskName(taskConfig.taskName)
 {
   startPublishing(&mObjectsList, MonitorObject::SYSTEM_OBJECT_PUBLICATION_LIST);
+  mMonitorObjects.SetOwner(true);
 }
 
 ObjectsManager::~ObjectsManager()
 {
-  for (auto& mMonitorObject : mMonitorObjects) {
-    delete mMonitorObject.second;
-  }
-  mMonitorObjects.clear();
 }
 
 void ObjectsManager::startPublishing(TObject* object, std::string objectName)
@@ -46,7 +43,7 @@ void ObjectsManager::startPublishing(TObject* object, std::string objectName)
   std::string nonEmptyName = objectName.empty() ? object->GetName() : objectName;
   auto* newObject = new MonitorObject(nonEmptyName, object, mTaskName);
   newObject->setIsOwner(false);
-  mMonitorObjects[nonEmptyName] = newObject;
+  mMonitorObjects.Add(newObject);
 
   // update index
   if (objectName != MonitorObject::SYSTEM_OBJECT_PUBLICATION_LIST) {
@@ -80,8 +77,10 @@ void ObjectsManager::addCheck(const std::string& objectName, const std::string& 
 
 MonitorObject* ObjectsManager::getMonitorObject(std::string objectName)
 {
-  if (mMonitorObjects.count(objectName) > 0) {
-    return mMonitorObjects[objectName];
+  TObject* mo = mMonitorObjects.FindObject(objectName.c_str());
+
+  if (mo) {
+    return dynamic_cast<MonitorObject*>(mo);
   } else {
     BOOST_THROW_EXCEPTION(ObjectNotFoundError() << errinfo_object_name(objectName));
   }

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -47,7 +47,7 @@ TaskRunner::TaskRunner(std::string taskName, std::string configurationSource, si
     mLastNumberObjects(0),
     mCycleOn(false),
     mCycleNumber(0),
-    mMonitorObjectsSpec(createTaskDataOrigin(), createTaskDataDescription(taskName), id),
+    mMonitorObjectsSpec({"mo"}, createTaskDataOrigin(), createTaskDataDescription(taskName), id),
     mResetAfterPublish(false),
     mTask(nullptr)
 {
@@ -269,20 +269,15 @@ void TaskRunner::finishCycle(DataAllocator& outputs)
 
 unsigned long TaskRunner::publish(DataAllocator& outputs)
 {
-  unsigned int sentMessages = 0;
+  outputs.adopt(
+    Output{ mMonitorObjectsSpec.origin,
+            mMonitorObjectsSpec.description,
+            mMonitorObjectsSpec.subSpec,
+            mMonitorObjectsSpec.lifetime },
+    dynamic_cast<TObject*>(mObjectsManager->getNonOwningArray())
+  );
 
-  for (auto& pair : *mObjectsManager) {
-
-    auto* mo = pair.second;
-    outputs.snapshot<MonitorObject>(Output{ mMonitorObjectsSpec.origin, mMonitorObjectsSpec.description,
-                                            mMonitorObjectsSpec.subSpec, mMonitorObjectsSpec.lifetime },
-                                    *mo);
-
-    QcInfoLogger::GetInstance() << "Sending \"" << mo->getName() << "\"" << AliceO2::InfoLogger::InfoLogger::endm;
-    sentMessages++;
-  }
-
-  return sentMessages;
+  return 1;
 }
 
 void TaskRunner::CustomCleanupTMessage(void* data, void* object) { delete (TMessage*)object; }

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -109,15 +109,19 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
 
         return (AlgorithmSpec::ProcessCallback) [](ProcessingContext& processingContext) mutable {
           LOG(INFO) << "printer invoked";
-          auto mo = processingContext.inputs().get<MonitorObject*>("checked-mo").get();
+          std::shared_ptr<TObjArray> moArray{ std::move(DataRefUtils::as<TObjArray>(*processingContext.inputs().begin())) };
 
-          if (mo->getName() == "example") {
-            auto* g = dynamic_cast<TH1F*>(mo->getObject());
-            std::string bins = "BINS:";
-            for (int i = 0; i < g->GetNbinsX(); i++) {
-              bins += " " + std::to_string((int) g->GetBinContent(i));
+          for (const auto& to : *moArray) {
+            MonitorObject* mo = dynamic_cast<MonitorObject*>(to);
+
+            if (mo->getName() == "example") {
+              auto* g = dynamic_cast<TH1F*>(mo->getObject());
+              std::string bins = "BINS:";
+              for (int i = 0; i < g->GetNbinsX(); i++) {
+                bins += " " + std::to_string((int) g->GetBinContent(i));
+              }
+              LOG(INFO) << bins;
             }
-            LOG(INFO) << bins;
           }
         };
       }


### PR DESCRIPTION
This just a proof that both `TMap` and `TObjArray` can be used as such container. As I expected, using `vector<MonitorObject>` didn't work even at the compilation level.
To do:
- [x] choose a container, 
- [x] consider using a messageable container already in `ObjectManager`, so less preparation before sending is required
- [x] adapt `HistoMerger` to accept a container