### PR TITLE
[QC-347] Error bars for graphs drawn by TrendingTask

### DIFF
--- a/Framework/include/QualityControl/TrendingTaskConfig.h
+++ b/Framework/include/QualityControl/TrendingTaskConfig.h
@@ -36,6 +36,7 @@ struct TrendingTaskConfig : PostProcessingConfig {
     std::string varexp;
     std::string selection;
     std::string option;
+    std::string graphErrors;
   };
 
   struct DataSource {

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -129,7 +129,7 @@ void TrendingTask::storePlots()
     // For graphs we allow to draw errors if they are specified.
     if (!plot.graphErrors.empty()) {
       if (plotOrder != 2) {
-        ILOG(Error) << "Non empty graphError seen for the plot '" << plot.name << "', which is not a graph, ignoring." << ENDM;
+        ILOG(Error) << "Non empty graphErrors seen for the plot '" << plot.name << "', which is not a graph, ignoring." << ENDM;
       } else {
         // We generate some 4-D points, where 2 dimensions represent graph points and 2 others are the error bars
         std::string varexpWithErrors(plot.varexp + ":" + plot.graphErrors);

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -116,7 +116,7 @@ void TrendingTask::storePlots()
 
     // we determine the order of the plot, i.e. if it is a histogram (1), graph (2), or any higher dimension.
     const size_t plotOrder = std::count(plot.varexp.begin(), plot.varexp.end(), ':') + 1;
-    // we have to delete the graph errors after the plot is saved, unfortunately the canvas does not take ownership
+    // we have to delete the graph errors after the plot is saved, unfortunately the canvas does not take its ownership
     TGraphErrors* graphErrors = nullptr;
 
     TCanvas* c = new TCanvas();
@@ -131,9 +131,11 @@ void TrendingTask::storePlots()
       if (plotOrder != 2) {
         ILOG(Error) << "Non empty graphError seen for the plot '" << plot.name << "', which is not a graph, ignoring." << ENDM;
       } else {
+        // We generate some 4-D points, where 2 dimensions represent graph points and 2 others are the error bars
         std::string varexpWithErrors(plot.varexp + ":" + plot.graphErrors);
         mTrend->Draw(varexpWithErrors.c_str(), plot.selection.c_str(), "goff");
         graphErrors = new TGraphErrors(mTrend->GetSelectedRows(), mTrend->GetVal(1), mTrend->GetVal(0), mTrend->GetVal(2), mTrend->GetVal(3));
+        // We draw on the same plot as the main graph, but only error bars
         graphErrors->Draw("SAME E");
       }
     }
@@ -176,9 +178,9 @@ void TrendingTask::storePlots()
     mo->setIsOwner(false);
     mDatabase->storeMO(mo);
 
-    // It should delete everything inside aside. Confirmed by trying to delete histo after and getting a segfault.
+    // It should delete everything inside. Confirmed by trying to delete histo after and getting a segfault.
     delete c;
-    // ...but not graphErrors
+    // ...but it does not delete graphErrors
     delete graphErrors;
   }
 }

--- a/Framework/src/TrendingTaskConfig.cxx
+++ b/Framework/src/TrendingTaskConfig.cxx
@@ -27,7 +27,8 @@ TrendingTaskConfig::TrendingTaskConfig(std::string name, const boost::property_t
                       plotConfig.second.get<std::string>("title", ""),
                       plotConfig.second.get<std::string>("varexp"),
                       plotConfig.second.get<std::string>("selection", ""),
-                      plotConfig.second.get<std::string>("option", "") });
+                      plotConfig.second.get<std::string>("option", ""),
+                      plotConfig.second.get<std::string>("graphErrors", "") });
   }
   for (const auto& dataSourceConfig : config.get_child("qc.postprocessing." + name + ".dataSources")) {
     if (const auto& sourceNames = dataSourceConfig.second.get_child_optional("names"); sourceNames.has_value()) {

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -192,8 +192,10 @@ Data sources are defined by filling the corresponding structure, as in the examp
 }
 ```
 
-Similarly, plots are defined by adding proper structures to the `"plots"` list, as shown below. The plot will be stored under the `"name"` value and it will have the `"title"` value shown on the top. The `"varexp"`, `"selection"` and `"option"` fields correspond to the arguments of the [`TTree::Draw`](https://root.cern/doc/master/classTTree.html#a73450649dc6e54b5b94516c468523e45) method.
-
+Similarly, plots are defined by adding proper structures to the `"plots"` list, as shown below. The plot will be
+ stored under the `"name"` value and it will have the `"title"` value shown on the top. The `"varexp"`, `"selection"` and `"option"` fields correspond to the arguments of the [`TTree::Draw`](https://root.cern/doc/master/classTTree.html#a73450649dc6e54b5b94516c468523e45) method.
+Optionally, one can use `"graphError"` to add x and y error bars to a graph, as in the first plot example.
+The `"name"` and `"varexp"` are the only compulsory arguments, others can be omitted to reduce configuration files size.
 ``` json
 {
         ...
@@ -203,7 +205,8 @@ Similarly, plots are defined by adding proper structures to the `"plots"` list, 
             "title": "Mean trend of the example histogram",
             "varexp": "example.mean:time",
             "selection": "",
-            "option": "*L"
+            "option": "*L",
+            "graphErrors": "5:example.stddev"
           },
           {
             "name": "histogram_of_means",


### PR DESCRIPTION
Based on the proposition of @cimordas and Marcel Lesch (sorry, I don't remember your nickname).
Here is what has changed:
- "error" changed to "graphErrors" as it only can be applied on graphs,
- added a warning if "graphErrors" are used in a different type of plot,
- errors are not drawn if "graphErrors" is empty, instead being equal to "none" - default behaviour should be invisible,
- the main graph is still drawn by TTree::Draw(), so we get uniform behaviour. TGraphError is used only to draw error bars.
- avoided the possible memory leak by deleting errorGraph.

@cimordas @stheckel Please tell me what you think. I especially wonder if using TGraphError only to draw error bars is okay with you (you might not have influence on how the error bars look like, though we can add another option for that, if needed).

To do:
- update the documentation