### PR TITLE
Increase the timeout values in the multinode test

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -309,7 +309,7 @@ add_test(NAME multinode_test COMMAND o2-qc-multinode-test.sh)
 set_tests_properties(multinode_test
   PROPERTIES ENVIRONMENT "JSON_DIR=${CMAKE_BINARY_DIR}/tests;UNIQUE_PORT_1=${UNIQUE_PORT_1};UNIQUE_PORT_2=${UNIQUE_PORT_2}")
 set_property(TEST multinode_test PROPERTY LABELS slow)
-set_property(TEST multinode_test PROPERTY TIMEOUT 60)
+set_property(TEST multinode_test PROPERTY TIMEOUT 75)
 
 # disable some tests in the CI to avoid un-expected failures.
 # to be removed when it is fixed / understood

--- a/Framework/script/o2-qc-multinode-test.sh
+++ b/Framework/script/o2-qc-multinode-test.sh
@@ -83,9 +83,9 @@ fi
 delete_data
 
 # store data
-o2-qc-run-producer --producers 2 --message-amount 15  --message-rate 1 -b | timeout -s INT 25s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --local --host localhost --run &
+o2-qc-run-producer --producers 2 --message-amount 15  --message-rate 1 -b | timeout -s INT 40s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --local --host localhost --run &
 
-timeout -s INT 30s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --remote --run
+timeout -s INT 35s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --remote --run
 
 # wait until the local QC quits before moving forward.
 wait


### PR DESCRIPTION
The previously used values were still not enough sometimes. The workflows would take even 15 seconds to start.