### PR TITLE
[QC-388] Use timestamps in TrendingTask

### DIFF
--- a/Framework/include/QualityControl/TrendingTask.h
+++ b/Framework/include/QualityControl/TrendingTask.h
@@ -56,9 +56,10 @@ class TrendingTask : public PostProcessingInterface
     Int_t runNumber = 0;
   };
 
-  void trendValues();
-  void storePlots();
-  void storeTrend();
+  // the three worker methods require a timestamp (ms since epoch) of objects to trend and store.
+  void trendValues(uint64_t timestamp);
+  void storePlots(uint64_t timestamp);
+  void storeTrend(uint64_t timestamp);
 
   TrendingTaskConfig mConfig;
   MetaData mMetaData;


### PR DESCRIPTION
After https://github.com/AliceO2Group/QualityControl/pull/458

This is an example how to retrieve data with use of timestamps. This will allow for running post-processing on older data by using triggers with associated timestamps.
@iravasen you have your own post processing tasks, so you might be interested about this.