### PR TITLE
Fix mac compilation error

### DIFF
--- a/Framework/src/runAdvanced.cxx
+++ b/Framework/src/runAdvanced.cxx
@@ -78,7 +78,7 @@ WorkflowSpec processingTopology(SubSpecificationType subspec)
             { "TST", "PARAM", subspec }},
     AlgorithmSpec{
       (AlgorithmSpec::ProcessCallback)
-        [generator = std::default_random_engine{ time(nullptr) }, subspec](ProcessingContext & ctx) mutable {
+        [generator = std::default_random_engine{ static_cast<unsigned int>(time(nullptr)) }, subspec](ProcessingContext & ctx) mutable {
           usleep(200000);
           auto data = ctx.outputs().make<int>(Output{ "TST", "DATA", subspec }, generator() % 10000);
           for (auto&& item : data) {


### PR DESCRIPTION
Fixes the following compilation error on mac
`/Users/awegrzyn/alice/sw/SOURCES/QualityControl/v0.9.0/v0.9.0/Framework/src/runAdvanced.cxx:81:50: error: non-constant-expression cannot be narrowed from type 'time_t' (aka 'long') to 'std::__1::linear_congruential_engine<unsigned int, 48271, 0, 2147483647>::result_type' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]`