### PR TITLE
[QC-357] Follow the change of the Data Sampling directory and namespace

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -95,7 +95,7 @@ target_link_libraries(QualityControl
                              ms_gsl::ms_gsl
                              QualityControlTypes
                              O2::Mergers
-                             O2::DataSampling
+                             $<$<TARGET_EXISTS:O2::DataSampling>:O2::DataSampling>
                       PRIVATE Boost::system
                               $<$<BOOL:${ENABLE_MYSQL}>:MySQL::MySQL>
                               $<$<BOOL:${ENABLE_MYSQL}>:ROOT::RMySQL> ROOT::Gui

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -95,6 +95,7 @@ target_link_libraries(QualityControl
                              ms_gsl::ms_gsl
                              QualityControlTypes
                              O2::Mergers
+                             O2::DataSampling
                       PRIVATE Boost::system
                               $<$<BOOL:${ENABLE_MYSQL}>:MySQL::MySQL>
                               $<$<BOOL:${ENABLE_MYSQL}>:ROOT::RMySQL> ROOT::Gui

--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -24,7 +24,12 @@
 #include "QualityControl/QcInfoLogger.h"
 
 #include <Configuration/ConfigurationFactory.h>
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include <Framework/DataSpecUtils.h>
 #include <Framework/ExternalFairMQDeviceProxy.h>
 #include <Mergers/MergerInfrastructureBuilder.h>

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -22,7 +22,12 @@
 #include <Common/Exceptions.h>
 #include <Configuration/ConfigurationFactory.h>
 #include <Monitoring/MonitoringFactory.h>
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include <Framework/CallbackService.h>
 #include <Framework/CompletionPolicyHelpers.h>
 #include <Framework/TimesliceIndex.h>

--- a/Framework/src/runAdvanced.cxx
+++ b/Framework/src/runAdvanced.cxx
@@ -30,7 +30,12 @@
 /// of glfw being installed or not, in the terminal all the logs will be shown as well.
 
 #include <Framework/CompletionPolicyHelpers.h>
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include <Framework/DataSpecUtils.h>
 #include <Framework/CompletionPolicyHelpers.h>
 #include "QualityControl/InfrastructureGenerator.h"

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -32,8 +32,12 @@
 /// If you have glfw installed, you should see a window with the workflow visualization and sub-windows for each Data
 /// Processor where their logs can be seen. The processing will continue until the main window it is closed. Regardless
 /// of glfw being installed or not, in the terminal all the logs will be shown as well.
-
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include "QualityControl/InfrastructureGenerator.h"
 
 using namespace o2;

--- a/Framework/src/runQC.cxx
+++ b/Framework/src/runQC.cxx
@@ -26,7 +26,12 @@
 /// generates both local and remote topologies, as it is the usual use-case for local development.
 
 #include <boost/asio/ip/host_name.hpp>
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include "QualityControl/InfrastructureGenerator.h"
 #include "QualityControl/QcInfoLogger.h"
 

--- a/Framework/src/runReadout.cxx
+++ b/Framework/src/runReadout.cxx
@@ -25,7 +25,12 @@
 /// Processor where their logs can be seen. The processing will continue until the main window it is closed. Regardless
 /// of glfw being installed or not, in the terminal all the logs will be shown as well.
 
+#if __has_include(<Framework/DataSamplingReadoutAdapter.h>)
 #include <Framework/DataSamplingReadoutAdapter.h>
+#else
+#include <DataSampling/DataSamplingReadoutAdapter.h>
+using namespace o2::utilities;
+#endif
 #include <Framework/runDataProcessing.h>
 
 using namespace o2;

--- a/Framework/src/runReadoutForDataDump.cxx
+++ b/Framework/src/runReadoutForDataDump.cxx
@@ -33,7 +33,14 @@
 /// of glfw being installed or not, in the terminal all the logs will be shown as well.
 ///
 
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#include <Framework/DataSamplingReadoutAdapter.h>
+#else
+#include <DataSampling/DataSampling.h>
+#include <DataSampling/DataSamplingReadoutAdapter.h>
+using namespace o2::utilities;
+#endif
 
 using namespace o2::framework;
 void customize(std::vector<CompletionPolicy>& policies)
@@ -45,7 +52,6 @@ void customize(std::vector<ChannelConfigurationPolicy>& policies)
   DataSampling::CustomizeInfrastructure(policies);
 }
 
-#include <Framework/DataSamplingReadoutAdapter.h>
 #include <Framework/runDataProcessing.h>
 #include <QualityControl/QcInfoLogger.h>
 

--- a/Framework/test/testCheck.cxx
+++ b/Framework/test/testCheck.cxx
@@ -16,7 +16,12 @@
 #include "QualityControl/CheckRunnerFactory.h"
 #include "QualityControl/MonitorObject.h"
 #include "getTestDataDirectory.h"
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include <Common/Exceptions.h>
 #include <TH1F.h>
 

--- a/Framework/test/testCheckRunner.cxx
+++ b/Framework/test/testCheckRunner.cxx
@@ -15,8 +15,6 @@
 
 #include "QualityControl/CheckRunnerFactory.h"
 #include "QualityControl/CheckRunner.h"
-#include <Framework/DataSampling.h>
-#include "getTestDataDirectory.h"
 
 #define BOOST_TEST_MODULE CheckRunner test
 #define BOOST_TEST_MAIN

--- a/Framework/test/testCheckWorkflow.cxx
+++ b/Framework/test/testCheckWorkflow.cxx
@@ -12,7 +12,12 @@
 /// \file    testCheckWorkflow.cxx
 /// \author  Rafal Pacholek
 ///
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include <Framework/CompletionPolicyHelpers.h>
 #include <Framework/DeviceSpec.h>
 #include "QualityControl/InfrastructureGenerator.h"

--- a/Framework/test/testTaskRunner.cxx
+++ b/Framework/test/testTaskRunner.cxx
@@ -16,7 +16,12 @@
 #include "getTestDataDirectory.h"
 #include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/TaskRunner.h"
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include <Framework/DataSpecUtils.h>
 
 #define BOOST_TEST_MODULE TaskRunner test

--- a/Framework/test/testWorkflow.cxx
+++ b/Framework/test/testWorkflow.cxx
@@ -14,7 +14,12 @@
 ///
 
 #include "QualityControl/InfrastructureGenerator.h"
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 
 using namespace o2;
 using namespace o2::framework;

--- a/Modules/EMCAL/src/runQCEMCALDigits.cxx
+++ b/Modules/EMCAL/src/runQCEMCALDigits.cxx
@@ -7,7 +7,7 @@ using namespace o2::framework;
 // TODO bring back full namespaces after the migration
 #else
 #include <DataSampling/DataSampling.h>
-using namespace o2::datasampling;
+using namespace o2::utilities;
 #endif
 #include <DataFormatsEMCAL/Digit.h>
 #include <DataFormatsEMCAL/Cell.h>

--- a/Modules/EMCAL/src/runQCEMCALDigits.cxx
+++ b/Modules/EMCAL/src/runQCEMCALDigits.cxx
@@ -1,7 +1,14 @@
 #include <string>
 #include <TH1.h>
 
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+using namespace o2::framework;
+// TODO bring back full namespaces after the migration
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::datasampling;
+#endif
 #include <DataFormatsEMCAL/Digit.h>
 #include <DataFormatsEMCAL/Cell.h>
 #include <EMCALWorkflow/PublisherSpec.h>
@@ -11,13 +18,13 @@
 
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
-  o2::framework::DataSampling::CustomizeInfrastructure(policies);
+  DataSampling::CustomizeInfrastructure(policies);
   o2::quality_control::customizeInfrastructure(policies);
 }
 
 void customize(std::vector<o2::framework::ChannelConfigurationPolicy>& policies)
 {
-  o2::framework::DataSampling::CustomizeInfrastructure(policies);
+  DataSampling::CustomizeInfrastructure(policies);
 }
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
@@ -95,7 +102,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
     ILOG(Info) << "Creating a local QC topology." << ENDM;
 
     // Generation of Data Sampling infrastructure
-    o2::framework::DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+    DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
 
     // Generation of the local QC topology (local QC tasks and their output proxies)
     o2::quality_control::generateLocalInfrastructure(specs, qcConfigurationSource, config.options().get<std::string>("host"));

--- a/Modules/Example/include/Example/ExampleCondition.h
+++ b/Modules/Example/include/Example/ExampleCondition.h
@@ -17,7 +17,11 @@
 #define QC_MODULE_EXAMPLE_EXAMPLECONDITION_H
 
 #include "QualityControl/TaskInterface.h"
+#if __has_include(<Framework/DataSamplingCondition.h>)
 #include <Framework/DataSamplingCondition.h>
+#else
+#include <DataSampling/DataSamplingCondition.h>
+#endif
 
 namespace o2::quality_control_modules::example
 {
@@ -27,7 +31,11 @@ namespace o2::quality_control_modules::example
 
 /// \brief A DataSamplingCondition which approves messages which have their first byte in the payload higher than
 /// specified value.
+#if __has_include(<Framework/DataSamplingCondition.h>)
 class ExampleCondition : public o2::framework::DataSamplingCondition
+#else
+class ExampleCondition : public o2::utilities::DataSamplingCondition
+#endif
 {
  public:
   /// \brief Constructor.

--- a/Modules/ITS/src/runITS.cxx
+++ b/Modules/ITS/src/runITS.cxx
@@ -18,7 +18,12 @@
 /// \brief This is an executable to run the ITS QC Task.
 ///
 
-#include "Framework/DataSampling.h"
+#if __has_include(<Framework/DataSampling.h>)
+#include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::datasampling;
+#endif
 #include "QualityControl/InfrastructureGenerator.h"
 
 using namespace o2;

--- a/Modules/ITS/src/runITS.cxx
+++ b/Modules/ITS/src/runITS.cxx
@@ -22,7 +22,7 @@
 #include <Framework/DataSampling.h>
 #else
 #include <DataSampling/DataSampling.h>
-using namespace o2::datasampling;
+using namespace o2::utilities;
 #endif
 #include "QualityControl/InfrastructureGenerator.h"
 

--- a/Modules/PHOS/src/runQCPHOSDigits.cxx
+++ b/Modules/PHOS/src/runQCPHOSDigits.cxx
@@ -1,7 +1,14 @@
 #include <string>
 #include <TH1.h>
 
+#if __has_include(<Framework/DataSampling.h>)
 #include <Framework/DataSampling.h>
+using namespace o2::framework;
+// TODO bring back full namespaces after the migration
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::utilities;
+#endif
 #include <DataFormatsPHOS/Digit.h>
 #include <PHOSWorkflow/PublisherSpec.h>
 #include "QualityControl/InfrastructureGenerator.h"
@@ -10,13 +17,13 @@
 
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
-  o2::framework::DataSampling::CustomizeInfrastructure(policies);
+  DataSampling::CustomizeInfrastructure(policies);
   o2::quality_control::customizeInfrastructure(policies);
 }
 
 void customize(std::vector<o2::framework::ChannelConfigurationPolicy>& policies)
 {
-  o2::framework::DataSampling::CustomizeInfrastructure(policies);
+  DataSampling::CustomizeInfrastructure(policies);
 }
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
@@ -67,7 +74,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   if (config.options().get<bool>("local") || !config.options().get<bool>("remote")) {
 
     // Generation of Data Sampling infrastructure
-    o2::framework::DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+    DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
 
     // Generation of the local QC topology (local QC tasks)
     o2::quality_control::generateLocalInfrastructure(specs, qcConfigurationSource, config.options().get<std::string>("host"));

--- a/Modules/TPC/run/runTPCQCTrackReader.cxx
+++ b/Modules/TPC/run/runTPCQCTrackReader.cxx
@@ -19,7 +19,12 @@
 // for some reason, if the 'customize' functions are below the other includes,
 // the options are not added to the workflow.
 // So the structure should be kept as it is
-#include "Framework/DataSampling.h"
+#if __has_include(<Framework/DataSampling.h>)
+#include <Framework/DataSampling.h>
+#else
+#include <DataSampling/DataSampling.h>
+using namespace o2::datasampling;
+#endif
 #include "QualityControl/InfrastructureGenerator.h"
 
 using namespace o2;

--- a/Modules/TPC/run/runTPCQCTrackReader.cxx
+++ b/Modules/TPC/run/runTPCQCTrackReader.cxx
@@ -23,7 +23,7 @@
 #include <Framework/DataSampling.h>
 #else
 #include <DataSampling/DataSampling.h>
-using namespace o2::datasampling;
+using namespace o2::utilities;
 #endif
 #include "QualityControl/InfrastructureGenerator.h"
 


### PR DESCRIPTION
This prepares QC for the change of the Data Sampling directory and namespace. It supports both versions - the current one and after the change, so it should be painless if done in right order.