### PR TITLE
Add an option to DaqTask to print header and payload

### DIFF
--- a/Framework/include/QualityControl/stringUtils.h
+++ b/Framework/include/QualityControl/stringUtils.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   stringUtils.h
+/// \author Barthelemy von Haller
+///
+
+#ifndef QC_STRING_UTILS_H
+#define QC_STRING_UTILS_H
+
+#include <string>
+#include <sstream>
+#include <vector>
+
+namespace o2::quality_control::core
+{
+
+std::vector<std::string> getBinRepresentation(unsigned char* data, size_t size)
+{
+  std::stringstream ss;
+  std::vector<std::string> result;
+  result.reserve(size);
+
+  for (size_t i = 0; i < size; i++) {
+    std::bitset<16> x(data[i]);
+    ss << x << " ";
+    result.push_back(ss.str());
+    ss.str(std::string());
+  }
+  return result;
+}
+
+std::vector<std::string> getHexRepresentation(unsigned char* data, size_t size)
+{
+  std::stringstream ss;
+  std::vector<std::string> result;
+  result.reserve(size);
+  ss << std::hex << std::setfill('0');
+
+  for (size_t i = 0; i < size; i++) {
+    ss << std::setw(2) << static_cast<unsigned>(data[i]) << " ";
+    result.push_back(ss.str());
+    ss.str(std::string());
+  }
+  return result;
+}
+} // namespace o2::quality_control::core
+
+#endif // QC_STRING_UTILS_H

--- a/Framework/include/QualityControl/stringUtils.h
+++ b/Framework/include/QualityControl/stringUtils.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <iomanip>
 
 namespace o2::quality_control::core
 {

--- a/Framework/include/QualityControl/stringUtils.h
+++ b/Framework/include/QualityControl/stringUtils.h
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <vector>
 #include <iomanip>
+#include <bitset>
 
 namespace o2::quality_control::core
 {

--- a/Framework/readout.json
+++ b/Framework/readout.json
@@ -34,7 +34,11 @@
           "type": "dataSamplingPolicy",
           "name": "readout"
         },
-        "location": "remote"
+        "location": "remote",
+        "taskParameters": {
+          "printHeaders": "0",               "": "set to 1 to print all headers, it will slow down the QC",
+          "printPayload": "no",              "": "hex or bin (anything else means no), it will slow down the QC"
+        }
       }
     }
   },

--- a/Framework/readout.json
+++ b/Framework/readout.json
@@ -36,8 +36,8 @@
         },
         "location": "remote",
         "taskParameters": {
-          "printHeaders": "0",               "": "set to 1 to print all headers, it will slow down the QC",
-          "printPayload": "no",              "": "hex or bin (anything else means no), it will slow down the QC"
+          "printHeaders": "false",           "": "set to true to print all headers, it will slow down the QC",
+          "printPayload": "false",           "": "hex or bin (anything else means no), it will slow down the QC"
         }
       }
     }

--- a/Framework/src/DataDumpGui.cxx
+++ b/Framework/src/DataDumpGui.cxx
@@ -16,6 +16,7 @@
 
 #include "QualityControl/DataDumpGui.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/stringUtils.h"
 #include "imgui/BaseGui.h"
 #include "imgui/imgui.h"
 #include <Headers/DataHeader.h>
@@ -29,36 +30,6 @@ namespace o2::quality_control::core
 
 GUIState DataDumpGui::guiState;
 void* DataDumpGui::window = nullptr;
-
-vector<string> getBinRepresentation(unsigned char* data, size_t size)
-{
-  stringstream ss;
-  vector<string> result;
-  result.reserve(size);
-
-  for (size_t i = 0; i < size; i++) {
-    std::bitset<16> x(data[i]);
-    ss << x << " ";
-    result.push_back(ss.str());
-    ss.str(std::string());
-  }
-  return result;
-}
-
-vector<string> getHexRepresentation(unsigned char* data, size_t size)
-{
-  stringstream ss;
-  vector<string> result;
-  result.reserve(size);
-  ss << std::hex << std::setfill('0');
-
-  for (size_t i = 0; i < size; i++) {
-    ss << std::setw(2) << static_cast<unsigned>(data[i]) << " ";
-    result.push_back(ss.str());
-    ss.str(std::string());
-  }
-  return result;
-}
 
 void DataDumpGui::InitTask() { window = initGUI("O2 Data Inspector"); }
 

--- a/Modules/Daq/include/Daq/DaqTask.h
+++ b/Modules/Daq/include/Daq/DaqTask.h
@@ -29,8 +29,10 @@ using namespace o2::quality_control::core;
 namespace o2::quality_control_modules::daq
 {
 
-/// \brief Example Quality Control Task
-/// It is final because there is no reason to derive from it. Just remove it if needed.
+/// \brief Dataflow task
+/// It does only look at the header and plots sizes (e.g. payload).
+/// It also can print the headers and the payloads by setting printHeaders to "1"
+/// and printPayload to "hex" or "bin" in the config file under "taskParameters".
 /// \author Barthelemy von Haller
 class DaqTask final : public TaskInterface
 {
@@ -56,9 +58,6 @@ class DaqTask final : public TaskInterface
   TH1F* mNumberSubblocks;
   TH1F* mSubPayloadSize;
   //  UInt_t mTimeLastRecord;
-  TObjString* mObjString;
-  TCanvas* mCanvas;
-  TPaveText* mPaveText;
 };
 
 } // namespace o2::quality_control_modules::daq

--- a/Modules/Daq/src/DaqTask.cxx
+++ b/Modules/Daq/src/DaqTask.cxx
@@ -103,20 +103,20 @@ void DaqTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (mCustomParameters.count("printHeaders") > 0 && mCustomParameters["printHeaders"] == "true") {
         header->print();
       }
-      if(mCustomParameters.count("printPayload") > 0) {
+      if (mCustomParameters.count("printPayload") > 0) {
         std::vector<std::string> representation;
-        if(mCustomParameters["printPayload"] == "hex"){
+        if (mCustomParameters["printPayload"] == "hex") {
           representation = getHexRepresentation((unsigned char*)payload, header->payloadSize);
         } else if (mCustomParameters["printPayload"] == "bin") {
           representation = getBinRepresentation((unsigned char*)payload, header->payloadSize);
         }
 
-        for(size_t i = 0 ; i < representation.size() ; ) {
+        for (size_t i = 0; i < representation.size();) {
           ILOG(Info) << std::setw(4) << i << " : ";
-          for (size_t col = 0 ; col < 4 ; col++) {
-            for(size_t word = 0 ; word < 2 ; word++) {
-              if(i+col*2+word < representation.size()) {
-                ILOG(Info) << representation[i+col*2+word];
+          for (size_t col = 0; col < 4; col++) {
+            for (size_t word = 0; word < 2; word++) {
+              if (i + col * 2 + word < representation.size()) {
+                ILOG(Info) << representation[i + col * 2 + word];
               } else {
                 ILOG(Info) << "   ";
               }
@@ -124,7 +124,7 @@ void DaqTask::monitorData(o2::framework::ProcessingContext& ctx)
             ILOG(Info) << " | ";
           }
           ILOG(Info) << ENDM;
-          i = i+8;
+          i = i + 8;
         }
       }
     }

--- a/Modules/Daq/src/DaqTask.cxx
+++ b/Modules/Daq/src/DaqTask.cxx
@@ -100,7 +100,7 @@ void DaqTask::monitorData(o2::framework::ProcessingContext& ctx)
       totalPayloadSize += size;
 
       // printing
-      if (mCustomParameters.count("printHeaders") > 0 && mCustomParameters["printHeaders"] == "1") {
+      if (mCustomParameters.count("printHeaders") > 0 && mCustomParameters["printHeaders"] == "true") {
         header->print();
       }
       if(mCustomParameters.count("printPayload") > 0) {
@@ -112,18 +112,18 @@ void DaqTask::monitorData(o2::framework::ProcessingContext& ctx)
         }
 
         for(size_t i = 0 ; i < representation.size() ; ) {
-          cout << std::setw(4) << i << " : ";
+          ILOG(Info) << std::setw(4) << i << " : ";
           for (size_t col = 0 ; col < 4 ; col++) {
             for(size_t word = 0 ; word < 2 ; word++) {
               if(i+col*2+word < representation.size()) {
-                cout << representation[i+col*2+word];
+                ILOG(Info) << representation[i+col*2+word];
               } else {
-                cout << "   ";
+                ILOG(Info) << "   ";
               }
             }
-            cout << " | ";
+            ILOG(Info) << " | ";
           }
-          cout << endl;
+          ILOG(Info) << ENDM;
           i = i+8;
         }
       }

--- a/Modules/Daq/src/DaqTask.cxx
+++ b/Modules/Daq/src/DaqTask.cxx
@@ -16,12 +16,9 @@
 #include "Daq/DaqTask.h"
 
 #include "QualityControl/QcInfoLogger.h"
-#include <TCanvas.h>
-#include <TDatime.h>
-#include <TObjString.h>
+#include "QualityControl/stringUtils.h"
 #include <TGraph.h>
 #include <TH1.h>
-#include <TPaveText.h>
 
 using namespace std;
 
@@ -34,18 +31,12 @@ DaqTask::DaqTask()
     mIds(nullptr),
     mNPoints(0),
     mNumberSubblocks(nullptr),
-    mSubPayloadSize(nullptr),
-    mObjString(nullptr),
-    mCanvas(nullptr),
-    mPaveText(nullptr)
+    mSubPayloadSize(nullptr)
 {
 }
 
 DaqTask::~DaqTask()
 {
-  delete mPaveText;
-  delete mCanvas;
-  delete mObjString;
   delete mPayloadSize;
   delete mIds;
   delete mNumberSubblocks;
@@ -76,18 +67,6 @@ void DaqTask::initialize(o2::framework::InitContext& /*ctx*/)
   mIds->GetXaxis()->SetLabelSize(0.02);
   mIds->GetYaxis()->SetLabelSize(0.02);
   getObjectsManager()->startPublishing(mIds);
-
-  mObjString = new TObjString("hello");
-  getObjectsManager()->startPublishing(mObjString);
-
-  mCanvas = new TCanvas();
-  mCanvas->cd();
-  getObjectsManager()->startPublishing(mCanvas);
-
-  mPaveText = new TPaveText(0.1, 0.1, 0.9, 0.9);
-  mPaveText->AddText("hello");
-  mPaveText->SetName("hello_pavetext"); // Remember to always set a name to objects that we publish
-  getObjectsManager()->startPublishing(mPaveText);
 }
 
 void DaqTask::startOfActivity(Activity& /*activity*/)
@@ -111,11 +90,43 @@ void DaqTask::monitorData(o2::framework::ProcessingContext& ctx)
   // in a loop
   uint32_t totalPayloadSize = 0;
   for (auto&& input : ctx.inputs()) {
-    if (input.header != nullptr && input.payload != nullptr) {
+    if (input.header != nullptr) {
       const auto* header = o2::header::get<header::DataHeader*>(input.header);
+      const char* payload = input.payload;
+
+      // payload size
       uint32_t size = header->payloadSize;
       mSubPayloadSize->Fill(size);
       totalPayloadSize += size;
+
+      // printing
+      if (mCustomParameters.count("printHeaders") > 0 && mCustomParameters["printHeaders"] == "1") {
+        header->print();
+      }
+      if(mCustomParameters.count("printPayload") > 0) {
+        std::vector<std::string> representation;
+        if(mCustomParameters["printPayload"] == "hex"){
+          representation = getHexRepresentation((unsigned char*)payload, header->payloadSize);
+        } else if (mCustomParameters["printPayload"] == "bin") {
+          representation = getBinRepresentation((unsigned char*)payload, header->payloadSize);
+        }
+
+        for(size_t i = 0 ; i < representation.size() ; ) {
+          cout << std::setw(4) << i << " : ";
+          for (size_t col = 0 ; col < 4 ; col++) {
+            for(size_t word = 0 ; word < 2 ; word++) {
+              if(i+col*2+word < representation.size()) {
+                cout << representation[i+col*2+word];
+              } else {
+                cout << "   ";
+              }
+            }
+            cout << " | ";
+          }
+          cout << endl;
+          i = i+8;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Just because it is handy and comes for almost free. Will be useless once we have a Data Inspector / Data Dump. 