### PR TITLE
[MCH] temporarily disable pedestals processing

### DIFF
--- a/Modules/MUON/MCH/include/MCH/PedestalsTask.h
+++ b/Modules/MUON/MCH/include/MCH/PedestalsTask.h
@@ -10,7 +10,6 @@
 #include "MCHRawElecMap/Mapper.h"
 #include "MCH/GlobalHistogram.h"
 #include "Framework/DataRef.h"
-#include "MCHCalibration/MCHChannelCalibrator.h"
 
 class TH1F;
 class TH2F;

--- a/Modules/MUON/MCH/include/MCH/PedestalsTask.h
+++ b/Modules/MUON/MCH/include/MCH/PedestalsTask.h
@@ -10,6 +10,7 @@
 #include "MCHRawElecMap/Mapper.h"
 #include "MCH/GlobalHistogram.h"
 #include "Framework/DataRef.h"
+#include "MCHCalibration/PedestalProcessor.h"
 
 class TH1F;
 class TH2F;

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -304,7 +304,7 @@ void PedestalsTask::PlotPedestalDE(uint16_t solarID, uint8_t dsID, uint8_t chann
   }
 }
 
-void PedestalsTask::monitorDataPedestals(o2::framework::ProcessingContext& ctx)
+void PedestalsTask::monitorDataPedestals(o2::framework::ProcessingContext& /*ctx*/)
 { /*
   QcInfoLogger::GetInstance() << "Plotting pedestals" << AliceO2::InfoLogger::InfoLogger::endm;
   using ChannelPedestal = o2::mch::calibration::PedestalCalibrator::ChannelPedestal;

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -22,6 +22,8 @@
 #ifdef MCH_HAS_MAPPING_FACTORY
 #include "MCHMappingFactory/CreateSegmentation.h"
 #endif
+#include "MCHCalibration/PedestalDigit.h"
+//#include "MCHCalibration/PedestalCalibrator.h"
 
 using namespace std;
 using namespace o2::framework;
@@ -303,9 +305,9 @@ void PedestalsTask::PlotPedestalDE(uint16_t solarID, uint8_t dsID, uint8_t chann
 }
 
 void PedestalsTask::monitorDataPedestals(o2::framework::ProcessingContext& ctx)
-{
+{/*
   QcInfoLogger::GetInstance() << "Plotting pedestals" << AliceO2::InfoLogger::InfoLogger::endm;
-  using ChannelPedestal = o2::mch::calibration::MCHChannelCalibrator::ChannelPedestal;
+  using ChannelPedestal = o2::mch::calibration::PedestalCalibrator::ChannelPedestal;
 
   auto pedestals = ctx.inputs().get<gsl::span<ChannelPedestal>>("pedestals");
   for (auto& p : pedestals) {
@@ -318,7 +320,7 @@ void PedestalsTask::monitorDataPedestals(o2::framework::ProcessingContext& ctx)
     auto channel = dsChID.getChannel();
 
     PlotPedestal(solarID, dsID, channel, mean, rms);
-  }
+  }*/
 }
 
 void PedestalsTask::monitorDataDigits(o2::framework::ProcessingContext& ctx)

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -305,7 +305,7 @@ void PedestalsTask::PlotPedestalDE(uint16_t solarID, uint8_t dsID, uint8_t chann
 }
 
 void PedestalsTask::monitorDataPedestals(o2::framework::ProcessingContext& ctx)
-{/*
+{ /*
   QcInfoLogger::GetInstance() << "Plotting pedestals" << AliceO2::InfoLogger::InfoLogger::endm;
   using ChannelPedestal = o2::mch::calibration::PedestalCalibrator::ChannelPedestal;
 


### PR DESCRIPTION
The code that processes the input from the calibrator is temporarily
removed due to the class names changes in AliceO2Group/AliceO2#5772

The code will be re-introduced once the O2 PR is merged.