### PR TITLE
Increase the timeout of functional_test

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -267,7 +267,7 @@ foreach(i RANGE ${count})
   target_link_libraries(${test_name}
                         PRIVATE O2QualityControl Boost::unit_test_framework)
   add_test(NAME ${test_name} COMMAND ${test_name} ${arg})
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT 30)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 45)
 endforeach()
 
 foreach(t testTaskInterface testWorkflow testTaskRunner testCheckWorkflow


### PR DESCRIPTION
I saw the following timeout of functional_test:
```
[13515:QC-TASK-RUNNER-FunctionalTest7CpvH]: [07:22:51][INFO] Successfully removed 'fmq_0d5e07b7_cv'.
[13515:QC-TASK-RUNNER-FunctionalTest7CpvH]: [07:22:51][STATE] RESETTING DEVICE ---> IDLE
[13515:QC-TASK-RUNNER-FunctionalTest7CpvH]: [07:22:51][STATE] IDLE ---> EXITING
[13515:QC-TASK-RUNNER-FunctionalTest7CpvH]: [07:22:51][STATE] Exiting FairMQ state machine
[INFO] Dumping used configuration in dpl-config.json
+++ date +%s
++ curl -L ccdb-test.cern.ch:8080/qc/TST/MO/FunctionalTest7CpvH/example/1626420171999 --write-out '%{http_code}' --silent --output /tmp/output7CpvH.root
+ code=200
+ ((  200 != 200  ))
+ root -b -l -q -e 'TFile f("/tmp/output${UNIQUE_ID}.root"); f.Print();'
```
It seems that it was very close to finish.