### PR TITLE
[EMCAL-524] Adding projections for EMCAL and DCAL, first checkers

### DIFF
--- a/Modules/EMCAL/CMakeLists.txt
+++ b/Modules/EMCAL/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(QcEMCAL)
 
-target_sources(QcEMCAL PRIVATE src/DigitsQcTask.cxx)
+target_sources(QcEMCAL PRIVATE src/DigitsQcTask.cxx src/DigitCheck.cxx)
 
 target_include_directories(
   QcEMCAL
@@ -14,6 +14,7 @@ target_link_libraries(QcEMCAL PUBLIC QualityControl O2::EMCALBase)
 
 add_root_dictionary(QcEMCAL
                     HEADERS include/EMCAL/DigitsQcTask.h
+		    include/EMCAL/DigitCheck.h
                     LINKDEF include/EMCAL/LinkDef.h
                     BASENAME QcEMCAL)
 

--- a/Modules/EMCAL/include/EMCAL/DigitCheck.h
+++ b/Modules/EMCAL/include/EMCAL/DigitCheck.h
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   DigitCheck.h
+/// \author Cristina Terrevoli
+///
+
+#ifndef QC_MODULE_EMCAL_EMCALDIGITCHECK_H
+#define QC_MODULE_EMCAL_EMCALDIGITCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+
+namespace o2::quality_control_modules::emcal
+{
+
+/// \brief  Check whether a plot is empty or not.
+///
+/// \author Barthelemy von Haller
+class DigitCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  DigitCheck() = default;
+  /// Destructor
+  ~DigitCheck() override = default;
+
+  // Override interface
+  void configure(std::string name) override;
+  Quality check(const MonitorObject* mo) override;
+  void beautify(MonitorObject* mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+  ClassDefOverride(DigitCheck, 1);
+};
+
+} // namespace o2::quality_control_modules::emcal
+
+#endif // QC_MODULE_EMCAL_EMCALDIGITCHECK_H

--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -1,6 +1,6 @@
 ///
 /// \file   DigitsQcTask.h
-/// \author Markus Fasel
+/// \author Markus Fasel, Cristina Terrevoli
 ///
 
 #ifndef QC_MODULE_EMCAL_DIGITSQCTASK_H

--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -7,13 +7,20 @@
 #define QC_MODULE_EMCAL_DIGITSQCTASK_H
 
 #include "QualityControl/TaskInterface.h"
+#include <array>
 
-class TH2F;
+class TH1;
+class TH2;
 
 using namespace o2::quality_control::core;
 
 namespace o2
 {
+namespace emcal
+{
+class Geometry;
+}
+
 namespace quality_control_modules
 {
 namespace emcal
@@ -44,8 +51,11 @@ class DigitsQcTask /*final*/ : public TaskInterface // todo add back the "final"
   void reset() override;
 
  private:
-  TH2F* mDigitAmplitude; ///< Digit amplitude
-  TH2F* mDigitTime;      ///< Digit time
+  std::array<TH2*, 2> mDigitAmplitude;      ///< Digit amplitude
+  std::array<TH2*, 2> mDigitTime;           ///< Digit time
+  TH1* mDigitAmplitudeEMCAL = nullptr;      ///< Digit amplitude in EMCAL
+  TH1* mDigitAmplitudeDCAL = nullptr;       ///< Digit amplitude in DCAL
+  o2::emcal::Geometry* mGeometry = nullptr; ///< EMCAL geometry
 };
 
 } // namespace emcal

--- a/Modules/EMCAL/include/EMCAL/LinkDef.h
+++ b/Modules/EMCAL/include/EMCAL/LinkDef.h
@@ -3,5 +3,8 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::quality_control_modules::emcal::DigitsQcTask+;
+#pragma link C++ class o2::quality_control_modules::emcal::DigitsQcTask + ;
+
+#pragma link C++ class o2::quality_control_modules::emcal::DigitCheck + ;
+
 #endif

--- a/Modules/EMCAL/src/DigitCheck.cxx
+++ b/Modules/EMCAL/src/DigitCheck.cxx
@@ -1,0 +1,144 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   DigitCheck.cxx
+/// \author Cristina Terrevoli
+///
+
+#include "EMCAL/DigitCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include <fairlogger/Logger.h>
+// ROOT
+#include <TH1.h>
+#include <TH2.h>
+#include <TPaveText.h>
+#include <TList.h>
+#include <iostream>
+
+using namespace std;
+
+namespace o2::quality_control_modules::emcal
+{
+
+void DigitCheck::configure(std::string) {}
+
+Quality DigitCheck::check(const MonitorObject* mo)
+{
+  Quality result = Quality::Good;
+
+  if (mo->getName() == "digitAmplitudeEMCAL") {
+    auto* h = dynamic_cast<TH1*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+  }
+  if (mo->getName() == "digitAmplitudeDCAL") {
+    auto* h = dynamic_cast<TH1*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+  }
+  if (mo->getName() == "digitAmplitudeHG") {
+    auto* h = dynamic_cast<TH2*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+  }
+  if (mo->getName() == "digitAmplitudeLG") {
+    auto* h = dynamic_cast<TH2*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+  }
+
+  if (mo->getName() == "digitTimeHG") {
+    auto* h = dynamic_cast<TH2*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+    else {
+      Float_t timeMean = h->GetMean();
+      Float_t timeThrs = 60.;
+      if (timeMean < timeThrs - 20. || timeMean > timeThrs + 20.) {
+        result = Quality::Bad;
+      }
+    }
+  }
+
+  if (mo->getName() == "digitTimeLG") {
+    auto* h = dynamic_cast<TH2*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+    else {
+      Float_t timeMean = h->GetMean();
+      Float_t timeThrs = 60;
+      if (timeMean < timeThrs - 20 || timeMean > timeThrs + 20) {
+        result = Quality::Bad;
+      }
+    }
+  }
+  return result;
+}
+
+std::string DigitCheck::getAcceptedType() { return "TH1"; }
+
+void DigitCheck::beautify(MonitorObject* mo, Quality checkResult)
+{
+  if (mo->getName().find("Time") != std::string::npos) {
+    auto* h = dynamic_cast<TH2*>(mo->getObject());
+    TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
+    h->GetListOfFunctions()->Add(msg);
+    msg->SetName(Form("%s_msg", mo->GetName()));
+
+    if (checkResult == Quality::Good) {
+      //
+      msg->Clear();
+      msg->AddText("Mean inside limits: OK!!!");
+      msg->SetFillColor(kGreen);
+      //
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      LOG(INFO) << "Quality::Bad, setting to red";
+      msg->Clear();
+      msg->AddText("Mean outside limits or no entries");
+      msg->AddText("If NOT a technical run,");
+      msg->AddText("call EMCAL on-call.");
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      LOG(INFO) << "Quality::medium, setting to orange";
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+  if (mo->getName().find("Amplitude") != std::string::npos) {
+    auto* h = dynamic_cast<TH1*>(mo->getObject());
+    TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
+    h->GetListOfFunctions()->Add(msg);
+    msg->SetName(Form("%s_msg", mo->GetName()));
+
+    if (checkResult == Quality::Good) {
+      //
+      msg->Clear();
+      msg->AddText("Mean inside limits: OK!!!");
+      msg->SetFillColor(kGreen);
+      //
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      LOG(INFO) << "Quality::Bad, setting to red";
+      msg->Clear();
+      msg->AddText("Mean outside limits or no entries");
+      msg->AddText("If NOT a technical run,");
+      msg->AddText("call EMCAL on-call.");
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      LOG(INFO) << "Quality::medium, setting to orange";
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+}
+} // namespace o2::quality_control_modules::emcal

--- a/Modules/EMCAL/src/DigitsQcTask.cxx
+++ b/Modules/EMCAL/src/DigitsQcTask.cxx
@@ -1,6 +1,6 @@
 ///
 /// \file   DigitsQcTask.cxx
-/// \author Markus Fasel
+/// \author Markus Fasel, Cristina Terrevoli
 ///
 
 #include <TCanvas.h>
@@ -26,13 +26,23 @@ DigitsQcTask::~DigitsQcTask()
   }
   for (auto h : mDigitTime) {
     delete h;
+    if (mDigitTime[0]) {
+      delete mDigitTime[0];
+    }
+    if (mDigitTime[1]) {
+      delete mDigitTime[1];
+    }
   }
+  if (mDigitAmplitudeEMCAL)
+    delete mDigitAmplitudeEMCAL;
+  if (mDigitAmplitudeDCAL)
+    delete mDigitAmplitudeDCAL;
 }
 
 void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   QcInfoLogger::GetInstance() << "initialize DigitsQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
-
+  //define histograms
   mDigitAmplitude[0] = new TH2F("digitAmplitudeHG", "Digit Amplitude (High gain)", 100, 0, 100, 20000, 0., 20000.);
   mDigitAmplitude[1] = new TH2F("digitAmplitudeLG", "Digit Amplitude (Low gain)", 100, 0, 100, 20000, 0., 20000.);
   mDigitTime[0] = new TH2F("digitTimeHG", "Digit Time (High gain)", 1000, 0, 1000, 20000, 0., 20000.);
@@ -40,16 +50,22 @@ void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   // 1D histograms for showing the integrated spectrum
   mDigitAmplitudeEMCAL = new TH1F("digitAmplitudeEMCAL", "Digit amplitude in EMCAL", 100, 0., 100.);
   mDigitAmplitudeDCAL = new TH1F("digitAmplitudeDCAL", "Digit amplitude in DCAL", 100, 0., 100.);
+  //Puglishing histograms
   for (auto h : mDigitAmplitude)
     getObjectsManager()->startPublishing(h);
   for (auto h : mDigitTime)
     getObjectsManager()->startPublishing(h);
+
   getObjectsManager()->startPublishing(mDigitAmplitudeEMCAL);
   getObjectsManager()->startPublishing(mDigitAmplitudeDCAL);
-  //getObjectsManager()->addCheck(mDigitAmplitude[0], "checkFromEMCAL", "o2::quality_control_modules::emcal::EMCALCheck",
-  //                              "QcEMCAL");
-  //getObjectsManager()->addCheck(mDigitTime[0], "checkFromEMCAL", "o2::quality_control_modules::emcal::EMCALCheck",
-  //                              "QcEMCAL");
+  //add checker for histograms //decide the name of ONE checker
+  getObjectsManager()->addCheck(mDigitAmplitude[0], "checkAmplHighG", "o2::quality_control_modules::emcal::DigitCheck", "QcEMCAL");
+  getObjectsManager()->addCheck(mDigitAmplitude[1], "checkAmplLowG", "o2::quality_control_modules::emcal::DigitCheck", "QcEMCAL");
+  getObjectsManager()->addCheck(mDigitTime[0], "checkDigitTimeHighG", "o2::quality_control_modules::emcal::DigitCheck", "QcEMCAL");
+  getObjectsManager()->addCheck(mDigitTime[1], "checkDigitTimeLowG", "o2::quality_control_modules::emcal::DigitCheck", "QcEMCAL");
+  //digitAmplitudeEMCAL-DCAL
+  getObjectsManager()->addCheck(mDigitAmplitudeEMCAL, "checkAmplEMCAL", "o2::quality_control_modules::emcal::DigitCheck", "QcEMCAL");
+  getObjectsManager()->addCheck(mDigitAmplitudeDCAL, "checkAmplDCAL", "o2::quality_control_modules::emcal::DigitCheck", "QcEMCAL");
 
   // initialize geometry
   if (!mGeometry)
@@ -69,7 +85,7 @@ void DigitsQcTask::startOfCycle()
 
 void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  QcInfoLogger::GetInstance() << "Start monitor data" << AliceO2::InfoLogger::InfoLogger::endm;
+  //  QcInfoLogger::GetInstance() << "Start monitor data" << AliceO2::InfoLogger::InfoLogger::endm;
 
   // check if we have payoad
   auto dataref = ctx.inputs().get("emcal-digits");
@@ -81,13 +97,14 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
   // Get payload and loop over digits
   auto digitcontainer = ctx.inputs().get<std::vector<o2::emcal::Digit>>("emcal-digits");
-  QcInfoLogger::GetInstance() << "Received " << digitcontainer.size() << " digits " << AliceO2::InfoLogger::InfoLogger::endm;
+  //  QcInfoLogger::GetInstance() << "Received " << digitcontainer.size() << " digits " << AliceO2::InfoLogger::InfoLogger::endm;
   for (auto digit : digitcontainer) {
     int index = digit.getHighGain() ? 0 : (digit.getLowGain() ? 1 : -1);
     if (index < 0)
       continue;
     mDigitAmplitude[index]->Fill(digit.getEnergy(), digit.getTower());
     mDigitTime[index]->Fill(digit.getTimeStamp(), digit.getTower());
+
     // get the supermodule for filling EMCAL/DCAL spectra
     try {
       auto cellindices = mGeometry->GetCellIndex(digit.getTower());
@@ -120,6 +137,8 @@ void DigitsQcTask::reset()
     h->Reset();
   for (auto h : mDigitTime)
     h->Reset();
+  mDigitAmplitudeEMCAL->Reset();
+  mDigitAmplitudeDCAL->Reset();
 }
 
 } // namespace emcal


### PR DESCRIPTION
Adding 1D spectra for EMCAL and DCAL for the
digits amplitude projection. In addition add
separate histograms for high and low gain cells.