### PR TITLE
[WIP] more output to understand the problem with failing ccdb test

### DIFF
--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -282,9 +282,11 @@ std::vector<std::string> CcdbDatabase::getPublishedObjectNames(std::string taskN
       } catch (std::out_of_range& ex) {
 
         ILOG(Info) << "std::out_of_range exception caught" << ENDM;
-        ILOG(Info) << "line: '" << line << "'";
-        ILOG(Info) << "taskNameEscaped: '" << taskNameEscaped << "'";
-        ILOG(Info) << "objNameStart: '" << objNameStart << "'";
+        ILOG(Info) << "line: '" << line << "'" << ENDM;
+        ILOG(Info) << "line.length(): '" << line.length() << "'" << ENDM;
+        ILOG(Info) << "line.length() - 2 - objNameStart: '" << line.length() - 2 - objNameStart << "'" << ENDM;
+        ILOG(Info) << "taskNameEscaped: '" << taskNameEscaped << "'" << ENDM;
+        ILOG(Info) << "objNameStart: '" << objNameStart << "'" << ENDM;
 
         throw ex;
       }

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -286,7 +286,7 @@ std::vector<std::string> CcdbDatabase::getPublishedObjectNames(std::string taskN
         ILOG(Info) << "line.length(): '" << line.length() << "'" << ENDM;
         ILOG(Info) << "line.length() - 2 - objNameStart: '" << line.length() - 2 - objNameStart << "'" << ENDM;
         ILOG(Info) << "taskNameEscaped: '" << taskNameEscaped << "'" << ENDM;
-        ILOG(Info) << "objNameStart: '" << objNameStart << "'" << ENDM;
+        ILOG(Info) << "objNameStart: '" << objNameStart << "' " << ENDM;
 
         throw ex;
       }

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -276,8 +276,18 @@ std::vector<std::string> CcdbDatabase::getPublishedObjectNames(std::string taskN
     rtrim(line);
     if (line.length() > 0 && line.find("\"path\"") == 0) {
       unsigned long objNameStart = 9 + taskNameEscaped.length();
-      string path = line.substr(objNameStart, line.length() - 2 /*final 2 char*/ - objNameStart);
-      result.push_back(path);
+      try {
+        string path = line.substr(objNameStart, line.length() - 2 /*final 2 char*/ - objNameStart);
+        result.push_back(path);
+      } catch (std::out_of_range& ex) {
+
+        ILOG(Info) << "std::out_of_range exception caught" << ENDM;
+        ILOG(Info) << "line: '" << line << "'";
+        ILOG(Info) << "taskNameEscaped: '" << taskNameEscaped << "'";
+        ILOG(Info) << "objNameStart: '" << objNameStart << "'";
+
+        throw ex;
+      }
     }
   }
 


### PR DESCRIPTION
@Barthelemy It seems that the problem is quite random, but happens only when listing the "qc" directory, which is probably the largest:
```
2020-01-10 04:43:54.281127     getPublishedObjectNames of task qc
Running 5 test cases...
unknown location(0): [4;31;49mfatal error: in "ccdb_getobjects_name": std::out_of_range: basic_string::substr: __pos (which is 11) > this->size() (which is 10)[0;39;49m
```
I think this is the place where the exception gets thrown, let's see what are the conditions when it happens.  