### PR TITLE
No need to check if O2::DataSampling exists

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -97,7 +97,7 @@ target_link_libraries(QualityControl
                              ms_gsl::ms_gsl
                              QualityControlTypes
                              O2::Mergers
-                             $<$<TARGET_EXISTS:O2::DataSampling>:O2::DataSampling>
+                             O2::DataSampling
                       PRIVATE Boost::system
                               $<$<BOOL:${ENABLE_MYSQL}>:MySQL::MySQL>
                               $<$<BOOL:${ENABLE_MYSQL}>:ROOT::RMySQL> ROOT::Gui


### PR DESCRIPTION
The changes to O2, which move Data Sampling to separate library, have been already merged.