### PR TITLE
[EMCAL-526] Convert online to offline mapping

### DIFF
--- a/Modules/EMCAL/src/RawTask.cxx
+++ b/Modules/EMCAL/src/RawTask.cxx
@@ -492,9 +492,9 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
         int supermoduleID = feeID / 2; //SM id
         auto& mapping = mMappings->getMappingForDDL(feeID);
 
-        //auto fecIndex = 0.;
-        //auto branchIndex = 0.;
-        //auto fecID = 0.;
+        auto fecIndex = 0;
+        auto branchIndex = 0;
+        auto fecID = 0;
 
         for (auto& chan : decoder.getChannels()) {
           // Row and column in online format, must be remapped to offline indexing,
@@ -513,10 +513,10 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
           if (chType == CHTYP::LEDMON || chType == CHTYP::TRU)
             continue;
 
-          //fecIndex = chan.getFECIndex();
-          //branchIndex = chan.getBranchIndex();
-          //fecID = mMappings->getFEEForChannelInDDL(supermoduleID, fecIndex, branchIndex);
-          nchannels[supermoduleID]++;
+          fecIndex = chan.getFECIndex();
+          branchIndex = chan.getBranchIndex();
+          fecID = mMappings->getFEEForChannelInDDL(supermoduleID, fecIndex, branchIndex);
+          nchannels[fecID]++;
 
           Short_t maxADC = 0;
           Short_t minADC = SHRT_MAX;

--- a/Modules/EMCAL/src/RawTask.cxx
+++ b/Modules/EMCAL/src/RawTask.cxx
@@ -227,7 +227,7 @@ void RawTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   //histos per SM and Trigger
   EventType triggers[2] = { EventType::CAL_EVENT, EventType::PHYS_EVENT };
-  TString histoStr[2] = { "PHYS", "CAL" };
+  TString histoStr[2] = { "CAL", "PHYS" };
   for (auto trg = 0; trg < 2; trg++) {
 
     TProfile2D* histosRawAmplRms; //Filling EMCAL/DCAL


### PR DESCRIPTION
Raw row/col IDs in the DCAL are different in the
online and offline scheme. As the cell index mapping
is using the offline scheme, using the online scheme
will lead to a crash when receiving data from SM 19
(DCAL 1/3) due to invalid cell ID. Local co and row
need to be shifted back to offline index scheme using
the corresponding wrapper function in the geometry.

In addition refactor jfecID -> supermoduleID for
readability.