### PR TITLE
Reorder setup steps in the documentation

### DIFF
--- a/doc/QuickStart.md
+++ b/doc/QuickStart.md
@@ -29,13 +29,14 @@ A Linux machine (CC7 or Ubuntu) or a Mac. See the O2 instructions below for the 
 3. Prepare the QualityControl development package
     * `aliBuild init QualityControl@master --defaults o2`
 
-4. Build/install the QualityControl, its GUI (qcg) and the readout. The simplest is to use the metapackage `flpproto`.
+4. Install GLFW to have GUIs in the DPL (optional, DPL GUIs do not work in containers).
+    * On CC7 : `sudo yum install glfw-devel --enablerepo=epel`
+    * On Mac : `brew install glfw`
+
+5. Build/install the QualityControl, its GUI (qcg) and the readout. The simplest is to use the metapackage `flpproto`.
     * `aliBuild build flpproto --defaults o2`
 
    At this point you might encounter a message about missing system requirements. Run `aliDoctor flpproto` to get a full information about what is missing and how to install it.
-5. Install GLFW to have GUIs in the DPL (optional, DPL GUIs do not work in containers).
-    * On CC7 : `sudo yum install glfw-devel --enablerepo=epel`
-    * On Mac : `brew install glfw`
 
 Note :  you can also use the alibuild "defaults" called `o2-dataflow` to avoid building simulation related packages.
 


### PR DESCRIPTION
In alidock the project won't not compile before glfw is installed.