### PR TITLE
Remove the log when detector is unknown.

### DIFF
--- a/Modules/Daq/src/DaqTask.cxx
+++ b/Modules/Daq/src/DaqTask.cxx
@@ -243,7 +243,6 @@ void DaqTask::monitorRDHs(o2::framework::InputRecord& inputRecord)
     rdhSource = RDHUtils::getSourceID(rdh);
     if (!isDetIdValid(rdhSource)) {
       rdhSource = DAQID::INVALID;
-      ILOG(Warning, Support) << "Unknown detector id: " << unsigned(rdhSource) << ENDM;
     }
     totalSize += RDHUtils::getMemorySize(rdh);
     rdhCounter++;


### PR DESCRIPTION
It is too verbose.