### PR TITLE
Better report on exceptions in ObjectsManager (QC-333)

### DIFF
--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -69,11 +69,15 @@ class ObjectsManager
    * @param obj
    * @throw ObjectNotFoundError if object is not found.
    */
-  void stopPublishing(const std::string& name);
+  void stopPublishing(const std::string& objectName);
 
+  /**
+   * Returns the published MonitorObject specified by its name
+   * @param objectName The name of the object to find.
+   * @return A pointer to the MonitorObject.
+   * @throw ObjectNotFoundError if the object is not found.
+   */
   MonitorObject* getMonitorObject(std::string objectName);
-
-  TObject* getObject(std::string objectName);
 
   MonitorObjectCollection* getNonOwningArray() const;
 
@@ -83,6 +87,7 @@ class ObjectsManager
    * @param objectName Name of the MonitorObject.
    * @param key Key of the metadata.
    * @param value Value of the metadata.
+   * @throw ObjectNotFoundError if object is not found.
    */
   void addMetadata(const std::string& objectName, const std::string& key, const std::string& value);
 

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -37,7 +37,7 @@ ObjectsManager::ObjectsManager(TaskConfig& taskConfig, bool noDiscovery) : mTask
   if (!noDiscovery) {
     mServiceDiscovery = std::make_unique<ServiceDiscovery>(taskConfig.consulUrl, taskConfig.taskName);
   } else {
-    QcInfoLogger::GetInstance() << "Service Discovery disabled" << infologger::endm;
+    ILOG(Info) << "Service Discovery disabled" << ENDM;
     mServiceDiscovery = nullptr;
   }
 }
@@ -47,8 +47,7 @@ ObjectsManager::~ObjectsManager() = default;
 void ObjectsManager::startPublishing(TObject* object)
 {
   if (mMonitorObjects->FindObject(object->GetName()) != 0) {
-    QcInfoLogger::GetInstance() << "Object already being published (" << object->GetName() << ")"
-                                << infologger::endm;
+    ILOG(Warning) << "Object already being published (" << object->GetName() << ")" << ENDM;
     BOOST_THROW_EXCEPTION(DuplicateObjectError() << errinfo_object_name(object->GetName()));
   }
   auto* newObject = new MonitorObject(object, mTaskConfig.taskName, mTaskConfig.detectorName);
@@ -87,30 +86,20 @@ void ObjectsManager::stopPublishing(TObject* object)
   stopPublishing(object->GetName());
 }
 
-void ObjectsManager::stopPublishing(const string& name)
+void ObjectsManager::stopPublishing(const string& objectName)
 {
-  auto* mo = dynamic_cast<MonitorObject*>(mMonitorObjects->FindObject(name.data()));
-  if (mo == nullptr) {
-    BOOST_THROW_EXCEPTION(ObjectNotFoundError() << errinfo_object_name(name));
-  }
+  auto* mo = dynamic_cast<MonitorObject*>(getMonitorObject(objectName));
   mMonitorObjects->Remove(mo);
 }
 
 MonitorObject* ObjectsManager::getMonitorObject(std::string objectName)
 {
-  TObject* mo = mMonitorObjects->FindObject(objectName.c_str());
-
-  if (mo != nullptr) {
-    return dynamic_cast<MonitorObject*>(mo);
-  } else {
+  TObject* object = mMonitorObjects->FindObject(objectName.c_str());
+  if (object == nullptr) {
+    ILOG(Error) << "ObjectsManager: Unable to find object \"" << objectName << "\"" << ENDM;
     BOOST_THROW_EXCEPTION(ObjectNotFoundError() << errinfo_object_name(objectName));
   }
-}
-
-TObject* ObjectsManager::getObject(std::string objectName)
-{
-  MonitorObject* mo = getMonitorObject(objectName);
-  return mo->getObject();
+  return dynamic_cast<MonitorObject*>(object);
 }
 
 MonitorObjectCollection* ObjectsManager::getNonOwningArray() const
@@ -122,7 +111,7 @@ void ObjectsManager::addMetadata(const std::string& objectName, const std::strin
 {
   MonitorObject* mo = getMonitorObject(objectName);
   mo->addMetadata(key, value);
-  QcInfoLogger::GetInstance() << "Added metadata on " << objectName << " : " << key << " -> " << value << infologger::endm;
+  ILOG(Info) << "Added metadata on " << objectName << " : " << key << " -> " << value << ENDM;
 }
 
 int ObjectsManager::getNumberPublishedObjects()

--- a/Framework/test/testObjectsManager.cxx
+++ b/Framework/test/testObjectsManager.cxx
@@ -84,9 +84,6 @@ BOOST_AUTO_TEST_CASE(getters_test)
   BOOST_CHECK_NO_THROW(objectsManager.getMonitorObject("content"));
   BOOST_CHECK_NO_THROW(objectsManager.getMonitorObject("histo"));
   BOOST_CHECK_THROW(objectsManager.getMonitorObject("unexisting object"), ObjectNotFoundError);
-  BOOST_CHECK_NO_THROW(objectsManager.getObject("content"));
-  BOOST_CHECK_NO_THROW(objectsManager.getObject("histo"));
-  BOOST_CHECK_THROW(objectsManager.getObject("unexisting object"), ObjectNotFoundError);
 
   // non owning array
   TObjArray* array = objectsManager.getNonOwningArray();

--- a/Framework/test/testPublisher.cxx
+++ b/Framework/test/testPublisher.cxx
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(publisher_test)
   TObjString s("content");
   objectsManager.startPublishing(&s);
 
-  TObjString* s2 = (TObjString*)(objectsManager.getObject("content"));
+  TObjString* s2 = (TObjString*)(objectsManager.getMonitorObject("content")->getObject());
   BOOST_CHECK_EQUAL(s.GetString(), s2->GetString());
   MonitorObject* mo = nullptr;
   BOOST_CHECK_THROW(mo = objectsManager.getMonitorObject("test"), AliceO2::Common::ObjectNotFoundError);


### PR DESCRIPTION
Log the exceptions before throwing.
Remove unused method getObject.
Consistently use macro ILOG for logging.