### PR TITLE
Store a test object in the CCDB 

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -297,8 +297,8 @@ foreach(t testTaskInterface testWorkflow testTaskRunner testCheckWorkflow
   target_include_directories(${t} PRIVATE ${CMAKE_SOURCE_DIR})
 endforeach()
 
-target_include_directories(testVersion PRIVATE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+target_include_directories(testVersion PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+target_include_directories(testCcdbDatabase PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
 set_property(TEST testWorkflow PROPERTY TIMEOUT 10)
 set_property(TEST testWorkflow PROPERTY LABELS slow)

--- a/Framework/test/testCcdbDatabase.cxx
+++ b/Framework/test/testCcdbDatabase.cxx
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include "QualityControl/CcdbDatabase.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/Version.h"
 
 #define BOOST_TEST_MODULE CcdbDatabase test
 #define BOOST_TEST_MAIN
@@ -95,6 +96,23 @@ BOOST_AUTO_TEST_CASE(ccdb_store)
   qo1->setQuality(Quality::Bad);
 
   oldTimestamp = CcdbDatabase::getCurrentTimestamp();
+  f.backend->storeMO(mo1);
+  f.backend->storeQO(qo1);
+}
+
+BOOST_AUTO_TEST_CASE(ccdb_store_for_future_tests)
+{
+  // this test is storing a version of the objects in a different directory.
+  // The goal is to keep old versions of the objects, in old formats, for future backward compatibility testing.
+  test_fixture f;
+
+  TH1F* h1 = new TH1F("to_be_kept", "asdf", 100, 0, 99);
+  h1->FillRandom("gaus", 12345);
+  shared_ptr<MonitorObject> mo1 = make_shared<MonitorObject>(h1, "task", "TST_KEEP");
+  mo1->addMetadata("Run", o2::quality_control::core::Version::GetQcVersion().getString());
+  shared_ptr<QualityObject> qo1 = make_shared<QualityObject>("check", vector{ string("input1"), string("input2") }, "TST_KEEP");
+  qo1->setQuality(Quality::Bad);
+
   f.backend->storeMO(mo1);
   f.backend->storeQO(qo1);
 }

--- a/Framework/test/testCcdbDatabase.cxx
+++ b/Framework/test/testCcdbDatabase.cxx
@@ -112,6 +112,7 @@ BOOST_AUTO_TEST_CASE(ccdb_store_for_future_tests)
   mo1->addMetadata("Run", o2::quality_control::core::Version::GetQcVersion().getString());
   shared_ptr<QualityObject> qo1 = make_shared<QualityObject>("check", vector{ string("input1"), string("input2") }, "TST_KEEP");
   qo1->setQuality(Quality::Bad);
+  qo1->addMetadata("Run", o2::quality_control::core::Version::GetQcVersion().getString());
 
   f.backend->storeMO(mo1);
   f.backend->storeQO(qo1);


### PR DESCRIPTION
with its version number for future backward compatibility testing

