### PR TITLE
MCH: module name updated to reflect current QC naming scheme

### DIFF
--- a/Modules/MUON/MCH/CMakeLists.txt
+++ b/Modules/MUON/MCH/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MODULE_NAME "QcMuonChambers")
+set(MODULE_NAME "O2QcMuonChambers")
 
 # ---- Files ----
 

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -26,7 +26,7 @@
 using namespace std;
 using namespace o2::framework;
 
-#define QC_MCH_SAVE_TEMP_ROOTFILE 1
+//#define QC_MCH_SAVE_TEMP_ROOTFILE 1
 
 #define MCH_FFEID_MAX (31 * 2 + 1)
 


### PR DESCRIPTION
This PR adapts the name of the MCH module to the new QC library naming scheme.