### PR TITLE
[WIP] TPC QC Tracks: now using gsl/span

### DIFF
--- a/Modules/TPC/src/Tracks.cxx
+++ b/Modules/TPC/src/Tracks.cxx
@@ -17,7 +17,7 @@
 #include <TCanvas.h>
 #include <TH1.h>
 #include <TH2.h>
-//#include <gsl/span>
+#include <gsl/span>
 
 // O2 includes
 #include "Framework/ProcessingContext.h"
@@ -60,16 +60,16 @@ void Tracks::startOfCycle()
 
 void Tracks::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  using TrackType = std::vector<o2::tpc::TrackTPC>;
-  auto tracks = ctx.inputs().get<TrackType>("inputTracks");
-  //using TracksType = gsl::span<o2::tpc::TrackTPC>;
-  //const auto tracks = ctx.inputs().get<TracksType>("inputTracks");
+  //using TrackType = std::vector<o2::tpc::TrackTPC>;
+  //auto tracks = ctx.inputs().get<TrackType>("inputTracks");
+  using TracksType = gsl::span<o2::tpc::TrackTPC>;
+  const auto tracks = ctx.inputs().get<TracksType>("inputTracks");
   QcInfoLogger::GetInstance() << "monitorData: " << tracks.size() << AliceO2::InfoLogger::InfoLogger::endm;
 
-  for (auto const& track : tracks) {
-    mQCTracks.processTrack(track);
-  }
-  //mQCTracks.processAllTracks(tracks);
+  //for (auto const& track : tracks) {
+  //  mQCTracks.processTrack(track);
+  //}
+  mQCTracks.processTracks(tracks);
 }
 
 void Tracks::endOfCycle()


### PR DESCRIPTION
This is the QC workflow part of the transition from a vector to gsl/span for the handing over of the TPC tracks from the QC workflow to the O2 TPC QC Tracks task.