### PR TITLE
[QC-415] Set detector field in infologger

### DIFF
--- a/Framework/include/QualityControl/QcInfoLogger.h
+++ b/Framework/include/QualityControl/QcInfoLogger.h
@@ -69,7 +69,7 @@ class QcInfoLogger : public AliceO2::InfoLogger::InfoLogger
   QcInfoLogger(const QcInfoLogger&) = delete;
 
   // remember the contexts
-  AliceO2::InfoLogger::InfoLoggerContext* mContext = nullptr;
+  std::shared_ptr<AliceO2::InfoLogger::InfoLoggerContext> mContext = nullptr;
   AliceO2::InfoLogger::InfoLoggerContext* mDplContext = nullptr;
 };
 

--- a/Framework/include/QualityControl/QcInfoLogger.h
+++ b/Framework/include/QualityControl/QcInfoLogger.h
@@ -51,6 +51,7 @@ class QcInfoLogger : public AliceO2::InfoLogger::InfoLogger
   }
 
   void setFacility(const std::string& facility);
+  void setDetector(const std::string& detector);
   void init(const std::string& facility,
             bool discardDebug = false,
             int discardFromLevel = 21 /* Discard Trace */,
@@ -66,6 +67,10 @@ class QcInfoLogger : public AliceO2::InfoLogger::InfoLogger
   // Disallow copying
   QcInfoLogger& operator=(const QcInfoLogger&) = delete;
   QcInfoLogger(const QcInfoLogger&) = delete;
+
+  // remember the contexts
+  AliceO2::InfoLogger::InfoLoggerContext* mContext = nullptr;
+  AliceO2::InfoLogger::InfoLoggerContext* mDplContext = nullptr;
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/src/QcInfoLogger.cxx
+++ b/Framework/src/QcInfoLogger.cxx
@@ -21,34 +21,40 @@ namespace o2::quality_control::core
 
 QcInfoLogger::QcInfoLogger()
 {
-  infoContext context;
-  context.setField(infoContext::FieldName::Facility, "QC");
-  context.setField(infoContext::FieldName::System, "QC");
-  this->setContext(context);
+  mContext = new AliceO2::InfoLogger::InfoLoggerContext();
+  mContext->setField(infoContext::FieldName::Facility, "QC");
+  mContext->setField(infoContext::FieldName::System, "QC");
+  this->setContext(*mContext);
   *this << "QC infologger initialized" << ENDM;
 }
 
 void QcInfoLogger::setFacility(const std::string& facility)
 {
-  infoContext context;
-  context.setField(infoContext::FieldName::Facility, facility);
-  context.setField(infoContext::FieldName::System, "QC");
-  this->setContext(context);
-  *this << LogDebugDevel << "Facility set to old " << facility << ENDM;
+  mContext->setField(infoContext::FieldName::Facility, facility);
+  mContext->setField(infoContext::FieldName::System, "QC");
+  if (mDplContext) {
+    mDplContext->setField(infoContext::FieldName::System, "QC");
+    mDplContext->setField(infoContext::FieldName::Facility, facility);
+  }
+  this->setContext(*mContext);
+  *this << LogDebugDevel << "Facility set to " << facility << ENDM;
 }
 
-void QcInfoLogger::init(const std::string& facility, bool discardDebug, int discardFromLevel, AliceO2::InfoLogger::InfoLoggerContext* dplContext)
+void QcInfoLogger::setDetector(const std::string& detector)
 {
-  // Set Facility and System
-  infoContext context;
-  context.setField(infoContext::FieldName::Facility, facility);
-  context.setField(infoContext::FieldName::System, "QC");
-  if (dplContext) {
-    dplContext->setField(infoContext::FieldName::System, "QC");
-    dplContext->setField(infoContext::FieldName::Facility, facility);
+  mContext->setField(infoContext::FieldName::Detector, detector);
+  if (mDplContext) {
+    mDplContext->setField(infoContext::FieldName::Detector, detector);
   }
-  this->setContext(context);
-  *this << LogDebugDevel << "Facility set to " << facility << ENDM;
+  this->setContext(*mContext);
+  *this << LogDebugDevel << "Detector set to " << detector << ENDM;
+}
+
+void QcInfoLogger::init(const std::string& facility, bool discardDebug, int discardFromLevel,
+                        AliceO2::InfoLogger::InfoLoggerContext* dplContext)
+{
+  mDplContext=dplContext;
+  setFacility(facility);
 
   // Set the proper discard filters
   ILOG_INST.filterDiscardDebug(discardDebug);
@@ -58,7 +64,8 @@ void QcInfoLogger::init(const std::string& facility, bool discardDebug, int disc
   std::cout << "Discard from level " << discardFromLevel << std::endl;
 }
 
-void QcInfoLogger::init(const std::string& facility, const boost::property_tree::ptree& config, AliceO2::InfoLogger::InfoLoggerContext* dplContext)
+void QcInfoLogger::init(const std::string& facility, const boost::property_tree::ptree& config,
+                        AliceO2::InfoLogger::InfoLoggerContext* dplContext)
 {
   std::string discardDebugStr = config.get<std::string>("qc.config.infologger.filterDiscardDebug", "false");
   bool discardDebug = discardDebugStr == "true" ? 1 : 0;

--- a/Framework/src/QcInfoLogger.cxx
+++ b/Framework/src/QcInfoLogger.cxx
@@ -53,7 +53,7 @@ void QcInfoLogger::setDetector(const std::string& detector)
 void QcInfoLogger::init(const std::string& facility, bool discardDebug, int discardFromLevel,
                         AliceO2::InfoLogger::InfoLoggerContext* dplContext)
 {
-  mDplContext=dplContext;
+  mDplContext = dplContext;
   setFacility(facility);
 
   // Set the proper discard filters

--- a/Framework/src/QcInfoLogger.cxx
+++ b/Framework/src/QcInfoLogger.cxx
@@ -21,7 +21,7 @@ namespace o2::quality_control::core
 
 QcInfoLogger::QcInfoLogger()
 {
-  mContext = new AliceO2::InfoLogger::InfoLoggerContext();
+  mContext = std::make_shared<AliceO2::InfoLogger::InfoLoggerContext>();
   mContext->setField(infoContext::FieldName::Facility, "QC");
   mContext->setField(infoContext::FieldName::System, "QC");
   this->setContext(*mContext);

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -344,6 +344,7 @@ void TaskRunner::loadTaskConfig()
   auto taskConfigTree = getTaskConfigTree();
   string test = taskConfigTree.get<std::string>("detectorName", "MISC");
   mTaskConfig.detectorName = validateDetectorName(taskConfigTree.get<std::string>("detectorName", "MISC"));
+  ILOG_INST.setDetector(mTaskConfig.detectorName);
   mTaskConfig.moduleName = taskConfigTree.get<std::string>("moduleName");
   mTaskConfig.className = taskConfigTree.get<std::string>("className");
   mTaskConfig.maxNumberCycles = taskConfigTree.get<int>("maxNumberCycles", -1);

--- a/Framework/test/testQcInfoLogger.cxx
+++ b/Framework/test/testQcInfoLogger.cxx
@@ -20,7 +20,7 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 #include <fairlogger/Logger.h>
-#include <InfoLogger/InfoLoggerFMQ.hxx>
+#include <cstdlib>
 
 using namespace std;
 using namespace AliceO2::InfoLogger;
@@ -70,6 +70,15 @@ BOOST_AUTO_TEST_CASE(qc_info_logger_2)
   ILOG(Warning, Ops) << "LogWarningOps" << ENDM;
   ILOG(Error, Support) << "LogErrorSupport" << ENDM;
   ILOG(Info, Trace) << "LogInfoTrace" << ENDM;
+}
+
+BOOST_AUTO_TEST_CASE(qc_info_logger_fields)
+{
+  ILOG(Info, Support) << "No fields set, facility=QC, system=QC, detector=<none>" << ENDM;
+  ILOG_INST.setDetector("ITS");
+  ILOG(Info, Support) << "Detector ITS set, facility=QC, system=QC, detector=ITS" << ENDM;
+  ILOG_INST.setFacility("Test");
+  ILOG(Info, Support) << "Facility Test set, facility=Test, system=QC, detector=ITS" << ENDM;
 }
 
 } // namespace o2::quality_control::core

--- a/doc/DevelopersTips.md
+++ b/doc/DevelopersTips.md
@@ -109,6 +109,8 @@ We use the infologger. There is a utility class, `QcInfoLogger`, that can be use
 
 Related issues : https://alice.its.cern.ch/jira/browse/QC-224
 
+To have the full details of what is sent to the logs, do `export INFOLOGGER_MODE=raw`.
+
 ### Service Discovery (Online mode)
 
 Service discovery (Online mode) is used to list currently published objects by running QC tasks and checkers. It uses Consul to store:


### PR DESCRIPTION
Set detector field in infologger in TaskRunner. It does not make sense to do it in the other Runners.
The IL contexts are also stored in the QCInfoLogger to reuse them when the config is changed.