### PR TITLE
updates in TPC PID, json file for piping of RecoWorkflow

### DIFF
--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -64,5 +64,6 @@ install(TARGETS QcTPC ${EXE_NAMES}
 
 # ---- Install config files ----
 
-install(FILES run/tpcQCPID.json
+install(FILES run/tpcQCPID_sampled.json
+              run/tpcQCPID_direct.json
         DESTINATION etc)

--- a/Modules/TPC/run/tpcQCPID_direct.json
+++ b/Modules/TPC/run/tpcQCPID_direct.json
@@ -23,7 +23,7 @@
       }
     },
     "tasks": {
-      "TPCQCPID": {
+      "PID": {
         "active": "true",
         "className": "o2::quality_control_modules::tpc::PID",
         "moduleName": "QcTPC",
@@ -32,11 +32,11 @@
         "maxNumberCycles": "-1",
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
-          "type": "dataSamplingPolicy",
-          "name": "tpc-tracks"
+          "type": "direct",
+	  "query" : "inputTracks:TPC/TRACKS/0"
         },
         "taskParameters": {
-          "myOwnKey": "myOwnValue"
+          "nothing": "rien"
         },
         "location": "remote"
       }
@@ -49,26 +49,13 @@
         "policy": "OnAny",
         "dataSource": [{
           "type": "Task",
-          "name": "TPCQCPID",
+          "name": "PID",
           "MOs": ["example"]
         }]
       }
     }
   },
   "dataSamplingPolicies": [
-    {
-      "id": "tpc-tracks",
-      "active": "true",
-      "machines": [],
-      "query" : "tpc-sampled-tracks:TPC/TRACKS/0",
-      "samplingConditions": [
-        {
-          "condition": "random",
-          "fraction": "0.9",
-          "seed": "1234"
-        }
-      ],
-      "blocking": "false"
-    }
+
   ]
 }

--- a/Modules/TPC/run/tpcQCPID_sampled.json
+++ b/Modules/TPC/run/tpcQCPID_sampled.json
@@ -1,0 +1,74 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "PID": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::PID",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "tpc-tracks"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "QcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
+        "moduleName": "QcSkeleton",
+        "policy": "OnAny",
+        "dataSource": [{
+          "type": "Task",
+          "name": "PID",
+          "MOs": ["example"]
+        }]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "tpc-tracks",
+      "active": "true",
+      "machines": [],
+      "query" : "inputTracks:TPC/TRACKS/0",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.9",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/Modules/TPC/src/PID.cxx
+++ b/Modules/TPC/src/PID.cxx
@@ -16,10 +16,12 @@
 // root includes
 #include <TCanvas.h>
 #include <TH1.h>
+#include <TH2.h>
 
 // O2 includes
 #include "Framework/ProcessingContext.h"
 #include "DataFormatsTPC/TrackTPC.h"
+#include "TPCQC/Helpers.h"
 
 // QC includes
 #include "QualityControl/QcInfoLogger.h"
@@ -39,10 +41,17 @@ void PID::initialize(o2::framework::InitContext& /*ctx*/)
   QcInfoLogger::GetInstance() << "initialize TPC PID QC task" << AliceO2::InfoLogger::InfoLogger::endm;
 
   mQCPID.initializeHistograms();
+  //o2::tpc::qc::helpers::setStyleHistogram1D(mQCPID.getHistograms1D());
+  o2::tpc::qc::helpers::setStyleHistogram2D(mQCPID.getHistograms2D());
 
   for (auto& hist : mQCPID.getHistograms1D()) {
     getObjectsManager()->startPublishing(&hist);
     getObjectsManager()->addMetadata(hist.GetName(), "custom", "34");
+  }
+
+  for (auto& hist : mQCPID.getHistograms2D()) {
+    getObjectsManager()->startPublishing(&hist);
+    getObjectsManager()->addMetadata(hist.GetName(), "custom", "43");
   }
 }
 
@@ -60,7 +69,7 @@ void PID::startOfCycle()
 void PID::monitorData(o2::framework::ProcessingContext& ctx)
 {
   using TrackType = std::vector<o2::tpc::TrackTPC>;
-  auto tracks = ctx.inputs().get<TrackType>("tpc-sampled-tracks");
+  auto tracks = ctx.inputs().get<TrackType>("inputTracks");
   QcInfoLogger::GetInstance() << "monitorData: " << tracks.size() << AliceO2::InfoLogger::InfoLogger::endm;
 
   for (auto const& track : tracks) {


### PR DESCRIPTION
Minor changes in the TPC PID part and added tpcQCPID_direct.json that can be used to pipe the tpc-reco-workflow into a QC workflow.