### PR TITLE
Add first version of QC task for TPC calibration data + more output for TPC cluster QC task

### DIFF
--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -8,7 +8,9 @@ target_sources(QcTPC PRIVATE src/PID.cxx
                              src/PIDClusterCheck.cxx
                              src/TrackClusterCheck.cxx
                              src/ROCReductor.cxx
-                             src/Clusters.cxx)
+                             src/Clusters.cxx
+                             src/CalDetPublisher.cxx
+                             src/Utility.cxx)
 
 target_include_directories(
   QcTPC
@@ -31,6 +33,8 @@ add_root_dictionary(QcTPC
                             include/TPC/TrackClusterCheck.h
                             include/TPC/ROCReductor.h
                             include/TPC/Clusters.h
+                            include/TPC/CalDetPublisher.h
+                            include/TPC/Utility.h
                     LINKDEF include/TPC/LinkDef.h
                     BASENAME QcTPC)
 
@@ -86,4 +90,5 @@ install(FILES run/tpcQCPID_sampled.json
               run/tpcQCTrendingClusters.json
               run/tpcQCClusters_direct.json
               run/tpcQCTrackingFromExternal_direct.json
+              run/tpcQCCalDetPublisher.json
         DESTINATION etc)

--- a/Modules/TPC/include/TPC/CalDetPublisher.h
+++ b/Modules/TPC/include/TPC/CalDetPublisher.h
@@ -1,0 +1,63 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CalDetPublisher.h
+/// \author Thomas Klemenz
+///
+
+#ifndef QUALITYCONTROL_CALDETPUBLISHER_H
+#define QUALITYCONTROL_CALDETPUBLISHER_H
+
+// QC includes
+#include "QualityControl/PostProcessingInterface.h"
+
+class TCanvas;
+
+namespace o2::quality_control_modules::tpc
+{
+
+/// \brief Quality Control task for the calibration data of the TPC
+/// \author Thomas Klemenz
+class CalDetPublisher final : public quality_control::postprocessing::PostProcessingInterface
+{
+ public:
+  /// \brief Constructor
+  CalDetPublisher() = default;
+  /// \brief Destructor
+  ~CalDetPublisher() = default;
+
+  /// \brief Initialization of a post-processing task.
+  /// Initialization of a post-processing task. User receives a Trigger which caused the initialization and a service
+  /// registry with singleton interfaces.
+  /// \param trigger  Trigger which caused the initialization, for example Trigger::SOR
+  /// \param services Interface containing optional interfaces, for example DatabaseInterface
+  void initialize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
+  /// \brief Update of a post-processing task.
+  /// Update of a post-processing task. User receives a Trigger which caused the update and a service
+  /// registry with singleton interfaces.
+  /// \param trigger  Trigger which caused the initialization, for example Trigger::Period
+  /// \param services Interface containing optional interfaces, for example DatabaseInterface
+  void update(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
+  /// \brief Finalization of a post-processing task.
+  /// Finalization of a post-processing task. User receives a Trigger which caused the finalization and a service
+  /// registry with singleton interfaces.
+  /// \param trigger  Trigger which caused the initialization, for example Trigger::EOR
+  /// \param services Interface containing optional interfaces, for example DatabaseInterface
+  void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
+
+ private:
+  std::vector<std::unique_ptr<TCanvas>> mPedestalCanvasVec{}; ///< vector holding the summary canvases of the pedestal object
+  std::vector<std::unique_ptr<TCanvas>> mNoiseCanvasVec{};    ///< vector holding the summary canvases of the noise object
+};
+
+} // namespace o2::quality_control_modules::tpc
+
+#endif //QUALITYCONTROL_CALDETPUBLISHER_H

--- a/Modules/TPC/include/TPC/CalDetPublisher.h
+++ b/Modules/TPC/include/TPC/CalDetPublisher.h
@@ -19,10 +19,18 @@
 // QC includes
 #include "QualityControl/PostProcessingInterface.h"
 
+#include <boost/property_tree/ptree_fwd.hpp>
+
 class TCanvas;
 
 namespace o2::quality_control_modules::tpc
 {
+
+/// \brief Valid CalDet objects
+/// This struct contains the valid CalDet objects to be fetched from the CCDB
+enum struct outputType { Pedestal,
+                         Noise
+};
 
 /// \brief Quality Control task for the calibration data of the TPC
 /// \author Thomas Klemenz
@@ -34,6 +42,11 @@ class CalDetPublisher final : public quality_control::postprocessing::PostProces
   /// \brief Destructor
   ~CalDetPublisher() = default;
 
+  /// \brief Configuration of a post-processing task.
+  /// Configuration of a post-processing task. Can be overridden if user wants to retrieve the configuration of the task.
+  /// \param name     Name of the task
+  /// \param config   ConfigurationInterface with prefix set to ""
+  void configure(std::string name, const boost::property_tree::ptree& config) override;
   /// \brief Initialization of a post-processing task.
   /// Initialization of a post-processing task. User receives a Trigger which caused the initialization and a service
   /// registry with singleton interfaces.
@@ -54,8 +67,10 @@ class CalDetPublisher final : public quality_control::postprocessing::PostProces
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
 
  private:
-  std::vector<std::unique_ptr<TCanvas>> mPedestalCanvasVec{}; ///< vector holding the summary canvases of the pedestal object
-  std::vector<std::unique_ptr<TCanvas>> mNoiseCanvasVec{};    ///< vector holding the summary canvases of the noise object
+  std::vector<std::string> mOutputList{};                                ///< list of CalDet objects to be processed
+  std::vector<std::vector<std::unique_ptr<TCanvas>>> mCalDetCanvasVec{}; ///< vector containing a vector of summary canvases for every CalDet object
+  std::vector<std::vector<std::string>> mMetaKeys{};                     ///< vector containing metaData keys; objects can have more than one key
+  std::vector<std::vector<std::string>> mMetaValues{};                   ///< vector containing metaData values
 };
 
 } // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/include/TPC/Clusters.h
+++ b/Modules/TPC/include/TPC/Clusters.h
@@ -24,7 +24,7 @@
 // QC includes
 #include "QualityControl/TaskInterface.h"
 
-#include "TH2F.h"
+class TCanvas;
 
 using namespace o2::quality_control::core;
 
@@ -40,8 +40,8 @@ class Clusters /*final*/ : public TaskInterface // todo add back the "final" whe
  public:
   /// \brief Constructor
   Clusters();
-  /// Destructor
-  ~Clusters() override;
+  /// \brief Destructor
+  ~Clusters() = default;
 
   // Definition of the methods for the template method pattern
   void initialize(o2::framework::InitContext& ctx) override;
@@ -53,9 +53,14 @@ class Clusters /*final*/ : public TaskInterface // todo add back the "final" whe
   void reset() override;
 
  private:
-  o2::tpc::qc::Clusters mQCClusters{};                      ///< O2 Cluster task to perform actions on cluster objects
-  std::vector<std::unique_ptr<TH2F>> mHistoVector{};        ///< vector holding TH2F showing average Cluster properties; published on QCG
-  std::vector<o2::tpc::qc::CalPadWrapper> mWrapperVector{}; ///< vector holding CalPad objects wrapped as TObjects; published on QCG; will be non-wrapped CalPad objects in the future
+  o2::tpc::qc::Clusters mQCClusters{};                         ///< O2 Cluster task to perform actions on cluster objects
+  std::vector<o2::tpc::qc::CalPadWrapper> mWrapperVector{};    ///< vector holding CalPad objects wrapped as TObjects; published on QCG; will be non-wrapped CalPad objects in the future
+  std::vector<std::unique_ptr<TCanvas>> mNClustersCanvasVec{}; ///< summary canvases of the NClusters object
+  std::vector<std::unique_ptr<TCanvas>> mQMaxCanvasVec{};      ///< summary canvases of the QMax object
+  std::vector<std::unique_ptr<TCanvas>> mQTotCanvasVec{};      ///< summary canvases of the QTot object
+  std::vector<std::unique_ptr<TCanvas>> mSigmaTimeCanvasVec{}; ///< summary canvases of the SigmaTime object
+  std::vector<std::unique_ptr<TCanvas>> mSigmaPadCanvasVec{};  ///< summary canvases of the SigmaPad object
+  std::vector<std::unique_ptr<TCanvas>> mTimeBinCanvasVec{};   ///< summary canvases of the TimeBin object
 };
 
 } // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/include/TPC/LinkDef.h
+++ b/Modules/TPC/include/TPC/LinkDef.h
@@ -10,4 +10,9 @@
 #pragma link C++ class o2::quality_control_modules::tpc::TrackClusterCheck+;
 #pragma link C++ class o2::quality_control_modules::tpc::ROCReductor+;
 #pragma link C++ class o2::quality_control_modules::tpc::Clusters+;
+#pragma link C++ class o2::quality_control_modules::tpc::CalDetPublisher+;
+
+#pragma link C++ function o2::quality_control_modules::tpc::addAndPublish+;
+#pragma link C++ function o2::quality_control_modules::tpc::toVector+;
+#pragma link C++ function o2::quality_control_modules::tpc::clusterHandler+;
 #endif

--- a/Modules/TPC/include/TPC/Utility.h
+++ b/Modules/TPC/include/TPC/Utility.h
@@ -31,15 +31,13 @@ namespace o2::quality_control_modules::tpc
 /// \param objectsManager ObjectsManager of the underlying PostProcessingInterface
 /// \param canVec Vector which holds TCanvas pointers persisting for the entire runtime of the task
 /// \param canvNames Names of the canvases
-/// \param Optional std::map to set meta data for the publishing
+/// \param metaData Optional std::map to set meta data for the publishing
 auto addAndPublish = [](std::shared_ptr<o2::quality_control::core::ObjectsManager> objectsManager, auto& canVec, std::vector<std::string_view> canvNames, const std::map<std::string, std::string>& metaData = std::map<std::string, std::string>()) {
   for (const auto& canvName : canvNames) {
     canVec.emplace_back(std::make_unique<TCanvas>(canvName.data()));
     auto canvas = canVec.back().get();
     objectsManager->startPublishing(canvas);
-    if (metaData.size() == 0) {
-      objectsManager->addMetadata(canvas->GetName(), "custom", "42");
-    } else {
+    if (metaData.size() != 0) {
       for (const auto& [key, value] : metaData) {
         objectsManager->addMetadata(canvas->GetName(), key, value);
       }

--- a/Modules/TPC/include/TPC/Utility.h
+++ b/Modules/TPC/include/TPC/Utility.h
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Utility.h
+/// \author Thomas Klemenz
+///
+
+#ifndef QUALITYCONTROL_TPCUTILITY_H
+#define QUALITYCONTROL_TPCUTILITY_H
+
+#include "QualityControl/ObjectsManager.h"
+
+#include "DataFormatsTPC/ClusterNative.h"
+#include "Framework/ProcessingContext.h"
+
+class TCanvas;
+
+namespace o2::quality_control_modules::tpc
+{
+
+/// \brief Prepare canvases to publish DalPad data
+/// This function creates canvases for CalPad data and registers them to be published on the QCG.
+/// \param objectsManager ObjectsManager of the underlying PostProcessingInterface
+/// \param canVec Vector which holds TCanvas pointers persisting for the entire runtime of the task
+/// \param canvNames Names of the canvases
+/// \param Optional std::map to set meta data for the publishing
+auto addAndPublish = [](std::shared_ptr<o2::quality_control::core::ObjectsManager> objectsManager, auto& canVec, std::vector<std::string_view> canvNames, const std::map<std::string, std::string>& metaData = std::map<std::string, std::string>()) {
+  for (const auto& canvName : canvNames) {
+    canVec.emplace_back(std::make_unique<TCanvas>(canvName.data()));
+    auto canvas = canVec.back().get();
+    objectsManager->startPublishing(canvas);
+    if (metaData.size() == 0) {
+      objectsManager->addMetadata(canvas->GetName(), "custom", "42");
+    } else {
+      for (const auto& [key, value] : metaData) {
+        objectsManager->addMetadata(canvas->GetName(), key, value);
+      }
+    }
+  }
+};
+
+/// \brief Converts std::vector<std::unique_ptr<TCanvas>> to std::vector<TCanvas*>
+/// \param input std::vector<std::unique_ptr<TCanvas>> to be converted to std::vector<TCanvas*>
+/// \return std::vector<TCanvas*>
+auto toVector = [](auto& input) {
+  std::vector<TCanvas*> output;
+  for (auto& in : input) {
+    output.emplace_back(in.get());
+  }
+  return output;
+};
+
+/// \brief Converts CLUSTERNATIVE from InputRecord to ClusterNativeAccess
+/// Convenience funtion to make native clusters accessible when receiving them from the DPL
+/// \param input InputReconrd from the ProcessingContext
+/// \return ClusterNativeAccess object for easy cluster access
+o2::tpc::ClusterNativeAccess clusterHandler(o2::framework::InputRecord& input);
+} //namespace o2::quality_control_modules::tpc
+#endif //QUALITYCONTROL_TPCUTILITY_H

--- a/Modules/TPC/run/tpcQCCalDetPublisher.json
+++ b/Modules/TPC/run/tpcQCCalDetPublisher.json
@@ -1,0 +1,43 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "postprocessing": {
+      "PadCalibration": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::CalDetPublisher",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "initTrigger": [
+          "once"
+        ],
+        "updateTrigger": [
+          "once"
+        ],
+        "stopTrigger": [
+          "once"
+        ]
+      }
+    }
+  }
+}

--- a/Modules/TPC/run/tpcQCCalDetPublisher.json
+++ b/Modules/TPC/run/tpcQCCalDetPublisher.json
@@ -28,6 +28,20 @@
         "className": "o2::quality_control_modules::tpc::CalDetPublisher",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
+        "outputList": [
+          "Pedestal",
+          "Noise"
+        ],
+        "metaData": [
+          {
+            "keys": [ "key1", "key2" ],
+            "values": [ "value1", "value2" ]
+          },
+          {
+            "keys": [ "key" ],
+            "values": [ "value" ]
+          }
+        ],
         "initTrigger": [
           "once"
         ],

--- a/Modules/TPC/src/CalDetPublisher.cxx
+++ b/Modules/TPC/src/CalDetPublisher.cxx
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CalDetPublisher.cxx
+/// \author Thomas Klemenz
+///
+
+// O2 includes
+#include "TPC/CalDetPublisher.h"
+#include "TPCBase/Painter.h"
+#include "TPCBase/CDBInterface.h"
+
+// QC includes
+#include "QualityControl/QcInfoLogger.h"
+#include "TPC/Utility.h"
+
+//root includes
+#include "TCanvas.h"
+
+using namespace o2::quality_control::postprocessing;
+
+namespace o2::quality_control_modules::tpc
+{
+
+void CalDetPublisher::initialize(Trigger, framework::ServiceRegistry&)
+{
+  addAndPublish(getObjectsManager(), mPedestalCanvasVec, { "c_Sides_Pedestals", "c_ROCs_Pedestals_1D", "c_ROCs_Pedestals_2D" });
+  addAndPublish(getObjectsManager(), mNoiseCanvasVec, { "c_Sides_Noise", "c_ROCs_Noise_1D", "c_ROCs_Noise_2D" });
+}
+
+void CalDetPublisher::update(Trigger t, framework::ServiceRegistry&)
+{
+  ILOG(Info, Support) << "Trigger type is: " << t.triggerType << ", the timestamp is " << t.timestamp << ENDM;
+
+  //========Pedestals==========
+  auto& pedestal = o2::tpc::CDBInterface::instance().getPedestals();
+  auto vecPtrPed = toVector(mPedestalCanvasVec);
+  o2::tpc::painter::makeSummaryCanvases(pedestal, 300, 0, 0, true, &vecPtrPed);
+
+  //==========Noise===========
+  auto& noise = o2::tpc::CDBInterface::instance().getNoise();
+  auto vecPtrNoise = toVector(mNoiseCanvasVec);
+  o2::tpc::painter::makeSummaryCanvases(noise, 300, 0, 0, true, &vecPtrNoise);
+}
+
+void CalDetPublisher::finalize(Trigger, framework::ServiceRegistry&)
+{
+  for (auto& canvas : mPedestalCanvasVec) {
+    getObjectsManager()->stopPublishing(canvas.get());
+  }
+
+  for (auto& canvas : mNoiseCanvasVec) {
+    getObjectsManager()->stopPublishing(canvas.get());
+  }
+}
+
+} // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/src/CalDetPublisher.cxx
+++ b/Modules/TPC/src/CalDetPublisher.cxx
@@ -25,40 +25,107 @@
 //root includes
 #include "TCanvas.h"
 
+#include <fmt/format.h>
+
 using namespace o2::quality_control::postprocessing;
 
 namespace o2::quality_control_modules::tpc
 {
 
+const std::unordered_map<std::string, outputType> OutputMap{
+  { "Pedestal", outputType::Pedestal },
+  { "Noise", outputType::Noise }
+};
+
+void CalDetPublisher::configure(std::string name, const boost::property_tree::ptree& config)
+{
+  for (const auto& output : config.get_child("qc.postprocessing." + name + ".outputList")) {
+    try {
+      OutputMap.at(output.second.data());
+      mOutputList.emplace_back(output.second.data());
+    } catch (std::out_of_range&) {
+      throw std::invalid_argument(std::string("Invalid output CalDet object specified in config: ") + output.second.data());
+    }
+  }
+
+  for (const auto& data : config.get_child("qc.postprocessing." + name + ".metaData")) {
+    mMetaKeys.emplace_back(std::vector<std::string>());
+    mMetaValues.emplace_back(std::vector<std::string>());
+    if (const auto& keys = data.second.get_child_optional("keys"); keys.has_value()) {
+      for (const auto& key : keys.value()) {
+        mMetaKeys.back().emplace_back(key.second.data());
+      }
+    } else {
+      mMetaKeys.back().emplace_back(std::string());
+    }
+    if (const auto& values = data.second.get_child_optional("values"); values.has_value()) {
+      for (const auto& value : values.value()) {
+        mMetaValues.back().emplace_back(value.second.data());
+      }
+    } else {
+      mMetaValues.back().emplace_back(std::string());
+    }
+  }
+
+  auto iter = 0;
+  for (auto& keyVec : mMetaKeys) {
+    if (keyVec.size() != mMetaValues.at(iter).size()) {
+      throw std::runtime_error("Number of keys and values for metaData are not matching");
+    }
+    if (keyVec.size() == 0) {
+      throw std::runtime_error("Empty key or value lists are not allowed! If you do not want meta data, remove 'keys' and 'values'");
+    }
+    iter++;
+  }
+}
+
 void CalDetPublisher::initialize(Trigger, framework::ServiceRegistry&)
 {
-  addAndPublish(getObjectsManager(), mPedestalCanvasVec, { "c_Sides_Pedestals", "c_ROCs_Pedestals_1D", "c_ROCs_Pedestals_2D" });
-  addAndPublish(getObjectsManager(), mNoiseCanvasVec, { "c_Sides_Noise", "c_ROCs_Noise_1D", "c_ROCs_Noise_2D" });
+  std::map<std::string, std::string> metaData{};
+
+  auto keyIter = 0;
+  if (mMetaKeys.size() == 1) {
+    for (auto& key : mMetaKeys.at(0)) {
+      metaData.insert(std::pair<std::string, std::string>(key, mMetaValues.at(0).at(keyIter)));
+      keyIter++;
+    }
+  }
+
+  auto CalDetIter = 0;
+  for (auto& type : mOutputList) {
+    if (mMetaKeys.size() > 1) {
+      metaData.clear();
+      keyIter = 0;
+      for (auto& key : mMetaKeys.at(CalDetIter)) {
+        metaData.insert(std::pair<std::string, std::string>(key, mMetaValues.at(CalDetIter).at(keyIter)));
+        keyIter++;
+      }
+    }
+    mCalDetCanvasVec.emplace_back(std::vector<std::unique_ptr<TCanvas>>());
+    addAndPublish(getObjectsManager(), mCalDetCanvasVec.back(), { fmt::format("c_Sides_{}", type).data(), fmt::format("c_ROCs_{}_1D", type).data(), fmt::format("c_ROCs_{}_2D", type).data() }, metaData);
+    CalDetIter++;
+  }
 }
 
 void CalDetPublisher::update(Trigger t, framework::ServiceRegistry&)
 {
   ILOG(Info, Support) << "Trigger type is: " << t.triggerType << ", the timestamp is " << t.timestamp << ENDM;
 
-  //========Pedestals==========
-  auto& pedestal = o2::tpc::CDBInterface::instance().getPedestals();
-  auto vecPtrPed = toVector(mPedestalCanvasVec);
-  o2::tpc::painter::makeSummaryCanvases(pedestal, 300, 0, 0, true, &vecPtrPed);
-
-  //==========Noise===========
-  auto& noise = o2::tpc::CDBInterface::instance().getNoise();
-  auto vecPtrNoise = toVector(mNoiseCanvasVec);
-  o2::tpc::painter::makeSummaryCanvases(noise, 300, 0, 0, true, &vecPtrNoise);
+  auto calDetIter = 0;
+  for (auto& type : mOutputList) {
+    auto& calDet = o2::tpc::CDBInterface::instance().getCalPad(fmt::format("TPC/Calib/{}", type).data());
+    auto vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
+    o2::tpc::painter::makeSummaryCanvases(calDet, 300, 0, 0, true, &vecPtr);
+    calDetIter++;
+  }
 }
 
 void CalDetPublisher::finalize(Trigger, framework::ServiceRegistry&)
 {
-  for (auto& canvas : mPedestalCanvasVec) {
-    getObjectsManager()->stopPublishing(canvas.get());
-  }
-
-  for (auto& canvas : mNoiseCanvasVec) {
-    getObjectsManager()->stopPublishing(canvas.get());
+  for (auto& calDetCanvasVec : mCalDetCanvasVec) {
+    for (auto& canvas : calDetCanvasVec) {
+      getObjectsManager()->stopPublishing(canvas.get());
+    }
   }
 }
 

--- a/Modules/TPC/src/Utility.cxx
+++ b/Modules/TPC/src/Utility.cxx
@@ -1,0 +1,102 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Utility.cxx
+/// \author Thomas Klemenz
+///
+
+// O2 includes
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputRecordWalker.h"
+#include "DataFormatsTPC/ClusterNativeHelper.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+
+// QC includes
+#include "TPC/Utility.h"
+
+// external includes
+#include <FairLogger.h>
+#include <bitset>
+
+namespace o2::quality_control_modules::tpc
+{
+o2::tpc::ClusterNativeAccess clusterHandler(o2::framework::InputRecord& input)
+{
+  using namespace o2::tpc;
+  using namespace o2::framework;
+
+  ClusterNativeAccess clusterIndex;
+
+  constexpr static size_t NSectors = o2::tpc::constants::MAXSECTOR;
+
+  std::vector<gsl::span<const char>> inputs;
+  struct InputRef {
+    DataRef data;
+    DataRef labels;
+  };
+  std::map<int, InputRef> inputrefs;
+
+  std::bitset<NSectors> validInputs = 0;
+
+  int operation = 0;
+  std::vector<int> inputIds(36);
+  std::iota(inputIds.begin(), inputIds.end(), 0);
+  std::vector<InputSpec> filter = {
+    { "check", ConcreteDataTypeMatcher{ o2::header::gDataOriginTPC, "CLUSTERNATIVE" }, Lifetime::Timeframe },
+  };
+  for (auto const& ref : InputRecordWalker(input, filter)) {
+    auto const* sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
+    if (sectorHeader == nullptr) {
+      // FIXME: think about error policy
+      LOG(ERROR) << "sector header missing on header stack";
+      return clusterIndex;
+    }
+    const int sector = sectorHeader->sector();
+    std::bitset<o2::tpc::constants::MAXSECTOR> sectorMask(sectorHeader->sectorBits);
+    LOG(INFO) << "Reading TPC cluster data, sector mask is " << sectorMask;
+
+    if (sector < 0) {
+      if (operation < 0 && operation != sector) {
+        // we expect the same operation on all inputs
+        LOG(ERROR) << "inconsistent lane operation, got " << sector << ", expecting " << operation;
+      } else if (operation == 0) {
+        // store the operation
+        operation = sector;
+      }
+      continue;
+    }
+    if ((validInputs & sectorMask).any()) {
+      // have already data for this sector, this should not happen in the current
+      // sequential implementation, for parallel path merged at the tracker stage
+      // multiple buffers need to be handled
+      throw std::runtime_error("can only have one cluster data set per sector");
+    }
+    validInputs |= sectorMask;
+    inputrefs[sector].data = ref;
+  }
+
+  for (auto const& refentry : inputrefs) {
+    //auto& sector = refentry.first;
+    auto& ref = refentry.second.data;
+    inputs.emplace_back(gsl::span(ref.payload, DataRefUtils::getPayloadSize(ref)));
+  }
+
+  std::unique_ptr<ClusterNative[]> clusterBuffer;
+  ClusterNativeHelper::ConstMCLabelContainerViewWithBuffer clustersMCBufferDummy;
+  std::vector<o2::dataformats::ConstMCLabelContainerView> mcInputsDummy;
+  memset(&clusterIndex, 0, sizeof(clusterIndex));
+  ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersMCBufferDummy,
+                                         inputs, mcInputsDummy, [&validInputs](auto& index) { return validInputs.test(index); });
+
+  return clusterIndex;
+}
+
+} // namespace o2::quality_control_modules::tpc


### PR DESCRIPTION
This adds:

- a first version of a QC task for TPC calibration data. For now it takes the most recent pedestal and noise CalPad object from the CCDB and publishes the data in 1D and 2D histograms.
- nicer output for the TPC cluster data.

The calibration data task can be run by simply calling  
`o2-qc --config json:/${QUALITYCONTROL_ROOT}/etc/tpcQCCalibration.json`