### PR TITLE
TPC Utility tmp workaround: remove fatal from clusterHandler

### DIFF
--- a/Modules/TPC/src/Utility.cxx
+++ b/Modules/TPC/src/Utility.cxx
@@ -108,12 +108,12 @@ o2::tpc::ClusterNativeAccess clusterHandler(o2::framework::InputRecord& input)
       }
       continue;
     }
-    if ((validInputs & sectorMask).any()) {
+    /*if ((validInputs & sectorMask).any()) {
       // have already data for this sector, this should not happen in the current
       // sequential implementation, for parallel path merged at the tracker stage
       // multiple buffers need to be handled
       throw std::runtime_error("can only have one cluster data set per sector");
-    }
+    }*/
     validInputs |= sectorMask;
     inputrefs[sector].data = ref;
   }


### PR DESCRIPTION
This is a temporary workaround to get rid of a fatal leading to crashes of the cluster workflow.

Once the underlying problem is fixed, this will be put back in.