### PR TITLE
Fix missing include

### DIFF
--- a/Modules/Daq/include/Daq/DaqTask.h
+++ b/Modules/Daq/include/Daq/DaqTask.h
@@ -19,6 +19,7 @@
 #include "QualityControl/TaskInterface.h"
 #include <Headers/DAQID.h>
 #include <map>
+#include <set>
 
 class TH1F;
 


### PR DESCRIPTION
This fails to me without the include, might depend on GCC / ROOT version, probably in the CI it is pulled in somewhere in the include chain.