### PR TITLE
[QC-426] Decrease verbosity

### DIFF
--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -172,10 +172,10 @@ CompletionPolicy::CompletionOp TaskRunner::completionPolicyCallback(o2::framewor
     }
   }
 
-  ILOG(Debug, Devel) << "Completion policy callback. "
-                     << "Total inputs possible: " << inputs.size()
-                     << ", data inputs: " << dataInputsPresent
-                     << ", timer inputs: " << (action == CompletionPolicy::CompletionOp::Consume) << ENDM;
+//  ILOG(Debug, Trace) << "Completion policy callback. "
+//                     << "Total inputs possible: " << inputs.size()
+//                     << ", data inputs: " << dataInputsPresent
+//                     << ", timer inputs: " << (action == CompletionPolicy::CompletionOp::Consume) << ENDM;
 
   if (dataInputsPresent == dataInputsExpected) {
     action = CompletionPolicy::CompletionOp::Consume;

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -172,10 +172,10 @@ CompletionPolicy::CompletionOp TaskRunner::completionPolicyCallback(o2::framewor
     }
   }
 
-//  ILOG(Debug, Trace) << "Completion policy callback. "
-//                     << "Total inputs possible: " << inputs.size()
-//                     << ", data inputs: " << dataInputsPresent
-//                     << ", timer inputs: " << (action == CompletionPolicy::CompletionOp::Consume) << ENDM;
+  //  ILOG(Debug, Trace) << "Completion policy callback. "
+  //                     << "Total inputs possible: " << inputs.size()
+  //                     << ", data inputs: " << dataInputsPresent
+  //                     << ", timer inputs: " << (action == CompletionPolicy::CompletionOp::Consume) << ENDM;
 
   if (dataInputsPresent == dataInputsExpected) {
     action = CompletionPolicy::CompletionOp::Consume;


### PR DESCRIPTION
The move to infologger in TaskRunner made it extremely noisy. This was not visible before we used the fairlogger and it skipped the debug messages by default (it seems).

Disable the log message in TaskRunner that creates this noise:
> [94720:QC-TASK-RUNNER-daqTask-old-random]: 2020-09-29 10:45:52.346429 Action: consumeCompletion policy callback. Total inputs possible: 2, data inputs: 1, timer inputs: 0