### PR TITLE
TPC: Add task for receiving TPCTrackingQA from external

### DIFF
--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -82,4 +82,5 @@ install(FILES run/tpcQCPID_sampled.json
               run/tpcQCSimpleTrending.json
               run/tpcQCTrendingClusters.json
               run/tpcQCClusters_direct.json
+              run/tpcQCTrackingFromExternal_direct.json
         DESTINATION etc)

--- a/Modules/TPC/run/tpcQCTrackingFromExternal_direct.json
+++ b/Modules/TPC/run/tpcQCTrackingFromExternal_direct.json
@@ -1,0 +1,38 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+    },
+    "externalTasks": {
+      "TPCTrackingQA": {
+        "active": "true",
+        "query": "TPCTrackingQA:TPC/TRACKINGQA/0", "": "Use the task name as binding (encouraged)"
+      }
+    },
+    "checks": {
+    }
+  },
+  "dataSamplingPolicies": [
+  ]
+}


### PR DESCRIPTION
This adds the TPC JSON configuration to receive TPC Tracking QA data as external input.
The second variant to process the QA in a real QC task will come in a second PR.