### PR TITLE
Tests rework related to Service Discovery 

### DIFF
--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -41,7 +41,12 @@ class ServiceDiscovery;
 class ObjectsManager
 {
  public:
-  explicit ObjectsManager(TaskConfig& taskConfig);
+  /**
+   * Constructor
+   * @param taskConfig The configuration of the task for which we are building this object manager
+   * @param noDiscovery If true disables the use of ServiceDiscovery
+   */
+  explicit ObjectsManager(TaskConfig& taskConfig, bool noDiscovery = false);
   virtual ~ObjectsManager();
 
   /**

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -27,13 +27,18 @@ using namespace std;
 namespace o2::quality_control::core
 {
 
-ObjectsManager::ObjectsManager(TaskConfig& taskConfig) : mTaskConfig(taskConfig), mUpdateServiceDiscovery(false)
+ObjectsManager::ObjectsManager(TaskConfig& taskConfig, bool noDiscovery) : mTaskConfig(taskConfig), mUpdateServiceDiscovery(false)
 {
   mMonitorObjects = std::make_unique<TObjArray>();
   mMonitorObjects->SetOwner(true);
 
   // register with the discovery service
-  mServiceDiscovery = std::make_unique<ServiceDiscovery>(taskConfig.consulUrl, taskConfig.taskName);
+  if(!noDiscovery) {
+    mServiceDiscovery = std::make_unique<ServiceDiscovery>(taskConfig.consulUrl, taskConfig.taskName);
+  } else {
+    QcInfoLogger::GetInstance() << "Service Discovery disabled" << infologger::endm;
+    mServiceDiscovery = nullptr;
+  }
 }
 
 ObjectsManager::~ObjectsManager() = default;

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -33,7 +33,7 @@ ObjectsManager::ObjectsManager(TaskConfig& taskConfig, bool noDiscovery) : mTask
   mMonitorObjects->SetOwner(true);
 
   // register with the discovery service
-  if(!noDiscovery) {
+  if (!noDiscovery) {
     mServiceDiscovery = std::make_unique<ServiceDiscovery>(taskConfig.consulUrl, taskConfig.taskName);
   } else {
     QcInfoLogger::GetInstance() << "Service Discovery disabled" << infologger::endm;

--- a/Framework/test/testObjectsManager.cxx
+++ b/Framework/test/testObjectsManager.cxx
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(invalid_url_test)
   TaskConfig config;
   config.taskName = "test";
   config.consulUrl = "bad-url:1234";
-  ObjectsManager objectsManager(config);
+  ObjectsManager objectsManager(config, true);
 }
 
 BOOST_AUTO_TEST_CASE(duplicate_object_test)
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(duplicate_object_test)
   TaskConfig config;
   config.taskName = "test";
   config.consulUrl = "http://consul-test.cern.ch:8500";
-  ObjectsManager objectsManager(config);
+  ObjectsManager objectsManager(config, true);
   TObjString s("content");
   objectsManager.startPublishing(&s);
   BOOST_CHECK_THROW(objectsManager.startPublishing(&s), o2::quality_control::core::DuplicateObjectError);
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(unpublish_test)
 {
   TaskConfig config;
   config.taskName = "test";
-  ObjectsManager objectsManager(config);
+  ObjectsManager objectsManager(config, true);
   TObjString s("content");
   objectsManager.startPublishing(&s);
   BOOST_CHECK_EQUAL(objectsManager.getNumberPublishedObjects(), 1);
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(getters_test)
   TaskConfig config;
   config.taskName = "test";
   config.consulUrl = "http://consul-test.cern.ch:8500";
-  ObjectsManager objectsManager(config);
+  ObjectsManager objectsManager(config, true);
 
   TObjString s("content");
   TH1F h("histo", "h", 100, 0, 99);
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(metadata_test)
   TaskConfig config;
   config.taskName = "test";
   config.consulUrl = "http://consul-test.cern.ch:8500";
-  ObjectsManager objectsManager(config);
+  ObjectsManager objectsManager(config, true);
 
   TObjString s("content");
   TH1F h("histo", "h", 100, 0, 99);

--- a/Modules/Common/CMakeLists.txt
+++ b/Modules/Common/CMakeLists.txt
@@ -39,5 +39,7 @@ foreach(test ${TEST_SRCS})
   target_link_libraries(${test_name}
                         PRIVATE QcCommon Boost::unit_test_framework)
   add_test(NAME ${test_name} COMMAND ${test_name})
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
+  set_property(TARGET ${test_name}
+    PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
 endforeach()

--- a/Modules/Daq/CMakeLists.txt
+++ b/Modules/Daq/CMakeLists.txt
@@ -33,5 +33,7 @@ foreach(test ${TEST_SRCS})
   target_link_libraries(${test_name}
                         PRIVATE QcDaq Boost::unit_test_framework)
   add_test(NAME ${test_name} COMMAND ${test_name})
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
+  set_property(TARGET ${test_name}
+    PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
 endforeach()

--- a/Modules/Daq/test/testQcDaq.cxx
+++ b/Modules/Daq/test/testQcDaq.cxx
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(instantiate_task)
   TaskConfig config;
   config.consulUrl = "http://consul-test.cern.ch:8500";
   config.taskName = "qcDaqTest";
-  auto manager = make_shared<ObjectsManager>(config);
+  auto manager = make_shared<ObjectsManager>(config, true);
   task.setObjectsManager(manager);
   //  o2::framework::InitContext ctx;
   //  task.initialize(ctx); // TODO

--- a/Modules/Daq/test/testQcDaq.cxx
+++ b/Modules/Daq/test/testQcDaq.cxx
@@ -23,6 +23,8 @@ BOOST_AUTO_TEST_CASE(instantiate_task)
 {
   DaqTask task;
   TaskConfig config;
+  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.taskName = "qcDaqTest";
   auto manager = make_shared<ObjectsManager>(config);
   task.setObjectsManager(manager);
   //  o2::framework::InitContext ctx;

--- a/Modules/EMCAL/CMakeLists.txt
+++ b/Modules/EMCAL/CMakeLists.txt
@@ -46,5 +46,7 @@ foreach(test ${TEST_SRCS})
   add_executable(${test_name} ${test})
   target_link_libraries(${test_name} PRIVATE ${MODULE_NAME} Boost::unit_test_framework)
   add_test(NAME ${test_name} COMMAND ${test_name})
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
+  set_property(TARGET ${test_name}
+    PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
 endforeach()

--- a/Modules/Example/CMakeLists.txt
+++ b/Modules/Example/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach(test ${TEST_SRCS})
   add_test(NAME ${test_name} COMMAND ${test_name})
   set_property(TARGET ${test_name}
                PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
 endforeach()
 
 target_sources(testFactory PRIVATE ${CMAKE_BINARY_DIR}/getTestDataDirectory.cxx)

--- a/Modules/Example/test/testQcExample.cxx
+++ b/Modules/Example/test/testQcExample.cxx
@@ -24,6 +24,8 @@ BOOST_AUTO_TEST_CASE(insantiate_task)
 {
   ExampleTask task;
   TaskConfig config;
+  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.taskName = "qcExampleTest";
   auto manager = make_shared<ObjectsManager>(config);
   task.setObjectsManager(manager);
   //  task.initialize();// TODO

--- a/Modules/Example/test/testQcExample.cxx
+++ b/Modules/Example/test/testQcExample.cxx
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(insantiate_task)
   TaskConfig config;
   config.consulUrl = "http://consul-test.cern.ch:8500";
   config.taskName = "qcExampleTest";
-  auto manager = make_shared<ObjectsManager>(config);
+  auto manager = make_shared<ObjectsManager>(config, true);
   task.setObjectsManager(manager);
   //  task.initialize();// TODO
 

--- a/Modules/Skeleton/.CMakeListsEmpty.txt
+++ b/Modules/Skeleton/.CMakeListsEmpty.txt
@@ -28,4 +28,6 @@ add_executable(testQcSkeleton test/testQcSkeleton.cxx)
 target_link_libraries(testQcSkeleton
                       PRIVATE QcSkeleton Boost::unit_test_framework)
 add_test(NAME testQcSkeleton COMMAND testQcSkeleton)
-set_tests_properties(testQcSkeleton PROPERTIES TIMEOUT 60)
+set_property(TARGET ${test_name}
+    PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+set_tests_properties(testQcSkeleton PROPERTIES TIMEOUT 20)

--- a/Modules/Skeleton/CMakeLists.txt
+++ b/Modules/Skeleton/CMakeLists.txt
@@ -37,5 +37,7 @@ foreach(test ${TEST_SRCS})
   target_link_libraries(${test_name}
                         PRIVATE QcSkeleton Boost::unit_test_framework)
   add_test(NAME ${test_name} COMMAND ${test_name})
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
+  set_property(TARGET ${test_name}
+    PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
 endforeach()

--- a/Modules/Skeleton/test/testQcSkeleton.cxx
+++ b/Modules/Skeleton/test/testQcSkeleton.cxx
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(instantiate_task)
   TaskConfig config;
   config.consulUrl = "http://consul-test.cern.ch:8500";
   config.taskName = "qcSkeletonTest";
-  auto manager = make_shared<ObjectsManager>(config);
+  auto manager = make_shared<ObjectsManager>(config, true);
   task.setObjectsManager(manager);
   //  o2::framework::InitContext ctx;
   //  task.initialize(ctx);

--- a/Modules/Skeleton/test/testQcSkeleton.cxx
+++ b/Modules/Skeleton/test/testQcSkeleton.cxx
@@ -34,6 +34,8 @@ BOOST_AUTO_TEST_CASE(instantiate_task)
 {
   SkeletonTask task;
   TaskConfig config;
+  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.taskName = "qcSkeletonTest";
   auto manager = make_shared<ObjectsManager>(config);
   task.setObjectsManager(manager);
   //  o2::framework::InitContext ctx;

--- a/Modules/TOF/CMakeLists.txt
+++ b/Modules/TOF/CMakeLists.txt
@@ -33,7 +33,9 @@ add_root_dictionary(QcTOF
 add_executable(testQcTOF test/testTOF.cxx)
 target_link_libraries(testQcTOF PRIVATE QcTOF Boost::unit_test_framework)
 add_test(NAME testQcTOF COMMAND testQcTOF)
-set_tests_properties(testQcTOF PROPERTIES TIMEOUT 60)
+set_property(TARGET ${test_name}
+  PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+set_tests_properties(testQcTOF PROPERTIES TIMEOUT 20)
 
 # ---- Executables ----
 


### PR DESCRIPTION
ServiceDiscovery and consul were causing problems in the CI of O2 for some reasons (unknown). 

We can now disable the ServiceDiscovery. It is used in the tests. Moreover we make sure that the tests are in folder tests and not bin. The timeout is decreased to 20 sec.