### PR TITLE
[QC-290] Test QualityObject

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -221,6 +221,7 @@ set(TEST_SRCS
     test/testCheckRunner.cxx
     test/testCheck.cxx
     test/testQuality.cxx
+    test/testQualityObject.cxx
     test/testObjectsManager.cxx
     test/testCcdbDatabase.cxx
     test/testCcdbDatabaseExtra.cxx
@@ -237,6 +238,7 @@ set(TEST_SRCS
   )
 
 set(TEST_ARGS
+    ""
     ""
     ""
     ""

--- a/Framework/include/QualityControl/CcdbDatabase.h
+++ b/Framework/include/QualityControl/CcdbDatabase.h
@@ -61,8 +61,8 @@ class CcdbDatabase : public DatabaseInterface
   std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = 0) override;
   // QualityObject
   void storeQO(std::shared_ptr<o2::quality_control::core::QualityObject> q) override;
-  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string checkerName, long timestamp = 0) override;
-  std::string retrieveQOJson(std::string checkName, long timestamp = 0) override;
+  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = 0) override;
+  std::string retrieveQOJson(std::string qoPath, long timestamp = 0) override;
 
   void disconnect() override;
   void prepareTaskDataContainer(std::string taskName) override;

--- a/Framework/include/QualityControl/DatabaseInterface.h
+++ b/Framework/include/QualityControl/DatabaseInterface.h
@@ -75,13 +75,13 @@ class DatabaseInterface
    * TODO evaluate whether we should have a method to retrieve a list of objects (optimization)
    */
   virtual std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = 0) = 0;
-  virtual std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string checkName, long timestamp = 0) = 0;
+  virtual std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = 0) = 0;
 
   /**
    * Returns JSON encoded object
    */
   virtual std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = 0) = 0;
-  virtual std::string retrieveQOJson(std::string checkName, long timestamp = 0) = 0;
+  virtual std::string retrieveQOJson(std::string qoPath, long timestamp = 0) = 0;
   virtual void disconnect() = 0;
   /**
    * \brief Prepare the container, such as a table in a relational database, that will contain the MonitorObject's for

--- a/Framework/include/QualityControl/MySqlDatabase.h
+++ b/Framework/include/QualityControl/MySqlDatabase.h
@@ -45,8 +45,8 @@ class MySqlDatabase : public DatabaseInterface
   std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = 0) override;
   // QualityObject
   void storeQO(std::shared_ptr<o2::quality_control::core::QualityObject> q) override;
-  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string checkerName, long timestamp = 0) override;
-  std::string retrieveQOJson(std::string checkName, long timestamp = 0) override;
+  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = 0) override;
+  std::string retrieveQOJson(std::string qoPath, long timestamp = 0) override;
 
   void disconnect() override;
   std::vector<std::string> getPublishedObjectNames(std::string taskName) override;

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -182,9 +182,9 @@ void CcdbDatabase::storeQO(std::shared_ptr<QualityObject> qo)
   ccdbApi.storeAsTFile(qo.get(), path, metadata, from, to);
 }
 
-std::shared_ptr<QualityObject> CcdbDatabase::retrieveQO(std::string checkerName, long timestamp)
+std::shared_ptr<QualityObject> CcdbDatabase::retrieveQO(std::string qoPath, long timestamp)
 {
-  string fullPath = checkerName;
+  string fullPath = qoPath;
   map<string, string> metadata;
   long when = timestamp == 0 ? getCurrentTimestamp() : timestamp;
 
@@ -200,14 +200,14 @@ std::shared_ptr<QualityObject> CcdbDatabase::retrieveQO(std::string checkerName,
   }
   std::shared_ptr<QualityObject> qo(dynamic_cast<QualityObject*>(object));
   if (qo == nullptr) {
-    LOG(ERROR) << "Could not cast the object " << checkerName << " to QualityObject";
+    LOG(ERROR) << "Could not cast the object " << qoPath << " to QualityObject";
   }
   return qo;
 }
 
-std::string CcdbDatabase::retrieveQOJson(std::string checkName, long /*timestamp*/)
+std::string CcdbDatabase::retrieveQOJson(std::string qoPath, long /*timestamp*/)
 {
-  auto qualityObject = retrieveQO(checkName);
+  auto qualityObject = retrieveQO(qoPath);
   if (qualityObject == nullptr) {
     return std::string();
   }

--- a/Framework/src/MySqlDatabase.cxx
+++ b/Framework/src/MySqlDatabase.cxx
@@ -235,14 +235,14 @@ void MySqlDatabase::storeForMonitorObject(std::string name)
   objects.clear();
 }
 
-std::shared_ptr<o2::quality_control::core::QualityObject> MySqlDatabase::retrieveQO(std::string checkName, long /*timestamp*/)
+std::shared_ptr<o2::quality_control::core::QualityObject> MySqlDatabase::retrieveQO(std::string qoPath, long /*timestamp*/)
 {
   // TODO use the timestamp
 
   string query;
   TMySQLStatement* statement = nullptr;
 
-  query += "SELECT object_name, data, updatetime, run, fill FROM data_" + checkName + " WHERE object_name = ?";
+  query += "SELECT object_name, data, updatetime, run, fill FROM data_" + qoPath + " WHERE object_name = ?";
   statement = (TMySQLStatement*)mServer->Statement(query.c_str());
   if (mServer->IsError()) {
     if (statement) {
@@ -253,7 +253,7 @@ std::shared_ptr<o2::quality_control::core::QualityObject> MySqlDatabase::retriev
                           << errinfo_db_message(mServer->GetErrorMsg()) << errinfo_db_errno(mServer->GetErrorCode()));
   }
   statement->NextIteration();
-  statement->SetString(0, checkName.c_str());
+  statement->SetString(0, qoPath.c_str());
 
   if (!(statement->Process() && statement->StoreResult())) {
     delete statement;
@@ -290,9 +290,9 @@ std::shared_ptr<o2::quality_control::core::QualityObject> MySqlDatabase::retriev
   return qo;
 }
 
-std::string MySqlDatabase::retrieveQOJson(std::string checkName, long /*timestamp*/)
+std::string MySqlDatabase::retrieveQOJson(std::string qoPath, long /*timestamp*/)
 {
-  auto qualityObject = retrieveQO(checkName);
+  auto qualityObject = retrieveQO(qoPath);
   if (qualityObject == nullptr) {
     return std::string();
   }

--- a/Framework/test/testQualityObject.cxx
+++ b/Framework/test/testQualityObject.cxx
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   testQualityObject.cxx
+/// \author Piotr Konopka
+///
+
+#include "QualityControl/QualityObject.h"
+#include "QualityControl/QcInfoLogger.h"
+
+#define BOOST_TEST_MODULE QualityObject test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+using namespace o2::quality_control::core;
+
+BOOST_AUTO_TEST_CASE(quality_object_test)
+{
+  QualityObject qo("xyzCheck");
+  qo.setDetectorName("INVALID");
+  qo.setDetectorName("TST");
+  qo.setQuality(Quality::Null);
+  qo.setQuality(Quality::Medium);
+  qo.setInputs({ "that should be overwritten" });
+  qo.setInputs({ "qc/TST/testTask/mo1", "qc/TST/testTask/mo2" });
+  qo.addMetadata("probability", "0.45");
+  qo.addMetadata("threshold_medium", "0.42");
+
+  BOOST_CHECK_EQUAL(qo.getName(), "xyzCheck");
+  BOOST_CHECK(strcmp(qo.GetName(), "xyzCheck") == 0);
+  BOOST_CHECK_EQUAL(qo.getDetectorName(), "TST");
+  BOOST_CHECK_EQUAL(qo.getQuality(), Quality::Medium);
+  BOOST_REQUIRE_EQUAL(qo.getInputs().size(), 2);
+  BOOST_CHECK_EQUAL(qo.getInputs()[0], "qc/TST/testTask/mo1");
+  BOOST_CHECK_EQUAL(qo.getInputs()[1], "qc/TST/testTask/mo2");
+  BOOST_REQUIRE_EQUAL(qo.getMetadataMap().count("probability"), 1);
+  BOOST_CHECK_EQUAL(qo.getMetadataMap()["probability"], "0.45");
+  BOOST_REQUIRE_EQUAL(qo.getMetadataMap().count("threshold_medium"), 1);
+  BOOST_CHECK_EQUAL(qo.getMetadataMap()["threshold_medium"], "0.42");
+}


### PR DESCRIPTION
There was just an empty test file.
Also giving more appropriate argument name to the `DatabaseInterface::retrieveQO` and `DatabaseInterface::retrieveQOJson` methods.