### PR TITLE
[QC-449] Avoid warning about ptr exposed which will be destroyed

### DIFF
--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -284,14 +284,14 @@ void TaskRunner::loadTopologyConfig()
 {
   auto taskConfigTree = getTaskConfigTree();
   auto policiesFilePath = mConfigFile->get<std::string>("dataSamplingPolicyFile", "");
-  ConfigurationInterface* config = policiesFilePath.empty() ? mConfigFile.get() : ConfigurationFactory::getConfiguration(policiesFilePath).get(); // todo make sure that it is ok to use the internal pointer of the unique_ptr
+  std::shared_ptr<configuration::ConfigurationInterface> config = policiesFilePath.empty() ? mConfigFile : ConfigurationFactory::getConfiguration(policiesFilePath);
   auto dataSourceTree = taskConfigTree.get_child("dataSource");
   auto type = dataSourceTree.get<std::string>("type");
 
   if (type == "dataSamplingPolicy") {
     auto policyName = dataSourceTree.get<std::string>("name");
     ILOG(Info, Support) << "policyName : " << policyName << ENDM;
-    mInputSpecs = DataSampling::InputSpecsForPolicy(config, policyName);
+    mInputSpecs = DataSampling::InputSpecsForPolicy(config.get(), policyName);
   } else if (type == "direct") {
     auto inputsQuery = dataSourceTree.get<std::string>("query");
     mInputSpecs = DataDescriptorQueryBuilder::parse(inputsQuery.c_str());


### PR DESCRIPTION
> error: object backing the pointer will be destroyed at the end of the full-expression [-Werror,-Wdangling-gsl]