### PR TITLE
Explicitly disable Objective-C in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,3 +49,6 @@ SpacesInParentheses: false
 Standard:        Cpp11
 TabWidth:        2
 UseTab:          Never
+
+Language: ObjC
+DisableFormat: true


### PR DESCRIPTION
This should fix clang-format in this PR: https://github.com/AliceO2Group/AliceO2/pull/1803