### PR TITLE
Remove default host for RepoCleaner

### DIFF
--- a/Framework/script/RepoCleaner/config-test.yaml
+++ b/Framework/script/RepoCleaner/config-test.yaml
@@ -7,4 +7,4 @@ Rules:
     policy: 1_per_hour
     
 Ccdb:
-   Url: http://ccdb-test.cern.ch:8080
+   Url: http://UPDATEME.cern.ch:8080

--- a/Framework/script/RepoCleaner/config.yaml
+++ b/Framework/script/RepoCleaner/config.yaml
@@ -51,4 +51,4 @@ Rules:
 #    policy: 1_per_hour
 
 Ccdb:
-  Url: http://ccdb-test.cern.ch:8080
+  Url: http://UPDATEME.cern.ch:8080


### PR DESCRIPTION
 It is a bit dangerous to have the ccdb-test as default value here. Removing it.