### PR TITLE
removed unused DataBlockId

### DIFF
--- a/Modules/Daq/include/Daq/EverIncreasingGraph.h
+++ b/Modules/Daq/include/Daq/EverIncreasingGraph.h
@@ -40,9 +40,8 @@ class EverIncreasingGraph : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
-  DataBlockId mLastId;
 
-  ClassDefOverride(EverIncreasingGraph, 1);
+ClassDefOverride(EverIncreasingGraph, 1);
 };
 
 } // namespace o2::quality_control_modules::daq

--- a/Modules/Daq/include/Daq/EverIncreasingGraph.h
+++ b/Modules/Daq/include/Daq/EverIncreasingGraph.h
@@ -41,7 +41,7 @@ class EverIncreasingGraph : public o2::quality_control::checker::CheckInterface
 
  private:
 
-ClassDefOverride(EverIncreasingGraph, 1);
+  ClassDefOverride(EverIncreasingGraph, 1);
 };
 
 } // namespace o2::quality_control_modules::daq


### PR DESCRIPTION
var is unused and not referenced.
Will allow Common DataBLock.h cleanup.