### PR TITLE
[QC-496] Allow Checks to associate (many) Reasons with Qualities

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(O2QualityControlTypes
   PUBLIC
   ROOT::Hist
   AliceO2::Common
+  O2::DataFormatsQualityControl
 )
 
 add_root_dictionary(O2QualityControlTypes

--- a/Framework/include/QualityControl/CheckInterface.h
+++ b/Framework/include/QualityControl/CheckInterface.h
@@ -60,7 +60,7 @@ class CheckInterface
   /// @param checkResult The quality returned by the check. It is not the same as the quality of the mo
   ///                    as the latter represents the combination of all the checks the mo passed. This
   ///                    parameter is to be used to pass the result of the check of the same class.
-  virtual void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) = 0;
+  virtual void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult) = 0;
 
   /// \brief Returns the name of the class that can be treated by this check.
   ///

--- a/Framework/include/QualityControl/QualitiesToTRFCollectionConverter.h
+++ b/Framework/include/QualityControl/QualitiesToTRFCollectionConverter.h
@@ -18,7 +18,7 @@
 
 #include <DataFormatsQualityControl/TimeRangeFlag.h>
 #include <memory>
-#include <optional>
+#include <vector>
 
 namespace o2::quality_control
 {
@@ -55,7 +55,7 @@ class QualitiesToTRFCollectionConverter
 
   uint64_t mCurrentStartTime;
   uint64_t mCurrentEndTime;
-  std::optional<TimeRangeFlag> mCurrentTRF;
+  std::vector<TimeRangeFlag> mCurrentTRFs;
   size_t mQOsIncluded;
   size_t mWorseThanGoodQOs;
 };

--- a/Framework/include/QualityControl/Quality.h
+++ b/Framework/include/QualityControl/Quality.h
@@ -19,9 +19,12 @@
 #include <Rtypes.h>
 #include <string>
 #include <map>
+#include <vector>
+#include <DataFormatsQualityControl/FlagReasons.h>
 
 namespace o2::quality_control::core
 {
+using CommentedFlagReasons = std::vector<std::pair<FlagReason, std::string>>;
 
 /// \brief  Class representing the quality of a MonitorObject.
 ///
@@ -31,10 +34,11 @@ class Quality
  public:
   /// Default constructor
   Quality(unsigned int level = Quality::NullLevel, std::string name = "");
+
   /// Destructor
   virtual ~Quality() = default;
   // Copy constructor
-  Quality(const Quality& q);
+  Quality(const Quality& q) = default;
 
   /// Move constructor
   Quality(Quality&& other) /*noexcept*/ = default;
@@ -43,14 +47,14 @@ class Quality
   /// Move assignment operator
   Quality& operator=(Quality&& other) /*noexcept*/ = default;
 
-  unsigned int getLevel() const;
-  const std::string& getName() const;
-
   static const Quality Null;
   static const Quality Good;
   static const Quality Medium;
   static const Quality Bad;
   static const unsigned int NullLevel;
+
+  unsigned int getLevel() const;
+  const std::string& getName() const;
 
   friend bool operator==(const Quality& lhs, const Quality& rhs)
   {
@@ -97,10 +101,18 @@ class Quality
   /// \return the value corresponding to the key if it was found, default value otherwise
   std::string getMetadata(std::string key, std::string defaultValue) const;
 
+  /// \brief Associate the Quality with a new reason and an optional comment
+  /// \return reference to *this
+  Quality& addReason(FlagReason reason, std::string comment = "");
+  /// \brief Get the reasons with associated comments for the Quality
+  /// \return reason, if exists
+  const CommentedFlagReasons& getReasons() const;
+
  private:
   unsigned int mLevel; /// 0 is no quality, 1 is best quality, then it only goes downhill...
   std::string mName;
   std::map<std::string, std::string> mUserMetadata;
+  std::vector<std::pair<FlagReason, std::string>> mReasons;
 
   ClassDef(Quality, 2);
 };

--- a/Framework/include/QualityControl/QualityObject.h
+++ b/Framework/include/QualityControl/QualityObject.h
@@ -110,6 +110,13 @@ class QualityObject : public TObject
   /// \return A string containing the path.
   std::string getPath() const;
 
+  /// \brief Associate the Quality with a new reason and an optional comment
+  /// \return reference to *this
+  QualityObject& addReason(FlagReason reason, std::string comment = "");
+  /// \brief Get the reasons with associated comments for the Quality
+  /// \return reason, if exists
+  const CommentedFlagReasons& getReasons() const;
+
   const std::string& getDetectorName() const;
   void setDetectorName(const std::string& detectorName);
   void setQuality(const Quality& quality);

--- a/Framework/include/QualityControl/TypesLinkDef.h
+++ b/Framework/include/QualityControl/TypesLinkDef.h
@@ -4,7 +4,6 @@
 #pragma link off all functions;
 
 #pragma link C++ namespace o2::quality_control::core;
-
 #pragma link C++ class o2::quality_control::core::MonitorObject + ;
 #pragma link C++ class o2::quality_control::core::QualityObject + ;
 #pragma link C++ class o2::quality_control::core::Quality + ;

--- a/Framework/src/Quality.cxx
+++ b/Framework/src/Quality.cxx
@@ -30,7 +30,6 @@ const Quality Quality::Bad(3, "Bad");
 const Quality Quality::Null(NullLevel, "Null"); // we consider it the worst of the worst
 
 Quality::Quality(unsigned int level, std::string name) : mLevel(level), mName(name), mUserMetadata{} {}
-Quality::Quality(const Quality& q) : mLevel(q.mLevel), mName(q.mName), mUserMetadata{ q.mUserMetadata } {}
 
 unsigned int Quality::getLevel() const { return mLevel; }
 
@@ -85,4 +84,13 @@ std::string Quality::getMetadata(std::string key, std::string defaultValue) cons
   return mUserMetadata.count(key) > 0 ? mUserMetadata.at(key) : defaultValue;
 }
 
+Quality& Quality::addReason(FlagReason reason, std::string comment)
+{
+  mReasons.emplace_back(std::move(reason), std::move(comment));
+  return *this;
+}
+const CommentedFlagReasons& Quality::getReasons() const
+{
+  return mReasons;
+}
 } // namespace o2::quality_control::core

--- a/Framework/src/QualityObject.cxx
+++ b/Framework/src/QualityObject.cxx
@@ -117,6 +117,17 @@ std::string QualityObject::getPath() const
   return path;
 }
 
+QualityObject& QualityObject::addReason(FlagReason reason, std::string comment)
+{
+  mQuality.addReason(reason, std::move(comment));
+  return *this;
+}
+
+const CommentedFlagReasons& QualityObject::getReasons() const
+{
+  return mQuality.getReasons();
+}
+
 const std::string& QualityObject::getDetectorName() const
 {
   return mDetectorName;

--- a/Framework/test/testQuality.cxx
+++ b/Framework/test/testQuality.cxx
@@ -55,4 +55,29 @@ BOOST_AUTO_TEST_CASE(quality_test)
   BOOST_CHECK(!Quality::Good.isBetterThan(Quality::Good));
 }
 
+BOOST_AUTO_TEST_CASE(quality_reasons)
+{
+  Quality myQuality = Quality::Bad;
+  myQuality.addReason(FlagReasonFactory::ProcessingError(), "exception in x");
+  myQuality.addReason(FlagReasonFactory::ProcessingError(), "exception in y");
+  myQuality.addReason(FlagReasonFactory::LimitedAcceptance(), "sector C off");
+
+  auto myReasons = myQuality.getReasons();
+  BOOST_CHECK_EQUAL(myReasons[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(myReasons[0].second, "exception in x");
+  BOOST_CHECK_EQUAL(myReasons[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(myReasons[1].second, "exception in y");
+  BOOST_CHECK_EQUAL(myReasons[2].first, FlagReasonFactory::LimitedAcceptance());
+  BOOST_CHECK_EQUAL(myReasons[2].second, "sector C off");
+
+  auto copyQuality = myQuality;
+  auto copyReasons = copyQuality.getReasons();
+  BOOST_CHECK_EQUAL(copyReasons[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(copyReasons[0].second, "exception in x");
+  BOOST_CHECK_EQUAL(copyReasons[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(copyReasons[1].second, "exception in y");
+  BOOST_CHECK_EQUAL(copyReasons[2].first, FlagReasonFactory::LimitedAcceptance());
+  BOOST_CHECK_EQUAL(copyReasons[2].second, "sector C off");
+}
+
 } // namespace o2::quality_control::core

--- a/Framework/test/testQualityObject.cxx
+++ b/Framework/test/testQualityObject.cxx
@@ -17,6 +17,8 @@
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/testUtils.h"
 
+#include <DataFormatsQualityControl/FlagReasons.h>
+
 #define BOOST_TEST_MODULE QualityObject test
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
@@ -25,6 +27,7 @@
 using namespace std;
 using namespace o2::quality_control::test;
 using namespace o2::quality_control::core;
+using namespace o2::quality_control;
 
 BOOST_AUTO_TEST_CASE(quality_object_test_constructors)
 {
@@ -108,4 +111,38 @@ BOOST_AUTO_TEST_CASE(qopath)
   // policy is OnEachSeparately and the vector is empty
   QualityObject qo4(Quality::Null, "xyzCheck", "DET", "OnEachSeparately", {}, {});
   BOOST_CHECK_EXCEPTION(qo4.getPath(), AliceO2::Common::FatalException, do_nothing);
+}
+
+BOOST_AUTO_TEST_CASE(qo_reasons)
+{
+  QualityObject qo1(Quality::Bad, "xyzCheck", "DET");
+  qo1.addReason(FlagReasonFactory::ProcessingError(), "exception in x");
+  qo1.addReason(FlagReasonFactory::ProcessingError(), "exception in y");
+  qo1.addReason(FlagReasonFactory::LimitedAcceptance(), "sector C off");
+
+  auto reasons1 = qo1.getReasons();
+  BOOST_CHECK_EQUAL(reasons1[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons1[0].second, "exception in x");
+  BOOST_CHECK_EQUAL(reasons1[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons1[1].second, "exception in y");
+  BOOST_CHECK_EQUAL(reasons1[2].first, FlagReasonFactory::LimitedAcceptance());
+  BOOST_CHECK_EQUAL(reasons1[2].second, "sector C off");
+
+  auto qo2 = qo1;
+  auto reasons2 = qo2.getReasons();
+  BOOST_CHECK_EQUAL(reasons2[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons2[0].second, "exception in x");
+  BOOST_CHECK_EQUAL(reasons2[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons2[1].second, "exception in y");
+  BOOST_CHECK_EQUAL(reasons2[2].first, FlagReasonFactory::LimitedAcceptance());
+  BOOST_CHECK_EQUAL(reasons2[2].second, "sector C off");
+
+  auto quality = qo1.getQuality();
+  auto reasons3 = quality.getReasons();
+  BOOST_CHECK_EQUAL(reasons3[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons3[0].second, "exception in x");
+  BOOST_CHECK_EQUAL(reasons3[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons3[1].second, "exception in y");
+  BOOST_CHECK_EQUAL(reasons3[2].first, FlagReasonFactory::LimitedAcceptance());
+  BOOST_CHECK_EQUAL(reasons3[2].second, "sector C off");
 }

--- a/Modules/Skeleton/src/SkeletonCheck.cxx
+++ b/Modules/Skeleton/src/SkeletonCheck.cxx
@@ -20,7 +20,10 @@
 // ROOT
 #include <TH1.h>
 
+#include <DataFormatsQualityControl/FlagReasons.h>
+
 using namespace std;
+using namespace o2::quality_control;
 
 namespace o2::quality_control_modules::skeleton
 {
@@ -42,9 +45,15 @@ Quality SkeletonCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
       for (int i = 0; i < h->GetNbinsX(); i++) {
         if (i > 0 && i < 8 && h->GetBinContent(i) == 0) {
           result = Quality::Bad;
+          result.addReason(FlagReasonFactory::Unknown(),
+                           "It is bad because there is nothing in bin " + std::to_string(i));
           break;
         } else if ((i == 0 || i > 7) && h->GetBinContent(i) > 0) {
           result = Quality::Medium;
+          result.addReason(FlagReasonFactory::Unknown(),
+                           "It is medium because bin " + std::to_string(i) + " is not empty");
+          result.addReason(FlagReasonFactory::ProcessingError(),
+                           "This is to demonstrate that we can assign more than one Reason to a Quality");
         }
       }
     }


### PR DESCRIPTION
It also makes `QualitiesToTRFCollectionConverter` extract FlagReasons during the conversion.