### PR TITLE
TRD: Use new Digit header location

### DIFF
--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -8,8 +8,8 @@
 #include <TH1.h>
 #include <TH2.h>
 #include <TProfile.h>
-#include "TRDBase/Digit.h"
 #include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/Digit.h"
 #include "QualityControl/ObjectsManager.h"
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/QcInfoLogger.h"


### PR DESCRIPTION
Drops the deprecated version of `TRDBase/Digit.h`, change in https://github.com/AliceO2Group/AliceO2/pull/6014.