### PR TITLE
Delete "ID" field in ServiceDiscovery JSON of a Check

### DIFF
--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -77,7 +77,6 @@ void ServiceDiscovery::_register(const std::string& objects)
   }
 
   boost::property_tree::ptree checks, check;
-  check.put("Id", mId);
   check.put("Name", "Health check " + mId);
   check.put("Interval", "5s");
   check.put("TCP", mHealthEndpoint);


### PR DESCRIPTION
The new version of Consul checks if there are any redundant keys and returns 400 if so.