### PR TITLE
Small fixes

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -94,7 +94,6 @@ target_link_libraries(QualityControl
                              AliceO2::Monitoring
                              AliceO2::Configuration
                              AliceO2::Occ
-                             AliceO2::DebugGUI
                              ROOT::Net
                              Boost::container
                              O2::Framework
@@ -108,6 +107,10 @@ target_link_libraries(QualityControl
                               $<$<BOOL:${ENABLE_MYSQL}>:MySQL::MySQL>
                               $<$<BOOL:${ENABLE_MYSQL}>:ROOT::RMySQL> ROOT::Gui
                               CURL::libcurl)
+
+if (TARGET AliceO2::DebugGUI) 
+  target_link_libraries(QualityControl PUBLIC AliceO2::DebugGUI)
+endif()
 
 target_compile_definitions(QualityControl PRIVATE
                            $<$<BOOL:${ENABLE_MYSQL}>:_WITH_MYSQL>)

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -24,7 +24,8 @@
 #include <TCanvas.h>
 #include <TPaveText.h>
 #include <TDatime.h>
-#include "TGraphErrors.h"
+#include <TGraphErrors.h>
+#include <TPoint.h>
 
 using namespace o2::quality_control;
 using namespace o2::quality_control::core;

--- a/Modules/MUON/MCH/include/MCH/TH1MCHReductor.h
+++ b/Modules/MUON/MCH/include/MCH/TH1MCHReductor.h
@@ -16,6 +16,7 @@
 #define QUALITYCONTROL_TH1MCHREDUCTOR_H
 
 #include "QualityControl/Reductor.h"
+#include <array>
 
 namespace o2::quality_control_modules::muonchambers
 {

--- a/Modules/MUON/MCH/src/PedestalsCheck.cxx
+++ b/Modules/MUON/MCH/src/PedestalsCheck.cxx
@@ -21,6 +21,7 @@
 #include <fairlogger/Logger.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TLine.h>
 #include <TList.h>
 #include <TMath.h>
 #include <TPaveText.h>


### PR DESCRIPTION
About the DebugGUI change : here I assume that QC can work without it, otherwise may be the `find_package(GLFW)` should specify `REQUIRED` (or the existence of the target DebugGUI be mandatory) ? 
Going a step further :  why is there an explicit find_package(GLFW) at all ? GLFW is only a transitive dependency, isn't it ?