### PR TITLE
A non-static Version

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -226,7 +226,9 @@ set(TEST_SRCS
     test/testPostProcessingInterface.cxx
     test/testPostProcessingConfig.cxx
     test/testCheckWorkflow.cxx
-    test/testWorkflow.cxx)
+    test/testWorkflow.cxx
+    test/testVersion.cxx
+  )
 
 set(TEST_ARGS
     ""
@@ -249,7 +251,9 @@ set(TEST_ARGS
     ""
     ""
     "-b --run"
-    "-b --run")
+    "-b --run"
+    ""
+  )
 
 list(LENGTH TEST_SRCS count)
 math(EXPR count "${count}-1")
@@ -272,11 +276,14 @@ endforeach()
 
 foreach(t testTaskInterface testWorkflow testTaskRunner testCheckWorkflow
         testInfrastructureGenerator testPostProcessingConfig testPostProcessingInterface
-        testPostProcessingRunner testCheck testCheckRunner)
+        testPostProcessingRunner testCheck testCheckRunner )
   target_sources(${t} PRIVATE
                  ${CMAKE_BINARY_DIR}/getTestDataDirectory.cxx)
   target_include_directories(${t} PRIVATE ${CMAKE_SOURCE_DIR})
 endforeach()
+
+target_include_directories(testVersion PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
 set_property(TEST testWorkflow PROPERTY TIMEOUT 10)
 set_property(TEST testWorkflow PROPERTY LABELS slow)

--- a/Framework/include/QualityControl/Version.h.in
+++ b/Framework/include/QualityControl/Version.h.in
@@ -10,8 +10,7 @@
 
 ///
 /// \file    Version.h
-/// \brief   Report the version for this package.
-/// \author  bvonhall
+/// \author  Barthelemy von Haller
 ///
 
 #ifndef QC_CORE_VERSION_H
@@ -20,71 +19,87 @@
 #include <string>
 #include <sstream>
 
-namespace o2::quality_control::core
+namespace o2::quality_control::core {
+
+/// Represents a software package version.
+/// Inspired from https://sourcey.com/articles/comparing-version-strings-in-cpp
+class Version
 {
+  public:
 
-/// The current major version.
-#define QUALITYCONTROL_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+    /// Create a version from a string.
+    /// @param version The version in the form X.Y.Z. If minor or patch is missing, it is replaced by 0.
+    Version(std::string version)
+    {
+      std::sscanf(version.c_str(), "%d.%d.%d", &mMajor, &mMinor, &mPatch);
+    }
 
-/// The current minor version.
-#define QUALITYCONTROL_VERSION_MINOR @PROJECT_VERSION_MINOR@
+    Version(int major, int minor, int patch): mMajor(major), mMinor(minor), mPatch(patch)
+    {
+    }
 
-/// The current patch level.
-#define QUALITYCONTROL_VERSION_PATCH @PROJECT_VERSION_PATCH@
+    ~Version() = default;
 
-/// True if the current version is newer than the given one.
-#define QUALITYCONTROL_VERSION_GT(MAJOR, MINOR, PATCH) \
-  ((QUALITYCONTROL_VERSION_MAJOR > MAJOR) ||           \
-   (QUALITYCONTROL_VERSION_MAJOR ==                    \
-    MAJOR&&(QUALITYCONTROL_VERSION_MINOR > MINOR || (QUALITYCONTROL_VERSION_MINOR == MINOR&& QUALITYCONTROL_VERSION_PATCH > PATCH))))
+    /// \brief Returns the version of the QC framework.
+    /// Returns the version of the QC framework as found in CMake.
+    static Version& GetQcVersion()
+    {
+      // Guaranteed to be destroyed. Instantiated on first use
+      static Version qcVersion{@PROJECT_VERSION_MAJOR@, @PROJECT_VERSION_MINOR@, @PROJECT_VERSION_PATCH@};
+      return qcVersion;
+    }
 
-/// True if the current version is equal or newer to the given.
-#define QUALITYCONTROL_VERSION_GE(MAJOR, MINOR, PATCH) \
-  ((QUALITYCONTROL_VERSION_MAJOR > MAJOR) ||           \
-   (QUALITYCONTROL_VERSION_MAJOR ==                    \
-    MAJOR&&(QUALITYCONTROL_VERSION_MINOR > MINOR || (QUALITYCONTROL_VERSION_MINOR == MINOR&& QUALITYCONTROL_VERSION_PATCH >= PATCH))))
+    int getMajor() const
+    {
+      return mMajor;
+    }
 
-/// True if the current version is older than the given one.
-#define QUALITYCONTROL_VERSION_LT(MAJOR, MINOR, PATCH) \
-  ((QUALITYCONTROL_VERSION_MAJOR < MAJOR) ||           \
-   (QUALITYCONTROL_VERSION_MAJOR ==                    \
-    MAJOR&&(QUALITYCONTROL_VERSION_MINOR < MINOR || (QUALITYCONTROL_VERSION_MINOR == MINOR&& QUALITYCONTROL_VERSION_PATCH < PATCH))))
+    int getMinor() const
+    {
+      return mMinor;
+    }
 
-/// True if the current version is older or equal to the given.
-#define QUALITYCONTROL_VERSION_LE(MAJOR, MINOR, PATCH) \
-  ((QUALITYCONTROL_VERSION_MAJOR < MAJOR) ||           \
-   (QUALITYCONTROL_VERSION_MAJOR ==                    \
-    MAJOR&&(QUALITYCONTROL_VERSION_MINOR < MINOR || (QUALITYCONTROL_VERSION_MINOR == MINOR&& QUALITYCONTROL_VERSION_PATCH <= PATCH))))
+    int getPatch() const
+    {
+      return mPatch;
+    }
 
-/// Information about the current QualityControl version.
-class Version {
-public:
-  /// @return the current major version of QualityControl.
-  static int getMajor()
-  {
-    return QUALITYCONTROL_VERSION_MAJOR;
-  }
+    bool operator<(const Version &other)
+    {
+      if (getMajor() < other.getMajor()) {
+        return true;
+      }
+      if (getMinor() < other.getMinor()) {
+        return true;
+      }
+      if (getPatch() < other.getPatch()) {
+        return true;
+      }
+      return false;
+    }
 
-  /// @return the current minor version of QualityControl.
-  static int getMinor()
-  {
-    return QUALITYCONTROL_VERSION_MINOR;
-  }
+    bool operator==(const Version &other)
+    {
+      return getMajor() == other.getMajor()
+             && getMinor() == other.getMinor()
+             && getPatch() == other.getPatch();
+    }
 
-  /// @return the current patch level of QualityControl.
-  static int getPatch()
-  {
-    return QUALITYCONTROL_VERSION_PATCH;
-  }
+    friend std::ostream &operator<<(std::ostream &stream, const Version &ver)
+    {
+      stream << ver.getMajor() << '.' << ver.getMinor() << '.' << ver.getPatch();
+      return stream;
+    }
 
-  /// @return the current QualityControl version (MM.mm.pp).
-  static std::string getString()
-  {
-    std::ostringstream version;
-    version << QUALITYCONTROL_VERSION_MAJOR << '.' << QUALITYCONTROL_VERSION_MINOR << '.' << QUALITYCONTROL_VERSION_PATCH;
-    return version.str();
-  }
+    std::string getString()
+    {
+      std::ostringstream version;
+      version << this;
+      return version.str();
+    }
 
+  private:
+    int mMajor = 0, mMinor = 0, mPatch = 0;
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -109,7 +109,7 @@ void CcdbDatabase::storeMO(std::shared_ptr<o2::quality_control::core::MonitorObj
   // metadata
   map<string, string> metadata;
   // QC metadata (prefix qc_)
-  metadata["qc_version"] = Version::getString();
+  metadata["qc_version"] = Version::GetQcVersion().getString();
   // user metadata
   map<string, string> userMetadata = mo->getMetadataMap();
   if (!userMetadata.empty()) {
@@ -165,7 +165,7 @@ void CcdbDatabase::storeQO(std::shared_ptr<QualityObject> qo)
   // metadata
   map<string, string> metadata;
   // QC metadata (prefix qc_)
-  metadata["qc_version"] = Version::getString();
+  metadata["qc_version"] = Version::GetQcVersion().getString();
   metadata["qc_quality"] = std::to_string(qo->getQuality().getLevel());
 
   // other attributes

--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -200,7 +200,7 @@ void InfrastructureGenerator::customizeInfrastructure(std::vector<framework::Com
 void InfrastructureGenerator::printVersion()
 {
   // Log the version number
-  QcInfoLogger::GetInstance() << "QC version " << o2::quality_control::core::Version::getString() << infologger::endm;
+  QcInfoLogger::GetInstance() << "QC version " << o2::quality_control::core::Version::GetQcVersion().getString() << infologger::endm;
 }
 
 } // namespace o2::quality_control::core

--- a/Framework/test/testVersion.cxx
+++ b/Framework/test/testVersion.cxx
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   testQuality.cxx
+/// \author Barthelemy von Haller
+///
+
+#include "QualityControl/Version.h"
+
+#define BOOST_TEST_MODULE Quality test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <boost/test/output_test_stream.hpp>
+
+using namespace std;
+
+namespace o2::quality_control::core
+{
+
+BOOST_AUTO_TEST_CASE(test_original_version)
+{
+  assert((Version("3.7.8.0") == Version("3.7.8.0")) == true);
+  assert((Version("3.7.8.0") == Version("3.7.8")) == true);
+  assert((Version("3.7.8.0") < Version("3.7.8")) == false);
+  assert((Version("3.7.9") < Version("3.7.8")) == false);
+  assert((Version("3") < Version("3.7.9")) == true);
+  assert((Version("1.7.9") < Version("3.1")) == true);
+  assert((Version("") == Version("0.0.0")) == true);
+  assert((Version("0") == Version("0.0.0")) == true);
+  assert((Version("") != Version("0.0.1")) == true);
+
+  std::cout << "Printing version (3.7.8): " << Version("3.7.8.0") << std::endl;
+}
+
+BOOST_AUTO_TEST_CASE(test_version)
+{
+  Version v("2.0.0");
+  BOOST_CHECK(v == Version("2.0.0"));
+  Version qc = Version::GetQcVersion();
+  BOOST_CHECK(qc.getMajor() != 0 || qc.getMinor() != 0 || qc.getPatch() != 0);
+  cout << qc << endl;
+}
+
+BOOST_AUTO_TEST_CASE(test_output)
+{
+  Version v("1.2.3");
+  boost::test_tools::output_test_stream output;
+  output << v;
+
+  BOOST_CHECK(output.is_equal("1.2.3"));
+}
+
+} // namespace o2::quality_control::core


### PR DESCRIPTION
It will be needed when comparing versions of objects from the repository. Until now it was solely representing the version of the software package itself. 