### PR TITLE
Do not hard-code task name in qcRunReadout

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
   src/RepositoryBenchmark.cxx
   src/HistoMerger.cxx
   src/InfrastructureGenerator.cxx
+  src/runnerUtils.h
 )
 
 set(

--- a/Framework/src/Quality.cxx
+++ b/Framework/src/Quality.cxx
@@ -7,9 +7,10 @@
 
 ClassImp(o2::quality_control::core::Quality)
 
+  // clang-format off
 namespace o2::quality_control::core
 {
-
+  // clang-format on
   const unsigned int Quality::NullLevel =
     10; // could be changed if needed but I don't see why we would need more than 10 levels
 

--- a/Framework/src/Quality.cxx
+++ b/Framework/src/Quality.cxx
@@ -7,7 +7,7 @@
 
 ClassImp(o2::quality_control::core::Quality)
 
-  namespace o2::quality_control::core
+namespace o2::quality_control::core
 {
 
   const unsigned int Quality::NullLevel =

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -113,8 +113,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
   DataProcessorSpec printer{
     "printer",
     Inputs{
-      { "checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0 }
-    },
+      { "checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0 } },
     Outputs{},
     adaptFromTask<o2::quality_control::example::ExamplePrinterSpec>()
   };

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -59,6 +59,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 #include "QualityControl/Checker.h"
 #include "QualityControl/InfrastructureGenerator.h"
+#include "runnerUtils.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -109,7 +110,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
   DataProcessorSpec printer{
     "printer",
     Inputs{
-      { "checked-mo", "QC", Checker::createCheckerDataDescription("QcTask"), 0 }
+      { "checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0 }
     },
     Outputs{},
     AlgorithmSpec{

--- a/Framework/src/runReadout.cxx
+++ b/Framework/src/runReadout.cxx
@@ -98,7 +98,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   DataProcessorSpec printer{
     "printer",
     Inputs{
-      {"checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0} },
+      { "checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0} },
     Outputs{},
     adaptFromTask<o2::quality_control::example::ExamplePrinterSpec>()
   };

--- a/Framework/src/runReadout.cxx
+++ b/Framework/src/runReadout.cxx
@@ -98,8 +98,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   DataProcessorSpec printer{
     "printer",
     Inputs{
-      {"checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0}
-    },
+      {"checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0} },
     Outputs{},
     adaptFromTask<o2::quality_control::example::ExamplePrinterSpec>()
   };

--- a/Framework/src/runReadout.cxx
+++ b/Framework/src/runReadout.cxx
@@ -98,7 +98,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   DataProcessorSpec printer{
     "printer",
     Inputs{
-      { "checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0} },
+      { "checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0 } },
     Outputs{},
     adaptFromTask<o2::quality_control::example::ExamplePrinterSpec>()
   };

--- a/Framework/src/runReadout.cxx
+++ b/Framework/src/runReadout.cxx
@@ -62,13 +62,13 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 #include "QualityControl/CheckerFactory.h"
 #include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/TaskRunner.h"
+#include "runnerUtils.h"
 
 #include <iostream>
 #include <string>
-#include <Configuration/ConfigurationFactory.h>
 
 std::string getConfigPath(const ConfigContext& config);
-std::string getTaskName(std::string configurationSource);
+
 using namespace o2;
 using namespace o2::quality_control::checker;
 
@@ -92,7 +92,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   DataProcessorSpec printer{
     "printer",
     Inputs{
-      {"checked-mo", "QC", Checker::createCheckerDataDescription(getTaskName(qcConfigurationSource)), 0}
+      {"checked-mo", "QC", Checker::createCheckerDataDescription(getFirstTaskName(qcConfigurationSource)), 0}
     },
     Outputs{},
     AlgorithmSpec{
@@ -136,23 +136,4 @@ std::string getConfigPath(const ConfigContext& config)
   std::string path = userConfigPath.empty() ? defaultConfigPath : userConfigPath;
   const std::string qcConfigurationSource = std::string("json:/") + path;
   return qcConfigurationSource;
-}
-
-/**
- * Returns the name of the first task encountered in the config file.
- * Ad-hoc solution to avoid hard-coding the task when we create the printer (he needs it to know the data description
- * of the data coming out of the checker).
- * @param config
- * @return The name of the first task in the config file.
- */
-std::string getTaskName(std::string configurationSource)
-{
-  auto config = o2::configuration::ConfigurationFactory::getConfiguration(configurationSource);
-
-  for (const auto&[taskName, taskConfig] : config->getRecursive("qc.tasks")) {
-    std::cout << "Name : " << taskName << std::endl;
-    return taskName;
-  }
-
-  throw;
 }

--- a/Framework/src/runnerUtils.h
+++ b/Framework/src/runnerUtils.h
@@ -1,0 +1,33 @@
+//
+// Created by bvonhall on 16/04/19.
+//
+
+#ifndef QUALITYCONTROL_RUNNERUTILS_H
+#define QUALITYCONTROL_RUNNERUTILS_H
+
+#include <Configuration/ConfigurationFactory.h>
+
+namespace o2::quality_control::core
+{
+
+/**
+ * Returns the name of the first task encountered in the config file.
+ * Ad-hoc solution to avoid hard-coding the task when we create the printer (he needs it to know the data description
+ * of the data coming out of the checker).
+ * @param config
+ * @return The name of the first task in the config file.
+ */
+std::string getFirstTaskName(std::string configurationSource)
+{
+  auto config = o2::configuration::ConfigurationFactory::getConfiguration(configurationSource);
+
+  for (const auto&[taskName, taskConfig] : config->getRecursive("qc.tasks")) {
+    return taskName;
+  }
+
+  throw;
+}
+
+} // o2::quality_control::core
+
+#endif //QUALITYCONTROL_RUNNERUTILS_H

--- a/Framework/src/runnerUtils.h
+++ b/Framework/src/runnerUtils.h
@@ -1,6 +1,17 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
 //
-// Created by bvonhall on 16/04/19.
+// See http://alice-o2.web.cern.ch/license for full licensing information.
 //
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   runnerUtils.h
+/// \author Barthelemy von Haller
+///
 
 #ifndef QUALITYCONTROL_RUNNERUTILS_H
 #define QUALITYCONTROL_RUNNERUTILS_H

--- a/doc/ModulesDevelopment.md
+++ b/doc/ModulesDevelopment.md
@@ -252,7 +252,7 @@ TODO give actual steps
 
 You can rename the task by simply changing its name in the config file. Change the name from 
 `QcTask` to whatever you like and run it again (no need to recompile). You should see the new name
-appear in the QCG.
+appear in the QCG. 
 
 ## Addition of a Check
 

--- a/doc/ModulesDevelopment.md
+++ b/doc/ModulesDevelopment.md
@@ -249,7 +249,9 @@ Once done, recompile it (see section above) and run it. You should see the secon
 
 TODO give actual steps
 
-TODO Rename the task in teh config file and see in QCG that it appears under a different name.
+You can rename the task by simply changing its name in the config file. Change the name from 
+`QcTask` to whatever you like and run it again (no need to recompile). You should see the new name
+appear in the QCG.  
 
 ## Addition of a Check
 

--- a/doc/ModulesDevelopment.md
+++ b/doc/ModulesDevelopment.md
@@ -252,7 +252,7 @@ TODO give actual steps
 
 You can rename the task by simply changing its name in the config file. Change the name from 
 `QcTask` to whatever you like and run it again (no need to recompile). You should see the new name
-appear in the QCG.  
+appear in the QCG.
 
 ## Addition of a Check
 

--- a/doc/ModulesDevelopment.md
+++ b/doc/ModulesDevelopment.md
@@ -252,7 +252,7 @@ TODO give actual steps
 
 You can rename the task by simply changing its name in the config file. Change the name from 
 `QcTask` to whatever you like and run it again (no need to recompile). You should see the new name
-appear in the QCG. 
+appear in the QCG.
 
 ## Addition of a Check
 


### PR DESCRIPTION
The aim is to be able to rename easily the task in the config file.