### PR TITLE
Update the CheckInterface version for ROOT dictionary

### DIFF
--- a/Framework/include/QualityControl/CheckInterface.h
+++ b/Framework/include/QualityControl/CheckInterface.h
@@ -90,7 +90,7 @@ class CheckInterface
   //  private:
   //    std::string mName;
 
-  ClassDef(CheckInterface, 1)
+  ClassDef(CheckInterface, 2)
 };
 
 } // namespace o2::quality_control::checker


### PR DESCRIPTION
We changed the interface, but we didn't update the version. Better later than never. It *might* have something to do with https://alice-talk.web.cern.ch/t/building-qualitycontrol-master-failed/495/2