### PR TITLE
Fix MySQL database connect function header

### DIFF
--- a/Framework/include/QualityControl/MySqlDatabase.h
+++ b/Framework/include/QualityControl/MySqlDatabase.h
@@ -31,7 +31,7 @@ class MySqlDatabase : public DatabaseInterface
   ~MySqlDatabase() override;
 
   void connect(std::string host, std::string database, std::string username, std::string password) override;
-  void connect(const std::unordered_map& config) override;
+  void connect(const std::unordered_map<std::string, std::string>& config) override;
   void store(std::shared_ptr<o2::quality_control::core::MonitorObject> mo) override;
   o2::quality_control::core::MonitorObject* retrieve(std::string taskName, std::string objectName) override;
   std::string retrieveJson(std::string taskName, std::string objectName) override;


### PR DESCRIPTION
There was a quite simple error introduced [here](https://github.com/AliceO2Group/QualityControl/commit/f16756b42c4d4b08cddece6a2089d6def1ea3d78), which got in unnoticed because of larger build problems.

I am still compiling it on my machine with Giulio's fixes to O2, to make sure that it fixes the problem