### PR TITLE
Replacing DataAllocator::adopt by snapshot to prepare for O2 PR 2887

### DIFF
--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -32,6 +32,7 @@
 #include "QualityControl/TaskFactory.h"
 
 #include <string>
+#include <memory>
 
 using namespace std;
 
@@ -380,16 +381,18 @@ int TaskRunner::publish(DataAllocator& outputs)
   QcInfoLogger::GetInstance() << "Send data from " << mTaskConfig.taskName << " len: " << mObjectsManager->getNumberPublishedObjects() << AliceO2::InfoLogger::InfoLogger::endm;
   AliceO2::Common::Timer publicationDurationTimer;
 
-  TObjArray* array = mObjectsManager->getNonOwningArray();
+  auto concreteOutput = framework::DataSpecUtils::asConcreteDataMatcher(mMonitorObjectsSpec);
+  // getNonOwningArray creates a TObjArray containing the monitoring objects, but not
+  // owning them. The array is created by new and must be cleaned up by the caller
+  std::unique_ptr<TObjArray> array(mObjectsManager->getNonOwningArray());
   int objectsPublished = array->GetEntries();
 
-  auto concreteOutput = framework::DataSpecUtils::asConcreteDataMatcher(mMonitorObjectsSpec);
-  outputs.adopt(
+  outputs.snapshot(
     Output{ concreteOutput.origin,
             concreteOutput.description,
             concreteOutput.subSpec,
             mMonitorObjectsSpec.lifetime },
-    dynamic_cast<TObject*>(array));
+    *array);
 
   mLastPublicationDuration = publicationDurationTimer.getTime();
   return objectsPublished;

--- a/Framework/src/runMergerTest.cxx
+++ b/Framework/src/runMergerTest.cxx
@@ -67,11 +67,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           MonitorObject* mo = new MonitorObject(histo, "histo-task");
           mo->setIsOwner(true);
 
-          TObjArray* array = new TObjArray;
+          auto* array = &processingContext.outputs().make<TObjArray>(Output{ "TST", "HISTO", static_cast<o2::framework::DataAllocator::SubSpecificationType>(p + 1) });
           array->SetOwner(true);
           array->Add(mo);
-
-          processingContext.outputs().adopt(Output{ "TST", "HISTO", static_cast<o2::framework::DataAllocator::SubSpecificationType>(p + 1) }, array);
         }
       }
     };


### PR DESCRIPTION
The RootContext will be removed in PR AliceO2Group/AliceO2#2887 and also
DataAllocator::adopt using the deprecated RootContext will be removed.
Method has been replaced with either `snapshot` or `make`.