### PR TITLE
Add TPC Tracking QA Task

### DIFF
--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_library(QcTPC)
 
 target_sources(QcTPC PRIVATE src/PID.cxx
+                             src/Tracking.cxx
                              src/Tracks.cxx
                              src/PIDClusterCheck.cxx
                              src/TrackClusterCheck.cxx
@@ -24,6 +25,7 @@ target_link_libraries(QcTPC
 
 add_root_dictionary(QcTPC
                     HEADERS include/TPC/PID.h
+                            include/TPC/Tracking.h
                             include/TPC/Tracks.h
                             include/TPC/PIDClusterCheck.h
                             include/TPC/TrackClusterCheck.h
@@ -78,6 +80,7 @@ install(FILES run/tpcQCPID_sampled.json
               run/tpcQCPID_direct.json
               run/tpcQCTracks_sampled.json
               run/tpcQCTracks_direct.json
+              run/tpcQCTracking_direct.json
               run/tpcQCClusterChecker.json
               run/tpcQCSimpleTrending.json
               run/tpcQCTrendingClusters.json

--- a/Modules/TPC/include/TPC/LinkDef.h
+++ b/Modules/TPC/include/TPC/LinkDef.h
@@ -4,6 +4,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::quality_control_modules::tpc::PID+;
+#pragma link C++ class o2::quality_control_modules::tpc::Tracking + ;
 #pragma link C++ class o2::quality_control_modules::tpc::Tracks+;
 #pragma link C++ class o2::quality_control_modules::tpc::PIDClusterCheck+;
 #pragma link C++ class o2::quality_control_modules::tpc::TrackClusterCheck+;

--- a/Modules/TPC/include/TPC/Tracking.h
+++ b/Modules/TPC/include/TPC/Tracking.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Tracking.h
+/// \author David Rohr
+///
+
+#ifndef QC_MODULE_TPC_TRACKING_H
+#define QC_MODULE_TPC_TRACKING_H
+
+// O2 includes
+#include "TPCQC/Tracking.h"
+
+// QC includes
+#include "QualityControl/TaskInterface.h"
+
+using namespace o2::quality_control::core;
+
+namespace o2::quality_control_modules::tpc
+{
+
+/// \brief TPC Tracking QC Task
+/// It is final because there is no reason to derive from it. Just remove it if needed.
+/// \author Jens Wiechula
+class Tracking final : public TaskInterface
+{
+ public:
+  /// \brief Constructor
+  Tracking();
+  /// Destructor
+  ~Tracking() override;
+
+  // Definition of the methods for the template method pattern
+  void initialize(o2::framework::InitContext& ctx) override;
+  void startOfActivity(Activity& activity) override;
+  void startOfCycle() override;
+  void monitorData(o2::framework::ProcessingContext& ctx) override;
+  void endOfCycle() override;
+  void endOfActivity(Activity& activity) override;
+  void reset() override;
+
+ private:
+  o2::tpc::qc::Tracking mQCTracking{};
+  o2::tpc::qc::Tracking::outputModes mOutputMode;
+};
+
+} // namespace o2::quality_control_modules::tpc
+
+#endif // QC_MODULE_TPC_TRACKING_H

--- a/Modules/TPC/run/tpcQCTracking_direct.json
+++ b/Modules/TPC/run/tpcQCTracking_direct.json
@@ -1,0 +1,49 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "TPCTrackingQA": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::Tracking",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+            "type": "direct",
+            "query": "inputTracks:TPC/TRACKS/0;inputTrackLabels:TPC/TRACKSMCLBL/0;inputClusRefs:TPC/CLUSREFS/0;inputClusters:TPC/CLUSTERNATIVE/0;inputClusterLabels:TPC/CLNATIVEMCLBL/0"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+    }
+  },
+  "dataSamplingPolicies": [
+
+  ]
+}

--- a/Modules/TPC/src/Tracking.cxx
+++ b/Modules/TPC/src/Tracking.cxx
@@ -1,0 +1,194 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Tracking.cxx
+/// \author David Rohr
+///
+
+// root includes
+#include <TCanvas.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TH1D.h>
+
+// O2 includes
+#include "Framework/ProcessingContext.h"
+#include "Framework/DataRefUtils.h"
+#include <Framework/InputRecord.h>
+#include "Framework/InputRecordWalker.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+#include "DataFormatsTPC/ClusterGroupAttribute.h"
+#include "DataFormatsTPC/ClusterNative.h"
+#include "DataFormatsTPC/ClusterNativeHelper.h"
+#include "TPCQC/Helpers.h"
+#include "GPUO2InterfaceQA.h"
+
+// QC includes
+#include "QualityControl/QcInfoLogger.h"
+#include "TPC/Tracking.h"
+
+using namespace o2::tpc;
+using namespace o2::dataformats;
+using namespace o2::framework;
+using namespace o2::header;
+
+namespace o2::quality_control_modules::tpc
+{
+
+Tracking::Tracking() : TaskInterface() {}
+
+Tracking::~Tracking()
+{
+}
+
+void Tracking::initialize(o2::framework::InitContext& /*ctx*/)
+{
+  QcInfoLogger::GetInstance() << "initialize TPC Tracking QC task" << AliceO2::InfoLogger::InfoLogger::endm;
+  mOutputMode = o2::tpc::qc::Tracking::outputMergeable;
+  mQCTracking.initialize(mOutputMode);
+
+  if (mOutputMode == o2::tpc::qc::Tracking::outputMergeable) {
+    const std::vector<TH1F>* h1;
+    const std::vector<TH2F>* h2;
+    const std::vector<TH1D>* h3;
+    mQCTracking.getHists(h1, h2, h3);
+    for (auto& hist : *h1) {
+      getObjectsManager()->startPublishing((TObject*)&hist);
+    }
+    for (auto& hist : *h2) {
+      getObjectsManager()->startPublishing((TObject*)&hist);
+    }
+    for (auto& hist : *h3) {
+      getObjectsManager()->startPublishing((TObject*)&hist);
+    }
+  }
+}
+
+void Tracking::startOfActivity(Activity& /*activity*/)
+{
+  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  mQCTracking.resetHistograms();
+}
+
+void Tracking::startOfCycle()
+{
+  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+}
+
+void Tracking::monitorData(o2::framework::ProcessingContext& ctx)
+{
+  auto tracks = ctx.inputs().get<std::vector<o2::tpc::TrackTPC>>("inputTracks");
+  auto trackLabels = ctx.inputs().get<std::vector<o2::MCCompLabel>>("inputTrackLabels");
+  auto clusRefs = ctx.inputs().get<std::vector<o2::tpc::TPCClRefElem>>("inputClusRefs");
+
+  constexpr unsigned long tpcSectorMask = 0xFFFFFFFFFul;
+  ClusterNativeAccess clusterIndex;
+  std::unique_ptr<ClusterNative[]> clusterBuffer;
+  ClusterNativeHelper::ConstMCLabelContainerViewWithBuffer clustersMCBuffer;
+  std::vector<gsl::span<const char>> inputs;
+  std::vector<ConstMCLabelContainerView> mcInputs;
+  struct InputRef {
+    DataRef data;
+    DataRef labels;
+  };
+  std::map<int, InputRef> inputrefs;
+  {
+    std::vector<InputSpec> filter = {
+      { "check", ConcreteDataTypeMatcher{ gDataOriginTPC, "CLNATIVEMCLBL" }, Lifetime::Timeframe }
+    };
+    unsigned long recvMask = 0;
+    for (auto const& ref : InputRecordWalker(ctx.inputs(), filter)) {
+      auto const* sectorHeader = DataRefUtils::getHeader<TPCSectorHeader*>(ref);
+      if (sectorHeader == nullptr) {
+        LOG(ERROR) << "sector header missing on header stack";
+        return;
+      }
+      const int sector = sectorHeader->sector();
+      if (sector < 0) {
+        continue;
+      }
+      if (recvMask & sectorHeader->sectorBits) {
+        throw std::runtime_error("can only have one MC data set per sector");
+      }
+      recvMask |= sectorHeader->sectorBits;
+      inputrefs[sector].labels = ref;
+    }
+    if (recvMask != tpcSectorMask) {
+      throw std::runtime_error("Incomplete set of MC labels received");
+    }
+  }
+
+  {
+    std::vector<InputSpec> filter = {
+      { "check", ConcreteDataTypeMatcher{ gDataOriginTPC, "CLUSTERNATIVE" }, Lifetime::Timeframe }
+    };
+    unsigned long recvMask = 0;
+    for (auto const& ref : InputRecordWalker(ctx.inputs(), filter)) {
+      auto const* sectorHeader = DataRefUtils::getHeader<TPCSectorHeader*>(ref);
+      if (sectorHeader == nullptr) {
+        throw std::runtime_error("sector header missing on header stack");
+      }
+      const int sector = sectorHeader->sector();
+      if (sector < 0) {
+        continue;
+      }
+      if (recvMask & sectorHeader->sectorBits) {
+        throw std::runtime_error("can only have one cluster data set per sector");
+      }
+      recvMask |= sectorHeader->sectorBits;
+      inputrefs[sector].data = ref;
+    }
+    if (recvMask != tpcSectorMask) {
+      throw std::runtime_error("Incomplete set of clusters/digits received");
+    }
+  }
+
+  for (auto const& refentry : inputrefs) {
+    auto& ref = refentry.second.data;
+    if (ref.payload == nullptr) {
+      // skip zero-length message
+      continue;
+    }
+    if (refentry.second.labels.header != nullptr && refentry.second.labels.payload != nullptr) {
+      mcInputs.emplace_back(ConstMCLabelContainerView(ctx.inputs().get<gsl::span<char>>(refentry.second.labels)));
+    }
+    inputs.emplace_back(gsl::span(ref.payload, DataRefUtils::getPayloadSize(ref)));
+  }
+  memset(&clusterIndex, 0, sizeof(clusterIndex));
+  ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersMCBuffer, inputs, mcInputs, [&](auto& index) { return tpcSectorMask & (1ul << index); });
+
+  LOG(INFO) << "RECEIVED tracks " << tracks.size() << " (MC " << trackLabels.size() << ", ClusRefs " << clusRefs.size() << ") clusters " << clusterIndex.nClustersTotal << " (MC " << clusterIndex.clustersMCTruth->getNElements() << ")";
+  mQCTracking.processTracks(&tracks, &trackLabels, &clusterIndex);
+}
+
+void Tracking::endOfCycle()
+{
+  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+}
+
+void Tracking::endOfActivity(Activity& /*activity*/)
+{
+  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+}
+
+void Tracking::reset()
+{
+  // clean all the monitor objects here
+
+  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  mQCTracking.resetHistograms();
+}
+
+} // namespace o2::quality_control_modules::tpc


### PR DESCRIPTION
@wiechula @stheckel @tklemenz : This adds the standalone TPC QA task to QC (needs AliceO2Group/AliceO2#4846)
- I can get the reconstructed tracks via `o2-qc-run-tpctrackreader`
- And I am reading the tpc track references from the ROOT file.
In addition, I would need:
- The track MC labels (can I get them also from `o2-qc-run-tpctrackreader` somehow).
- The cluster MC labels (I need to cut on how many clusters are found in the TPC to define some findable criterion, and I think for this I need the MC labels). The O2 workflows usually just initialize a RootTreeReader to read tpc clusters + mc labels internally. Is there already a way I can easily provide them for a QC task?