### PR TITLE
Fix sector filter for TPC input

### DIFF
--- a/Modules/TPC/src/Utility.cxx
+++ b/Modules/TPC/src/Utility.cxx
@@ -94,7 +94,7 @@ o2::tpc::ClusterNativeAccess clusterHandler(o2::framework::InputRecord& input)
   std::vector<o2::dataformats::ConstMCLabelContainerView> mcInputsDummy;
   memset(&clusterIndex, 0, sizeof(clusterIndex));
   ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersMCBufferDummy,
-                                         inputs, mcInputsDummy, [&validInputs](auto& index) { return validInputs.test(index); });
+                                         inputs, mcInputsDummy);
 
   return clusterIndex;
 }


### PR DESCRIPTION
The old logic is broken, since the filter in the TPC helper is not on the sector index, but on the index in the input array (which is only the same if all TPC sectors are present) - quite misleading actually, I ran into the same misinterpretation yesterday. This PR removes the filter and takes the default, which is anyway always correct and simpler.

@Barthelemy : Could I have a new tag with this fix once it passes the CI? It is required for AliceO2Group/AliceO2#5808 which rewrites and fixes this filter logic.

@tklemenz : In general, users do not need to use this copy & pasted code fragment any more to parse the TPC sectors, but there is `DataFormatsTPC/WorkflowHelper.h` which provides `getWorkflowTPCInput(...) `, which already provides all the functionality of `Modules/TPC/src/Utility.cxx`. I just couldn't trivially plug it in, since it returns a data object (say `const auto& tpcData = getWorkflowTPCInput(...)`) that must be kept, and the `clusterIndex` is then available as `tpcData.clusterIndex`. Perhaps it makes sense to adopt this in the TPC QC (e.g. `QC/Modules/TPC/src/Tracking.cxx` uses that already).