### PR TITLE
[CPV] Some make up for CPV Pedestal task

### DIFF
--- a/Modules/CPV/include/CPV/PedestalTask.h
+++ b/Modules/CPV/include/CPV/PedestalTask.h
@@ -54,7 +54,6 @@ class PedestalTask final : public TaskInterface
 
  private:
   void initHistograms();
-  // void fillHistograms(const gsl::span<const o2::cpv::Digit>& digits, const gsl::span<const o2::cpv::TriggerRecord>& triggerRecords);
   void fillHistograms();
   void resetHistograms();
 
@@ -100,6 +99,7 @@ class PedestalTask final : public TaskInterface
 
   int mNEventsTotal;
   int mNEventsFromLastFillHistogramsCall;
+  int mMinNEventsToUpdatePedestals = 1000; ///< min number of events needed to update pedestals
 
   std::array<TH1F*, kNHist1D> mHist1D = { nullptr }; ///< Array of 1D histograms
   std::array<TH2F*, kNHist2D> mHist2D = { nullptr }; ///< Array of 2D histograms

--- a/Modules/CPV/src/PedestalCheck.cxx
+++ b/Modules/CPV/src/PedestalCheck.cxx
@@ -136,6 +136,7 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
+        msg->AddText(Form("Run %d", mo->getRunNumber()));
         //count number of too small pedestals + too big pedestals
         int nOfBadPedestalValues = h->Integral(1, mMinGoodPedestalValueM[iMod]) + h->GetBinContent(h->GetNbinsX() + 1); //underflow + small pedestals + overflow
         if (nOfBadPedestalValues > mToleratedBadPedestalValueChannelsM[iMod]) {
@@ -171,6 +172,7 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
+        msg->AddText(Form("Run %d", mo->getRunNumber()));
         //count number of too small pedestals + too big pedestals
         float binWidth = h->GetBinWidth(1);
         int nOfBadPedestalSigmas = h->Integral(mMaxGoodPedestalSigmaM[iMod] / binWidth + 1,
@@ -198,6 +200,7 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
+        msg->AddText(Form("Run %d", mo->getRunNumber()));
         //count number of too small pedestals + too big pedestals
         float binWidth = h->GetBinWidth(1);
         int nOfBadPedestalEfficiencies = 7680 -

--- a/Modules/CPV/src/PedestalTask.cxx
+++ b/Modules/CPV/src/PedestalTask.cxx
@@ -55,8 +55,10 @@ void PedestalTask::initialize(o2::framework::InitContext& /*ctx*/)
   ILOG(Info, Support) << "initialize PedestalTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
 
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
-  if (auto param = mCustomParameters.find("myOwnKey"); param != mCustomParameters.end()) {
-    ILOG(Info, Devel) << "Custom parameter - myOwnKey: " << param->second << ENDM;
+  if (auto param = mCustomParameters.find("minNEventsToUpdatePedestals"); param != mCustomParameters.end()) {
+    ILOG(Info, Devel) << "Custom parameter : minNEventsToUpdatePedestals " << param->second << ENDM;
+    mMinNEventsToUpdatePedestals = stoi(param->second);
+    ILOG(Info, Devel) << "I set minNEventsToUpdatePedestals = " << mMinNEventsToUpdatePedestals << ENDM;
   }
   initHistograms();
   mNEventsTotal = 0;
@@ -65,7 +67,7 @@ void PedestalTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void PedestalTask::startOfActivity(Activity& activity)
 {
-  ILOG(Info, Support) << "startOfActivity" << activity.mId << ENDM;
+  ILOG(Info, Support) << "startOfActivity() : resetting everything" << activity.mId << ENDM;
   resetHistograms();
   mNEventsTotal = 0;
   mNEventsFromLastFillHistogramsCall = 0;
@@ -73,7 +75,7 @@ void PedestalTask::startOfActivity(Activity& activity)
 
 void PedestalTask::startOfCycle()
 {
-  ILOG(Info, Support) << "startOfCycle" << ENDM;
+  ILOG(Info, Devel) << "startOfCycle" << ENDM;
   //at at the startOfCycle all HistAmplitudes are not updated by definition
   for (int i = 0; i < kNChannels; i++)
     mIsUpdatedAmplitude[i] = false;
@@ -114,24 +116,25 @@ void PedestalTask::monitorData(o2::framework::ProcessingContext& ctx)
   // 2. Using get("<binding>")
   auto digits = ctx.inputs().get<gsl::span<o2::cpv::Digit>>("digits");
   mHist1D[H1DNDigitsPerInput]->Fill(digits.size());
-  for (const auto& digit : digits) {
-    mHist1D[H1DDigitIds]->Fill(digit.getAbsId());
-    short relId[3];
-    mCPVGeometry.absToRelNumbering(digit.getAbsId(), relId);
-    //reminder: relId[3]={Module, phi col, z row} where Module=2..4, phi col=0..127, z row=0..59
-    mHist2D[H2DDigitMapM2 + relId[0] - 2]->Fill(relId[1], relId[2]);
-    mHistAmplitudes[digit.getAbsId()]->Fill(digit.getAmplitude());
-    mIsUpdatedAmplitude[digit.getAbsId()] = true;
-  }
 
   auto digitsTR = ctx.inputs().get<gsl::span<o2::cpv::TriggerRecord>>("dtrigrec");
   //mNEventsTotal += digitsTR.size();//number of events in the current input
   for (const auto& trigRecord : digitsTR) {
-    ILOG(Info, Devel) << " monitorData() : trigger record #" << mNEventsTotal
-                      << " contains " << trigRecord.getNumberOfObjects() << " objects." << ENDM;
+    LOG(DEBUG) << " monitorData() : trigger record #" << mNEventsTotal
+               << " contains " << trigRecord.getNumberOfObjects() << " objects." << ENDM;
     if (trigRecord.getNumberOfObjects() > 0) { //at least 1 digit -> pedestal event
       mNEventsTotal++;
       mNEventsFromLastFillHistogramsCall++;
+      for (int iDig = trigRecord.getFirstEntry(); iDig < trigRecord.getFirstEntry() + trigRecord.getNumberOfObjects(); iDig++) {
+        mHist1D[H1DDigitIds]->Fill(digits[iDig].getAbsId());
+        short relId[3];
+        if (mCPVGeometry.absToRelNumbering(digits[iDig].getAbsId(), relId)) {
+          //reminder: relId[3]={Module, phi col, z row} where Module=2..4, phi col=0..127, z row=0..59
+          mHist2D[H2DDigitMapM2 + relId[0] - 2]->Fill(relId[1], relId[2]);
+          mHistAmplitudes[digits[iDig].getAbsId()]->Fill(digits[iDig].getAmplitude());
+          mIsUpdatedAmplitude[digits[iDig].getAbsId()] = true;
+        }
+      }
     }
   }
   // get the payload of a specific input, which is a char array. "random" is the binding specified in the config file.
@@ -163,20 +166,22 @@ void PedestalTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void PedestalTask::endOfCycle()
 {
-  ILOG(Info, Support) << "endOfCycle. I call fillHistograms()" << ENDM;
+  ILOG(Info, Devel) << "endOfCycle. I call fillHistograms()" << ENDM;
   //fit histograms if have sufficient increment of event number
-  if (mNEventsFromLastFillHistogramsCall > 1000)
+  if (mNEventsFromLastFillHistogramsCall >= mMinNEventsToUpdatePedestals) {
     fillHistograms();
-  mNEventsFromLastFillHistogramsCall = 0;
+    mNEventsFromLastFillHistogramsCall = 0;
+  }
 }
 
 void PedestalTask::endOfActivity(Activity& /*activity*/)
 {
   ILOG(Info, Support) << "endOfActivity" << ENDM;
   //do a final fill of histograms (if needed)
-  if (mNEventsFromLastFillHistogramsCall)
+  if (mNEventsFromLastFillHistogramsCall) {
+    ILOG(Info, Devel) << "Final call of fillHistograms() " << ENDM;
     fillHistograms();
-  mNEventsFromLastFillHistogramsCall = 0;
+  }
 }
 
 void PedestalTask::reset()
@@ -190,15 +195,17 @@ void PedestalTask::reset()
 
 void PedestalTask::initHistograms()
 {
+  ILOG(Info, Devel) << "initing histograms" << ENDM;
+
   //create monitoring histograms (or reset, if they already exist)
   for (int i = 0; i < kNChannels; i++) {
     if (!mHistAmplitudes[i]) {
       mHistAmplitudes[i] =
         new TH1F(Form("HistAmplitude%d", i), Form("HistAmplitude%d", i), 4096, 0., 4096.);
       //publish some of them
-      if (i % 1000 == 0)
+      if (i % 1000 == 0) {
         getObjectsManager()->startPublishing(mHistAmplitudes[i]);
-
+      }
     } else {
       mHistAmplitudes[i]->Reset();
     }


### PR DESCRIPTION
Run number indication added to CPV Pedestal. Processing of digits is done within triggerRecords.
Minimum number of events needed to trigger fit of histograms became configurable parameter. 
