### PR TITLE
Disable resources monitoring by default

### DIFF
--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -404,7 +404,6 @@ void CheckRunner::initMonitoring()
 {
   auto monitoringUrl = mConfigFile->get<std::string>("qc.config.monitoring.url", "infologger:///debug?qc");
   mCollector = MonitoringFactory::Get(monitoringUrl);
-  mCollector->enableProcessMonitoring();
   mCollector->addGlobalTag(tags::Key::Subsystem, tags::Value::QC);
   mCollector->addGlobalTag("CheckRunnerName", mDeviceName);
   mTimer.reset(10000000); // 10 s.

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -495,7 +495,7 @@ void TaskRunner::publishCycleStats()
 
 int TaskRunner::publish(DataAllocator& outputs)
 {
-  ILOG(Debug, Support) << "Send data from " << mTaskConfig.taskName << " len: " << mObjectsManager->getNumberPublishedObjects() << ENDM;
+  ILOG(Info, Support) << "Publishing " << mObjectsManager->getNumberPublishedObjects() << " MonitorObjects" << ENDM;
   AliceO2::Common::Timer publicationDurationTimer;
 
   auto concreteOutput = framework::DataSpecUtils::asConcreteDataMatcher(mMonitorObjectsSpec);

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -105,7 +105,6 @@ void TaskRunner::init(InitContext& iCtx)
   // setup monitoring
   auto monitoringUrl = mConfigFile->get<std::string>("qc.config.monitoring.url", "infologger:///debug?qc");
   mCollector = MonitoringFactory::Get(monitoringUrl);
-  mCollector->enableProcessMonitoring();
   mCollector->addGlobalTag(tags::Key::Subsystem, tags::Value::QC);
   mCollector->addGlobalTag("TaskName", mTaskConfig.taskName);
 

--- a/Modules/Benchmark/script/o2-qc-benchmark-checks.sh
+++ b/Modules/Benchmark/script/o2-qc-benchmark-checks.sh
@@ -91,7 +91,7 @@ function benchmark() {
   printf "Test duration [s]:      %s\n" "$test_duration" >> $results_filename
   printf "Warm up cycles:         %s\n" "$warm_up_cycles" >> $results_filename
   echo "nb_checks   , nb_histograms,      nb_bins, objs_per_second, checks_per_second" >> $results_filename
-  local qc_common_args="--run -b --shm-segment-size 50000000000 --infologger-severity info --config json:/"`pwd`'/'$config_file_concrete
+  local qc_common_args="--run -b -b --resources-monitoring 10 --monitoring-backend stdout:// --shm-segment-size 50000000000 --infologger-severity info --config json:/"`pwd`'/'$config_file_concrete
   local producer_common_args="-b"
   if [[ $fill == "no" ]]; then
     producer_common_args=$producer_common_args' --empty'

--- a/Modules/Benchmark/script/o2-qc-benchmark-tasks.sh
+++ b/Modules/Benchmark/script/o2-qc-benchmark-tasks.sh
@@ -90,7 +90,7 @@ function benchmark() {
   printf "Test duration [s]:      %s\n" "$test_duration" >> $results_filename
   printf "Warm up cycles:         %s\n" "$warm_up_cycles" >> $results_filename
   echo "nb_producers, payload_sizes, nb_histograms,      nb_bins, msgs_per_second, data_per_second, objs_published_per_second" >> $results_filename
-  local qc_common_args="--run -b --shm-segment-size 50000000000 --infologger-severity info --config json:/"`pwd`'/'$config_file_concrete
+  local qc_common_args="--run -b -b --resources-monitoring 10 --monitoring-backend stdout:// --shm-segment-size 50000000000 --infologger-severity info --config json:/"`pwd`'/'$config_file_concrete
   local producer_common_args="-b"
   if [[ $fill == "no" ]]; then
     producer_common_args=$producer_common_args' --empty'

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ For a general overview of our (O2) software, organization and processes, please 
     * [Custom QC object metadata](doc/Advanced.md#custom-qc-object-metadata)
     * [Canvas options](doc/Advanced.md#canvas-options)
     * [QC with DPL Analysis](doc/Advanced.md#qc-with-dpl-analysis)
+    * [Monitoring metrics](doc/Advanced.md#monitoring-metrics)
     * [Details on the data storage format in the CCDB](doc/Advanced.md#details-on-the-data-storage-format-in-the-ccdb)
     * [Local CCDB setup](doc/Advanced.md#local-ccdb-setup)
     * [Local QCG (QC GUI) setup](doc/Advanced.md#local-qcg-qc-gui-setup)

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -21,6 +21,7 @@
       * [Getting AODs directly](#getting-aods-directly)
       * [Merging with other analysis workflows](#merging-with-other-analysis-workflows)
       * [Enabling a workflow to run on Hyperloop](#enabling-a-workflow-to-run-on-hyperloop)
+   * [Monitoring metrics](#monitoring-metrics)
    * [Details on the data storage format in the CCDB](#details-on-the-data-storage-format-in-the-ccdb)
       * [Data storage format before v0.14 and ROOT 6.18](#data-storage-format-before-v014-and-root-618)
    * [Local CCDB setup](#local-ccdb-setup)
@@ -432,6 +433,14 @@ configure_file("etc/analysisDerived.json" "${CMAKE_INSTALL_PREFIX}/etc/analysisD
 o2_add_qc_workflow(WORKFLOW_NAME o2-qc-example-analysis-direct CONFIG_FILE_PATH ${CMAKE_INSTALL_PREFIX}/etc/analysisDirect.json)
 o2_add_qc_workflow(WORKFLOW_NAME o2-qc-example-analysis-derived CONFIG_FILE_PATH ${CMAKE_INSTALL_PREFIX}/etc/analysisDerived.json)
 ```
+## Monitoring metrics
+
+The QC framework publishes monitoring metrics concerning data/object rates, which are published to the monitoring backend
+specified in the `"monitoring.url"` parameter in config files. If QC is run in standalone mode (no AliECS) and with 
+`"infologger:///debug?qc"` as the monitoring backend, the metrics will appear in logs in buffered chunks. To force
+printing them as soon as they are reported, please also add `--monitoring-backend infologger://` as the argument.
+
+One can also enable publishing metrics related to CPU/memory usage. To do so, use `--resources-monitoring <interval_sec>`.
 
 ## Details on the data storage format in the CCDB
 


### PR DESCRIPTION
Now it is enabled centrally by AliECS&DPL (--resources-monitoring <interval>). On development setups it creates a lot of logs without a particular need for those imho. @Barthelemy Feel free to contest my views ;)

What I don't understand is why I don't get to see our custom QC metrics without adding `--monitoring-backend stdout://` to an executable. I would expect that removing `enableProcessingMonitoring()` disables only the CPU/RAM metrics, isn't that correct?