### PR TITLE
Fix TPC PID json file: add checker

### DIFF
--- a/Modules/TPC/run/tpcQCPID.json
+++ b/Modules/TPC/run/tpcQCPID.json
@@ -36,9 +36,22 @@
           "name": "tpc-tracks"
         },
         "taskParameters": {
-          "nothing": "rien"
+          "myOwnKey": "myOwnValue"
         },
         "location": "remote"
+      }
+    },
+    "checks": {
+      "QcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
+        "moduleName": "QcSkeleton",
+        "policy": "OnAny",
+        "dataSource": [{
+          "type": "Task",
+          "name": "TPCQCPID",
+          "MOs": ["example"]
+        }]
       }
     }
   },


### PR DESCRIPTION
A checker is added to the tpcQCPID.json file, because this is needed for the output to be stored and send to the QCG.