### PR TITLE
Add indirect header which came with Data Sampling

### DIFF
--- a/Framework/test/testCheckWorkflow.cxx
+++ b/Framework/test/testCheckWorkflow.cxx
@@ -14,6 +14,7 @@
 ///
 #include <Framework/DataSampling.h>
 #include <Framework/CompletionPolicyHelpers.h>
+#include <Framework/DeviceSpec.h>
 #include "QualityControl/InfrastructureGenerator.h"
 
 using namespace o2;

--- a/Modules/Example/src/ExampleCondition.cxx
+++ b/Modules/Example/src/ExampleCondition.cxx
@@ -14,6 +14,7 @@
 ///
 
 #include "Example/ExampleCondition.h"
+#include <boost/property_tree/ptree.hpp>
 
 namespace o2::quality_control_modules::example
 {


### PR DESCRIPTION
I plan to post a header cleanup in Data Sampling which should reduce the compilation time a bit. These two headers were previously brought by DataSampling, soon they won't be.