### PR TITLE
Unify CMakeLists.txt in modules

### DIFF
--- a/Modules/Common/CMakeLists.txt
+++ b/Modules/Common/CMakeLists.txt
@@ -6,7 +6,9 @@ configure_file("include/Common/Version.h.in"
 
 # ---- Library ----
 
-add_library(QcCommon src/NonEmpty.cxx src/MeanIsAbove.cxx)
+add_library(QcCommon)
+
+target_sources(QcCommon PRIVATE src/NonEmpty.cxx src/MeanIsAbove.cxx)
 
 target_include_directories(
   QcCommon

--- a/Modules/Daq/CMakeLists.txt
+++ b/Modules/Daq/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ---- Library ----
 
-add_library(QcDaq src/DaqTask.cxx src/EverIncreasingGraph.cxx)
+add_library(QcDaq)
+
+target_sources(QcDaq PRIVATE src/DaqTask.cxx src/EverIncreasingGraph.cxx)
 
 target_include_directories(
   QcDaq

--- a/Modules/Daq/include/Daq/LinkDef.h
+++ b/Modules/Daq/include/Daq/LinkDef.h
@@ -5,5 +5,4 @@
 
 #pragma link C++ class o2::quality_control_modules::daq::DaqTask + ;
 #pragma link C++ class o2::quality_control_modules::daq::EverIncreasingGraph + ;
-
 #endif

--- a/Modules/EMCAL/CMakeLists.txt
+++ b/Modules/EMCAL/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ---- Library ----
 
-add_library(QcEMCAL src/DigitsQcTask.cxx)
+add_library(QcEMCAL)
+
+target_sources(QcEMCAL PRIVATE src/DigitsQcTask.cxx)
 
 target_include_directories(
   QcEMCAL

--- a/Modules/Skeleton/.CMakeListsEmpty.txt
+++ b/Modules/Skeleton/.CMakeListsEmpty.txt
@@ -24,10 +24,18 @@ add_root_dictionary(QcSkeleton
 
 # ---- Test(s) ----
 
-add_executable(testQcSkeleton test/testQcSkeleton.cxx)
-target_link_libraries(testQcSkeleton
-                      PRIVATE QcSkeleton Boost::unit_test_framework)
-add_test(NAME testQcSkeleton COMMAND testQcSkeleton)
-set_property(TARGET ${test_name}
+set(TEST_SRCS test/testQcSkeleton.cxx)
+
+foreach(test ${TEST_SRCS})
+  get_filename_component(test_name ${test} NAME)
+  string(REGEX REPLACE ".cxx" "" test_name ${test_name})
+
+  add_executable(${test_name} ${test})
+  target_link_libraries(${test_name}
+                        PRIVATE QcSkeleton Boost::unit_test_framework)
+  add_test(NAME ${test_name} COMMAND ${test_name})
+  set_property(TARGET ${test_name}
     PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
-set_tests_properties(testQcSkeleton PROPERTIES TIMEOUT 20)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
+endforeach()
+

--- a/Modules/TOF/CMakeLists.txt
+++ b/Modules/TOF/CMakeLists.txt
@@ -1,9 +1,9 @@
 # ---- Library ----
 
-add_library(QcTOF src/TOFTask.cxx src/TOFCheckRawsMulti.cxx
-                  src/TOFCheckRawsTime.cxx src/TOFCheckRawsToT.cxx)
+add_library(QcTOF)
 
-target_sources(QcTOF PRIVATE)
+target_sources(QcTOF PRIVATE src/TOFTask.cxx src/TOFCheckRawsMulti.cxx
+        src/TOFCheckRawsTime.cxx src/TOFCheckRawsToT.cxx)
 
 target_include_directories(
   QcTOF


### PR DESCRIPTION
Thanks to that, module-configurator will still work for the existing modules.