### PR TITLE
[EMCAL-704] Add debug printouts for subevents and filter deadbeaf messages

### DIFF
--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -98,6 +98,7 @@ class DigitsQcTask final : public TaskInterface
     int mSpecification;
     dataformats::RangeReference<int, int> mCellRange;
   };
+
   struct CombinedEvent {
     InteractionRecord mInteractionRecord;
     uint32_t mTriggerType;
@@ -110,6 +111,11 @@ class DigitsQcTask final : public TaskInterface
         nObjects += ev.mCellRange.getEntries();
       return nObjects;
     }
+
+    int getNumberOfSubevents()
+    {
+      return mSubevents.size();
+    };
   };
   std::vector<CombinedEvent> buildCombinedEvents(const std::unordered_map<int, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const;
   void startPublishing(DigitsHistograms& histos);

--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -25,6 +25,7 @@
 #include <TProfile2D.h>
 #include "CommonDataFormat/InteractionRecord.h"
 #include "CommonDataFormat/RangeReference.h"
+#include "Headers/DataHeader.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 
 class TH1;
@@ -95,7 +96,7 @@ class DigitsQcTask final : public TaskInterface
 
  private:
   struct SubEvent {
-    int mSpecification;
+    header::DataHeader::SubSpecificationType mSpecification;
     dataformats::RangeReference<int, int> mCellRange;
   };
 
@@ -107,8 +108,9 @@ class DigitsQcTask final : public TaskInterface
     int getNumberOfObjects() const
     {
       int nObjects = 0;
-      for (auto ev : mSubevents)
+      for (auto ev : mSubevents) {
         nObjects += ev.mCellRange.getEntries();
+      }
       return nObjects;
     }
 
@@ -117,7 +119,7 @@ class DigitsQcTask final : public TaskInterface
       return mSubevents.size();
     };
   };
-  std::vector<CombinedEvent> buildCombinedEvents(const std::unordered_map<int, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const;
+  std::vector<CombinedEvent> buildCombinedEvents(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const;
   void startPublishing(DigitsHistograms& histos);
   Double_t mCellThreshold = 0.5;                               ///< energy cell threshold
   Bool_t mDoEndOfPayloadCheck = false;                         ///< Do old style end-of-payload check

--- a/Modules/EMCAL/src/DigitsQcTask.cxx
+++ b/Modules/EMCAL/src/DigitsQcTask.cxx
@@ -128,7 +128,7 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (!trg.getNumberOfObjects()) {
       continue;
     }
-    QcInfoLogger::GetInstance() << QcInfoLogger::Debug << "Next event " << eventcounter << " has " << trg.getNumberOfObjects() << " digits" << QcInfoLogger::endm;
+    QcInfoLogger::GetInstance() << QcInfoLogger::Debug << "Next event " << eventcounter << " has " << trg.getNumberOfObjects() << " digits from " << trg.getNumberOfSubevents() << " subevent(s)" << QcInfoLogger::endm;
 
     //trigger type
     auto triggertype = trg.mTriggerType;
@@ -151,6 +151,7 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (cellsSubspec == cellSubEvents.end()) {
         QcInfoLogger::GetInstance() << QcInfoLogger::Error << "No cell data found for subspecification " << subev.mSpecification << QcInfoLogger::endm;
       } else {
+        QcInfoLogger::GetInstance() << QcInfoLogger::Debug << subev.mCellRange.getEntries() << " digits in subevent from equipment " << subev.mSpecification << QcInfoLogger::endm;
         gsl::span<const o2::emcal::Cell> eventdigits(cellsSubspec->second.data() + subev.mCellRange.getFirstEntry(), subev.mCellRange.getEntries());
         for (auto digit : eventdigits) {
           int index = digit.getHighGain() ? 0 : (digit.getLowGain() ? 1 : -1);


### PR DESCRIPTION
For the initial debugging phase adding printouts
for the digits received from subevents.