### PR TITLE
Removing additional exception information for better clarity

### DIFF
--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -90,7 +90,12 @@ void ObjectsManager::stopPublishing(const string& name)
 {
   auto* mo = dynamic_cast<MonitorObject*>(mMonitorObjects->FindObject(name.data()));
   if (mo == nullptr) {
-    BOOST_THROW_EXCEPTION(ObjectNotFoundError() << errinfo_object_name(name));
+    // TODO: ideally we want to pass the object name to the exception but the implementation
+    // of AliceO2::Common::ObjectNotFoundError drops additional information. For clarity we
+    // better skip
+    //    << errinfo_object_name(name));
+    // until this is fixed
+    BOOST_THROW_EXCEPTION(ObjectNotFoundError());
   }
   mMonitorObjects->Remove(mo);
 }
@@ -102,7 +107,12 @@ MonitorObject* ObjectsManager::getMonitorObject(std::string objectName)
   if (mo != nullptr) {
     return dynamic_cast<MonitorObject*>(mo);
   } else {
-    BOOST_THROW_EXCEPTION(ObjectNotFoundError() << errinfo_object_name(objectName));
+    // TODO: ideally we want to pass the object name to the exception but the implementation
+    // of AliceO2::Common::ObjectNotFoundError drops additional information. For clarity we
+    // better skip
+    //    << errinfo_object_name(objectName));
+    // until this is fixed
+    BOOST_THROW_EXCEPTION(ObjectNotFoundError());
   }
 }
 


### PR DESCRIPTION
I have been trying to help @tklemenz with debugging a qc workflow. There is an unhandled exception
```
[8009:QC-TASK-RUNNER-Clusters]: [19:10:11][ERROR] Unhandled exception reached the top of main: Object not found error, device shutting down.
```
which I wanted to understand. Since there is no further name string in the exception message my first assumption was that the methods are called with an empty string. But then I found that the implementation of of `AliceO2::Common::ObjectNotFoundError` drops additional information and for clarity we better skip writing more details into the exception until this is fixed.

https://github.com/AliceO2Group/Common/blob/3f92059e08f191ce6c65a5a9a119e5aba02b89ec/include/Common/Exceptions.h#L28

We can also take this suggestion as a trigger to fix the implementation in AliceO2/Common and maybe even add a sanity check for the arguments in `stopPublishing`/`getMonitoObject` to make the exception message more usable.

Last but not least, I suggest to handle the exception on the level of the QC framework, and only rethrow with additional information if the condition is really fatal.