### PR TITLE
Update clang-format workflow to clang-format-11

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,12 +3,21 @@ name: Clang format
 on: [pull_request]
 
 jobs:
-  clang-format-8:
-    runs-on: ubuntu-latest
+  clang-format:
+    # We need at least 20.04 to install clang-format-11.
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install prerequisites
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt update -y
+          sudo apt install -y clang-format-11
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
+          sudo update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-11 100
       - name: Run clang-foramt on changed files
         run: |
           set -x
@@ -20,11 +29,11 @@ jobs:
             exit 0 ;# nothing to check
           fi
 
-          RESULT_OUTPUT=$(git-clang-format-8 --commit ${BASE_COMMIT} --diff --binary $(which clang-format-8) ${COMMIT_FILES})
+          RESULT_OUTPUT=$(git-clang-format --commit ${BASE_COMMIT} --diff ${COMMIT_FILES})
           if [ "$RESULT_OUTPUT" == "no modified files to format" ] || [ "$RESULT_OUTPUT" == "clang-format did not modify any files" ]; then
             exit 0 ;# all good
           else
-            git-clang-format-8 --commit $BASE_COMMIT --diff --binary $(which clang-format-8)
+            git-clang-format --commit $BASE_COMMIT --diff
             echo "$RESULT_OUTPUT"
             exit 1
           fi


### PR DESCRIPTION
Only updated code is checked for each PR, so existing code won't fail CI unless it's touched.