### PR TITLE
[QC-298] Doxygen-related cleanups

### DIFF
--- a/Modules/Common/src/TH2Reductor.cxx
+++ b/Modules/Common/src/TH2Reductor.cxx
@@ -31,7 +31,6 @@ const char* TH2Reductor::getBranchLeafList()
 
 void TH2Reductor::update(TObject* obj)
 {
-  // todo: use GetStats() instead?
   auto histo = dynamic_cast<TH2*>(obj);
   if (histo) {
     histo->GetStats(mStats.sums.array);

--- a/Modules/Daq/include/Daq/DaqTask.h
+++ b/Modules/Daq/include/Daq/DaqTask.h
@@ -32,7 +32,7 @@ namespace o2::quality_control_modules::daq
 /// \brief Example Quality Control Task
 /// It is final because there is no reason to derive from it. Just remove it if needed.
 /// \author Barthelemy von Haller
-class DaqTask /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+class DaqTask final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -33,7 +33,7 @@ namespace emcal
 /// Monitoring observables:
 /// - Digit amplitude for different towers
 /// - Digit time for different towers
-class DigitsQcTask /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+class DigitsQcTask final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/EMCAL/include/EMCAL/RawCheck.h
+++ b/Modules/EMCAL/include/EMCAL/RawCheck.h
@@ -25,10 +25,10 @@ using namespace o2::quality_control::core;
 namespace o2::quality_control_modules::emcal
 {
 
-/// \brief Example Quality Control DPL Task
+/// \brief EMCAL raw data check
 /// It is final because there is no reason to derive from it. Just remove it if needed.
-/// \author Barthelemy von Haller
-class RawCheck /*final*/ : public o2::quality_control::checker::CheckInterface // todo add back the "final" when doxygen is fixed
+/// \author Cristina Terrevoli
+class RawCheck final : public o2::quality_control::checker::CheckInterface
 {
  public:
   /// Default constructor

--- a/Modules/EMCAL/include/EMCAL/RawTask.h
+++ b/Modules/EMCAL/include/EMCAL/RawTask.h
@@ -35,7 +35,7 @@ namespace o2::quality_control_modules::emcal
 /// It is final because there is no reason to derive from it. Just remove it if needed.
 /// \author Barthelemy von Haller
 /// \author Piotr Konopka
-class RawTask /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+class RawTask final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/Example/include/Example/ExampleTask.h
+++ b/Modules/Example/include/Example/ExampleTask.h
@@ -18,7 +18,7 @@ namespace o2::quality_control_modules::example
 /// \brief Example Quality Control Task
 /// It is final because there is no reason to derive from it. Just remove it if needed.
 /// \author Barthelemy von Haller
-class ExampleTask /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+class ExampleTask final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/MFT/include/MFT/BasicDigitQcTask.h
+++ b/Modules/MFT/include/MFT/BasicDigitQcTask.h
@@ -30,7 +30,7 @@ namespace o2::quality_control_modules::mft
 ///
 /// \author Tomas Herman
 /// \author Guillermo Contreras
-class BasicDigitQcTask /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+class BasicDigitQcTask final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/Skeleton/include/Skeleton/SkeletonCheck.h
+++ b/Modules/Skeleton/include/Skeleton/SkeletonCheck.h
@@ -10,7 +10,7 @@
 
 ///
 /// \file   SkeletonCheck.h
-/// \author Piotr Konopka
+/// \author My Name
 ///
 
 #ifndef QC_MODULE_SKELETON_SKELETONCHECK_H
@@ -21,9 +21,8 @@
 namespace o2::quality_control_modules::skeleton
 {
 
-/// \brief  Check whether a plot is empty or not.
-///
-/// \author Barthelemy von Haller
+/// \brief  Example QC Check
+/// \author My Name
 class SkeletonCheck : public o2::quality_control::checker::CheckInterface
 {
  public:

--- a/Modules/Skeleton/include/Skeleton/SkeletonPostProcessing.h
+++ b/Modules/Skeleton/include/Skeleton/SkeletonPostProcessing.h
@@ -9,8 +9,8 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// \file    SkeletonPostProcessing.cxx
-/// \author  Piotr Konopka
+/// \file   SkeletonPostProcessing.h
+/// \author My Name
 ///
 
 #ifndef QUALITYCONTROL_SKELETONPOSTPROCESSING_H
@@ -24,7 +24,7 @@ namespace o2::quality_control_modules::skeleton
 {
 
 /// \brief Example Quality Control Postprocessing Task
-/// \author Piotr Konopka
+/// \author My Name
 class SkeletonPostProcessing final : public quality_control::postprocessing::PostProcessingInterface
 {
  public:

--- a/Modules/Skeleton/include/Skeleton/SkeletonTask.h
+++ b/Modules/Skeleton/include/Skeleton/SkeletonTask.h
@@ -10,8 +10,7 @@
 
 ///
 /// \file   SkeletonTask.h
-/// \author Barthelemy von Haller
-/// \author Piotr Konopka
+/// \author My Name
 ///
 
 #ifndef QC_MODULE_SKELETON_SKELETONTASK_H
@@ -27,10 +26,8 @@ namespace o2::quality_control_modules::skeleton
 {
 
 /// \brief Example Quality Control DPL Task
-/// It is final because there is no reason to derive from it. Just remove it if needed.
-/// \author Barthelemy von Haller
-/// \author Piotr Konopka
-class SkeletonTask /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+/// \author My Name
+class SkeletonTask final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/Skeleton/src/SkeletonCheck.cxx
+++ b/Modules/Skeleton/src/SkeletonCheck.cxx
@@ -10,7 +10,7 @@
 
 ///
 /// \file   SkeletonCheck.cxx
-/// \author Piotr Konopka
+/// \author My Name
 ///
 
 #include "Skeleton/SkeletonCheck.h"

--- a/Modules/Skeleton/src/SkeletonPostProcessing.cxx
+++ b/Modules/Skeleton/src/SkeletonPostProcessing.cxx
@@ -10,7 +10,7 @@
 
 ///
 /// \file   PostProcessingInterface.cxx
-/// \author Piotr Konopka
+/// \author My Name
 ///
 
 #include "Skeleton/SkeletonPostProcessing.h"

--- a/Modules/Skeleton/src/SkeletonTask.cxx
+++ b/Modules/Skeleton/src/SkeletonTask.cxx
@@ -10,8 +10,7 @@
 
 ///
 /// \file   SkeletonTask.cxx
-/// \author Barthelemy von Haller
-/// \author Piotr Konopka
+/// \author My Name
 ///
 
 #include <TCanvas.h>

--- a/Modules/Skeleton/test/.testEmpty.cxx
+++ b/Modules/Skeleton/test/.testEmpty.cxx
@@ -10,7 +10,7 @@
 
 ///
 /// \file   .testEmpty.cxx
-/// \author
+/// \author My Name
 ///
 
 #include "QualityControl/TaskFactory.h"

--- a/Modules/TOF/include/TOF/TOFDecoderCompressed.h
+++ b/Modules/TOF/include/TOF/TOFDecoderCompressed.h
@@ -30,9 +30,7 @@ namespace o2::quality_control_modules::tof
 
 /// \brief TOF Quality Control class for Decoding Compressed data for TOF Compressed data QC Task
 /// \author Nicolo' Jacazio
-class TOFDecoderCompressed /*final*/
-  : public DecoderBase
-// todo add back the "final" when doxygen is fixed
+class TOFDecoderCompressed final : public DecoderBase
 {
  public:
   /// \brief Constructor

--- a/Modules/TOF/include/TOF/TOFTask.h
+++ b/Modules/TOF/include/TOF/TOFTask.h
@@ -30,8 +30,7 @@ namespace o2::quality_control_modules::tof
 
 /// \brief TOF Quality Control DPL Task
 /// \author Nicolo' Jacazio
-class TOFTask            /*final*/
-  : public TaskInterface // todo add back the "final" when doxygen is fixed
+class TOFTask final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/TOF/include/TOF/TOFTaskCompressed.h
+++ b/Modules/TOF/include/TOF/TOFTaskCompressed.h
@@ -32,8 +32,7 @@ namespace o2::quality_control_modules::tof
 
 /// \brief TOF Quality Control DPL Task for TOF Compressed data
 /// \author Nicolo' Jacazio
-class TOFTaskCompressed  /*final*/
-  : public TaskInterface // todo add back the "final" when doxygen is fixed
+class TOFTaskCompressed final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/TPC/include/TPC/PID.h
+++ b/Modules/TPC/include/TPC/PID.h
@@ -29,11 +29,10 @@ using namespace o2::quality_control::core;
 namespace o2::quality_control_modules::tpc
 {
 
-/// \brief Example Quality Control DPL Task
+/// \brief TPC PID QC Task
 /// It is final because there is no reason to derive from it. Just remove it if needed.
-/// \author Barthelemy von Haller
-/// \author Piotr Konopka
-class PID /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+/// \author Jens Wiechula
+class PID final : public TaskInterface
 {
  public:
   /// \brief Constructor

--- a/Modules/TPC/include/TPC/Tracks.h
+++ b/Modules/TPC/include/TPC/Tracks.h
@@ -30,7 +30,7 @@ namespace o2::quality_control_modules::tpc
 /// \brief Quality Control DPL Task for QC Module TPC for track related observables
 /// \author Stefan Heckel
 
-class Tracks /*final*/ : public TaskInterface // todo add back the "final" when doxygen is fixed
+class Tracks final : public TaskInterface
 {
  public:
   /// \brief Constructor


### PR DESCRIPTION
Added back `final`, because it doesn't break doxygen anymore. Also removed our names from Skeleton classes, putting "My Name" instead, to encourage users to put their names there.