### PR TITLE
Revert "Bump to clang-format 8 (#140)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-8
+            - llvm-toolchain-xenial-7
           packages:
-            - clang-format-8
+            - clang-format-7
       compiler: clang
 script:
   - if [[ $TOOL == "clang-format" ]] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
       cd $TRAVIS_BUILD_DIR;
       BASE_COMMIT=$(git rev-parse $TRAVIS_BRANCH);
       COMMIT_FILES=$(git diff --name-only $BASE_COMMIT | grep -i -v LinkDef);
-      RESULT_OUTPUT="$(git-clang-format-8 --commit $BASE_COMMIT --diff --binary `which clang-format-8` $COMMIT_FILES)";
+      RESULT_OUTPUT="$(git-clang-format-7 --commit $BASE_COMMIT --diff --binary `which clang-format-7` $COMMIT_FILES)";
       if [ "$RESULT_OUTPUT" == "no modified files to format" ] || [ "$RESULT_OUTPUT" == "clang-format did not modify any files" ] ; then
         exit 0;
       else


### PR DESCRIPTION
Since the travis build machine has some problems downloading clang-format 8, let's roll it back to the 7 for now.
This reverts commit bb48eca9cab5d57913e7228a898ce1a3b3b2c98c.