### PR TITLE
No need to check if ptr is null before deleting

### DIFF
--- a/Modules/Skeleton/src/SkeletonTask.cxx
+++ b/Modules/Skeleton/src/SkeletonTask.cxx
@@ -24,9 +24,7 @@ namespace o2::quality_control_modules::skeleton
 
 SkeletonTask::~SkeletonTask()
 {
-  if (mHistogram) {
-    delete mHistogram;
-  }
+  delete mHistogram;
 }
 
 void SkeletonTask::initialize(o2::framework::InitContext& /*ctx*/)


### PR DESCRIPTION
If a pointer is null, nothing will happen. Since this piece of code is a template for all tasks, let's give a better example.