### PR TITLE
Add missing includes

### DIFF
--- a/Framework/src/Check.cxx
+++ b/Framework/src/Check.cxx
@@ -25,6 +25,8 @@
 #include "QualityControl/TaskRunner.h"
 #include "QualityControl/InputUtils.h"
 #include "QualityControl/RootClassFactory.h"
+// Fairlogger
+#include <fairlogger/Logger.h>
 
 using namespace AliceO2::Common;
 using namespace AliceO2::InfoLogger;

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -33,6 +33,8 @@
 #include "QualityControl/DatabaseFactory.h"
 #include "QualityControl/TaskRunner.h"
 #include "QualityControl/ServiceDiscovery.h"
+// Fairlogger
+#include <fairlogger/Logger.h>
 
 using namespace std::chrono;
 using namespace AliceO2::Common;

--- a/Framework/src/HistoProducer.cxx
+++ b/Framework/src/HistoProducer.cxx
@@ -18,6 +18,7 @@
 #include <TH1F.h>
 #include <QualityControl/MonitorObjectCollection.h>
 #include <string>
+#include <fairlogger/Logger.h>
 
 using namespace o2::framework;
 

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -35,6 +35,9 @@ using namespace o2::utilities;
 #include <Framework/DataDescriptorQueryBuilder.h>
 #include <Framework/ConfigParamRegistry.h>
 
+// Fairlogger
+#include <fairlogger/Logger.h>
+
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/TaskFactory.h"
 

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -23,6 +23,7 @@
 #include <TH1.h>
 #include <TCanvas.h>
 #include <TPaveText.h>
+#include <TDatime.h>
 #include "TGraphErrors.h"
 
 using namespace o2::quality_control;

--- a/Modules/Daq/src/DaqTask.cxx
+++ b/Modules/Daq/src/DaqTask.cxx
@@ -18,6 +18,7 @@
 #include "QualityControl/QcInfoLogger.h"
 #include <TCanvas.h>
 #include <TDatime.h>
+#include <TObjString.h>
 #include <TGraph.h>
 #include <TH1.h>
 #include <TPaveText.h>

--- a/Modules/ITS/src/TrendingTaskITSFhr.cxx
+++ b/Modules/ITS/src/TrendingTaskITSFhr.cxx
@@ -22,6 +22,7 @@
 #include "ITS/TH2XlineReductor.h"
 #include <TCanvas.h>
 #include <TH1.h>
+#include <TDatime.h>
 #include <map>
 #include <string>
 

--- a/Modules/ITS/src/TrendingTaskITSThr.cxx
+++ b/Modules/ITS/src/TrendingTaskITSThr.cxx
@@ -21,6 +21,7 @@
 #include "QualityControl/Reductor.h"
 #include <TCanvas.h>
 #include <TH1.h>
+#include <TDatime.h>
 
 using namespace o2::quality_control;
 using namespace o2::quality_control::core;

--- a/Modules/MUON/MCH/src/Decoding.cxx
+++ b/Modules/MUON/MCH/src/Decoding.cxx
@@ -13,6 +13,7 @@
 #include "MCHBase/Digit.h"
 #define __STDC_FORMAT_MACROS
 #include <cinttypes>
+#include <fstream>
 
 using namespace std;
 

--- a/Modules/MUON/MCH/src/Mapping.cxx
+++ b/Modules/MUON/MCH/src/Mapping.cxx
@@ -5,6 +5,7 @@
 
 #include "QualityControl/QcInfoLogger.h"
 #include "MCH/Mapping.h"
+#include <fstream>
 #ifdef MCH_HAS_MAPPING_FACTORY
 #include "MCHMappingFactory/CreateSegmentation.h"
 #else

--- a/Modules/TOF/include/Base/Counter.h
+++ b/Modules/TOF/include/Base/Counter.h
@@ -27,6 +27,9 @@
 // QC includes
 #include "QualityControl/QcInfoLogger.h"
 
+// Fairlogger includes
+#include <fairlogger/Logger.h>
+
 namespace o2::quality_control_modules::tof
 {
 

--- a/Modules/TOF/src/TaskCompressedData.cxx
+++ b/Modules/TOF/src/TaskCompressedData.cxx
@@ -25,6 +25,9 @@
 #include "Headers/RAWDataHeader.h"
 #include "DetectorsRaw/HBFUtils.h"
 
+// Fairlogger includes
+#include <fairlogger/Logger.h>
+
 using namespace o2::framework;
 
 // QC includes

--- a/Modules/TOF/src/TaskDigits.cxx
+++ b/Modules/TOF/src/TaskDigits.cxx
@@ -26,6 +26,9 @@
 #include "TOFBase/Digit.h"
 #include "TOFBase/Geo.h"
 
+// Fairlogger includes
+#include <fairlogger/Logger.h>
+
 // QC includes
 #include "QualityControl/QcInfoLogger.h"
 #include "TOF/TaskDigits.h"


### PR DESCRIPTION
This adds includes needed to bump ROOT and FairMQ, which have cleaned up some of their includes, and so far QC has been relying on the includes provided by these packages. Needed in particular for alisw/alidist#2458. @Barthelemy : could you create a new tag with this PR in and bump QC in alidist, such that I can try to continue to bump the other packages.