### PR TITLE
(QC-150) Allow tasks to run without DS

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -285,6 +285,7 @@ install(
 install(
   FILES
     basic.json
+    basic-no-sampling.json
     advanced.json
     readout.json
     readoutForDataDump.json

--- a/Framework/advanced.json
+++ b/Framework/advanced.json
@@ -20,7 +20,10 @@
         "moduleName": "QcSkeleton",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
-        "dataSamplingPolicy": "tst2",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "tst2"
+        },
         "location": "local",
         "machines": [
           "o2flptst1",
@@ -34,7 +37,10 @@
         "moduleName": "QcSkeleton",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
-        "dataSamplingPolicy": "tst1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "tst1"
+        },
         "location": "remote"
       }
     }

--- a/Framework/basic-no-sampling.json
+++ b/Framework/basic-no-sampling.json
@@ -21,8 +21,11 @@
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
         "dataSource": {
-          "type": "dataSamplingPolicy",
-          "name": "its-raw"
+          "type": "direct",
+          "binding": "its-rawdata",
+          "dataOrigin": "ITS",
+          "dataDescription": "RAWDATA",
+          "subSpec": "0"
         },
         "taskParameters": {
           "nothing": "rien"
@@ -32,26 +35,6 @@
     }
   },
   "dataSamplingPolicies": [
-    {
-      "id": "its-raw",
-      "active": "true",
-      "machines": [],
-      "dataHeaders": [
-        {
-          "binding": "random",
-          "dataOrigin": "ITS",
-          "dataDescription": "RAWDATA"
-        }
-      ],
-      "subSpec": "0",
-      "samplingConditions": [
-        {
-          "condition": "random",
-          "fraction": "0.1",
-          "seed": "1234"
-        }
-      ],
-      "blocking": "false"
-    }
+
   ]
 }

--- a/Framework/basic.json
+++ b/Framework/basic.json
@@ -20,6 +20,7 @@
         "moduleName": "QcSkeleton",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
           "type": "dataSamplingPolicy",
           "name": "its-raw"

--- a/Framework/basic.json
+++ b/Framework/basic.json
@@ -20,7 +20,14 @@
         "moduleName": "QcSkeleton",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
-        "dataSamplingPolicy": "its-raw",
+        "dataSource": {
+          "type": "direct",
+          "binding": "its-rawdata",
+          "dataOrigin": "ITS",
+          "dataDescription": "RAWDATA",
+          "subSpec": "0",
+          "name": "its-raw"
+        },
         "taskParameters": {
           "nothing": "rien"
         },

--- a/Framework/example-default.json
+++ b/Framework/example-default.json
@@ -19,7 +19,10 @@
         "moduleName": "QcExample",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
-        "dataSamplingPolicy": "ex1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "ex1"
+        },
         "location": "remote"
       },
       "daqTask": {
@@ -27,14 +30,20 @@
         "moduleName": "QcDaq",
         "maxNumberCycles": "-1",
         "cycleDurationSeconds": "10",
-        "dataSamplingPolicy": "mftclusters",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "mftclusters"
+        },
         "location": "remote"
       },
       "benchmarkTask_0": {
         "className": "o2::quality_control_modules::example::BenchmarkTask",
         "moduleName": "QcExample",
         "cycleDurationSeconds": "1",
-        "dataSamplingPolicy": "ex1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "ex1"
+        },
         "location": "local",
         "machines": [
           "o2flp1",

--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -68,7 +68,7 @@ class TaskRunner
   /// \param taskName - name of the task, which exists in tasks list in the configuration file
   /// \param configurationSource - absolute path to configuration file, preceded with backend (f.e. "json://")
   /// \param id - subSpecification for taskRunner's OutputSpec, useful to avoid outputs collisions one more complex topologies
-  TaskRunner(const std::string &taskName, const std::string &configurationSource, size_t id = 0);
+  TaskRunner(const std::string& taskName, const std::string& configurationSource, size_t id = 0);
   ~TaskRunner();
 
   /// \brief To be invoked during initialization of Data Processor

--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -68,7 +68,7 @@ class TaskRunner
   /// \param taskName - name of the task, which exists in tasks list in the configuration file
   /// \param configurationSource - absolute path to configuration file, preceded with backend (f.e. "json://")
   /// \param id - subSpecification for taskRunner's OutputSpec, useful to avoid outputs collisions one more complex topologies
-  TaskRunner(std::string taskName, std::string configurationSource, size_t id = 0);
+  TaskRunner(const std::string &taskName, const std::string &configurationSource, size_t id = 0);
   ~TaskRunner();
 
   /// \brief To be invoked during initialization of Data Processor

--- a/Framework/readout.json
+++ b/Framework/readout.json
@@ -20,7 +20,10 @@
         "moduleName": "QcSkeleton",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
-        "dataSamplingPolicy": "readout",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "readout"
+        },
         "location": "remote"
       }
     }

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -194,7 +194,6 @@ void TaskRunner::populateConfig(std::string taskName)
     } else if (type == "direct") {
 
       auto subSpecString = dataSourceTree.get<std::string>("subSpec");
-      LOG(INFO) << "subSpecString : " << subSpecString;
       auto subSpec = std::strtoull(subSpecString.c_str(), nullptr, 10);
 
       header::DataOrigin origin;
@@ -211,7 +210,7 @@ void TaskRunner::populateConfig(std::string taskName)
 
     } else {
       std::string message = std::string("Configuration error : dataSource type unknown : ") + type; // TODO pass this message to the exception
-      throw AliceO2::Common::FatalException();
+      BOOST_THROW_EXCEPTION(AliceO2::Common::FatalException() << AliceO2::Common::errinfo_details(message));
     }
 
   } catch (...) { // catch already here the configuration exception and print it

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -42,9 +42,9 @@ using namespace o2::configuration;
 using namespace o2::monitoring;
 using namespace std::chrono;
 
-TaskRunner::TaskRunner(const std::string &taskName, const std::string &configurationSource, size_t id)
+TaskRunner::TaskRunner(const std::string& taskName, const std::string& configurationSource, size_t id)
   : mTaskName(taskName),
-    mMonitorObjectsSpec({"mo"}, createTaskDataOrigin(), createTaskDataDescription(taskName), id),
+    mMonitorObjectsSpec({ "mo" }, createTaskDataOrigin(), createTaskDataDescription(taskName), id),
     mTask(nullptr),
     mNumberBlocks(0),
     mResetAfterPublish(false),
@@ -187,7 +187,7 @@ void TaskRunner::populateConfig(std::string taskName)
     auto dataSourceTree = taskConfigTree->second.get_child("dataSource");
     std::string type = dataSourceTree.get<std::string>("type");
 
-    if(type == "dataSamplingPolicy") {
+    if (type == "dataSamplingPolicy") {
       auto policyName = dataSourceTree.get<std::string>("name");
       LOG(INFO) << "policyName : " << policyName;
       mInputSpecs = framework::DataSampling::InputSpecsForPolicy(config, policyName);
@@ -207,11 +207,10 @@ void TaskRunner::populateConfig(std::string taskName)
           dataSourceTree.get<std::string>("binding"),
           origin,
           description,
-          subSpec
-        });
+          subSpec });
 
     } else {
-      std::string message = std::string("Configuration error : dataSource type unknown : ")+type; // TODO pass this message to the exception
+      std::string message = std::string("Configuration error : dataSource type unknown : ") + type; // TODO pass this message to the exception
       throw AliceO2::Common::FatalException();
     }
 

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -47,7 +47,7 @@ void customize(std::vector<ChannelConfigurationPolicy>& policies)
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.push_back(
-    ConfigParamSpec{"no-data-sampling", VariantType::Bool, false, {"Skips data sampling, connects directly the task to the producer."}});
+    ConfigParamSpec{ "no-data-sampling", VariantType::Bool, false, { "Skips data sampling, connects directly the task to the producer." } });
 }
 
 #include <FairLogger.h>

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -95,13 +95,12 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
 
   specs.push_back(producer);
 
-  const std::string qcConfigurationSource = std::string("json://") + getenv("QUALITYCONTROL_ROOT") + "/etc/basic.json";
+  std::string filename = !noDS ? "basic.json" : "basic-no-sampling.json";
+  const std::string qcConfigurationSource = std::string("json://") + getenv("QUALITYCONTROL_ROOT") + "/etc/" + filename;
   LOG(INFO) << "Using config file '" << qcConfigurationSource << "'";
 
   // Generation of Data Sampling infrastructure
-  if(!noDS) {
-    DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
-  }
+  DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
 
   // Generation of the QC topology (one task, one checker in this case)
   quality_control::generateRemoteInfrastructure(specs, qcConfigurationSource);

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -35,6 +35,7 @@
 
 #include "Framework/DataSampling.h"
 using namespace o2::framework;
+
 void customize(std::vector<CompletionPolicy>& policies)
 {
   DataSampling::CustomizeInfrastructure(policies);
@@ -42,6 +43,11 @@ void customize(std::vector<CompletionPolicy>& policies)
 void customize(std::vector<ChannelConfigurationPolicy>& policies)
 {
   DataSampling::CustomizeInfrastructure(policies);
+}
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{"no-data-sampling", VariantType::Bool, false, {"Skips data sampling, connects directly the task to the producer."}});
 }
 
 #include <FairLogger.h>
@@ -59,9 +65,11 @@ using namespace o2::framework;
 using namespace o2::quality_control::checker;
 using namespace std::chrono;
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(const ConfigContext& config)
 {
   WorkflowSpec specs;
+  bool noDS = config.options().get<bool>("no-data-sampling");
+
   // The producer to generate some data in the workflow
   DataProcessorSpec producer{
     "producer",
@@ -91,7 +99,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   LOG(INFO) << "Using config file '" << qcConfigurationSource << "'";
 
   // Generation of Data Sampling infrastructure
-  DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+  if(!noDS) {
+    DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+  }
 
   // Generation of the QC topology (one task, one checker in this case)
   quality_control::generateRemoteInfrastructure(specs, qcConfigurationSource);

--- a/README.md
+++ b/README.md
@@ -227,7 +227,10 @@ Data Sampling is used by Quality Control to feed the tasks with data. Below we p
     "tasks": {
       "QcTask": {
         ...
-        "dataSamplingPolicy": "its-raw",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "its-raw"
+        },
         ...
       }
     }
@@ -259,6 +262,35 @@ Data Sampling is used by Quality Control to feed the tasks with data. Below we p
 ```
 
 An example of using the data sampling in a DPL workflow is visible in [runAdvanced.cxx](https://github.com/AliceO2Group/QualityControl/blob/master/Framework/runAdvanced.cxx).
+
+### Bypassing the Data Sampling
+
+In case one needs to sample at a very high rate, or even monitor 100% of the data, the Data Sampling can be omitted altogether. As a result the task is connected directly to the the Device producing the data to be monitored. To do so, change the _dataSource's_ type in the config file from `dataSamplingPolicy` to `direct`. In addition, add the information about the type of data that is expected (dataOrigin, binding, etc...) and remove the dataSamplingPolicies :  
+
+```json
+{
+  "qc": {
+    ...
+    "tasks": {
+      "QcTask": {
+        ...
+        "dataSource": {
+          "type": "direct",
+          "binding": "its-rawdata",
+          "dataOrigin": "ITS",
+          "dataDescription": "RAWDATA",
+          "subSpec": "0"
+        },
+        ...
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+  ]
+}
+```
+
+The file `basic-no-sampling.json` is provided as an example. To test it, you can run `qcRunBasic` with the option `--no-data-sampling` (it makes it use this config file instead of `basic.json`).
 
 ## Code Organization
 


### PR DESCRIPTION
- Config file : introduction of "dataSource" whose "type" can be either "direct" or "dataSamplingPolicy".
- At the moment, one should call qcRunBasic with "--no-data-sampling" AND update the config file (see above)
- only implemented for qcRunBasic