### PR TITLE
[QC-420] Integrate post-processing with DPL

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(QualityControl
             src/PostProcessingFactory.cxx
             src/PostProcessingConfig.cxx
             src/PostProcessingInterface.cxx
+            src/PostProcessingDevice.cxx
             src/TrendingTask.cxx
             src/TrendingTaskConfig.cxx
             src/DummyDatabase.cxx

--- a/Framework/include/QualityControl/InfrastructureGenerator.h
+++ b/Framework/include/QualityControl/InfrastructureGenerator.h
@@ -144,6 +144,7 @@ class InfrastructureGenerator
                               size_t numberOfLocalMachines,
                               double cycleDurationSeconds);
   static void generateCheckRunners(framework::WorkflowSpec& workflow, std::string configurationSource);
+  static void generatePostProcessing(framework::WorkflowSpec& workflow, std::string configurationSource);
 };
 
 } // namespace core

--- a/Framework/include/QualityControl/PostProcessingDevice.h
+++ b/Framework/include/QualityControl/PostProcessingDevice.h
@@ -38,13 +38,12 @@ class PostProcessingDevice : public framework::Task
   ///
   /// \param taskName - name of the task, which exists in tasks list in the configuration file
   /// \param configurationSource - absolute path to configuration file, preceded with backend (f.e. "json://")
-  /// \param id - subSpecification for taskRunner's OutputSpec, useful to avoid outputs collisions one more complex topologies
   PostProcessingDevice(const std::string& taskName, const std::string& configurationSource);
   ~PostProcessingDevice() override = default;
 
-  /// \brief TaskRunner's init callback
+  /// \brief PostProcessingDevice's init callback
   void init(framework::InitContext&) override;
-  /// \brief TaskRunner's process callback
+  /// \brief PostProcessingDevice's process callback
   void run(framework::ProcessingContext&) override;
 
   const std::string& getDeviceName();
@@ -52,11 +51,11 @@ class PostProcessingDevice : public framework::Task
   framework::Outputs getOutputSpecs();
   framework::Options getOptions();
 
-  /// \brief ID string for all TaskRunner devices
+  /// \brief ID string for all PostProcessingDevices
   static std::string createPostProcessingIdString();
-  /// \brief Unified DataOrigin for Quality Control tasks
+  /// \brief Unified DataOrigin for Post-processing tasks
   static header::DataOrigin createPostProcessingDataOrigin();
-  /// \brief Unified DataDescription naming scheme for all tasks
+  /// \brief Unified DataDescription naming scheme for all Post-processing tasks
   static header::DataDescription createPostProcessingDataDescription(const std::string& taskName);
 
  private:

--- a/Framework/include/QualityControl/PostProcessingDevice.h
+++ b/Framework/include/QualityControl/PostProcessingDevice.h
@@ -16,7 +16,6 @@
 #ifndef QUALITYCONTROL_POSTPROCESSINGDEVICE_H
 #define QUALITYCONTROL_POSTPROCESSINGDEVICE_H
 
-
 #include <Framework/Task.h>
 #include <Framework/DataProcessorSpec.h>
 #include <Headers/DataHeader.h>
@@ -74,6 +73,6 @@ class PostProcessingDevice : public framework::Task
   std::string mConfigSource;
 };
 
-} // namespace o2::quality_control::core
+} // namespace o2::quality_control::postprocessing
 
 #endif //QUALITYCONTROL_POSTPROCESSINGDEVICE_H

--- a/Framework/include/QualityControl/PostProcessingDevice.h
+++ b/Framework/include/QualityControl/PostProcessingDevice.h
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   PostProcessingDevice.h
+/// \author Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_POSTPROCESSINGDEVICE_H
+#define QUALITYCONTROL_POSTPROCESSINGDEVICE_H
+
+
+#include <Framework/Task.h>
+#include <Framework/DataProcessorSpec.h>
+#include <Headers/DataHeader.h>
+
+#include <string>
+#include <memory>
+
+namespace o2::quality_control::postprocessing
+{
+
+class PostProcessingRunner;
+
+/// \brief A class driving the execution of a QC PostProcessing task inside DPL.
+///
+/// \author Piotr Konopka
+class PostProcessingDevice : public framework::Task
+{
+ public:
+  /// \brief Constructor
+  ///
+  /// \param taskName - name of the task, which exists in tasks list in the configuration file
+  /// \param configurationSource - absolute path to configuration file, preceded with backend (f.e. "json://")
+  /// \param id - subSpecification for taskRunner's OutputSpec, useful to avoid outputs collisions one more complex topologies
+  PostProcessingDevice(const std::string& taskName, const std::string& configurationSource);
+  ~PostProcessingDevice() override = default;
+
+  /// \brief TaskRunner's init callback
+  void init(framework::InitContext&) override;
+  /// \brief TaskRunner's process callback
+  void run(framework::ProcessingContext&) override;
+
+  const std::string& getDeviceName();
+  framework::Inputs getInputsSpecs();
+  framework::Outputs getOutputSpecs();
+  framework::Options getOptions();
+
+  /// \brief ID string for all TaskRunner devices
+  static std::string createPostProcessingIdString();
+  /// \brief Unified DataOrigin for Quality Control tasks
+  static header::DataOrigin createPostProcessingDataOrigin();
+  /// \brief Unified DataDescription naming scheme for all tasks
+  static header::DataDescription createPostProcessingDataDescription(const std::string& taskName);
+
+ private:
+  /// \brief Callback for CallbackService::Id::Start (DPL) a.k.a. RUN transition (FairMQ)
+  void start();
+  /// \brief Callback for CallbackService::Id::Stop (DPL) a.k.a. STOP transition (FairMQ)
+  void stop();
+  /// \brief Callback for CallbackService::Id::Reset (DPL) a.k.a. RESET DEVICE transition (FairMQ)
+  void reset();
+
+ private:
+  std::shared_ptr<PostProcessingRunner> mRunner;
+  std::string mDeviceName;
+  std::string mConfigSource;
+};
+
+} // namespace o2::quality_control::core
+
+#endif //QUALITYCONTROL_POSTPROCESSINGDEVICE_H

--- a/Framework/include/QualityControl/PostProcessingRunner.h
+++ b/Framework/include/QualityControl/PostProcessingRunner.h
@@ -70,6 +70,9 @@ class PostProcessingRunner
   /// \param callback MonitorObjectCollection publication callback
   void setPublicationCallback(MOCPublicationCallback callback);
 
+  const std::string& getName();
+  double getPeriod();
+
  private:
   void doInitialize(Trigger trigger);
   void doUpdate(Trigger trigger);

--- a/Framework/include/QualityControl/PostProcessingRunner.h
+++ b/Framework/include/QualityControl/PostProcessingRunner.h
@@ -71,7 +71,6 @@ class PostProcessingRunner
   void setPublicationCallback(MOCPublicationCallback callback);
 
   const std::string& getName();
-  double getPeriod();
 
  private:
   void doInitialize(Trigger trigger);

--- a/Framework/src/PostProcessingDevice.cxx
+++ b/Framework/src/PostProcessingDevice.cxx
@@ -1,0 +1,133 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   PostProcessingDevice.cxx
+/// \author Piotr Konopka
+///
+
+#include "QualityControl/PostProcessingDevice.h"
+
+#include "QualityControl/PostProcessingRunner.h"
+#include "QualityControl/QcInfoLogger.h"
+
+#include <Common/Exceptions.h>
+#include <Configuration/ConfigurationFactory.h>
+#include <Framework/CallbackService.h>
+#include <Framework/ControlService.h>
+
+using namespace AliceO2::Common;
+using namespace o2::configuration;
+using namespace o2::framework;
+
+constexpr auto outputBinding = "mo";
+
+namespace o2::quality_control::postprocessing
+{
+
+PostProcessingDevice::PostProcessingDevice(const std::string& taskName, const std::string& configurationSource)
+  : mRunner(std::make_unique<PostProcessingRunner>(taskName)), mDeviceName(createPostProcessingIdString() + "-" + taskName), mConfigSource(configurationSource)
+{
+  ILOG_INST.setFacility("PostProcessing");
+}
+
+void PostProcessingDevice::init(framework::InitContext& ctx)
+{
+  // todo: eventually we should retrieve the configuration from context
+  auto config = ConfigurationFactory::getConfiguration(mConfigSource);
+  mRunner->init(config->getRecursive());
+
+  // registering state machine callbacks
+  ctx.services().get<CallbackService>().set(CallbackService::Id::Start, [this]() { start(); });
+  ctx.services().get<CallbackService>().set(CallbackService::Id::Stop, [this]() { stop(); });
+  ctx.services().get<CallbackService>().set(CallbackService::Id::Reset, [this]() { reset(); });
+}
+
+void PostProcessingDevice::run(framework::ProcessingContext& ctx)
+{
+  // todo: enable once check runners can store the results.
+  //  Now we still choose the default option - storing data directly to the repo.
+  // we set the publication callback each time, because we cannot be sure that
+  // the reference to DataAllocator does not change
+  // mRunner.setPublicationCallback(publishToDPL(ctx.outputs(), outputBinding));
+
+  // When run returns false, it has done its processing.
+  if (!mRunner->run()) {
+    ctx.services().get<ControlService>().endOfStream();
+    ctx.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+std::string PostProcessingDevice::createPostProcessingIdString()
+{
+  return "PP-TASK-RUNNER";
+}
+o2::header::DataOrigin PostProcessingDevice::createPostProcessingDataOrigin()
+{
+  return header::DataOrigin{ "QC" };
+}
+header::DataDescription PostProcessingDevice::createPostProcessingDataDescription(const std::string& taskName)
+{
+  if (taskName.empty()) {
+    BOOST_THROW_EXCEPTION(FatalException() << errinfo_details("Empty taskName for pp-task's data description"));
+  }
+  o2::header::DataDescription description;
+  description.runtimeInit(std::string(taskName.substr(0, header::DataDescription::size - 3) + "-mo").c_str());
+  return description;
+}
+
+void PostProcessingDevice::start()
+{
+  mRunner->start();
+}
+
+void PostProcessingDevice::stop()
+{
+  mRunner->stop();
+}
+
+void PostProcessingDevice::reset()
+{
+  mRunner->reset();
+}
+
+const std::string& PostProcessingDevice::getDeviceName()
+{
+  return mDeviceName;
+}
+
+framework::Inputs PostProcessingDevice::getInputsSpecs()
+{
+  o2::header::DataDescription timerDescription;
+  timerDescription.runtimeInit(std::string("T-" + mRunner->getName()).substr(0, o2::header::DataDescription::size).c_str());
+
+  return { { "timer-pp-" + mRunner->getName(),
+             createPostProcessingDataOrigin(),
+             timerDescription,
+             0,
+             Lifetime::Timer } };
+}
+
+framework::Outputs PostProcessingDevice::getOutputSpecs()
+{
+  return { { { outputBinding }, createPostProcessingDataOrigin(), createPostProcessingDataDescription(mRunner->getName()), 0 } };
+}
+
+framework::Options PostProcessingDevice::getOptions()
+{
+  // Getting a configurable value for timer period is not straightforward at all.
+  // Passing it as an exec argument would make a long route through InfrastructureGenerator and others
+  // Putting it in the config file is not possible, because we need this parameter during workflow
+  // creation, but PostProcessingRunner reads the config during device initialisation, not sooner.
+  // It is still possible to tweak the value through AliECS, by setting a custom argument value when running this process.
+  return { { "period-timer-pp-" + mRunner->getName(), framework::VariantType::Int, static_cast<int>(10 * 1000000), { "PP task timer period" } } };
+}
+
+} // namespace o2::quality_control::postprocessing

--- a/Framework/src/PostProcessingRunner.cxx
+++ b/Framework/src/PostProcessingRunner.cxx
@@ -193,6 +193,10 @@ void PostProcessingRunner::doFinalize(Trigger trigger)
   mPublicationCallback(mObjectManager->getNonOwningArray(), trigger.timestamp, trigger.timestamp + objectValidity);
   mTaskState = TaskState::Finished;
 }
+const std::string& PostProcessingRunner::getName()
+{
+  return mName;
+}
 
 MOCPublicationCallback publishToDPL(framework::DataAllocator& allocator, std::string outputBinding)
 {

--- a/Framework/test/testInfrastructureGenerator.cxx
+++ b/Framework/test/testInfrastructureGenerator.cxx
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(qc_factory_remote_test)
 
   // the infrastructure should consist of a proxy, merger and checker for the 'skeletonTask' (its taskRunner is declared to be
   // local) and also taskRunner and checker for the 'abcTask' and 'xyzTask'.
-  BOOST_REQUIRE_EQUAL(workflow.size(), 8);
+  BOOST_REQUIRE_EQUAL(workflow.size(), 9);
 
   auto tcpclustProxy = std::find_if(
     workflow.begin(), workflow.end(),
@@ -143,6 +143,15 @@ BOOST_AUTO_TEST_CASE(qc_factory_remote_test)
              d.inputs.size() == 1;
     });
   BOOST_REQUIRE_EQUAL(checkRunnerCount, 3);
+
+  auto postprocessingTask = std::find_if(
+    workflow.begin(), workflow.end(),
+    [](const DataProcessorSpec& d) {
+      return d.name == "PP-TASK-RUNNER-SkeletonPostProcessing" &&
+             d.inputs.size() == 1 &&
+             d.outputs.size() == 1;
+    });
+  BOOST_CHECK(postprocessingTask != workflow.end());
 }
 
 BOOST_AUTO_TEST_CASE(qc_factory_standalone_test)
@@ -150,8 +159,8 @@ BOOST_AUTO_TEST_CASE(qc_factory_standalone_test)
   std::string configFilePath = std::string("json://") + getTestDataDirectory() + "testSharedConfig.json";
   auto workflow = InfrastructureGenerator::generateStandaloneInfrastructure(configFilePath);
 
-  // the infrastructure should consist of 3 TaskRunners, 3 CheckRunners
-  BOOST_REQUIRE_EQUAL(workflow.size(), 6);
+  // the infrastructure should consist of 3 TaskRunners, 3 CheckRunners, 1 PostProcessingRunner
+  BOOST_REQUIRE_EQUAL(workflow.size(), 7);
 
   auto taskRunnerSkeleton = std::find_if(
     workflow.begin(), workflow.end(),
@@ -187,6 +196,15 @@ BOOST_AUTO_TEST_CASE(qc_factory_standalone_test)
              d.inputs.size() == 1;
     });
   BOOST_REQUIRE_EQUAL(checkRunnerCount, 3);
+
+  auto postprocessingTask = std::find_if(
+    workflow.begin(), workflow.end(),
+    [](const DataProcessorSpec& d) {
+      return d.name == "PP-TASK-RUNNER-SkeletonPostProcessing" &&
+             d.inputs.size() == 1 &&
+             d.outputs.size() == 1;
+    });
+  BOOST_CHECK(postprocessingTask != workflow.end());
 }
 
 BOOST_AUTO_TEST_CASE(qc_factory_empty_config)

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -104,7 +104,18 @@ Each of the three methods can be invoked by one or more triggers. Below are list
 
 ## Running it
 
-The post-processing tasks can be run by using the `o2-qc-run-postprocessing` application (only for development) or with `o2-qc-run-postprocessing-occ` (both development and production).
+The post-processing tasks can be run in three ways. First uses the usual `o2-qc` executable which relies on DPL and
+ it is the only one which allows to run checks over objects generated in post-processing tasks. This is will be one
+ of two ways to run PP tasks in production.
+To try it out, use it like for any other QC configuration:
+```
+o2-qc -b --config json://${QUALITYCONTROL_ROOT}/etc/postprocessing.json
+```
+All declared and active tasks in the configuration file will be run in parallel.
+
+Debugging post-processing tasks might be easier when using the `o2-qc-run-postprocessing` application (only for
+ development) or with `o2-qc-run-postprocessing-occ` (both development and production), as they are one-process
+  executables, running only one, chosen task.
 
 To run the basic example, use the command below. The `--config` parameter should point to the configuration file. The `--period` parameter specifies the time interval of checking the specified triggers (in seconds).
 
@@ -118,7 +129,10 @@ This executable also allows to run a Post-processing task in batch mode, i.e. wi
  `--timestamps` argument). This way, one can rerun a task over old data, if such a task actually respects given
   timestamps.
 
-To have more control over the state transitions or to run a post-processing task in production, one should use `o2-qc-run-postprocessing-occ`. It is run almost exactly as the previously mentioned application, however one has to use [`peanut`](https://github.com/AliceO2Group/Control/tree/master/occ#single-process-control-with-peanut) to drive its state transitions and push the configuration.
+To have more control over the state transitions or to run a standalone post-processing task in production, one should
+ use `o2-qc-run-postprocessing-occ`. It is run almost exactly as the previously mentioned application, however one has
+ to use [`peanut`](https://github.com/AliceO2Group/Control/tree/master/occ#single-process-control-with-peanut) to drive
+ its state transitions and push the configuration.
 
 To try it out locally, run the following in the first terminal window (we will try out a different task this time):
 ```


### PR DESCRIPTION
TODO
- merge QC-419
- make "tasks", "checks", "dataSamplingPolicies" and "postprocessing" structures optional in config files
- fix the problem with DPL when two PP tasks are running and finishing one causes the other one to finish
- documentaiton