### PR TITLE
[EMCAL-526, EMCAL-507] Adapt digits QC to timeframe handling

### DIFF
--- a/Modules/EMCAL/etc/digits.json
+++ b/Modules/EMCAL/etc/digits.json
@@ -32,7 +32,7 @@
           "maxNumberCycles": "-1",
           "dataSource": {
             "type": "direct",
-            "query": "emcal-digits:EMC/DIGITS/0"
+            "query": "emcal-digits:EMC/DIGITS/0;emcal-triggerecords:EMC/DIGITSTRGR/0"
           },
           "taskParameters": {
             "nothing": "rien"

--- a/Modules/EMCAL/src/runQCEMCALDigits.cxx
+++ b/Modules/EMCAL/src/runQCEMCALDigits.cxx
@@ -2,6 +2,7 @@
 #include <TH1.h>
 
 #include <Framework/DataSampling.h>
+#include <DataFormatsEMCAL/Digit.h>
 #include <EMCALWorkflow/PublisherSpec.h>
 #include "QualityControl/InfrastructureGenerator.h"
 #include "QualityControl/CheckRunner.h"
@@ -33,14 +34,17 @@ std::string getConfigPath(const o2::framework::ConfigContext& config);
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& config)
 {
   o2::framework::WorkflowSpec specs;
-  specs.push_back(o2::emcal::getPublisherSpec(o2::emcal::PublisherConf{
-                                                "emcal-digit-reader",
-                                                "o2sim",
-                                                { "digitbranch", "EMCALDigit", "Digit branch" },
-                                                { "mcbranch", "EMCALDigitMCTruth", "MC label branch" },
-                                                o2::framework::OutputSpec{ "EMC", "DIGITS" },
-                                                o2::framework::OutputSpec{ "EMC", "DIGITSMCTR" } },
-                                              false));
+  using digitInputType = std::vector<o2::emcal::Digit>;
+  specs.push_back(o2::emcal::getPublisherSpec<digitInputType>(o2::emcal::PublisherConf{
+                                                                "emcal-digit-reader",
+                                                                "o2sim",
+                                                                { "digitbranch", "EMCALDigit", "Digit branch" },
+                                                                { "triggerrecordbranch", "EMCALDigitTRGR", "Trigger record branch" },
+                                                                { "mcbranch", "EMCALDigitMCTruth", "MC label branch" },
+                                                                o2::framework::OutputSpec{ "EMC", "DIGITS" },
+                                                                o2::framework::OutputSpec{ "EMC", "DIGITSTRGR" },
+                                                                o2::framework::OutputSpec{ "EMC", "DIGITSMCTR" } },
+                                                              false));
 
   // Path to the config file
   std::string qcConfigurationSource = getConfigPath(config);


### PR DESCRIPTION
- Digits publisher adapted to read trigger records branch
- DigitQC looping over trigger records and digits in span
  defined by range in trigger record
- DigitsQC reading gsl::span instead of std::vector profiting
  from copyless access to data vectors