### PR TITLE
Decrease the timeout time for the ServiceDiscovery. 

### DIFF
--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -52,8 +52,8 @@ CURL* ServiceDiscovery::initCurl()
     throw std::runtime_error(std::string("cURL init") + curl_easy_strerror(globalInitResult));
   }
   CURL* curl = curl_easy_init();
-  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10);
-  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10);
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 2);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 2);
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
   curl_easy_setopt(curl, CURLOPT_TCP_KEEPIDLE, 120L);
   curl_easy_setopt(curl, CURLOPT_TCP_KEEPINTVL, 60L);


### PR DESCRIPTION
10 seconds makes it very slow for people who are not at CERN and hit the timetout each time.