### PR TITLE
TPC QC: change duplicate checker names

### DIFF
--- a/Modules/TPC/run/tpcQCClusters_direct.json
+++ b/Modules/TPC/run/tpcQCClusters_direct.json
@@ -41,7 +41,7 @@
       }
     },
     "checks": {
-      "QcCheck": {
+      "QcCheckClusters": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
         "moduleName": "QcSkeleton",

--- a/Modules/TPC/run/tpcQCPID_direct.json
+++ b/Modules/TPC/run/tpcQCPID_direct.json
@@ -30,10 +30,9 @@
         "detectorName": "TPC",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
-        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
           "type": "direct",
-	  "query" : "inputTracks:TPC/TRACKS/0"
+          "query" : "inputTracks:TPC/TRACKS/0"
         },
         "taskParameters": {
           "nothing": "rien"
@@ -42,7 +41,7 @@
       }
     },
     "checks": {
-      "QcCheck": {
+      "QcCheckPID": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
         "moduleName": "QcSkeleton",

--- a/Modules/TPC/run/tpcQCPID_sampled.json
+++ b/Modules/TPC/run/tpcQCPID_sampled.json
@@ -42,7 +42,7 @@
       }
     },
     "checks": {
-      "QcCheck": {
+      "QcCheckPIDSampled": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
         "moduleName": "QcSkeleton",

--- a/Modules/TPC/run/tpcQCTracks_direct.json
+++ b/Modules/TPC/run/tpcQCTracks_direct.json
@@ -30,7 +30,6 @@
         "detectorName": "TPC",
         "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
-        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
           "type": "direct",
           "query": "inputTracks:TPC/TRACKS/0"
@@ -42,7 +41,7 @@
       }
     },
     "checks": {
-      "QcCheck": {
+      "QcCheckTracks": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
         "moduleName": "QcSkeleton",

--- a/Modules/TPC/run/tpcQCTracks_sampled.json
+++ b/Modules/TPC/run/tpcQCTracks_sampled.json
@@ -42,7 +42,7 @@
       }
     },
     "checks": {
-      "QcCheck": {
+      "QcCheckTracksSampled": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
         "moduleName": "QcSkeleton",


### PR DESCRIPTION
Changed duplicate checker names to avoid crashes when running multiple instances of o2-qc at once with pipes.