### PR TITLE
Align to O2 updates in TOF

### DIFF
--- a/Modules/TOF/include/TOF/Diagnostics.h
+++ b/Modules/TOF/include/TOF/Diagnostics.h
@@ -97,7 +97,8 @@ class Diagnostics final
   // void frameHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
   //                   const FrameHeader_t* frameHeader, const PackedHit_t* packedHits) override;
   void trailerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
-                      const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics) override;
+                      const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics,
+                      const Error_t* errors) override;
 };
 
 } // namespace o2::quality_control_modules::tof

--- a/Modules/TOF/include/TOF/TOFDecoderCompressed.h
+++ b/Modules/TOF/include/TOF/TOFDecoderCompressed.h
@@ -53,7 +53,8 @@ class TOFDecoderCompressed final : public DecoderBase
   void frameHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
                     const FrameHeader_t* frameHeader, const PackedHit_t* packedHits) override;
   void trailerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
-                      const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics) override;
+                      const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics,
+                      const Error_t* errors) override;
 };
 
 } // namespace o2::quality_control_modules::tof

--- a/Modules/TOF/include/TOF/TOFTaskCompressed.h
+++ b/Modules/TOF/include/TOF/TOFTaskCompressed.h
@@ -56,7 +56,7 @@ class TOFTaskCompressed final : public TaskInterface
   std::shared_ptr<TH1F> mTimeBC;         /// Time in Bunch Crossing
   std::shared_ptr<TH1F> mTOT;            /// Time-Over-Threshold
   std::shared_ptr<TH1F> mIndexE;         /// Index in electronic
-  std::shared_ptr<TH2F> mSlotEnableMask; /// Enabled slot
+  std::shared_ptr<TH2F> mSlotPartMask;   /// Participating slot
   std::shared_ptr<TH2F> mDiagnostic;     /// Diagnostic histogram
 };
 

--- a/Modules/TOF/src/Diagnostics.cxx
+++ b/Modules/TOF/src/Diagnostics.cxx
@@ -91,7 +91,8 @@ void Diagnostics::headerHandler(const CrateHeader_t* crateHeader, const CrateOrb
 }
 
 void Diagnostics::trailerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* /*crateOrbit*/,
-                                 const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics)
+                                 const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics,
+                                 const Error_t* /*errors*/)
 {
   LOG(INFO) << "DECODING!!!" << ENDM;
   Int_t drmID = crateHeader->drmID;

--- a/Modules/TOF/src/Diagnostics.cxx
+++ b/Modules/TOF/src/Diagnostics.cxx
@@ -83,7 +83,7 @@ void Diagnostics::headerHandler(const CrateHeader_t* crateHeader, const CrateOrb
   // mDRMCounter[crateHeader->drmID].Count(counters::kDRM_HAS_DATA);
   mDRMCounter[crateHeader->drmID].Count(0);
   for (Int_t i = 1; i < 11; i++) {
-    if (crateHeader->slotEnableMask & 1 << i) { // Magari includere l'LTM come i==0
+    if (crateHeader->slotPartMask & 1 << i) { // Magari includere l'LTM come i==0
       // mTRMCounter[crateHeader->drmID][i - 1].Count(counters::kTRM_HAS_DATA);
       mTRMCounter[crateHeader->drmID][i - 1].Count(0);
     }

--- a/Modules/TOF/src/TOFDecoderCompressed.cxx
+++ b/Modules/TOF/src/TOFDecoderCompressed.cxx
@@ -67,7 +67,8 @@ void TOFDecoderCompressed::frameHandler(const CrateHeader_t* crateHeader, const 
 }
 
 void TOFDecoderCompressed::trailerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* /*crateOrbit*/,
-                                          const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics)
+                                          const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics,
+                                          const Error_t* /*errors*/)
 {
   for (int i = 0; i < crateTrailer->numberOfDiagnostics; ++i) {
     auto diagnostic = diagnostics + i;

--- a/Modules/TOF/src/TOFDecoderCompressed.cxx
+++ b/Modules/TOF/src/TOFDecoderCompressed.cxx
@@ -38,8 +38,8 @@ void TOFDecoderCompressed::decode()
 void TOFDecoderCompressed::headerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* /*crateOrbit*/)
 {
   for (int ibit = 0; ibit < 11; ++ibit) {
-    if (crateHeader->slotEnableMask & (1 << ibit)) {
-      mHistos.at("hSlotEnableMask")->Fill(crateHeader->drmID, ibit + 2);
+    if (crateHeader->slotPartMask & (1 << ibit)) {
+      mHistos.at("hSlotPartMask")->Fill(crateHeader->drmID, ibit + 2);
     }
   }
 }

--- a/Modules/TOF/src/TOFTaskCompressed.cxx
+++ b/Modules/TOF/src/TOFTaskCompressed.cxx
@@ -39,7 +39,7 @@ TOFTaskCompressed::TOFTaskCompressed() : TaskInterface(),
                                          mTimeBC(nullptr),
                                          mTOT(nullptr),
                                          mIndexE(nullptr),
-                                         mSlotEnableMask(nullptr),
+                                         mSlotPartMask(nullptr),
                                          mDiagnostic(nullptr)
 {
 }
@@ -51,7 +51,7 @@ TOFTaskCompressed::~TOFTaskCompressed()
   mTimeBC.reset();
   mTOT.reset();
   mIndexE.reset();
-  mSlotEnableMask.reset();
+  mSlotPartMask.reset();
   mDiagnostic.reset();
 }
 
@@ -79,9 +79,9 @@ void TOFTaskCompressed::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mIndexE.get());
   mDecoder.mHistos[mIndexE->GetName()] = mIndexE;
   //
-  mSlotEnableMask.reset(new TH2F("hSlotEnableMask", "hSlotEnableMask;crate;slot", 72, 0., 72., 12, 1., 13.));
-  getObjectsManager()->startPublishing(mSlotEnableMask.get());
-  mDecoder.mHistos[mSlotEnableMask->GetName()] = mSlotEnableMask;
+  mSlotPartMask.reset(new TH2F("hSlotPartMask", "hSlotPartMask;crate;slot", 72, 0., 72., 12, 1., 13.));
+  getObjectsManager()->startPublishing(mSlotPartMask.get());
+  mDecoder.mHistos[mSlotPartMask->GetName()] = mSlotPartMask;
   //
   mDiagnostic.reset(new TH2F("hDiagnostic", "hDiagnostic;crate;slot", 72, 0., 72., 12, 1., 13.));
   getObjectsManager()->startPublishing(mDiagnostic.get());
@@ -97,7 +97,7 @@ void TOFTaskCompressed::startOfActivity(Activity& /*activity*/)
   mTimeBC->Reset();
   mTOT->Reset();
   mIndexE->Reset();
-  mSlotEnableMask->Reset();
+  mSlotPartMask->Reset();
   mDiagnostic->Reset();
 }
 
@@ -141,7 +141,7 @@ void TOFTaskCompressed::reset()
   mTime->Reset();
   mTOT->Reset();
   mIndexE->Reset();
-  mSlotEnableMask->Reset();
+  mSlotPartMask->Reset();
   mDiagnostic->Reset();
 }
 


### PR DESCRIPTION
This PR is needed to align the TOF `QualityControl` code to the changes in the decoding API provided by the `o2` .

Now, the issue is that the `o2` PR is failing checks because of a build error in `QualityControl`.
https://github.com/AliceO2Group/AliceO2/pull/3404

I imagine that this PR will also fail because the changes need the `o2` PR to be merged.
I hope this situation can be solved somehow.
@ktf suggested that both PR could be merged at the same time, but I don't know how technically this can be done with all checks passed