### PR TITLE
The MCHMappingFactory library will disappear in O2

### DIFF
--- a/Modules/MUON/MCH/CMakeLists.txt
+++ b/Modules/MUON/MCH/CMakeLists.txt
@@ -28,8 +28,10 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-#target_link_libraries(${MODULE_NAME} PUBLIC QualityControl)
-target_link_libraries(${MODULE_NAME} PUBLIC QualityControl O2::CommonDataFormat O2::GPUCommon O2::MCHMappingFactory O2::MCHMappingImpl3 O2::MCHMappingSegContour)
+target_link_libraries(${MODULE_NAME} PUBLIC QualityControl O2::CommonDataFormat O2::GPUCommon 
+        $<TARGET_NAME_IF_EXISTS:O2::MCHMappingFactory> O2::MCHMappingImpl3 O2::MCHMappingSegContour)
+
+target_compile_definitions(${MODULE_NAME} PRIVATE $<$<TARGET_EXISTS:O2::MCHMappingFactory>:MCH_HAS_MAPPING_FACTORY>)
 
 install(
         TARGETS ${MODULE_NAME}
@@ -40,8 +42,6 @@ install(
 
 # ---- ROOT dictionary ----
 
-#generate_root_dict(MODULE_NAME ${MODULE_NAME} LINKDEF "include/MCH/LinkDef.h" DICT_CLASS "${MODULE_NAME}Dict")
-
 add_root_dictionary(${MODULE_NAME}
                     HEADERS include/MCH/Mapping.h
                             include/MCH/Decoding.h
@@ -49,8 +49,7 @@ add_root_dictionary(${MODULE_NAME}
                             include/MCH/PhysicsTask.h
                             include/MCH/PedestalsCheck.h
                             include/MCH/sampa_header.h
-                    LINKDEF include/MCH/LinkDef.h
-                    BASENAME ${MODULE_NAME})
+                    LINKDEF include/MCH/LinkDef.h)
 
 # ---- Tests ----
 

--- a/Modules/MUON/MCH/include/MCH/PedestalsTask.h
+++ b/Modules/MUON/MCH/include/MCH/PedestalsTask.h
@@ -8,7 +8,6 @@
 
 #include "QualityControl/TaskInterface.h"
 #include "MCH/Mapping.h"
-#include "MCHMappingFactory/CreateSegmentation.h"
 #include "MCH/Decoding.h"
 #include "MCHBase/Digit.h"
 

--- a/Modules/MUON/MCH/src/Mapping.cxx
+++ b/Modules/MUON/MCH/src/Mapping.cxx
@@ -5,8 +5,11 @@
 
 #include "QualityControl/QcInfoLogger.h"
 #include "MCH/Mapping.h"
-//#include "MCHMappingInterface/Segmentation.h"
+#ifdef MCH_HAS_MAPPING_FACTORY
 #include "MCHMappingFactory/CreateSegmentation.h"
+#else
+#include "MCHMappingInterface/Segmentation.h"
+#endif
 
 using namespace std;
 

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -19,7 +19,9 @@
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHMappingInterface/CathodeSegmentation.h"
 #include "MCHRawElecMap/Mapper.h"
-
+#ifdef MCH_HAS_MAPPING_FACTORY
+#include "MCHMappingFactory/CreateSegmentation.h"
+#endif
 //#define QC_MCH_SAVE_TEMP_ROOTFILE
 
 using namespace std;
@@ -450,7 +452,7 @@ void PedestalsTask::monitorDataReadout(o2::framework::ProcessingContext& ctx)
 
 void PedestalsTask::monitorDataDigits(const o2::framework::DataRef& input)
 {
-  //QcInfoLogger::GetInstance() << "monitorDataDigits" << AliceO2::InfoLogger::InfoLogger::endm;
+//QcInfoLogger::GetInstance() << "monitorDataDigits" << AliceO2::InfoLogger::InfoLogger::endm;
 
 #ifdef QC_MCH_SAVE_TEMP_ROOTFILE
   if ((count % 10) == 0 /*&& count <= 5000*/) {

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -452,7 +452,7 @@ void PedestalsTask::monitorDataReadout(o2::framework::ProcessingContext& ctx)
 
 void PedestalsTask::monitorDataDigits(const o2::framework::DataRef& input)
 {
-//QcInfoLogger::GetInstance() << "monitorDataDigits" << AliceO2::InfoLogger::InfoLogger::endm;
+  //QcInfoLogger::GetInstance() << "monitorDataDigits" << AliceO2::InfoLogger::InfoLogger::endm;
 
 #ifdef QC_MCH_SAVE_TEMP_ROOTFILE
   if ((count % 10) == 0 /*&& count <= 5000*/) {


### PR DESCRIPTION
This commit lets the MCH QC Module handle gracefully that removal.
The function, CreateSegmentation, that is provided by the MCHMappingFactory, will still exist, but will be defined in the MCHMappingInterface library instead.
 
This QualityControl PR will in turn will allow the O2 PR https://github.com/AliceO2Group/AliceO2/pull/3313 to succeed the O2 suite check.