### PR TITLE
Deactivate tests that relied on old data

### DIFF
--- a/Framework/test/testCcdbDatabase.cxx
+++ b/Framework/test/testCcdbDatabase.cxx
@@ -175,61 +175,61 @@ BOOST_AUTO_TEST_CASE(ccdb_retrieve_inexisting_mo)
   BOOST_CHECK(mo == nullptr);
 }
 
-BOOST_AUTO_TEST_CASE(ccdb_retrieve_data_024)
-{
-  // test whether we can read data from version 0.24
-  test_fixture f;
-  map<string, string> filter = { { "qc_version", "0.24.0" } };
-  long timestamp = CcdbDatabase::getFutureTimestamp(60 * 60 * 24 * 365 * 5); // target 5 years in the future as we store with validity of 10 years
-
-  auto* mo = dynamic_cast<MonitorObject*>(f.backend->retrieveTObject("qc/TST_KEEP/task/to_be_kept", filter, timestamp));
-  BOOST_CHECK_NE(mo, nullptr);
-  BOOST_CHECK_EQUAL(mo->getName(), "to_be_kept");
-  BOOST_CHECK_EQUAL(dynamic_cast<TH1F*>(mo->getObject())->GetEntries(), 12345);
-
-  auto* qo = dynamic_cast<QualityObject*>(f.backend->retrieveTObject("qc/checks/TST_KEEP/check", filter, timestamp));
-  BOOST_CHECK_NE(qo, nullptr);
-  BOOST_CHECK_EQUAL(qo->getName(), "check");
-  BOOST_CHECK_EQUAL(qo->getQuality(), o2::quality_control::core::Quality::Bad);
-
-  auto jsonMO = f.backend->retrieveJson("qc/TST_KEEP/task/to_be_kept", timestamp, filter);
-  BOOST_CHECK(!jsonMO.empty());
-
-  auto jsonQO = f.backend->retrieveJson("qc/checks/TST_KEEP/check", timestamp, filter);
-  BOOST_CHECK(!jsonQO.empty());
-}
-
-BOOST_AUTO_TEST_CASE(ccdb_retrieve_data_026)
-{
-  // test whether we can read data from version 0.26
-  test_fixture f;
-  map<string, string> filter = { { "qc_version", "0.26.0" } };
-  long timestamp = CcdbDatabase::getFutureTimestamp(60 * 60 * 24 * 365 * 5); // target 5 years in the future as we store with validity of 10 years
-
-  auto* tobj = f.backend->retrieveTObject("qc/TST_KEEP/task/to_be_kept", filter, timestamp);
-  BOOST_CHECK_NE(tobj, nullptr);
-  BOOST_CHECK_EQUAL(tobj->GetName(), "to_be_kept");
-  BOOST_CHECK_EQUAL(dynamic_cast<TH1F*>(tobj)->GetEntries(), 12345);
-
-  std::map<std::string, std::string> headers;
-  auto* qo = dynamic_cast<QualityObject*>(f.backend->retrieveTObject("qc/checks/TST_KEEP/check", filter, timestamp, &headers));
-  BOOST_CHECK_NE(qo, nullptr);
-  BOOST_CHECK_EQUAL(qo->getName(), "check");
-  BOOST_CHECK_EQUAL(qo->getQuality(), o2::quality_control::core::Quality::Bad);
-  BOOST_CHECK(headers.count("Valid-From") > 0);
-  string validityQO = headers["Valid-From"];
-
-  auto qo2 = f.backend->retrieveQO("qc/checks/TST_KEEP/check", std::stol(validityQO));
-  string run = qo2->getMetadata("Run");
-  cout << "Run : " << run << endl;
-  BOOST_CHECK(run == "0.26.0");
-
-  auto jsonMO = f.backend->retrieveJson("qc/TST_KEEP/task/to_be_kept", timestamp, filter);
-  BOOST_CHECK(!jsonMO.empty());
-
-  auto jsonQO = f.backend->retrieveJson("qc/checks/TST_KEEP/check", timestamp, filter);
-  BOOST_CHECK(!jsonQO.empty());
-}
+//BOOST_AUTO_TEST_CASE(ccdb_retrieve_data_024)
+//{
+//  // test whether we can read data from version 0.24
+//  test_fixture f;
+//  map<string, string> filter = { { "qc_version", "0.24.0" } };
+//  long timestamp = CcdbDatabase::getFutureTimestamp(60 * 60 * 24 * 365 * 5); // target 5 years in the future as we store with validity of 10 years
+//
+//  auto* mo = dynamic_cast<MonitorObject*>(f.backend->retrieveTObject("qc/TST_KEEP/task/to_be_kept", filter, timestamp));
+//  BOOST_CHECK_NE(mo, nullptr);
+//  BOOST_CHECK_EQUAL(mo->getName(), "to_be_kept");
+//  BOOST_CHECK_EQUAL(dynamic_cast<TH1F*>(mo->getObject())->GetEntries(), 12345);
+//
+//  auto* qo = dynamic_cast<QualityObject*>(f.backend->retrieveTObject("qc/checks/TST_KEEP/check", filter, timestamp));
+//  BOOST_CHECK_NE(qo, nullptr);
+//  BOOST_CHECK_EQUAL(qo->getName(), "check");
+//  BOOST_CHECK_EQUAL(qo->getQuality(), o2::quality_control::core::Quality::Bad);
+//
+//  auto jsonMO = f.backend->retrieveJson("qc/TST_KEEP/task/to_be_kept", timestamp, filter);
+//  BOOST_CHECK(!jsonMO.empty());
+//
+//  auto jsonQO = f.backend->retrieveJson("qc/checks/TST_KEEP/check", timestamp, filter);
+//  BOOST_CHECK(!jsonQO.empty());
+//}
+//
+//BOOST_AUTO_TEST_CASE(ccdb_retrieve_data_026)
+//{
+//  // test whether we can read data from version 0.26
+//  test_fixture f;
+//  map<string, string> filter = { { "qc_version", "0.26.0" } };
+//  long timestamp = CcdbDatabase::getFutureTimestamp(60 * 60 * 24 * 365 * 5); // target 5 years in the future as we store with validity of 10 years
+//
+//  auto* tobj = f.backend->retrieveTObject("qc/TST_KEEP/task/to_be_kept", filter, timestamp);
+//  BOOST_CHECK_NE(tobj, nullptr);
+//  BOOST_CHECK_EQUAL(tobj->GetName(), "to_be_kept");
+//  BOOST_CHECK_EQUAL(dynamic_cast<TH1F*>(tobj)->GetEntries(), 12345);
+//
+//  std::map<std::string, std::string> headers;
+//  auto* qo = dynamic_cast<QualityObject*>(f.backend->retrieveTObject("qc/checks/TST_KEEP/check", filter, timestamp, &headers));
+//  BOOST_CHECK_NE(qo, nullptr);
+//  BOOST_CHECK_EQUAL(qo->getName(), "check");
+//  BOOST_CHECK_EQUAL(qo->getQuality(), o2::quality_control::core::Quality::Bad);
+//  BOOST_CHECK(headers.count("Valid-From") > 0);
+//  string validityQO = headers["Valid-From"];
+//
+//  auto qo2 = f.backend->retrieveQO("qc/checks/TST_KEEP/check", std::stol(validityQO));
+//  string run = qo2->getMetadata("Run");
+//  cout << "Run : " << run << endl;
+//  BOOST_CHECK(run == "0.26.0");
+//
+//  auto jsonMO = f.backend->retrieveJson("qc/TST_KEEP/task/to_be_kept", timestamp, filter);
+//  BOOST_CHECK(!jsonMO.empty());
+//
+//  auto jsonQO = f.backend->retrieveJson("qc/checks/TST_KEEP/check", timestamp, filter);
+//  BOOST_CHECK(!jsonQO.empty());
+//}
 
 BOOST_AUTO_TEST_CASE(ccdb_retrieve_qo, *utf::depends_on("ccdb_store"))
 {


### PR DESCRIPTION
Following the failure of ccdb-test, the data in previous format is lost. Deactivating these tests until we decide if we scrap them or try to recreate the data. 