### PR TITLE
Remove MO name (QC-123)

### DIFF
--- a/Framework/include/QualityControl/MonitorObject.h
+++ b/Framework/include/QualityControl/MonitorObject.h
@@ -39,7 +39,7 @@ class MonitorObject : public TObject
  public:
   /// Default constructor
   MonitorObject();
-  MonitorObject(const std::string& name, TObject* object, const std::string& taskName);
+  MonitorObject(TObject* object, const std::string& taskName);
 
   /// Destructor
   ~MonitorObject() override;
@@ -53,13 +53,13 @@ class MonitorObject : public TObject
   /// Move assignment operator
   MonitorObject& operator=(MonitorObject&& other) /*noexcept*/ = default;
 
-  const std::string& getName() const { return mName; }
+  /// \brief Return the name of the encapsulated object (if any).
+  /// @return The name of the encapsulated object or "" if there is no object.
+  const std::string getName() const;
 
   /// \brief Overwrite the TObject's method just to avoid confusion.
   ///        One should rather use getName().
   const char* GetName() const override { return getName().c_str(); }
-
-  void setName(const std::string& name) { mName = name; }
 
   const std::string& getTaskName() const { return mTaskName; }
 
@@ -119,12 +119,13 @@ class MonitorObject : public TObject
   void Draw(Option_t* option) override;
   TObject* DrawClone(Option_t* option) const override;
 
+
+
   // Names of special objects published by the framework for each task, behind the scene.
  public:
   static constexpr char SYSTEM_OBJECT_PUBLICATION_LIST[] = "objectsList"; // list of objects published by the task
 
  private:
-  std::string mName;
   TObject* mObject;
   std::map<std::string /*checkName*/, CheckDefinition> mChecks;
   std::string mTaskName;

--- a/Framework/include/QualityControl/MonitorObject.h
+++ b/Framework/include/QualityControl/MonitorObject.h
@@ -119,8 +119,6 @@ class MonitorObject : public TObject
   void Draw(Option_t* option) override;
   TObject* DrawClone(Option_t* option) const override;
 
-
-
   // Names of special objects published by the framework for each task, behind the scene.
  public:
   static constexpr char SYSTEM_OBJECT_PUBLICATION_LIST[] = "objectsList"; // list of objects published by the task

--- a/Framework/include/QualityControl/MonitorObject.h
+++ b/Framework/include/QualityControl/MonitorObject.h
@@ -133,7 +133,7 @@ class MonitorObject : public TObject
   // TODO : maybe we should always be the owner ?
   bool mIsOwner;
 
-  ClassDefOverride(MonitorObject, 2);
+  ClassDefOverride(MonitorObject, 3);
 };
 
 } // namespace core

--- a/Framework/src/MonitorObject.cxx
+++ b/Framework/src/MonitorObject.cxx
@@ -13,21 +13,24 @@
 /// \author Barthelemy von Haller
 ///
 
+#include <iostream>
 #include "QualityControl/MonitorObject.h"
 #include "Common/Exceptions.h"
 
 ClassImp(o2::quality_control::core::MonitorObject)
 
-  namespace o2
+using namespace std;
+
+namespace o2
 {
-  namespace quality_control
-  {
-  namespace core
-  {
+namespace quality_control
+{
+namespace core
+{
 
   constexpr char MonitorObject::SYSTEM_OBJECT_PUBLICATION_LIST[];
 
-  MonitorObject::MonitorObject() : TObject(), mName(""), mObject(nullptr), mTaskName(""), mIsOwner(true) {}
+  MonitorObject::MonitorObject() : TObject(), mObject(nullptr), mTaskName(""), mIsOwner(true) {}
 
   MonitorObject::~MonitorObject()
   {
@@ -36,8 +39,8 @@ ClassImp(o2::quality_control::core::MonitorObject)
     }
   }
 
-  MonitorObject::MonitorObject(const std::string& name, TObject* object, const std::string& taskName)
-    : TObject(), mName(name), mObject(object), mTaskName(taskName), mIsOwner(true)
+  MonitorObject::MonitorObject(TObject* object, const std::string& taskName)
+    : TObject(), mObject(object), mTaskName(taskName), mIsOwner(true)
   {
   }
 
@@ -46,10 +49,18 @@ ClassImp(o2::quality_control::core::MonitorObject)
   TObject* MonitorObject::DrawClone(Option_t* option) const
   {
     auto* clone = new MonitorObject();
-    clone->setName(this->getName());
     clone->setTaskName(this->getTaskName());
     clone->setObject(mObject->DrawClone(option));
     return clone;
+  }
+
+  const std::string MonitorObject::getName() const
+  {
+    if(mObject == nullptr) {
+      cerr << "MonitorObject::getName() : No object in this MonitorObject, returning empty string";
+      return "";
+    }
+    return mObject->GetName();
   }
 
   void MonitorObject::setQualityForCheck(std::string checkName, Quality quality)

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -40,14 +40,13 @@ ObjectsManager::~ObjectsManager()
 
 void ObjectsManager::startPublishing(TObject* object, std::string objectName)
 {
-  std::string nonEmptyName = objectName.empty() ? object->GetName() : objectName;
-  auto* newObject = new MonitorObject(nonEmptyName, object, mTaskName);
+  auto* newObject = new MonitorObject(object, mTaskName);
   newObject->setIsOwner(false);
   mMonitorObjects.Add(newObject);
 
   // update index
   if (objectName != MonitorObject::SYSTEM_OBJECT_PUBLICATION_LIST) {
-    UpdateIndex(nonEmptyName);
+    UpdateIndex(object->GetName());
   }
 }
 

--- a/Framework/src/RepositoryBenchmark.cxx
+++ b/Framework/src/RepositoryBenchmark.cxx
@@ -51,6 +51,41 @@ RepositoryBenchmark::RepositoryBenchmark()
 {
 }
 
+TH1* RepositoryBenchmark::createHisto(uint64_t sizeObjects, string name)
+{
+  TH1* myHisto;
+
+  // Prepare objects (and clean up existing ones)
+  switch (sizeObjects) {
+    case 1:
+      myHisto = new TH1F(name.c_str(), "h", 100, 0, 99); // 1kB
+      break;
+    case 10:
+      myHisto = new TH1F(name.c_str(), "h", 2400, 0, 99); // 10kB
+      break;
+    case 100:
+      myHisto = new TH2F(name.c_str(), "h", 260, 0, 99, 100, 0, 99); // 100kB
+      break;
+    case 500:
+      myHisto = new TH2F(name.c_str(), "h", 1250, 0, 99, 100, 0, 99); // 500kB
+      break;
+    case 1000:
+      myHisto = new TH2F(name.c_str(), "h", 2500, 0, 99, 100, 0, 99); // 1MB
+      break;
+    case 2500:
+      myHisto = new TH2F(name.c_str(), "h", 6250, 0, 99, 100, 0, 99); // 2.5MB
+      break;
+    case 5000:
+      myHisto = new TH2F(name.c_str(), "h", 12500, 0, 99, 100, 0, 99); // 5MB
+      break;
+    default:
+      BOOST_THROW_EXCEPTION(
+        FatalException() << errinfo_details(
+          "size of histo must be 1, 10, 100, 500, 1000, 2500 or 5000 (was: " + to_string(mSizeObjects) + ")"));
+  }
+  return myHisto;
+}
+
 void RepositoryBenchmark::InitTask()
 {
   // parse arguments database
@@ -98,41 +133,11 @@ void RepositoryBenchmark::InitTask()
     emptyDatabase();
   }
 
-  // Prepare objects (and clean up existing ones)
-  switch (mSizeObjects) {
-    case 1:
-      mMyHisto = new TH1F("h", "h", 100, 0, 99); // 1kB
-      break;
-    case 10:
-      mMyHisto = new TH1F("h", "h", 2400, 0, 99); // 10kB
-      break;
-    case 100:
-      mMyHisto = new TH2F("h", "h", 260, 0, 99, 100, 0, 99); // 100kB
-      break;
-    case 500:
-      mMyHisto = new TH2F("h", "h", 1250, 0, 99, 100, 0, 99); // 500kB
-      break;
-    case 1000:
-      mMyHisto = new TH2F("h", "h", 2500, 0, 99, 100, 0, 99); // 1MB
-      break;
-    case 2500:
-      mMyHisto = new TH2F("h", "h", 6250, 0, 99, 100, 0, 99); // 2.5MB
-      break;
-    case 5000:
-      mMyHisto = new TH2F("h", "h", 12500, 0, 99, 100, 0, 99); // 5MB
-      break;
-    default:
-      BOOST_THROW_EXCEPTION(
-        FatalException() << errinfo_details(
-          "size of histo must be 1, 10, 100, 500, 1000, 2500 or 5000 (was: " + to_string(mSizeObjects) + ")"));
-  }
-
-  // TODO : CREATE MANY HISTOGRAMS, ONE FOR EACH MO
-
   // prepare objects
   for (uint64_t i = 0; i < mNumberObjects; i++) {
-    shared_ptr<MonitorObject> mo = make_shared<MonitorObject>(mMyHisto, mTaskName);
-    mo->setIsOwner(false);
+    TH1* histo = createHisto(mSizeObjects, mObjectName + to_string(i));
+    shared_ptr<MonitorObject> mo = make_shared<MonitorObject>(histo, mTaskName);
+    mo->setIsOwner(true);
     mMyObjects.push_back(mo);
   }
 

--- a/Framework/src/RepositoryBenchmark.cxx
+++ b/Framework/src/RepositoryBenchmark.cxx
@@ -127,9 +127,11 @@ void RepositoryBenchmark::InitTask()
           "size of histo must be 1, 10, 100, 500, 1000, 2500 or 5000 (was: " + to_string(mSizeObjects) + ")"));
   }
 
+  // TODO : CREATE MANY HISTOGRAMS, ONE FOR EACH MO
+
   // prepare objects
   for (uint64_t i = 0; i < mNumberObjects; i++) {
-    shared_ptr<MonitorObject> mo = make_shared<MonitorObject>(mObjectName + to_string(i), mMyHisto, mTaskName);
+    shared_ptr<MonitorObject> mo = make_shared<MonitorObject>(mMyHisto, mTaskName);
     mo->setIsOwner(false);
     mMyObjects.push_back(mo);
   }

--- a/Framework/src/RepositoryBenchmark.h
+++ b/Framework/src/RepositoryBenchmark.h
@@ -40,6 +40,7 @@ class RepositoryBenchmark : public FairMQDevice
   virtual bool ConditionalRun();
   void emptyDatabase();
   void checkTimedOut();
+  TH1* createHisto(uint64_t sizeObjects, std::string name);
 
  private:
   // user params
@@ -60,7 +61,7 @@ class RepositoryBenchmark : public FairMQDevice
   // internal state
   std::unique_ptr<o2::quality_control::repository::DatabaseInterface> mDatabase;
   std::vector<std::shared_ptr<MonitorObject>> mMyObjects;
-  TH1* mMyHisto;
+//  TH1* mMyHisto;
 
   // variables for the timer
   boost::asio::deadline_timer* mTimer; /// the asynchronous timer to send monitoring data

--- a/Framework/src/runMergerTest.cxx
+++ b/Framework/src/runMergerTest.cxx
@@ -60,7 +60,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           TH1F* histo = new TH1F("gauss", "gauss", producersAmount, 0, 1);
           histo->Fill(p/(double)producersAmount);
 
-          MonitorObject* mo = new MonitorObject("histo", histo, "histo-task");
+          MonitorObject* mo = new MonitorObject(histo, "histo-task");
           mo->setIsOwner(true);
 
           TObjArray* array = new TObjArray;
@@ -98,7 +98,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           auto moArray = processingContext.inputs().get<TObjArray*>("moarray");
           auto mo = dynamic_cast<MonitorObject*>(moArray->First());
 
-          if (mo->getName() == "histo") {
+          if (mo->getName() == "gauss") {
             auto* g = dynamic_cast<TH1F*>(mo->getObject());
             std::string bins = "BINS:";
             for (int i = 0; i <= g->GetNbinsX(); i++) {

--- a/Framework/test/testDbFactory.cxx
+++ b/Framework/test/testDbFactory.cxx
@@ -71,10 +71,10 @@ BOOST_AUTO_TEST_CASE(db_ccdb_listing)
   ccdb->truncate("functional_test", "path/to/object3");
   auto* h1 = new TH1F("object1", "object1", 100, 0, 99);
   auto* h2 = new TH1F("object2", "object2", 100, 0, 99);
-  auto* h3 = new TH1F("object3", "object3", 100, 0, 99);
-  shared_ptr<MonitorObject> mo1 = make_shared<MonitorObject>("object1", h1, "functional_test");
-  shared_ptr<MonitorObject> mo2 = make_shared<MonitorObject>("object2", h2, "functional_test");
-  shared_ptr<MonitorObject> mo3 = make_shared<MonitorObject>("path/to/object3", h3, "functional_test");
+  auto* h3 = new TH1F("path/to/object3", "object3", 100, 0, 99);
+  shared_ptr<MonitorObject> mo1 = make_shared<MonitorObject>(h1, "functional_test");
+  shared_ptr<MonitorObject> mo2 = make_shared<MonitorObject>(h2, "functional_test");
+  shared_ptr<MonitorObject> mo3 = make_shared<MonitorObject>(h3, "functional_test");
   ccdb->store(mo1);
   ccdb->store(mo2);
   ccdb->store(mo3);
@@ -159,7 +159,7 @@ curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
                                                   if(res != CURLE_OK)
                                                     fprintf(stderr, "curl_easy_perform() failed: %s\n",
                                                             curl_easy_strerror(res));
-                                                   
+
                                                   */
 /* always cleanup */                                                      /*
                                                     curl_easy_cleanup(curl);
@@ -194,7 +194,7 @@ res = curl_easy_perform(curl);
                                   fprintf(stderr, "curl_easy_perform() failed: %s\n",
                                           curl_easy_strerror(res));
                                 }
-                                 
+
                                 */
 /* always cleanup */                                    /*
                                   curl_easy_cleanup(curl);

--- a/Framework/test/testMonitorObject.cxx
+++ b/Framework/test/testMonitorObject.cxx
@@ -22,8 +22,6 @@ BOOST_AUTO_TEST_CASE(mo)
 {
   o2::quality_control::core::MonitorObject obj;
   BOOST_CHECK_EQUAL(obj.getName(), "");
-  obj.setName("test");
-  BOOST_CHECK_EQUAL(obj.getName(), "test");
 
   obj.addCheck("first", "class1", "lib1");
   obj.addCheck("second", "class1", "lib1");

--- a/Modules/Common/test/testMeanIsAbove.cxx
+++ b/Modules/Common/test/testMeanIsAbove.cxx
@@ -24,7 +24,6 @@ namespace common
 BOOST_AUTO_TEST_CASE(test_checks)
 {
   o2::quality_control::core::MonitorObject mo;
-  mo.setName("test");
   mo.addCheck("test", "test", "test");
   mo.setQualityForCheck("test", Quality::Null);
   TH1F th1f("h1", "h1", 10, 0, 9);
@@ -55,7 +54,6 @@ BOOST_AUTO_TEST_CASE(test_checks)
 BOOST_AUTO_TEST_CASE(test_types)
 {
   o2::quality_control::core::MonitorObject mo;
-  mo.setName("test");
   mo.addCheck("test", "test", "test");
   mo.setQualityForCheck("test", Quality::Null);
   TObject obj;

--- a/Modules/Common/test/testNonEmpty.cxx
+++ b/Modules/Common/test/testNonEmpty.cxx
@@ -22,8 +22,8 @@ namespace common
 
 BOOST_AUTO_TEST_CASE(checkable)
 {
-  TH1F histo("test", "test", 100, 0, 99);
-  MonitorObject monitorObject("testObject", &histo, "task");
+  TH1F histo("testObject", "test", 100, 0, 99);
+  MonitorObject monitorObject(&histo, "task");
   monitorObject.setIsOwner(false);
   NonEmpty myCheck;
   myCheck.configure("test");
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(checkable)
 
 BOOST_AUTO_TEST_CASE(beautify)
 {
-  auto* histo = new TH1F("test", "test", 100, 0, 99);
-  MonitorObject monitorObject("testObject", histo, "task"); // here we are the owner of the histo
+  auto* histo = new TH1F("testObject", "test", 100, 0, 99);
+  MonitorObject monitorObject(histo, "task"); // here we are the owner of the histo
   NonEmpty myCheck;
   myCheck.configure("test");
 
@@ -58,8 +58,8 @@ BOOST_AUTO_TEST_CASE(beautify)
 
 BOOST_AUTO_TEST_CASE(nonempty)
 {
-  TH1F histo("test", "test", 100, 0, 99);
-  MonitorObject monitorObject("testObject", &histo, "task");
+  TH1F histo("testObject", "test", 100, 0, 99);
+  MonitorObject monitorObject(&histo, "task");
   monitorObject.setIsOwner(false);
   NonEmpty myCheck;
 


### PR DESCRIPTION
* Remove the name attribute from MonitorObject
* Preserve the interface
* RepositoryBenchmark : update to create multiple objects instead of sending the same. 