### PR TITLE
[QC-346] Fix checking each MO separately when "all" MOs are specified

### DIFF
--- a/Framework/src/Check.cxx
+++ b/Framework/src/Check.cxx
@@ -98,11 +98,14 @@ void Check::initConfig(std::string checkName)
       mInputs.push_back({ taskName, TaskRunner::createTaskDataOrigin(), TaskRunner::createTaskDataDescription(taskName) });
 
       /*
-         * Subscribe on predefined MOs.
-         * If "MOs" not set or "MOs" set to "all", the check function will be triggered whenever a new MO appears.
-         */
+       * Subscribe on predefined MOs.
+       * If "MOs" are not set or "MOs" is set to "all", the check function will be triggered whenever a new MO appears.
+       */
       if (dataSource.count("MOs") == 0 || dataSource.get<std::string>("MOs") == "all") {
-        mCheckConfig.policyType = "_OnGlobalAny";
+        // fixme: this is a dirty fix. Policies should be refactored, so this check won't be needed.
+        if (mCheckConfig.policyType != "OnEachSeparately") {
+          mCheckConfig.policyType = "_OnGlobalAny";
+        }
         mCheckConfig.allMOs = true;
       } else {
         for (const auto& moName : dataSource.get_child("MOs")) {
@@ -114,7 +117,7 @@ void Check::initConfig(std::string checkName)
       }
     }
 
-    // Here can be implemented other sources for the Check then Task if needed
+    // Support for sources other than Tasks can be implemented here.
   }
   mInputsStringified = stringifyInput(mInputs);
 
@@ -174,6 +177,10 @@ void Check::initPolicy(std::string policyType)
      * only one MO to a check at once.
      */
     mPolicy = [&](std::map<std::string, unsigned int>& revisionMap) {
+      if (mCheckConfig.allMOs) {
+        return true;
+      }
+
       for (const auto& moname : mCheckConfig.moNames) {
         if (revisionMap.count(moname) && revisionMap[moname] > mMORevision) {
           return true;

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -47,6 +47,7 @@ namespace o2::quality_control::checker
 {
 
 /// Static functions
+// fixme: this is not actually used. collectOutputs() is used instead.
 o2::header::DataDescription CheckRunner::createCheckRunnerDataDescription(const std::string taskName)
 {
   if (taskName.empty()) {

--- a/doc/ModulesDevelopment.md
+++ b/doc/ModulesDevelopment.md
@@ -285,7 +285,7 @@ A Check is a function that determines the quality of the Monitor Objects produce
 * __dataSource__ - declaration of the `check` input
     * _type_ - currently only supported is _Task_
     * _name_ - name of the _Task_
-    * _MOs_ - list of MonitorObjects name or "all"
+    * _MOs_ - list of MonitorObjects name or "all" (not as a list!)
 
 ### Implementation
 After the creation of the module described in the above section, every Check functionality requires a separate implementation. The module might implement several Check classes.


### PR DESCRIPTION
This is a quite dirty fix, which should anyway disappear when policies are refactored.