### PR TITLE
[O2-2018] No need to link to ms_gsl...

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -97,7 +97,6 @@ target_link_libraries(O2QualityControl
                              O2::Framework
                              O2::CCDB
                              O2::MCHBase
-                             ms_gsl::ms_gsl
                              O2QualityControlTypes
                              O2::Mergers
                              O2::DataSampling


### PR DESCRIPTION
... which is to be renamed to Microsoft.GSL::GSL anyway