### PR TITLE
TPC QC Tracks workflow including json configs

### DIFF
--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 add_library(QcTPC)
 
-target_sources(QcTPC PRIVATE src/PID.cxx)
+target_sources(QcTPC PRIVATE src/PID.cxx
+                             src/Tracks.cxx)
 
 target_include_directories(
   QcTPC
@@ -19,6 +20,7 @@ target_link_libraries(QcTPC
 
 add_root_dictionary(QcTPC
                     HEADERS include/TPC/PID.h
+                            include/TPC/Tracks.h
                     LINKDEF include/TPC/LinkDef.h
                     BASENAME QcTPC)
 
@@ -66,4 +68,6 @@ install(TARGETS QcTPC ${EXE_NAMES}
 
 install(FILES run/tpcQCPID_sampled.json
               run/tpcQCPID_direct.json
+              run/tpcQCTracks_sampled.json
+              run/tpcQCTracks_direct.json
         DESTINATION etc)

--- a/Modules/TPC/include/TPC/LinkDef.h
+++ b/Modules/TPC/include/TPC/LinkDef.h
@@ -4,4 +4,5 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::quality_control_modules::tpc::PID+;
+#pragma link C++ class o2::quality_control_modules::tpc::Tracks+;
 #endif

--- a/Modules/TPC/include/TPC/Tracks.h
+++ b/Modules/TPC/include/TPC/Tracks.h
@@ -28,16 +28,15 @@ namespace o2::quality_control_modules::tpc
 {
 
 /// \brief Quality Control DPL Task for QC Module TPC for track related observables
-/// It is final because there is no reason to derive from it. Just remove it if needed.
-/// \author Barthelemy von Haller
-/// \author Piotr Konopka
+/// \author Stefan Heckel
+
 class Tracks /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
 {
  public:
   /// \brief Constructor
-  Tracks();
+  Tracks() = default;
   /// Destructor
-  ~Tracks() override;
+  ~Tracks() override = default;
 
   // Definition of the methods for the template method pattern
   void initialize(o2::framework::InitContext& ctx) override;
@@ -49,7 +48,7 @@ class Tracks /*final*/ : public TaskInterface // todo add back the "final" when 
   void reset() override;
 
  private:
-  o2::tpc::qc::Tracks mQCTracks{};
+  o2::tpc::qc::Tracks mQCTracks{}; ///< TPC QC class from o2
 };
 
 } // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/include/TPC/Tracks.h
+++ b/Modules/TPC/include/TPC/Tracks.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Tracks.h
+/// \author Stefan Heckel, sheckel@cern.ch
+///
+
+#ifndef QC_MODULE_TPC_Tracks_H
+#define QC_MODULE_TPC_Tracks_H
+
+// O2 includes
+#include "TPCQC/Tracks.h"
+
+// QC includes
+#include "QualityControl/TaskInterface.h"
+
+using namespace o2::quality_control::core;
+
+namespace o2::quality_control_modules::tpc
+{
+
+/// \brief Quality Control DPL Task for QC Module TPC for track related observables
+/// It is final because there is no reason to derive from it. Just remove it if needed.
+/// \author Barthelemy von Haller
+/// \author Piotr Konopka
+class Tracks /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+{
+ public:
+  /// \brief Constructor
+  Tracks();
+  /// Destructor
+  ~Tracks() override;
+
+  // Definition of the methods for the template method pattern
+  void initialize(o2::framework::InitContext& ctx) override;
+  void startOfActivity(Activity& activity) override;
+  void startOfCycle() override;
+  void monitorData(o2::framework::ProcessingContext& ctx) override;
+  void endOfCycle() override;
+  void endOfActivity(Activity& activity) override;
+  void reset() override;
+
+ private:
+  o2::tpc::qc::Tracks mQCTracks{};
+};
+
+} // namespace o2::quality_control_modules::tpc
+
+#endif // QC_MODULE_TPC_Tracks_H

--- a/Modules/TPC/run/tpcQCTracks_direct.json
+++ b/Modules/TPC/run/tpcQCTracks_direct.json
@@ -1,0 +1,61 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "Tracks": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::Tracks",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "direct",
+          "query": "inputTracks:TPC/TRACKS/0"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "QcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
+        "moduleName": "QcSkeleton",
+        "policy": "OnAny",
+        "dataSource": [{
+          "type": "Task",
+          "name": "Tracks",
+          "MOs": ["example"]
+        }]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+
+  ]
+}

--- a/Modules/TPC/run/tpcQCTracks_sampled.json
+++ b/Modules/TPC/run/tpcQCTracks_sampled.json
@@ -1,0 +1,74 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "Tracks": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::Tracks",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "tpc-tracks"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "QcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
+        "moduleName": "QcSkeleton",
+        "policy": "OnAny",
+        "dataSource": [{
+          "type": "Task",
+          "name": "Tracks",
+          "MOs": ["example"]
+        }]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "tpc-tracks",
+      "active": "true",
+      "machines": [],
+      "query": "inputTracks:TPC/TRACKS/0",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.9",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/Modules/TPC/src/Tracks.cxx
+++ b/Modules/TPC/src/Tracks.cxx
@@ -17,7 +17,7 @@
 #include <TCanvas.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <gsl/span>
+//#include <gsl/span>
 
 // O2 includes
 #include "Framework/ProcessingContext.h"
@@ -60,14 +60,16 @@ void Tracks::startOfCycle()
 
 void Tracks::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  using TracksType = gsl::span<o2::tpc::TrackTPC>;
-  const auto tracks = ctx.inputs().get<TracksType>("inputTracks");
+  using TrackType = std::vector<o2::tpc::TrackTPC>;
+  auto tracks = ctx.inputs().get<TrackType>("inputTracks");
+  //using TracksType = gsl::span<o2::tpc::TrackTPC>;
+  //const auto tracks = ctx.inputs().get<TracksType>("inputTracks");
   QcInfoLogger::GetInstance() << "monitorData: " << tracks.size() << AliceO2::InfoLogger::InfoLogger::endm;
 
-  mQCTracks.processTracks(tracks);
-  //for (auto const& track : tracks) {
-  //  mQCTracks.processTrack(track);
-  //}
+  for (auto const& track : tracks) {
+    mQCTracks.processTrack(track);
+  }
+  //mQCTracks.processAllTracks(tracks);
 }
 
 void Tracks::endOfCycle()

--- a/Modules/TPC/src/Tracks.cxx
+++ b/Modules/TPC/src/Tracks.cxx
@@ -17,6 +17,7 @@
 #include <TCanvas.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <gsl/span>
 
 // O2 includes
 #include "Framework/ProcessingContext.h"
@@ -28,12 +29,6 @@
 
 namespace o2::quality_control_modules::tpc
 {
-
-Tracks::Tracks() : TaskInterface() {}
-
-Tracks::~Tracks()
-{
-}
 
 void Tracks::initialize(o2::framework::InitContext& /*ctx*/)
 {
@@ -65,13 +60,14 @@ void Tracks::startOfCycle()
 
 void Tracks::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  using TrackType = std::vector<o2::tpc::TrackTPC>;
-  auto tracks = ctx.inputs().get<TrackType>("inputTracks");
+  using TracksType = gsl::span<o2::tpc::TrackTPC>;
+  const auto tracks = ctx.inputs().get<TracksType>("inputTracks");
   QcInfoLogger::GetInstance() << "monitorData: " << tracks.size() << AliceO2::InfoLogger::InfoLogger::endm;
 
-  for (auto const& track : tracks) {
-    mQCTracks.processTrack(track);
-  }
+  mQCTracks.processTracks(tracks);
+  //for (auto const& track : tracks) {
+  //  mQCTracks.processTrack(track);
+  //}
 }
 
 void Tracks::endOfCycle()

--- a/Modules/TPC/src/Tracks.cxx
+++ b/Modules/TPC/src/Tracks.cxx
@@ -1,0 +1,95 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Tracks.cxx
+/// \author Stefan Heckel, sheckel@cern.ch
+///
+
+// root includes
+#include <TCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+
+// O2 includes
+#include "Framework/ProcessingContext.h"
+#include "DataFormatsTPC/TrackTPC.h"
+
+// QC includes
+#include "QualityControl/QcInfoLogger.h"
+#include "TPC/Tracks.h"
+
+namespace o2::quality_control_modules::tpc
+{
+
+Tracks::Tracks() : TaskInterface() {}
+
+Tracks::~Tracks()
+{
+}
+
+void Tracks::initialize(o2::framework::InitContext& /*ctx*/)
+{
+  QcInfoLogger::GetInstance() << "initialize TPC Tracks QC task" << AliceO2::InfoLogger::InfoLogger::endm;
+
+  mQCTracks.initializeHistograms();
+
+  for (auto& hist : mQCTracks.getHistograms1D()) {
+    getObjectsManager()->startPublishing(&hist);
+    getObjectsManager()->addMetadata(hist.GetName(), "custom", "34");
+  }
+
+  for (auto& hist2 : mQCTracks.getHistograms2D()) {
+    getObjectsManager()->startPublishing(&hist2);
+    getObjectsManager()->addMetadata(hist2.GetName(), "custom", "42");
+  }
+}
+
+void Tracks::startOfActivity(Activity& /*activity*/)
+{
+  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  mQCTracks.resetHistograms();
+}
+
+void Tracks::startOfCycle()
+{
+  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+}
+
+void Tracks::monitorData(o2::framework::ProcessingContext& ctx)
+{
+  using TrackType = std::vector<o2::tpc::TrackTPC>;
+  auto tracks = ctx.inputs().get<TrackType>("inputTracks");
+  QcInfoLogger::GetInstance() << "monitorData: " << tracks.size() << AliceO2::InfoLogger::InfoLogger::endm;
+
+  for (auto const& track : tracks) {
+    mQCTracks.processTrack(track);
+  }
+}
+
+void Tracks::endOfCycle()
+{
+  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+}
+
+void Tracks::endOfActivity(Activity& /*activity*/)
+{
+  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+}
+
+void Tracks::reset()
+{
+  // clean all the monitor objects here
+
+  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  mQCTracks.resetHistograms();
+}
+
+} // namespace o2::quality_control_modules::tpc


### PR DESCRIPTION
o This is the QualityControl part of the TPC QC task for the tracks
o It implements the workflow for the O2 TPC QC Tracks task
o It can be run with the also provided json configs, either:
  - using the availble TPC track reader and the sampled json
  - piped to a TPC reco workflow using the direct json