### PR TITLE
CCDB api : Unify default value timestamp to -1 like in O2

### DIFF
--- a/Framework/include/QualityControl/CcdbDatabase.h
+++ b/Framework/include/QualityControl/CcdbDatabase.h
@@ -61,12 +61,12 @@ class CcdbDatabase : public DatabaseInterface
   void storeQO(std::shared_ptr<o2::quality_control::core::QualityObject> q) override;
 
   // retrieval - MO
-  std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = 0) override;
-  std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = 0) override;
+  std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = -1) override;
+  std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = -1) override;
 
   // retrieval - QO
-  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = 0) override;
-  std::string retrieveQOJson(std::string qoPath, long timestamp = 0) override;
+  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = -1) override;
+  std::string retrieveQOJson(std::string qoPath, long timestamp = -1) override;
 
   // retrieval - general
   std::string retrieveJson(std::string path, long timestamp, const std::map<std::string, std::string>& metadata) override;

--- a/Framework/include/QualityControl/DatabaseInterface.h
+++ b/Framework/include/QualityControl/DatabaseInterface.h
@@ -72,13 +72,13 @@ class DatabaseInterface
    * Look up a monitor object and return it if found or nullptr if not.
    * @deprecated
    */
-  virtual std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = 0) = 0;
+  virtual std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = -1) = 0;
   /**
    * \brief Look up a quality object and return it.
    * Look up a quality object and return it if found or nullptr if not.
    * @deprecated
    */
-  virtual std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = 0) = 0;
+  virtual std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = -1) = 0;
   /**
    * \brief Look up an object and return it.
    * Look up an object and return it if found or nullptr if not. It is a raw pointer because we might need it to build a MO.
@@ -94,13 +94,13 @@ class DatabaseInterface
    * Look up a monitor object and return it in JSON format if found or an empty string if not.
    * @deprecated
    */
-  virtual std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = 0) = 0;
+  virtual std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = -1) = 0;
   /**
    * \brief Look up a quality object and return it in JSON format.
    * Look up a quality object and return it in JSON format if found or an empty string if not.
    * @deprecated
    */
-  virtual std::string retrieveQOJson(std::string qoPath, long timestamp = 0) = 0;
+  virtual std::string retrieveQOJson(std::string qoPath, long timestamp = -1) = 0;
   /**
    * \brief Look up an object and return it in JSON format.
    * Look up an object and return it in JSON format if found or an empty string if not.

--- a/Framework/include/QualityControl/MySqlDatabase.h
+++ b/Framework/include/QualityControl/MySqlDatabase.h
@@ -41,12 +41,12 @@ class MySqlDatabase : public DatabaseInterface
   void connect(const std::unordered_map<std::string, std::string>& config) override;
   // MonitorObject
   void storeMO(std::shared_ptr<o2::quality_control::core::MonitorObject> q) override;
-  std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = 0) override;
-  std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = 0) override;
+  std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = -1) override;
+  std::string retrieveMOJson(std::string taskName, std::string objectName, long timestamp = -1) override;
   // QualityObject
   void storeQO(std::shared_ptr<o2::quality_control::core::QualityObject> q) override;
-  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = 0) override;
-  std::string retrieveQOJson(std::string qoPath, long timestamp = 0) override;
+  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = -1) override;
+  std::string retrieveQOJson(std::string qoPath, long timestamp = -1) override;
   // General
   std::string retrieveJson(std::string path, long timestamp, const std::map<std::string, std::string>& metadata) override;
   TObject* retrieveTObject(std::string path, const std::map<std::string, std::string>& metadata, long timestamp = -1, std::map<std::string, std::string>* headers = nullptr) override;

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -163,13 +163,11 @@ void CcdbDatabase::storeQO(std::shared_ptr<QualityObject> qo)
 
 TObject* CcdbDatabase::retrieveTObject(std::string path, std::map<std::string, std::string> const& metadata, long timestamp, std::map<std::string, std::string>* headers)
 {
-  long when = timestamp == 0 ? getCurrentTimestamp() : timestamp;
-
   // we try first to load a TFile
-  auto* object = ccdbApi.retrieveFromTFileAny<TObject>(path, metadata, when, headers);
+  auto* object = ccdbApi.retrieveFromTFileAny<TObject>(path, metadata, timestamp, headers);
   if (object == nullptr) {
     // We could not open a TFile we should now try to open an object directly serialized
-    object = ccdbApi.retrieve(path, metadata, when);
+    object = ccdbApi.retrieve(path, metadata, timestamp);
     if (object == nullptr) {
       ILOG(Error) << "We could NOT retrieve the object " << path << "." << ENDM;
       return nullptr;

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -180,10 +180,9 @@ TObject* CcdbDatabase::retrieveTObject(std::string path, std::map<std::string, s
 std::shared_ptr<core::MonitorObject> CcdbDatabase::retrieveMO(std::string taskName, std::string objectName, long timestamp)
 {
   string path = taskName + "/" + objectName;
-  long when = timestamp == 0 ? getCurrentTimestamp() : timestamp;
   map<string, string> headers;
   map<string, string> metadata;
-  TObject* obj = retrieveTObject(path, metadata, when, &headers);
+  TObject* obj = retrieveTObject(path, metadata, timestamp, &headers);
 
   // no object found
   if (obj == nullptr) {
@@ -217,10 +216,9 @@ std::shared_ptr<core::MonitorObject> CcdbDatabase::retrieveMO(std::string taskNa
 
 std::shared_ptr<QualityObject> CcdbDatabase::retrieveQO(std::string qoPath, long timestamp)
 {
-  long when = timestamp == 0 ? getCurrentTimestamp() : timestamp;
   map<string, string> headers;
   map<string, string> metadata;
-  TObject* obj = retrieveTObject(qoPath, metadata, when, &headers);
+  TObject* obj = retrieveTObject(qoPath, metadata, timestamp, &headers);
   std::shared_ptr<QualityObject> qo(dynamic_cast<QualityObject*>(obj));
   if (qo == nullptr) {
     ILOG(Error) << "Could not cast the object " << qoPath << " to QualityObject" << ENDM;

--- a/Framework/test/testCcdbDatabase.cxx
+++ b/Framework/test/testCcdbDatabase.cxx
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(ccdb_retrieve_json, *utf::depends_on("ccdb_store"))
   std::string task = "qc/TST/my/task";
   std::string object = "quarantine";
   std::cout << "[json retrieve]: " << task << "/" << object << std::endl;
-  auto json = f.backend->retrieveJson(task + "/" + object, 0, f.metadata);
+  auto json = f.backend->retrieveJson(task + "/" + object, -1, f.metadata);
   auto json2 = f.backend->retrieveMOJson(task, object);
 
   BOOST_CHECK(!json.empty());
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(ccdb_retrieve_json, *utf::depends_on("ccdb_store"))
 
   string qualityPath = "qc/checks/TST/test-ccdb-check";
   std::cout << "[json retrieve]: " << qualityPath << std::endl;
-  auto json3 = f.backend->retrieveJson(qualityPath, 0, f.metadata);
+  auto json3 = f.backend->retrieveJson(qualityPath, -1, f.metadata);
   auto json4 = f.backend->retrieveQOJson(qualityPath);
   BOOST_CHECK(!json3.empty());
   BOOST_CHECK_EQUAL(json3, json4);
@@ -217,8 +217,8 @@ BOOST_AUTO_TEST_CASE(ccdb_metadata, *utf::depends_on("ccdb_store"))
   test_fixture f;
   std::map<std::string, std::string> headers1;
   std::map<std::string, std::string> headers2;
-  TObject* obj1 = f.backend->retrieveTObject("qc/TST/my/task/quarantine", f.metadata, 0, &headers1);
-  TObject* obj2 = f.backend->retrieveTObject("qc/TST/my/task/metadata", f.metadata, 0, &headers2);
+  TObject* obj1 = f.backend->retrieveTObject("qc/TST/my/task/quarantine", f.metadata, -1, &headers1);
+  TObject* obj2 = f.backend->retrieveTObject("qc/TST/my/task/metadata", f.metadata, -1, &headers2);
   BOOST_CHECK_NE(obj1, nullptr);
   BOOST_CHECK_NE(obj2, nullptr);
   BOOST_CHECK(headers1.size() > 0);


### PR DESCRIPTION
There was a mixture of '0' and '-1' as default value for the timestamp parameter of the retrieval methods. In O2 we use '-1' thus I moved all the default values to '-1' (meaning current time stamp).