### PR TITLE
Handle special directory TST_KEEP

### DIFF
--- a/Framework/script/RepoCleaner/config.yaml
+++ b/Framework/script/RepoCleaner/config.yaml
@@ -3,6 +3,10 @@ Rules:
     delay: 240
     policy: 1_per_run
     delete_when_no_run: True
+  - object_path: qc/TST_KEEP/.*
+    delay: 240
+    policy: 1_per_run
+    delete_when_no_run: True
   - object_path: qc/.*       # Path in the CCDB to a certain object
     delay: 1440              # Delay in minutes during which a new object is not touched. (1 day)
     policy: 1_per_hour       # name of the policy to apply, must correspond to a python script.


### PR DESCRIPTION
1 per run (this is to keep the possibility to test backward compatibility)