### PR TITLE
Beautify only the checked objects

### DIFF
--- a/Framework/src/Check.cxx
+++ b/Framework/src/Check.cxx
@@ -191,7 +191,7 @@ void Check::initPolicy(std::string policyType)
 
     mPolicy = [](std::map<std::string, unsigned int>& revisionMap) {
       // Expecting check of this policy only if any change
-      (void)revisionMap; // Supprses Unused warning
+      (void)revisionMap; // Suppress Unused warning
       return true;
     };
 
@@ -316,7 +316,7 @@ QualityObjectsType Check::check(std::map<std::string, std::shared_ptr<MonitorObj
       mCheckConfig.policyType,
       mInputsStringified,
       monitorObjectsNames));
-    beautify(shadowMap, quality);
+    beautify(moMapToCheck, quality);
   }
 
   return qualityObjects;

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -278,7 +278,7 @@ void CheckRunner::update(std::shared_ptr<MonitorObject> mo)
 
 QualityObjectsType CheckRunner::check(std::map<std::string, std::shared_ptr<MonitorObject>> moMap)
 {
-  mLogger << "Running " << mChecks.size() << " checks for " << moMap.size() << " monitor objects"
+  mLogger << "Trying " << mChecks.size() << " checks for " << moMap.size() << " monitor objects"
           << ENDM;
 
   QualityObjectsType allQOs;


### PR DESCRIPTION
Objects were checked separately when requested, but beautified with all the qualities received.
This concerned only the new feature with the policy "OnEachSeparately", others should not have been affected.