### PR TITLE
Include explicitly ConfigParamRegistry.h

### DIFF
--- a/Framework/test/testTaskInterface.cxx
+++ b/Framework/test/testTaskInterface.cxx
@@ -21,6 +21,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <Framework/InitContext.h>
+#include <Framework/ConfigParamRegistry.h>
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 


### PR DESCRIPTION
InitContext will drop implicit include soon.