### PR TITLE
Survive missing QUALITYCONTROL_ROOT

### DIFF
--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -51,7 +51,12 @@ CcdbDatabase::~CcdbDatabase() { disconnect(); }
 
 void CcdbDatabase::loadDeprecatedStreamerInfos()
 {
-  string path = getenv("QUALITYCONTROL_ROOT") ? string(getenv("QUALITYCONTROL_ROOT")) + "/etc/" : "";
+  if(getenv("QUALITYCONTROL_ROOT") == nullptr) {
+    LOG(WARNING) << "QUALITYCONTROL_ROOT is not set thus the the streamerinfo ROOT file can't be found.\n"
+                 << "Consequently, old data might not be readable.";
+    return;
+  }
+  string path = string(getenv("QUALITYCONTROL_ROOT")) + "/etc/";
   path += "streamerinfos.root";
   TFile file(path.data(), "READ");
   if (file.IsZombie()) {

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -51,7 +51,7 @@ CcdbDatabase::~CcdbDatabase() { disconnect(); }
 
 void CcdbDatabase::loadDeprecatedStreamerInfos()
 {
-  if(getenv("QUALITYCONTROL_ROOT") == nullptr) {
+  if (getenv("QUALITYCONTROL_ROOT") == nullptr) {
     LOG(WARNING) << "QUALITYCONTROL_ROOT is not set thus the the streamerinfo ROOT file can't be found.\n"
                  << "Consequently, old data might not be readable.";
     return;


### PR DESCRIPTION
If QUALITYCONTROL_ROOT is not set we ignore the loading of old streamer infos