### PR TITLE
Switch testCcdbDatabase off in CI

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -300,7 +300,7 @@ set_property(TEST testCheckWorkflow PROPERTY LABELS slow)
 set_property(TEST testObjectsManager PROPERTY TIMEOUT 20)
 set_property(TEST testObjectsManager PROPERTY LABELS slow)
 set_property(TEST testCcdbDatabase PROPERTY TIMEOUT 15)
-set_property(TEST testCcdbDatabase PROPERTY LABELS slow)
+set_property(TEST testCcdbDatabase PROPERTY LABELS manual slow)
 set_property(TEST testCcdbDatabaseExtra PROPERTY LABELS manual)
 set_property(TEST testTrendingTask PROPERTY LABELS manual)
 


### PR DESCRIPTION
it is failing randomly with this:
```
 9/30 Test #13: testCcdbDatabase .................***Failed    3.91 sec
2020-02-10 11:05:50.474372     QC infologger initialized
2020-02-10 11:05:50.474388     CCDB backend selected
2020-02-10 11:05:50.474587  !  [1;33mWarning - QUALITYCONTROL_ROOT is not set thus the the streamerinfo ROOT file can't be found.
Consequently, old data might not be readable.[0m
2020-02-10 11:05:50.474611     *** ccdb_create ***
2020-02-10 11:05:50.474622     truncating data for my/task/*
2020-02-10 11:05:50.496021     CCDB backend selected
2020-02-10 11:05:50.496064  !  [1;33mWarning - QUALITYCONTROL_ROOT is not set thus the the streamerinfo ROOT file can't be found.
Consequently, old data might not be readable.[0m
2020-02-10 11:05:50.496085     *** ccdb_getobjects_name ***
2020-02-10 11:05:50.496102     getListing()
2020-02-10 11:05:50.516895     getPublishedObjectNames of task ABCCheck
2020-02-10 11:05:50.531720     getPublishedObjectNames of task Costin
2020-02-10 11:05:50.547783     getPublishedObjectNames of task DataQuality
2020-02-10 11:05:50.563137     getPublishedObjectNames of task ITSQCTrhesholdTask
2020-02-10 11:05:50.625411     getPublishedObjectNames of task ITSRAWDSTEST2
2020-02-10 11:05:50.779404     getPublishedObjectNames of task MLQC
2020-02-10 11:05:50.794036     getPublishedObjectNames of task no_cleanup
2020-02-10 11:05:50.810387     getPublishedObjectNames of task o2eveTest
2020-02-10 11:05:50.826828     getPublishedObjectNames of task PHOS
2020-02-10 11:05:50.839863     getPublishedObjectNames of task qc
Running 5 test cases...
unknown location(0): [4;31;49mfatal error: in "ccdb_getobjects_name": std::out_of_range: basic_string::substr: __pos (which is 11) > this->size() (which is 10)[0;39;49m
/mnt/mesos/sandbox/sandbox/sw/SOURCES/QualityControl/build_QualityControl_o2-dataflow/0/Framework/test/testCcdbDatabase.cxx(68): [1;36;49mlast checkpoint: "ccdb_getobjects_name" test entry[0;39;49m
2020-02-10 11:05:53.196690     CCDB backend selected
2020-02-10 11:05:53.196726  !  [1;33mWarning - QUALITYCONTROL_ROOT is not set thus the the streamerinfo ROOT file can't be found.
Consequently, old data might not be readable.[0m
2020-02-10 11:05:53.196738     *** ccdb_store ***
2020-02-10 11:05:53.366884     CCDB backend selected
2020-02-10 11:05:53.366932  !  [1;33mWarning - QUALITYCONTROL_ROOT is not set thus the the streamerinfo ROOT file can't be found.
Consequently, old data might not be readable.[0m
2020-02-10 11:05:53.366951     *** ccdb_retrieve ***
2020-02-10 11:05:53.378413     CCDB backend selected
2020-02-10 11:05:53.378444  !  [1;33mWarning - QUALITYCONTROL_ROOT is not set thus the the streamerinfo ROOT file can't be found.
Consequently, old data might not be readable.[0m
2020-02-10 11:05:53.378457     *** ccdb_retrieve_json ***
[json retrieve]: qc/TST/my/task/asdf/asdf

[1;31;49m*** 1 failure is detected in the test module "CcdbDatabase test"
[0;39;49m
```
Let's not pollute CI until it is fixed.