### PR TITLE
moved executable and config file for example TPC PID task to Modules/TPC/run

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -126,7 +126,6 @@ set(EXE_SRCS
     src/runDataProducerExample.cxx
     src/runQC.cxx
     src/runBasic.cxx
-    src/runTPCQCPID.cxx
     src/runAdvanced.cxx
     src/runReadout.cxx
     src/runMergerTest.cxx
@@ -140,7 +139,6 @@ set(EXE_NAMES
     o2-qc-run-producer-basic
     o2-qc
     o2-qc-run-basic
-    o2-qc-run-tpcpid
     o2-qc-run-advanced
     o2-qc-run-readout
     o2-qc-run-merger-test
@@ -156,7 +154,6 @@ set(EXE_OLD_NAMES
     o2-qc-run-producer-basic
     o2-qc-run-qc
     qcRunBasic
-    qcRunTPCPID
     qcRunAdvanced
     qcRunReadout
     runMergerTest
@@ -366,7 +363,6 @@ install(FILES example-default.json
               alfa.json
               dataDump.json
               basic.json
-              tpcQCPID.json
               basic-no-sampling.json
               advanced.json
               readout.json

--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -11,12 +11,11 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
           ${O2_ROOT}/include/GPU)
 
-target_link_libraries(QcTPC PUBLIC QualityControl O2::TPCQC)
+target_link_libraries(QcTPC
+                      PUBLIC QualityControl
+                             O2::TPCQC)
 
-install(TARGETS QcTPC
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 
 add_root_dictionary(QcTPC
                     HEADERS include/TPC/PID.h
@@ -38,3 +37,32 @@ foreach(test ${TEST_SRCS})
   add_test(NAME ${test_name} COMMAND ${test_name})
   set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
 endforeach()
+
+# ---- Executables ----
+
+set(EXE_SRCS
+    run/runTPCQCTrackReader.cxx)
+
+set(EXE_NAMES
+    o2-qc-run-tpctrackreader)
+
+list(LENGTH EXE_SRCS count)
+math(EXPR count "${count}-1")
+foreach(i RANGE ${count})
+  list(GET EXE_SRCS ${i} src)
+  list(GET EXE_NAMES ${i} name)
+  add_executable(${name} ${src})
+  target_link_libraries(${name} PRIVATE QcTPC ROOT::Tree)
+endforeach()
+
+# ---- Install ----
+
+install(TARGETS QcTPC ${EXE_NAMES}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# ---- Install config files ----
+
+install(FILES run/tpcQCPID.json
+        DESTINATION etc)

--- a/Modules/TPC/run/runTPCQCTrackReader.cxx
+++ b/Modules/TPC/run/runTPCQCTrackReader.cxx
@@ -108,17 +108,5 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
 
 specs.push_back(producer);
 
-// ===| QC task |=============================================================
-//
-std::string filename = "tpcQCPID.json";
-const std::string qcConfigurationSource = std::string("json://") + getenv("QUALITYCONTROL_ROOT") + "/etc/" + filename;
-LOG(INFO) << "Using config file '" << qcConfigurationSource << "'";
-
-// Generation of Data Sampling infrastructure
-DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
-
-// Generation of the QC topology (one task, one checker in this case)
-o2::quality_control::generateRemoteInfrastructure(specs, qcConfigurationSource);
-
 return specs;
 }

--- a/Modules/TPC/run/tpcQCPID.json
+++ b/Modules/TPC/run/tpcQCPID.json
@@ -11,6 +11,15 @@
       "Activity": {
         "number": "42",
         "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
       }
     },
     "tasks": {
@@ -18,6 +27,7 @@
         "active": "true",
         "className": "o2::quality_control_modules::tpc::PID",
         "moduleName": "QcTPC",
+        "detectorName": "TPC",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
@@ -37,14 +47,7 @@
       "id": "tpc-tracks",
       "active": "true",
       "machines": [],
-      "dataHeaders": [
-        {
-          "binding": "tpc-sampled-tracks",
-          "dataOrigin": "TPC",
-          "dataDescription": "TRACKS"
-        }
-      ],
-      "subSpec": "0",
+      "query" : "tpc-sampled-tracks:TPC/TRACKS/0",
       "samplingConditions": [
         {
           "condition": "random",


### PR DESCRIPTION
- moved config file of the TPC PID task to Modules/TPC/run + some changes to config file
- moved and renamed the executable of the example TPC PID task to Modules/TPC/run and removed the "QC task" part so that it is a pure file reader for tracks and can be piped into o2-qc