### PR TITLE
[EMCAL-702] Add protection against empty timeframes

### DIFF
--- a/Modules/EMCAL/include/EMCAL/RawTask.h
+++ b/Modules/EMCAL/include/EMCAL/RawTask.h
@@ -24,6 +24,7 @@
 #include <array>
 #include <cstdint>
 #include <unordered_map>
+#include <string_view>
 
 #include "DetectorsRaw/RDHUtils.h"
 #include "Headers/RAWDataHeader.h"
@@ -65,6 +66,15 @@ class RawTask final : public TaskInterface
   void endOfActivity(Activity& activity) override;
   void reset() override;
 
+  /// \brief Set the data origin
+  /// \param origin Data origin
+  ///
+  /// Normally data origin is EMC, however in case the
+  /// Task subscribes directly to readout or the origin
+  /// is different in the STFbuilder this needs to be handled
+  /// accordingly
+  void setDataOrigin(const std::string_view origin) { mDataOrigin = origin; }
+
   enum class EventType {
     CAL_EVENT,
     PHYS_EVENT
@@ -94,7 +104,10 @@ class RawTask final : public TaskInterface
     }
   };
 
+  bool isLostTimeframe(framework::ProcessingContext& ctx) const;
+
   o2::emcal::Geometry* mGeometry = nullptr; ///< EMCAL geometry
+  std::string mDataOrigin = "EMC";
   TH1* mPayloadSize = nullptr;
   TH1* mMessageCounter = nullptr;
   TH1* mNumberOfSuperpagesPerMessage;


### PR DESCRIPTION
-Filter deadbeaf messages and treat them as 
  empty timeframe
- Iterate over origin/RAWDATA with the help of
  InputRecordWalker in preparation of the support
  for FLP/DISTSUBTIMEFRAME
- Make origin settable (default: EMC) in order to
  allow to connect the Raw QC directly to readout.