### PR TITLE
Use the correct proxy for dispatching data in multinode setups

### DIFF
--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -246,7 +246,7 @@ void InfrastructureGenerator::generateDataSamplingPolicyLocalProxy(framework::Wo
                               ",rateLogging=60,transport=zeromq";
 
   workflow.emplace_back(
-    specifyFairMQDeviceOutputProxy(
+    specifyFairMQDeviceMultiOutputProxy(
       proxyName.c_str(),
       inputSpecs,
       channelConfig.c_str()));


### PR DESCRIPTION
Probably no one uses this yet, so it went unnoticed, but multinode setups with remote QC tasks and parallel sampling were also broken :)