### PR TITLE
[QC-538] Follow the breaking changes in O2 regarding output proxies

### DIFF
--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -288,7 +288,7 @@ void InfrastructureGenerator::generateLocalTaskLocalProxy(framework::WorkflowSpe
                               remoteHost + ":" + remotePort + ",rateLogging=60,transport=zeromq";
 
   workflow.emplace_back(
-    specifyFairMQDeviceOutputProxy(
+    specifyFairMQDeviceMultiOutputProxy(
       proxyName.c_str(),
       { proxyInput },
       channelConfig.c_str()));


### PR DESCRIPTION
https://github.com/AliceO2Group/AliceO2/pull/5254 this broke output proxies for local QC tasks. We need to somehow test multinode setups automatically.