### PR TITLE
Add and remove monitoring metrics

### DIFF
--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -194,9 +194,7 @@ class CheckRunner : public framework::Task
 
   // monitoring
   std::shared_ptr<o2::monitoring::Monitoring> mCollector;
-  //  std::chrono::system_clock::time_point startFirstObject;
-  //  std::chrono::system_clock::time_point endLastObject;
-  int mTotalNumberHistosReceived;
+  int mTotalNumberObjectsReceived;
   int mTotalNumberCheckExecuted;
   int mTotalNumberQOStored;
   int mTotalNumberMOStored;

--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -29,6 +29,7 @@
 #include <Framework/Task.h>
 #include <Headers/DataHeader.h>
 #include <Monitoring/MonitoringFactory.h>
+#include <Configuration/ConfigurationInterface.h>
 #include <Framework/DataProcessorSpec.h>
 // QC
 #include "QualityControl/CheckInterface.h"
@@ -176,13 +177,13 @@ class CheckRunner : public framework::Task
   // General state
   std::string mDeviceName;
   std::vector<Check> mChecks;
-  std::string mConfigurationSource;
   o2::quality_control::core::QcInfoLogger& mLogger;
   std::shared_ptr<o2::quality_control::repository::DatabaseInterface> mDatabase;
   std::map<std::string, unsigned int> mMonitorObjectRevision;
   unsigned int mGlobalRevision = 1;
   std::unordered_set<std::string> mInputStoreSet;
   std::vector<std::shared_ptr<MonitorObject>> mMonitorObjectStoreVector;
+  std::shared_ptr<o2::configuration::ConfigurationInterface> mConfigFile;
 
   // DPL
   o2::framework::Inputs mInputs;
@@ -193,9 +194,12 @@ class CheckRunner : public framework::Task
 
   // monitoring
   std::shared_ptr<o2::monitoring::Monitoring> mCollector;
-  std::chrono::system_clock::time_point startFirstObject;
-  std::chrono::system_clock::time_point endLastObject;
+//  std::chrono::system_clock::time_point startFirstObject;
+//  std::chrono::system_clock::time_point endLastObject;
   int mTotalNumberHistosReceived;
+  int mTotalNumberCheckExecuted;
+  int mTotalNumberQOStored;
+  int mTotalNumberMOStored;
   AliceO2::Common::Timer timer;
 };
 

--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -88,7 +88,7 @@ class CheckRunner : public framework::Task
    * Create a sink for the Input. It is expected to receive Monitor Object to store.
    * It will not run any checks on a given input.
    *
-   * @param input Monitor Object input spec.
+   * @param input Monitor Object input spec
    * @param configSource Path to configuration
    */
   CheckRunner(o2::framework::InputSpec input, std::string configurationSource);

--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -194,8 +194,8 @@ class CheckRunner : public framework::Task
 
   // monitoring
   std::shared_ptr<o2::monitoring::Monitoring> mCollector;
-//  std::chrono::system_clock::time_point startFirstObject;
-//  std::chrono::system_clock::time_point endLastObject;
+  //  std::chrono::system_clock::time_point startFirstObject;
+  //  std::chrono::system_clock::time_point endLastObject;
   int mTotalNumberHistosReceived;
   int mTotalNumberCheckExecuted;
   int mTotalNumberQOStored;

--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -88,7 +88,7 @@ class CheckRunner : public framework::Task
    * Create a sink for the Input. It is expected to receive Monitor Object to store.
    * It will not run any checks on a given input.
    *
-   * @param input Monitor Object input spec
+   * @param input Monitor Object input spec.
    * @param configSource Path to configuration
    */
   CheckRunner(o2::framework::InputSpec input, std::string configurationSource);

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -152,7 +152,7 @@ CheckRunner::CheckRunner(std::vector<Check> checks, std::string configurationSou
     /* All checks have the same Input */
     mInputs(checks.front().getInputs()),
     mOutputs(CheckRunner::collectOutputs(checks)),
-    mTotalNumberHistosReceived(0),
+    mTotalNumberObjectsReceived(0),
     mTotalNumberCheckExecuted(0),
     mTotalNumberQOStored(0),
     mTotalNumberMOStored(0)
@@ -178,7 +178,7 @@ CheckRunner::CheckRunner(InputSpec input, std::string configurationSource)
     mLogger(QcInfoLogger::GetInstance()),
     mInputs{ input },
     mOutputs{},
-    mTotalNumberHistosReceived(0),
+    mTotalNumberObjectsReceived(0),
     mTotalNumberCheckExecuted(0),
     mTotalNumberQOStored(0),
     mTotalNumberMOStored(0)
@@ -227,7 +227,7 @@ void CheckRunner::run(framework::ProcessingContext& ctx)
 
         if (mo) {
           update(mo);
-          mTotalNumberHistosReceived++;
+          mTotalNumberObjectsReceived++;
 
           // Add monitor object to store later, after possible beautification
           if (store) {
@@ -252,7 +252,7 @@ void CheckRunner::run(framework::ProcessingContext& ctx)
   // monitoring
   if (timer.isTimeout()) {
     timer.reset(1000000); // 10 s.
-    mCollector->send({ mTotalNumberHistosReceived, "qc_objects_received" }, DerivedMetricMode::RATE);
+    mCollector->send({ mTotalNumberObjectsReceived, "qc_objects_received" }, DerivedMetricMode::RATE);
     mCollector->send({ mTotalNumberCheckExecuted, "qc_checks_executed" }, DerivedMetricMode::RATE);
     mCollector->send({ mTotalNumberQOStored, "qc_qo_stored" }, DerivedMetricMode::RATE);
     mCollector->send({ mTotalNumberMOStored, "qc_mo_stored" }, DerivedMetricMode::RATE);

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -161,7 +161,8 @@ CheckRunner::CheckRunner(std::vector<Check> checks, std::string configurationSou
     mConfigFile = ConfigurationFactory::getConfiguration(configurationSource);
   } catch (...) {
     // catch the exceptions and print it (the ultimate caller might not know how to display it)
-    ILOG(Fatal) << "Unexpected exception during initialization:\n" << boost::current_exception_diagnostic_information(true) << ENDM;
+    ILOG(Fatal) << "Unexpected exception during initialization:\n"
+                << boost::current_exception_diagnostic_information(true) << ENDM;
     throw;
   }
 }
@@ -186,7 +187,8 @@ CheckRunner::CheckRunner(InputSpec input, std::string configurationSource)
     mConfigFile = ConfigurationFactory::getConfiguration(configurationSource);
   } catch (...) {
     // catch the exceptions and print it (the ultimate caller might not know how to display it)
-    ILOG(Fatal) << "Unexpected exception during initialization:\n" << boost::current_exception_diagnostic_information(true) << ENDM;
+    ILOG(Fatal) << "Unexpected exception during initialization:\n"
+                << boost::current_exception_diagnostic_information(true) << ENDM;
     throw;
   }
 }

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -361,7 +361,6 @@ void CheckRunner::initMonitoring()
   mCollector->enableProcessMonitoring();
   mCollector->addGlobalTag(tags::Key::Subsystem, tags::Value::QC);
   mCollector->addGlobalTag("CheckRunnerName", mDeviceName);
-  startFirstObject = system_clock::time_point::min();
   timer.reset(1000000); // 10 s.
 }
 

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -41,7 +41,6 @@ using namespace o2::monitoring;
 using namespace o2::quality_control::core;
 using namespace o2::quality_control::repository;
 
-namespace bfs = boost::filesystem;
 const auto current_diagnostic = boost::current_exception_diagnostic_information;
 
 namespace o2::quality_control::checker


### PR DESCRIPTION
Keep only 4 metrics : 
- qc_objects_received
- qc_checks_executed 
- qc_mo_stored
- qc_qo_stored

They all have their rate published.