### PR TITLE
Remove all references to curl 

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -114,7 +114,6 @@ target_link_libraries(
     Boost::system
     $<$<BOOL:${ENABLE_MYSQL}>:MySQL::MySQL>
     $<$<BOOL:${ENABLE_MYSQL}>:ROOT::RMySQL>
-    CURL::CURL
     ROOT::Gui
 )
 

--- a/Framework/include/QualityControl/CcdbDatabase.h
+++ b/Framework/include/QualityControl/CcdbDatabase.h
@@ -27,11 +27,11 @@ namespace repository
 {
 
 /*
- * Notes
+ * Notes (also concerning the underlying CcdbApi)
  * - having 1 file per object per version server-side might lead to a tremendous number of files.
  *    --> they are aware of it
  * - how to add a new filter ? such as expert/shifter flag
- * - we really need a C++ interface hiding the curl complexity.
+ *    --> new metadata
  * - what are those time intervals ? what does it mean for us ?
  *    --> epoch milliseconds as long values
  * - how to know the real time at which the object was stored ?
@@ -45,7 +45,6 @@ namespace repository
  *    --> doc has been udpated.
  * - initial tests show that it seems pretty slow.
  *    --> ok on their server with the new metadata database (postgresql)
- * - We need getListOfTasksWithPublications() and getPublishedObjectNames()
  * - Current path to objects : .../task/object with object possibly a slash separated subpath (up to 6 levels). Also
  * consider having a task name such as "TPC/Task1" such as to build a tree of tasks with subsystems prefix.
  *

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -102,8 +102,7 @@ std::string CcdbDatabase::retrieveJson(std::string taskName, std::string objectN
 
 void CcdbDatabase::disconnect()
 {
-  /* we're done with libcurl, so clean it up */
-  curl_global_cleanup();
+  // NOOP for CCDB
 }
 
 void CcdbDatabase::prepareTaskDataContainer(std::string taskName)

--- a/Framework/test/testDbFactory.cxx
+++ b/Framework/test/testDbFactory.cxx
@@ -14,7 +14,6 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include "curl/curl.h"
 #include <boost/test/unit_test.hpp>
 #include <cassert>
 #include <iostream>
@@ -22,7 +21,6 @@
 #include <QualityControl/CcdbDatabase.h>
 #include <QualityControl/MonitorObject.h>
 #include <TH1F.h>
-#include <curl/curl.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/stat.h>


### PR DESCRIPTION
It is hidden away in CcdbApi, and it caused troubles with the latest O2. 