### PR TITLE
Add explicit dependency on AliceO2::DebugGUI

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -94,6 +94,7 @@ target_link_libraries(QualityControl
                              AliceO2::Monitoring
                              AliceO2::Configuration
                              AliceO2::Occ
+                             AliceO2::DebugGUI
                              ROOT::Net
                              Boost::container
                              O2::Framework


### PR DESCRIPTION
GUI support is going to be moved from O2::Framework to a non linkable
plugin soon, to minimize framework dependencies.