### PR TITLE
[QC-545] Fix memory leaks associated with Monitor Objects

### DIFF
--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -226,6 +226,7 @@ std::shared_ptr<core::MonitorObject> CcdbDatabase::retrieveMO(std::string taskNa
     // TODO should we remove the headers we know are general such as ETag and qc_task_name ?
     mo->addMetadata(headers);
   }
+  mo->setIsOwner(true);
   return mo;
 }
 

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -252,6 +252,7 @@ void CheckRunner::prepareCacheData(framework::InputRecord& inputRecord)
         }
 
         if (mo) {
+          mo->setIsOwner(true);
           mMonitorObjects[mo->getFullName()] = mo;
           updatePolicyManager.updateObjectRevision(mo->getFullName());
           mTotalNumberObjectsReceived++;


### PR DESCRIPTION
When Tasks publish MonitorObjects, they do not own underlying objects - the user algorithm does. However, after they are published, received and deserialized, they should own these objects as there is no one else to delete them.