### PR TITLE
Improvements to avoid random crash in testFactory

### DIFF
--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -46,7 +46,7 @@ class ObjectsManager
    * @param taskConfig The configuration of the task for which we are building this object manager
    * @param noDiscovery If true disables the use of ServiceDiscovery
    */
-  explicit ObjectsManager(TaskConfig& taskConfig, bool noDiscovery = false);
+  explicit ObjectsManager(const TaskConfig& taskConfig, bool noDiscovery = false);
   virtual ~ObjectsManager();
 
   static const std::string gDrawOptionsKey;
@@ -154,7 +154,7 @@ class ObjectsManager
 
  private:
   std::unique_ptr<MonitorObjectCollection> mMonitorObjects;
-  TaskConfig& mTaskConfig;
+  TaskConfig mTaskConfig;
   std::unique_ptr<ServiceDiscovery> mServiceDiscovery;
   bool mUpdateServiceDiscovery;
 };

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -31,7 +31,7 @@ namespace o2::quality_control::core
 const std::string ObjectsManager::gDrawOptionsKey = "drawOptions";
 const std::string ObjectsManager::gDisplayHintsKey = "displayHints";
 
-ObjectsManager::ObjectsManager(TaskConfig& taskConfig, bool noDiscovery) : mTaskConfig(taskConfig), mUpdateServiceDiscovery(false)
+ObjectsManager::ObjectsManager(const TaskConfig& taskConfig, bool noDiscovery) : mTaskConfig(taskConfig), mUpdateServiceDiscovery(false)
 {
   mMonitorObjects = std::make_unique<MonitorObjectCollection>();
   mMonitorObjects->SetOwner(true);

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -39,7 +39,9 @@ ObjectsManager::ObjectsManager(const TaskConfig& taskConfig, bool noDiscovery) :
   // register with the discovery service
   if (!noDiscovery) {
     std::string uniqueTaskID = taskConfig.taskName + "_" + std::to_string(mTaskConfig.parallelTaskID);
+    ILOG(Info) << "Creation of Service Discovery with id " << uniqueTaskID << ENDM;
     mServiceDiscovery = std::make_unique<ServiceDiscovery>(taskConfig.consulUrl, taskConfig.taskName, uniqueTaskID);
+    ILOG(Info) << "Finished creation SD " << ENDM;
   } else {
     ILOG(Info) << "Service Discovery disabled" << ENDM;
     mServiceDiscovery = nullptr;

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -39,9 +39,7 @@ ObjectsManager::ObjectsManager(const TaskConfig& taskConfig, bool noDiscovery) :
   // register with the discovery service
   if (!noDiscovery) {
     std::string uniqueTaskID = taskConfig.taskName + "_" + std::to_string(mTaskConfig.parallelTaskID);
-    ILOG(Info) << "Creation of Service Discovery with id " << uniqueTaskID << ENDM;
     mServiceDiscovery = std::make_unique<ServiceDiscovery>(taskConfig.consulUrl, taskConfig.taskName, uniqueTaskID);
-    ILOG(Info) << "Finished creation SD " << ENDM;
   } else {
     ILOG(Info) << "Service Discovery disabled" << ENDM;
     mServiceDiscovery = nullptr;

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -106,7 +106,7 @@ void ServiceDiscovery::deregister()
 void ServiceDiscovery::runHealthServer(unsigned int port)
 {
   std::cout << "cout in runHealthServer" << std::endl;
-  ILOG(Info) << "ServiceDiscovery::runHealthServer - ILOG " << ENDM;
+//  ILOG(Info) << "ServiceDiscovery::runHealthServer - ILOG " << ENDM;
   std::cout << "cout in runHealthServer 2" << std::endl;
   using boost::asio::ip::tcp;
   mThreadRunning = true;
@@ -130,7 +130,7 @@ void ServiceDiscovery::runHealthServer(unsigned int port)
     }
   } catch (std::exception& e) {
     mThreadRunning = false;
-    ILOG(Error) << "ServiceDiscovery::runHealthServer - " << e.what() << ENDM;
+    std::cerr << "ServiceDiscovery::runHealthServer - " << e.what() << std::endl;
   }
 }
 

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -132,8 +132,7 @@ void ServiceDiscovery::runHealthServer(unsigned int port)
     }
   } catch (std::exception& e) {
     mThreadRunning = false;
-    threadInfoLogger << AliceO2::InfoLogger::InfoLogger::Severity::Error <<
-      "ServiceDiscovery::runHealthServer - " << e.what() << ENDM;
+    threadInfoLogger << AliceO2::InfoLogger::InfoLogger::Severity::Error << "ServiceDiscovery::runHealthServer - " << e.what() << ENDM;
   }
 }
 

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -27,12 +27,15 @@ namespace o2::quality_control::core
 ServiceDiscovery::ServiceDiscovery(const std::string& url, const std::string& name, const std::string& id, const std::string& healthEndpoint)
   : curlHandle(initCurl(), &ServiceDiscovery::deleteCurl), mConsulUrl(url), mName(name), mId(id), mHealthEndpoint(healthEndpoint)
 {
+  ILOG(Info) << "Service Discovery constructor" << ENDM;
   // parameter check
   if (mHealthEndpoint.find(':') == std::string::npos) {
     mHealthEndpoint = GetDefaultUrl();
   }
 
+  ILOG(Info) << "Thread health creation" << ENDM;
   mHealthThread = std::thread([=] { runHealthServer(std::stoi(mHealthEndpoint.substr(mHealthEndpoint.find(":") + 1))); });
+  ILOG(Info) << "ready to register" << ENDM;
   _register("");
 }
 
@@ -102,6 +105,9 @@ void ServiceDiscovery::deregister()
 
 void ServiceDiscovery::runHealthServer(unsigned int port)
 {
+  std::cout << "cout in runHealthServer" << std::endl;
+  ILOG(Info) << "ServiceDiscovery::runHealthServer - ILOG " << ENDM;
+  std::cout << "cout in runHealthServer 2" << std::endl;
   using boost::asio::ip::tcp;
   mThreadRunning = true;
   try {

--- a/Modules/Example/test/testFactory.cxx
+++ b/Modules/Example/test/testFactory.cxx
@@ -24,21 +24,15 @@ namespace o2::quality_control_modules::example
 
 BOOST_AUTO_TEST_CASE(Task_Factory)
 {
-  cout << "Start of test Task_Factory" << endl;
-
   TaskFactory factory;
   TaskConfig config;
   config.taskName = "task";
   config.moduleName = "QcCommon";
   config.className = "o2::quality_control_modules::example::ExampleTask";
-  cout << "Create ObjectsManager" << endl;
   auto manager = make_shared<ObjectsManager>(config);
-  cout << "Done ObjectsManager" << endl;
   try {
     gSystem->AddDynamicPath("lib:../../lib:../../../lib:.:"); // add local paths for the test
-    cout << "Create Task" << endl;
     factory.create(config, manager);
-    cout << "Done Task" << endl;
   } catch (...) {
     BOOST_TEST_FAIL(boost::current_exception_diagnostic_information());
   }
@@ -48,8 +42,6 @@ bool is_critical(AliceO2::Common::FatalException const&) { return true; }
 
 BOOST_AUTO_TEST_CASE(Task_Factory_failures, *utf::depends_on("Task_Factory") /* make sure we don't run both tests at the same time */)
 {
-  cout << "Start of test Task_Factory_failures" << endl;
-
   TaskFactory factory;
   TaskConfig config;
   auto manager = make_shared<ObjectsManager>(config);

--- a/Modules/Example/test/testFactory.cxx
+++ b/Modules/Example/test/testFactory.cxx
@@ -31,10 +31,14 @@ BOOST_AUTO_TEST_CASE(Task_Factory)
   config.taskName = "task";
   config.moduleName = "QcCommon";
   config.className = "o2::quality_control_modules::example::ExampleTask";
+  cout << "Create ObjectsManager" << endl;
   auto manager = make_shared<ObjectsManager>(config);
+  cout << "Done ObjectsManager" << endl;
   try {
     gSystem->AddDynamicPath("lib:../../lib:../../../lib:.:"); // add local paths for the test
+    cout << "Create Task" << endl;
     factory.create(config, manager);
+    cout << "Done Task" << endl;
   } catch (...) {
     BOOST_TEST_FAIL(boost::current_exception_diagnostic_information());
   }

--- a/Modules/Example/test/testFactory.cxx
+++ b/Modules/Example/test/testFactory.cxx
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(Task_Factory)
   config.className = "o2::quality_control_modules::example::ExampleTask";
   auto manager = make_shared<ObjectsManager>(config);
   try {
-    gSystem->AddDynamicPath("lib:../../lib:../../../lib:.:"); // add local paths for the test
+    gSystem->AddDynamicPath("lib:../../lib:../../../lib:.:"); // add local  paths for the test
     factory.create(config, manager);
   } catch (...) {
     BOOST_TEST_FAIL(boost::current_exception_diagnostic_information());


### PR DESCRIPTION
I strongly suspect something wrong with the way strings are handled between ObjectsManager and ServiceDiscovery. Copying TaskConfig in ObjectsManager should help.