### PR TITLE
[QC-577] [QC-578] Allow for more than one query in multinode sampling policy

### DIFF
--- a/Framework/include/QualityControl/InfrastructureGenerator.h
+++ b/Framework/include/QualityControl/InfrastructureGenerator.h
@@ -125,8 +125,10 @@ class InfrastructureGenerator
   static void generateDataSamplingPolicyLocalProxy(framework::WorkflowSpec& workflow,
                                                    const std::string& policyName,
                                                    const framework::Inputs& inputSpecs,
+                                                   const std::string& localMachine,
                                                    const std::string& localPort);
   static void generateDataSamplingPolicyRemoteProxy(framework::WorkflowSpec& workflow,
+                                                    const std::string& policyName,
                                                     const framework::Outputs& outputSpecs,
                                                     const std::string& localMachine,
                                                     const std::string& localPort);

--- a/Framework/multinode-test.json.in
+++ b/Framework/multinode-test.json.in
@@ -111,7 +111,7 @@
         "localhost"
       ],
       "port": "@UNIQUE_PORT_2@",
-      "query": "random:TST/RAWDATA",
+      "query": "random0:TST/RAWDATA/0;random1:TST/RAWDATA/1",
       "samplingConditions": [
         {
           "condition": "random",

--- a/Framework/script/o2-qc-multinode-test.sh
+++ b/Framework/script/o2-qc-multinode-test.sh
@@ -69,7 +69,7 @@ fi
 delete_data
 
 # store data
-o2-qc-run-producer --message-amount 15  --message-rate 1 -b | timeout 25s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --local --host localhost --run &
+o2-qc-run-producer --producers 2 --message-amount 15  --message-rate 1 -b | timeout 25s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --local --host localhost --run &
 
 timeout 30s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --remote --run
 

--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -132,7 +132,7 @@ WorkflowSpec InfrastructureGenerator::generateLocalInfrastructure(std::string co
     std::vector<std::string> machines = DataSampling::MachinesForPolicy(config.get(), policyName);
     for (const auto& machine : machines) {
       if (machine == host) {
-        generateDataSamplingPolicyLocalProxy(workflow, policyName, inputSpecs, port);
+        generateDataSamplingPolicyLocalProxy(workflow, policyName, inputSpecs, machine, port);
       }
     }
   }
@@ -205,7 +205,7 @@ o2::framework::WorkflowSpec InfrastructureGenerator::generateRemoteInfrastructur
     Outputs outputSpecs = DataSampling::OutputSpecsForPolicy(config.get(), policyName);
     std::vector<std::string> machines = DataSampling::MachinesForPolicy(config.get(), policyName);
     for (const auto& machine : machines) {
-      generateDataSamplingPolicyRemoteProxy(workflow, outputSpecs, machine, port);
+      generateDataSamplingPolicyRemoteProxy(workflow, policyName, outputSpecs, machine, port);
     }
   }
 
@@ -238,27 +238,33 @@ void InfrastructureGenerator::printVersion()
 void InfrastructureGenerator::generateDataSamplingPolicyLocalProxy(framework::WorkflowSpec& workflow,
                                                                    const string& policyName,
                                                                    const framework::Inputs& inputSpecs,
+                                                                   const std::string& localMachine,
                                                                    const string& localPort)
 {
   std::string proxyName = policyName + "-proxy";
-  std::string channelName = inputSpecs.at(0).binding; // channel name has to match binding name.
+  std::string channelName = policyName + "-" + localMachine;
   std::string channelConfig = "name=" + channelName + ",type=push,method=bind,address=tcp://*:" + localPort +
                               ",rateLogging=60,transport=zeromq";
+  auto channelSelector = [channelName](InputSpec const&, const std::unordered_map<std::string, std::vector<FairMQChannel>>&) {
+    return channelName;
+  };
 
   workflow.emplace_back(
     specifyFairMQDeviceMultiOutputProxy(
       proxyName.c_str(),
       inputSpecs,
-      channelConfig.c_str()));
+      channelConfig.c_str(),
+      channelSelector));
 }
 
 void InfrastructureGenerator::generateDataSamplingPolicyRemoteProxy(framework::WorkflowSpec& workflow,
+                                                                    const std::string& policyName,
                                                                     const Outputs& outputSpecs,
                                                                     const std::string& localMachine,
                                                                     const std::string& localPort)
 {
-  std::string channelName = outputSpecs.at(0).binding.value; // channel name has to match binding name.
-  std::string proxyName = channelName;                       // channel name has to match proxy name
+  std::string channelName = policyName + "-" + localMachine;
+  const std::string& proxyName = channelName; // channel name has to match proxy name
 
   std::string channelConfig = "name=" + channelName + ",type=pull,method=connect,address=tcp://" +
                               localMachine + ":" + localPort + ",rateLogging=60,transport=zeromq";

--- a/Framework/test/testInfrastructureGenerator.cxx
+++ b/Framework/test/testInfrastructureGenerator.cxx
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(qc_factory_remote_test)
   auto tcpclustProxy = std::find_if(
     workflow.begin(), workflow.end(),
     [](const DataProcessorSpec& d) {
-      return d.name == "clusters" &&
+      return d.name == "tpcclust-o2flp1" &&
              d.inputs.size() == 0 &&
              d.outputs.size() == 1;
     });


### PR DESCRIPTION
It also gives a more meaningful name for the proxies (sampling policy name instead of binding).

Needs https://github.com/AliceO2Group/AliceO2/pull/6072