### PR TITLE
Implement missing handler in view of abstract DecoderBase

### DIFF
--- a/Modules/TOF/include/TOF/TaskDiagnostics.h
+++ b/Modules/TOF/include/TOF/TaskDiagnostics.h
@@ -103,10 +103,10 @@ class DiagnosticsCounter final
 
  private:
   /** decoding handlers **/
-  // void rdhHandler(const o2::header::RAWDataHeader* rdh) override;
+  void rdhHandler(const o2::header::RAWDataHeader* /* rdh */) override{};
   void headerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit) override;
-  // void frameHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
-  //                   const FrameHeader_t* frameHeader, const PackedHit_t* packedHits) override;
+  void frameHandler(const CrateHeader_t* /* crateHeader */, const CrateOrbit_t* /* crateOrbit */,
+                    const FrameHeader_t* /* frameHeader */, const PackedHit_t* /* packedHits */) override{};
   void trailerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
                       const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics,
                       const Error_t* errors) override;


### PR DESCRIPTION
@njacazio 
This PR implements two missing decoder handlers.
This is needed because the functions will be shortly declared as pure virtual in the base class in the O2.