### PR TITLE
Allow for an alternative path to the config file

### DIFF
--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -70,7 +70,9 @@ void TaskRunner::initCallback(InitContext& iCtx)
   iCtx.services().get<framework::CallbackService>().set(framework::CallbackService::Id::Reset, [this]() { reset(); });
 
   // setup monitoring
-  mCollector = MonitoringFactory::Get("infologger://");
+//  mCollector = MonitoringFactory::Get("infologger:///debug?qc");
+    mCollector = MonitoringFactory::Get("influxdb-udp://aido2mon-gpn.cern.ch:8087");
+  mCollector->enableProcessMonitoring();
 
   // setup publisher
   mObjectsManager = std::make_shared<ObjectsManager>(mTaskConfig);

--- a/Framework/src/runReadout.cxx
+++ b/Framework/src/runReadout.cxx
@@ -53,6 +53,9 @@ void customize(std::vector<ChannelConfigurationPolicy>& policies)
 #include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/TaskRunner.h"
 
+#include <iostream>
+#include <string>
+
 using namespace o2;
 using namespace o2::quality_control::checker;
 
@@ -68,7 +71,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   };
 
   // Generation of the QC topology
-  const std::string qcConfigurationSource = std::string("json:/") + getenv("QUALITYCONTROL_ROOT") + "/etc/readout.json";
+  const std::string qcConfigurationUserPath =
+    getenv("QUALITYCONTROL_CONFIG_PATH") != nullptr ? getenv("QUALITYCONTROL_CONFIG_PATH") :
+    std::string(getenv("QUALITYCONTROL_ROOT")) + "/etc/readout.json";
+  const std::string qcConfigurationSource = std::string("json:/") + qcConfigurationUserPath ;
   quality_control::generateRemoteInfrastructure(specs, qcConfigurationSource);
 
   DataProcessorSpec printer{

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The data sampling is configured to sample 1% of the data as the readout should r
 __Configuration file__
 
 The configuration file is in `$QUALITY_CONTROL/readout.json`. It is installed in `$QUALITY_CONTROL/etc`. Each time you rebuild the code, `$QUALITY_CONTROL/etc/readout.json` is overwritten by the file in the source directory (`~/alice/QualityControl/Framework/readout.json`).
+To avoid this behaviour and preserve the changes you do to the configuration, you can copy the file and specify the path to the copy with the environment variable QUALITYCONTROL_CONFIG_PATH.
 
 To change the fraction of the data being monitored, change the option `fraction`.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The data sampling is configured to sample 1% of the data as the readout should r
 __Configuration file__
 
 The configuration file is in `$QUALITY_CONTROL/readout.json`. It is installed in `$QUALITY_CONTROL/etc`. Each time you rebuild the code, `$QUALITY_CONTROL/etc/readout.json` is overwritten by the file in the source directory (`~/alice/QualityControl/Framework/readout.json`).
-To avoid this behaviour and preserve the changes you do to the configuration, you can copy the file and specify the path to the copy with the environment variable QUALITYCONTROL_CONFIG_PATH.
+To avoid this behaviour and preserve the changes you do to the configuration, you can copy the file and specify the path to it with the parameter `--config-path` when launch `qcRunReadout`.
 
 To change the fraction of the data being monitored, change the option `fraction`.
 
@@ -352,11 +352,11 @@ To commit your new or modified code, please follow this procedure
 2. Push the branch : `git push --set-upstream origin feature-new-stuff`
 2. Add and commit your changes onto this branch : `git add Abc.cxx ; git commit Abc.cxx`
 3. Push your commits : `git push`
-4. Once you are satisfied with your changes, make a _Pull Request_ (PR). Go to your branches on the github webpage, and click "New Pull Request". Explain what you did. 
-5. One of the QC developers will check your code. It will also be automatically tested. 
-6. Once approved the changes will be merged in the main repo. You can delete your branch. 
+4. Once you are satisfied with your changes, make a _Pull Request_ (PR). Go to your branches on the github webpage, and click "New Pull Request". Explain what you did.
+5. One of the QC developers will check your code. It will also be automatically tested.
+6. Once approved the changes will be merged in the main repo. You can delete your branch.
 
-For a new feature, just create a new branch for it and use the same procedure. Do not fork again. You can work on several features at the same time by having parallel branches. 
+For a new feature, just create a new branch for it and use the same procedure. Do not fork again. You can work on several features at the same time by having parallel branches.
 
 ---
 
@@ -380,9 +380,9 @@ Build the QualityControl as usual.
 ### Execution
 
 To monitor the readout, 3 processes have to be started : the Readout,
-the Data Sampling and the Data Inspector. 
+the Data Sampling and the Data Inspector.
 
-First make sure that the datasampling is enabled in the readout : 
+First make sure that the datasampling is enabled in the readout :
 ```
 [consumer-data-sampling]
 consumerType=DataSampling
@@ -422,10 +422,10 @@ and $QUALITY_CONTROL/dataDump.json.
    alienv enter qcg/latest
    qcDatabaseSetup.sh
    ```
-   
+
 ## Local CCDB setup
 
-Having a central ccdb for test (ccdb-test) is handy but also means that everyone can access, modify or delete the data. If you prefer to have a local instance of the CCDB, for example in your lab or on your development machine, follow these instructions. 
+Having a central ccdb for test (ccdb-test) is handy but also means that everyone can access, modify or delete the data. If you prefer to have a local instance of the CCDB, for example in your lab or on your development machine, follow these instructions.
 
 1. Download the local repository service from http://alimonitor.cern.ch/download/local.jar
 
@@ -436,7 +436,7 @@ It will start listening by default on port 8080. This can be changed either with
 
 By default the local repository is located in /tmp/QC (or java.io.tmpdir/QC to be more precise). You can change this location in a similar way by setting the java parameter “file.repository.location” or the environment variable “FILE_REPOSITORY_LOCATION”.
 
-The address of the CCDB will have to be updated in the Tasks config file. 
+The address of the CCDB will have to be updated in the Tasks config file.
 
 At the moment, the description of the REST api can be found in this document : https://docs.google.com/presentation/d/1PJ0CVW7QHgnFzi0LELc06V82LFGPgmG3vsmmuurPnUg
 


### PR DESCRIPTION
the environment variable QUALITYCONTROL_CONFIG_PATH can be set to point to a different config file to be used when running qcRunReadout.