### PR TITLE
Allow .clang-format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ README.md.*
 cmake-build-*
 Framework/test/testCcdbApi2.cxx
 local_history.patch
-.clang-format


### PR DESCRIPTION
New logic in AliceO2Group/CodingGuidelines will sync it.