### PR TITLE
Fixes in QualityObject

### DIFF
--- a/Framework/include/QualityControl/QualityObject.h
+++ b/Framework/include/QualityControl/QualityObject.h
@@ -99,10 +99,10 @@ class QualityObject : public TObject
   /// \brief Get a metadata
   /// \return the value corresponding to the key if it was found.
   /// \throw ObjectNotFoundError in case the key is not found.
-  std::string getMetadata(std::string key);
+  std::string getMetadata(std::string key) const;
   /// \brief Get a metadata
   /// \return the value corresponding to the key if it was found, default value otherwise
-  std::string getMetadata(std::string key, std::string defaultValue);
+  std::string getMetadata(std::string key, std::string defaultValue) const;
 
   /// \brief Build the path to this object.
   /// Build the path to this object as it will appear in the GUI.

--- a/Framework/src/Quality.cxx
+++ b/Framework/src/Quality.cxx
@@ -30,7 +30,7 @@ const Quality Quality::Bad(3, "Bad");
 const Quality Quality::Null(NullLevel, "Null"); // we consider it the worst of the worst
 
 Quality::Quality(unsigned int level, std::string name) : mLevel(level), mName(name), mUserMetadata{} {}
-Quality::Quality(const Quality& q) : mLevel(q.mLevel), mName(q.mName), mUserMetadata{} {}
+Quality::Quality(const Quality& q) : mLevel(q.mLevel), mName(q.mName), mUserMetadata{ q.mUserMetadata } {}
 
 unsigned int Quality::getLevel() const { return mLevel; }
 

--- a/Framework/src/QualityObject.cxx
+++ b/Framework/src/QualityObject.cxx
@@ -36,7 +36,7 @@ QualityObject::QualityObject(
     mMonitorObjectsNames{ std::move(monitorObjectsNames) },
     mRunNumber(runNumber)
 {
-  mQuality.overwriteMetadata(metadata);
+  mQuality.overwriteMetadata(std::move(metadata));
 }
 
 QualityObject::~QualityObject() = default;
@@ -95,12 +95,12 @@ void QualityObject::updateMetadata(std::string key, std::string value)
   mQuality.updateMetadata(key, value);
 }
 
-std::string QualityObject::getMetadata(std::string key)
+std::string QualityObject::getMetadata(std::string key) const
 {
   return mQuality.getMetadata(key);
 }
 
-std::string QualityObject::getMetadata(std::string key, std::string defaultValue)
+std::string QualityObject::getMetadata(std::string key, std::string defaultValue) const
 {
   return mQuality.getMetadata(key, defaultValue);
 }

--- a/Framework/test/testQualityObject.cxx
+++ b/Framework/test/testQualityObject.cxx
@@ -26,7 +26,44 @@ using namespace std;
 using namespace o2::quality_control::test;
 using namespace o2::quality_control::core;
 
-BOOST_AUTO_TEST_CASE(quality_object_test)
+BOOST_AUTO_TEST_CASE(quality_object_test_constructors)
+{
+  QualityObject qo(Quality::Medium,
+                   "xyzCheck",
+                   "TST",
+                   "",
+                   { "qc/TST/testTask/mo1", "qc/TST/testTask/mo2" },
+                   {},
+                   { { "probability", "0.45" }, { "threshold_medium", "0.42" } });
+
+  BOOST_CHECK_EQUAL(qo.getName(), "xyzCheck");
+  BOOST_CHECK(strcmp(qo.GetName(), "xyzCheck") == 0);
+  BOOST_CHECK_EQUAL(qo.getDetectorName(), "TST");
+  BOOST_CHECK_EQUAL(qo.getQuality(), Quality::Medium);
+  BOOST_REQUIRE_EQUAL(qo.getInputs().size(), 2);
+  BOOST_CHECK_EQUAL(qo.getInputs()[0], "qc/TST/testTask/mo1");
+  BOOST_CHECK_EQUAL(qo.getInputs()[1], "qc/TST/testTask/mo2");
+  BOOST_REQUIRE_EQUAL(qo.getMetadataMap().count("probability"), 1);
+  BOOST_CHECK_EQUAL(qo.getMetadataMap().at("probability"), "0.45");
+  BOOST_REQUIRE_EQUAL(qo.getMetadataMap().count("threshold_medium"), 1);
+  BOOST_CHECK_EQUAL(qo.getMetadataMap().at("threshold_medium"), "0.42");
+
+  auto qo2 = qo;
+
+  BOOST_CHECK_EQUAL(qo2.getName(), "xyzCheck");
+  BOOST_CHECK(strcmp(qo2.GetName(), "xyzCheck") == 0);
+  BOOST_CHECK_EQUAL(qo2.getDetectorName(), "TST");
+  BOOST_CHECK_EQUAL(qo2.getQuality(), Quality::Medium);
+  BOOST_REQUIRE_EQUAL(qo2.getInputs().size(), 2);
+  BOOST_CHECK_EQUAL(qo2.getInputs()[0], "qc/TST/testTask/mo1");
+  BOOST_CHECK_EQUAL(qo2.getInputs()[1], "qc/TST/testTask/mo2");
+  BOOST_REQUIRE_EQUAL(qo2.getMetadataMap().count("probability"), 1);
+  BOOST_CHECK_EQUAL(qo2.getMetadataMap().at("probability"), "0.45");
+  BOOST_REQUIRE_EQUAL(qo2.getMetadataMap().count("threshold_medium"), 1);
+  BOOST_CHECK_EQUAL(qo2.getMetadataMap().at("threshold_medium"), "0.42");
+}
+
+BOOST_AUTO_TEST_CASE(quality_object_test_setters)
 {
   QualityObject qo(Quality::Null, "xyzCheck");
   qo.setDetectorName("INVALID");


### PR DESCRIPTION
Includes making getMetadata() const methods, copying metadata map in the copy constructor and making one less copy in the main constructor.