### PR TITLE
[QC-427] Fix time stored in trends generated by TrendingTask

### DIFF
--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -83,7 +83,7 @@ void TrendingTask::storeTrend(uint64_t timestamp, repository::DatabaseInterface&
 
 void TrendingTask::trendValues(uint64_t timestamp, repository::DatabaseInterface& qcdb)
 {
-  mTime = timestamp;
+  mTime = timestamp / 1000; // ROOT expects seconds since epoch
   // todo get run number when it is available. consider putting it inside monitor object's metadata (this might be not
   //  enough if we trend across runs).
   mMetaData.runNumber = -1;


### PR DESCRIPTION
The move to database timestamps destroyed the plots with time on x axis, this fixes the problem.