### PR TITLE
Add namespace indicator for runtime_error

### DIFF
--- a/Framework/src/HistoProducer.cxx
+++ b/Framework/src/HistoProducer.cxx
@@ -120,7 +120,7 @@ framework::AlgorithmSpec getHistoPrinterAlgorithm()
         shared_ptr<const TH1F> th1f = nullptr;
         try {
           array = processingContext.inputs().get<TObjArray*>("in");
-        } catch (runtime_error& e) {
+        } catch (std::runtime_error& e) {
           // we failed to get the TObjArray, let's try a TH1F. If it fails it will throw.
           th1f = processingContext.inputs().get<TH1F*>("in");
         }


### PR DESCRIPTION
This would collide with `o2::framework::runtime_error` after https://github.com/AliceO2Group/AliceO2/pull/4150 is merged