### PR TITLE
[EMCAL-524] Make histograms vs cell ID optional

### DIFF
--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -20,6 +20,7 @@
 #include "QualityControl/TaskInterface.h"
 #include <array>
 #include <unordered_map>
+#include <string_view>
 #include <gsl/span>
 #include <CCDB/TObjectWrapper.h>
 #include <TProfile2D.h>
@@ -40,6 +41,7 @@ namespace emcal
 class Geometry;
 class BadChannelMap;
 class TimeCalibrationParams;
+class Cell;
 } // namespace emcal
 
 namespace quality_control_modules
@@ -58,27 +60,36 @@ class DigitsQcTask final : public TaskInterface
 {
  public:
   struct DigitsHistograms {
-    std::string mTriggerClass;
+    o2::emcal::Geometry* mGeometry;
+    double mCellThreshold = 0; //
     //std::array<TH2*, 2> mDigitAmplitude;      ///< Digit amplitude
-    TH2* mDigitAmplitude; ///< Digit amplitude
-                          //    std::array<TH2*, 2> mDigitTime;           ///< Digit time
-    TH2* mDigitTime;      ///< Digit time
+    TH2* mDigitAmplitude = nullptr; ///< Digit amplitude
+                                    //    std::array<TH2*, 2> mDigitTime;           ///< Digit time
+    TH2* mDigitTime = nullptr;      ///< Digit time
     //std::array<TH2*, 2> mDigitAmplitudeCalib; ///< Digit amplitude calibrated
-    TH2* mDigitAmplitudeCalib; ///< Digit amplitude calibrated
-                               //  std::array<TH2*, 2> mDigitTimeCalib;      ///< Digit time calibrated
-    TH2* mDigitTimeCalib;      ///< Digit time calibrated
+    TH2* mDigitAmplitudeCalib = nullptr; ///< Digit amplitude calibrated
+                                         //  std::array<TH2*, 2> mDigitTimeCalib;      ///< Digit time calibrated
+    TH2* mDigitTimeCalib = nullptr;      ///< Digit time calibrated
 
-    TH2* mDigitOccupancy = nullptr;             ///< Digit occupancy EMCAL and DCAL
-    TH2* mDigitOccupancyThr = nullptr;          ///< Digit occupancy EMCAL and DCAL with Energy trheshold
-    TProfile2D* mIntegratedOccupancy = nullptr; ///< Digit integrated occupancy
-    TH1* mDigitAmplitudeEMCAL = nullptr;        ///< Digit amplitude in EMCAL
-    TH1* mDigitAmplitudeDCAL = nullptr;         ///< Digit amplitude in DCAL
-    TH1* mnumberEvents = nullptr;               ///< Number of Events for normalization
+    TH2* mDigitAmpSupermodule = nullptr;
+    TH2* mDigitAmpSupermoduleCalib = nullptr;
+    TH2* mDigitTimeSupermodule = nullptr;
+    TH2* mDigitTimeSupermoduleCalib = nullptr;
 
-    void initForTrigger(const char* trigger);
-    void startPublishing();
+    TH2* mDigitOccupancy = nullptr;      ///< Digit occupancy EMCAL and DCAL
+    TH2* mDigitOccupancyThr = nullptr;   ///< Digit occupancy EMCAL and DCAL with Energy trheshold
+    TH2* mIntegratedOccupancy = nullptr; ///< Digit integrated occupancy
+    TH1* mDigitAmplitudeEMCAL = nullptr; ///< Digit amplitude in EMCAL
+    TH1* mDigitAmplitudeDCAL = nullptr;  ///< Digit amplitude in DCAL
+    TH1* mnumberEvents = nullptr;        ///< Number of Events for normalization
+
+    void initForTrigger(const std::string trigger, bool hasAmpVsCellID, bool hasTimeVsCellID, bool hasHistosCalib2D);
+    void startPublishing(o2::quality_control::core::ObjectsManager& manager);
     void reset();
     void clean();
+
+    void fillHistograms(const o2::emcal::Cell& cell, bool isGood, double timeoffset);
+    void countEvent();
   };
 
   /// \brief Constructor
@@ -95,8 +106,11 @@ class DigitsQcTask final : public TaskInterface
   void endOfActivity(Activity& activity) override;
   void reset() override;
 
-  void setThreshold(Double_t threshold) { mCellThreshold = threshold; }
   void setEndOfPayloadCheck(Bool_t doCheck) { mDoEndOfPayloadCheck = doCheck; }
+
+  bool hasConfigValue(const std::string_view key);
+  std::string getConfigValue(const std::string_view key);
+  std::string getConfigValueLower(const std::string_view key);
 
  private:
   struct SubEvent {
@@ -124,8 +138,6 @@ class DigitsQcTask final : public TaskInterface
     };
   };
   std::vector<CombinedEvent> buildCombinedEvents(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const;
-  void startPublishing(DigitsHistograms& histos);
-  Double_t mCellThreshold = 0.5;                               ///< energy cell threshold
   Bool_t mDoEndOfPayloadCheck = false;                         ///< Do old style end-of-payload check
   std::map<std::string, DigitsHistograms> mHistogramContainer; ///< Container with histograms per trigger class
   o2::emcal::Geometry* mGeometry = nullptr;                    ///< EMCAL geometry

--- a/Modules/EMCAL/src/DigitsQcTask.cxx
+++ b/Modules/EMCAL/src/DigitsQcTask.cxx
@@ -14,6 +14,8 @@
 /// \author Markus Fasel, Cristina Terrevoli
 ///
 
+#include <boost/algorithm/string.hpp>
+
 #include <TCanvas.h>
 #include <TH2.h>
 #include <TProfile2D.h>
@@ -53,17 +55,49 @@ void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   QcInfoLogger::GetInstance() << "initialize DigitsQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
   //define histograms
 
-  std::array<std::string, 2> triggers = { { "CAL", "PHYS" } };
-  for (const auto& trg : triggers) {
-    DigitsHistograms histos;
-    histos.initForTrigger(trg.data());
-    startPublishing(histos);
-    mHistogramContainer[trg] = histos;
-  } //trigger type
+  auto get_bool = [](const std::string_view input) -> bool {
+    return input == "true";
+  };
+
+  auto get_double = [](const std::string_view input) -> double {
+    double result = 0.;
+    if (input.length()) {
+      try {
+        result = std::stof(input.data());
+      } catch (...) {
+      }
+    }
+    return result;
+  };
+
+  auto hasAmpVsCell = get_bool(getConfigValueLower("hasAmpVsCell")),
+       hasTimeVsCell = get_bool(getConfigValueLower("hasTimeVsCell")),
+       hasCalib2D = get_bool(getConfigValueLower("hasHistValibVsCell"));
+  double threshold = hasConfigValue("threshold") ? get_double(getConfigValue("threshold")) : 0.5;
+
+  if (hasAmpVsCell) {
+    QcInfoLogger::GetInstance() << QcInfoLogger::Debug << "Enabling histograms : Amplitude vs. cellID" << QcInfoLogger::endm;
+  }
+  if (hasTimeVsCell) {
+    QcInfoLogger::GetInstance() << QcInfoLogger::Debug << "Enabling histograms : Time vs. cellID" << QcInfoLogger::endm;
+  }
+  if (hasCalib2D) {
+    QcInfoLogger::GetInstance() << QcInfoLogger::Debug << "Enabling calibrated histograms" << QcInfoLogger::endm;
+  }
 
   // initialize geometry
   if (!mGeometry)
     mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
+
+  std::array<std::string, 2> triggers = { { "CAL", "PHYS" } };
+  for (const auto& trg : triggers) {
+    DigitsHistograms histos;
+    histos.mCellThreshold = threshold;
+    histos.mGeometry = mGeometry;
+    histos.initForTrigger(trg.data(), hasAmpVsCell, hasTimeVsCell, hasCalib2D);
+    histos.startPublishing(*getObjectsManager());
+    mHistogramContainer[trg] = histos;
+  } //trigger type
 }
 
 void DigitsQcTask::startOfActivity(Activity& /*activity*/)
@@ -161,51 +195,24 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
       } else {
         QcInfoLogger::GetInstance() << QcInfoLogger::Debug << subev.mCellRange.getEntries() << " digits in subevent from equipment " << subev.mSpecification << QcInfoLogger::endm;
         gsl::span<const o2::emcal::Cell> eventdigits(cellsSubspec->second.data() + subev.mCellRange.getFirstEntry(), subev.mCellRange.getEntries());
+        int ndigit = 0, ndigitGlobal = subev.mCellRange.getFirstEntry();
         for (auto digit : eventdigits) {
           //int index = digit.getHighGain() ? 0 : (digit.getLowGain() ? 1 : -1);
           //if (index < 0)
           //  continue;
-          auto cellindices = mGeometry->GetCellIndex(digit.getTower());
-          histos.mDigitAmplitude->Fill(digit.getEnergy(), digit.getTower());
-          //histos.mDigitAmplitude[index]->Fill(digit.getEnergy(), digit.getTower());
-
           auto timeoffset = mTimeCalib ? mTimeCalib->getTimeCalibParam(digit.getTower(), digit.getLowGain()) : 0.;
-
-          if (!mBadChannelMap || (mBadChannelMap->getChannelStatus(digit.getTower()) == MaskType_t::GOOD_CELL)) {
-            histos.mDigitAmplitudeCalib->Fill(digit.getEnergy(), digit.getTower());
-            //histos.mDigitAmplitudeCalib[index]->Fill(digit.getEnergy(), digit.getTower());
-            histos.mDigitTimeCalib->Fill(digit.getTimeStamp() - timeoffset, digit.getTower());
-            //histos.mDigitTimeCalib[index]->Fill(digit.getTimeStamp() - timeoffset, digit.getTower());
+          bool goodcell = true;
+          if (mBadChannelMap) {
+            goodcell = mBadChannelMap->getChannelStatus(digit.getTower()) != MaskType_t::GOOD_CELL;
           }
-          histos.mDigitTime->Fill(digit.getTimeStamp(), digit.getTower());
-          //histos.mDigitTime[index]->Fill(digit.getTimeStamp(), digit.getTower());
-
-          // get the supermodule for filling EMCAL/DCAL spectra
-
-          try {
-
-            auto [row, col] = mGeometry->GlobalRowColFromIndex(digit.getTower());
-            if (digit.getEnergy() > 0) {
-              histos.mDigitOccupancy->Fill(col, row);
-            }
-            if (digit.getEnergy() > mCellThreshold) {
-              histos.mDigitOccupancyThr->Fill(col, row);
-            }
-            histos.mIntegratedOccupancy->Fill(col, row, digit.getEnergy());
-
-            if (std::get<0>(cellindices) < 12)
-              histos.mDigitAmplitudeEMCAL->Fill(digit.getEnergy());
-
-            else
-              histos.mDigitAmplitudeDCAL->Fill(digit.getEnergy());
-          } catch (o2::emcal::InvalidCellIDException& e) {
-            QcInfoLogger::GetInstance() << "Invalid cell ID: " << e.getCellID() << AliceO2::InfoLogger::InfoLogger::endm;
-          };
+          histos.fillHistograms(digit, goodcell, timeoffset);
+          ndigit++;
+          ndigitGlobal++;
         }
       }
     }
+    histos.countEvent();
 
-    histos.mnumberEvents->Fill(1);
     eventcounter++;
   }
 }
@@ -267,63 +274,171 @@ std::vector<DigitsQcTask::CombinedEvent> DigitsQcTask::buildCombinedEvents(const
   return events;
 }
 
-void DigitsQcTask::startPublishing(DigitsHistograms& histos)
+bool DigitsQcTask::hasConfigValue(const std::string_view key)
 {
-  //  for (auto h : histos.mDigitAmplitude) {
-  //    getObjectsManager()->startPublishing(h);
-  //  }
-
-  //  for (auto h : histos.mDigitTime) {
-  //    getObjectsManager()->startPublishing(h);
-  //  }
-  //  for (auto h : histos.mDigitAmplitudeCalib) {
-  //    getObjectsManager()->startPublishing(h);
-  //  }
-
-  // for (auto h : histos.mDigitTimeCalib) {
-  //   getObjectsManager()->startPublishing(h);
-  //}
-
-  getObjectsManager()->startPublishing(histos.mDigitTime);
-  getObjectsManager()->startPublishing(histos.mDigitTimeCalib);
-  getObjectsManager()->startPublishing(histos.mDigitAmplitude);
-  getObjectsManager()->startPublishing(histos.mDigitAmplitudeCalib);
-
-  getObjectsManager()->startPublishing(histos.mDigitAmplitudeEMCAL);
-  getObjectsManager()->startPublishing(histos.mDigitAmplitudeDCAL);
-  getObjectsManager()->startPublishing(histos.mDigitOccupancy);
-  getObjectsManager()->startPublishing(histos.mDigitOccupancyThr);
-  getObjectsManager()->startPublishing(histos.mIntegratedOccupancy);
-  getObjectsManager()->startPublishing(histos.mnumberEvents);
+  if (auto param = mCustomParameters.find(key.data()); param != mCustomParameters.end()) {
+    return true;
+  }
+  return false;
 }
 
-void DigitsQcTask::DigitsHistograms::initForTrigger(const char* trigger)
+std::string DigitsQcTask::getConfigValue(const std::string_view key)
 {
-  mTriggerClass = trigger;
+  std::string result;
+  if (auto param = mCustomParameters.find(key.data()); param != mCustomParameters.end()) {
+    result = param->second;
+  }
+  return result;
+}
 
-  mDigitAmplitude = new TH2F(Form("digitAmplitudeHG_%s", mTriggerClass.data()), Form("Digit Amplitude (High gain) %s", mTriggerClass.data()), 100, 0, 100, 17664, -0.5, 17663.5);
-  //mDigitAmplitude[1] = new TH2F(Form("digitAmplitudeLG_%s", mTriggerClass.data()), Form("Digit Amplitude (Low gain) %s", mTriggerClass.data()), 100, 0, 100, 17664, -0.5, 17663.5);
+std::string DigitsQcTask::getConfigValueLower(const std::string_view key)
+{
+  auto input = getConfigValue(key);
+  std::string result;
+  if (input.length()) {
+    result = boost::algorithm::to_lower_copy(input);
+  }
+  return result;
+}
 
-  mDigitAmplitudeCalib = new TH2F(Form("digitAmplitudeHGCalib_%s", mTriggerClass.data()), Form("Digit Amplitude (High gain) %s", mTriggerClass.data()), 100, 0, 100, 17664, -0.5, 17663.5);
-  //mDigitAmplitudeCalib[1] = new TH2F(Form("digitAmplitudeLGCalib_%s", mTriggerClass.data()), Form("Digit Amplitude (Low gain) %s", mTriggerClass.data()), 100, 0, 100, 17664, -0.5, 17663.5);
+void DigitsQcTask::DigitsHistograms::initForTrigger(const std::string trigger, bool hasAmpVsCellID, bool hasTimeVsCellID, bool hasHistosCalib2D)
+{
+  auto histBuilder1D = [trigger](const std::string name, const std::string title, int nbinsx, double xmin, double xmax) -> TH1* {
+    std::string histname = name + "_" + trigger,
+                histtitle = title + " " + trigger;
+    return new TH1D(histname.data(), histtitle.data(), nbinsx, xmin, xmax);
+  };
+  auto histBuilder2D = [trigger](const std::string_view name, const std::string_view title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, bool profile) -> TH2* {
+    std::string histname = std::string(name.data()) + "_" + trigger,
+                histtitle = std::string(title.data()) + " " + trigger;
+    if (profile)
+      return new TProfile2D(histname.data(), histtitle.data(), nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+    return new TH2D(histname.data(), histtitle.data(), nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+  };
 
-  mDigitTime = new TH2F(Form("digitTimeHG_%s", mTriggerClass.data()), Form("Digit Time (High gain) %s", mTriggerClass.data()), 2000, -200, 200, 17664, -0.5, 17663.5);
-  //  mDigitTime[1] = new TH2F(Form("digitTimeLG_%s", mTriggerClass.data()), Form("Digit Time (Low gain) %s", mTriggerClass.data()), 2000, -200, 200, 17664, -0.5, 17663.5);
+  bool isPhysTrigger = trigger == "PHYS";
+  if (isPhysTrigger) {
+    if (hasAmpVsCellID) {
+      mDigitAmplitude = histBuilder2D("digitAmplitudeHG", "Digit Amplitude (High gain)", 80, 0, 16, 17664, -0.5, 17663.5, false);
 
-  mDigitTimeCalib = new TH2F(Form("digitTimeHGCalib_%s", mTriggerClass.data()), Form("Digit Time Calib (High gain) %s", mTriggerClass.data()), 2000, -200, 200, 17664, -0.5, 17663.5);
-  //  mDigitTimeCalib[1] = new TH2F(Form("digitTimeLGCalib_%s", mTriggerClass.data()), Form("Digit Time Calib (Low gain) %s", mTriggerClass.data()), 2000, -200, 200, 17664, -0.5, 17663.5);
+      //mDigitAmplitude[1] = histBuilder2D("digitAmplitudeLG", "Digit Amplitude (Low gain)", 100, 0, 100, 17664, -0.5, 17663.5, false);
+      if (hasHistosCalib2D) {
+        mDigitAmplitudeCalib = histBuilder2D("digitAmplitudeHGCalib", "Digit Amplitude (High gain)", 80, 0, 16, 17664, -0.5, 17663.5, false);
+        //mDigitAmplitudeCalib[1] = histBuilder2D("digitAmplitudeLGCalib", "Digit Amplitude (Low gain)", 100, 0, 100, 17664, -0.5, 17663.5, false);
+      }
+    }
+    if (hasTimeVsCellID) {
+      mDigitTime = histBuilder2D("digitTimeHG", "Digit Time (High gain)", 400, -200, 200, 17664, -0.5, 17663.5, false);
+      // mDigitTime[1] = histBuilder2D("digitTimeLG", "Digit Time (Low gain)", 400, -200, 200, 17664, -0.5, 17663.5, false);
+      if (hasHistosCalib2D) {
+        mDigitTimeCalib = histBuilder2D("digitTimeHGCalib", "Digit Time Calib (High gain)", 400, -200, 200, 17664, -0.5, 17663.5, false);
+        // mDigitTimeCalib[1] = histBuilder2D("digitTimeLGCalib", "Digit Time Calib (Low gain)", 400, -200, 200, 17664, -0.5, 17663.5, false);
+      }
+    }
 
-  mDigitOccupancy = new TH2F(Form("digitOccupancyEMC_%s", mTriggerClass.data()), Form("Digit Occupancy EMCAL %s", mTriggerClass.data()), 96, -0.5, 95.5, 208, -0.5, 207.5);
-  mDigitOccupancyThr = new TH2F(Form("digitOccupancyEMCwThr_%s", mTriggerClass.data()), Form("Digit Occupancy EMCAL with E>0.5 GeV/c %s", mTriggerClass.data()), 96, -0.5, 95.5, 208, -0.5, 207.5);
+    mDigitAmpSupermodule = histBuilder2D("digitAmplitudeSupermodule", "Digit amplitude vs. supermodule ID ", 400, 0., 100, 20, -0.5, 19.5, false);
+    mDigitTimeSupermodule = histBuilder2D("digitTimeSupermodule", "Digit Time vs. supermodule ID (High gain)", 400, -200, 200, 20, -0.5, 19.5, false);
+    if (hasHistosCalib2D) {
+      mDigitAmpSupermoduleCalib = histBuilder2D("digitAmplitudeSupermoduleCalib", "Digit amplitude (Calib) vs. supermodule ID ", 400, 0., 100, 20, -0.5, 19.5, false);
+      mDigitTimeSupermoduleCalib = histBuilder2D("digitTimeSupermoduleCalib", "Digit Time (Calib) vs. supermodule ID (High gain)", 400, -200, 200, 20, -0.5, 19.5, false);
+    }
+  }
 
-  mIntegratedOccupancy = new TProfile2D(Form("digitOccupancyInt_%s", mTriggerClass.data()), Form("Digit Occupancy Integrated %s", mTriggerClass.data()), 96, -0.5, 95.5, 208, -0.5, 207.5);
+  mDigitOccupancy = histBuilder2D("digitOccupancyEMC", "Digit Occupancy EMCAL", 96, -0.5, 95.5, 208, -0.5, 207.5, false);
+  mDigitOccupancyThr = histBuilder2D("digitOccupancyEMCwThr", Form("Digit Occupancy EMCAL with E>%.1f GeV/c", mCellThreshold), 96, -0.5, 95.5, 208, -0.5, 207.5, false);
+
+  mIntegratedOccupancy = histBuilder2D("digitOccupancyInt", "Digit Occupancy Integrated", 96, -0.5, 95.5, 208, -0.5, 207.5, true);
   mIntegratedOccupancy->GetXaxis()->SetTitle("col");
   mIntegratedOccupancy->GetYaxis()->SetTitle("row");
   // 1D histograms for showing the integrated spectrum
 
-  mDigitAmplitudeEMCAL = new TH1F(Form("digitAmplitudeEMCAL_%s", mTriggerClass.data()), Form("Digit amplitude in EMCAL %s", mTriggerClass.data()), 500, 0., 500.);
-  mDigitAmplitudeDCAL = new TH1F(Form("digitAmplitudeDCAL_%s", mTriggerClass.data()), Form("Digit amplitude in DCAL %s", mTriggerClass.data()), 500, 0., 500.);
-  mnumberEvents = new TH1F(Form("NumberOfEvents_%s", mTriggerClass.data()), Form("Number Of Events %s", mTriggerClass.data()), 1, 0.5, 1.5);
+  mDigitAmplitudeEMCAL = histBuilder1D("digitAmplitudeEMCAL", "Digit amplitude in EMCAL", 400, 0., 100.);
+  mDigitAmplitudeDCAL = histBuilder1D("digitAmplitudeDCAL", "Digit amplitude in DCAL", 400, 0., 100.);
+  mnumberEvents = histBuilder1D("NumberOfEvents", "Number Of Events", 1, 0.5, 1.5);
+}
+
+void DigitsQcTask::DigitsHistograms::fillHistograms(const o2::emcal::Cell& digit, bool goodCell, double timecalib)
+{
+  auto fillOptional1D = [](TH1* hist, double x, double weight = 1.) {
+    if (hist)
+      hist->Fill(x, weight);
+  };
+  auto fillOptional2D = [](TH2* hist, double x, double y, double weight = 1.) {
+    if (hist)
+      hist->Fill(x, y, weight);
+  };
+
+  fillOptional2D(mDigitAmplitude, digit.getEnergy(), digit.getTower());
+  //fillOptional2D(mDigitAmplitude[index], digit.getEnergy(), digit.getTower());
+
+  if (goodCell) {
+    fillOptional2D(mDigitAmplitudeCalib, digit.getEnergy(), digit.getTower());
+    fillOptional2D(mDigitTimeCalib, digit.getTimeStamp() - timecalib, digit.getTower());
+    //fillOptional2D(mDigitAmplitudeCalib[index], digit.getEnergy(), digit.getTower());
+    //fillOptional2D(mDigitTimeCalib[index], digit.getTimeStamp() - timeoffset, digit.getTower());
+  }
+  fillOptional2D(mDigitTime, digit.getTimeStamp(), digit.getTower());
+  //fillOptional2D(mDigitTime[index], digit.getTimeStamp(), digit.getTower());
+
+  try {
+    auto [row, col] = mGeometry->GlobalRowColFromIndex(digit.getTower());
+    if (digit.getEnergy() > 0) {
+      fillOptional2D(mDigitOccupancy, col, row);
+    }
+    if (digit.getEnergy() > mCellThreshold) {
+      fillOptional2D(mDigitOccupancyThr, col, row);
+    }
+    fillOptional2D(mIntegratedOccupancy, col, row, digit.getEnergy());
+
+  } catch (o2::emcal::InvalidCellIDException& e) {
+    QcInfoLogger::GetInstance() << "Invalid cell ID: " << e.getCellID() << QcInfoLogger::endm;
+  };
+
+  try {
+    auto cellindices = mGeometry->GetCellIndex(digit.getTower());
+    auto supermoduleID = std::get<0>(cellindices);
+    fillOptional2D(mDigitAmpSupermodule, digit.getEnergy(), supermoduleID);
+    fillOptional2D(mDigitTimeSupermodule, digit.getTimeStamp(), supermoduleID);
+    if (goodCell) {
+      fillOptional2D(mDigitAmpSupermoduleCalib, digit.getEnergy(), supermoduleID);
+      fillOptional2D(mDigitTimeSupermoduleCalib, digit.getTimeStamp() - timecalib, supermoduleID);
+    }
+    if (supermoduleID) {
+      fillOptional1D(mDigitAmplitudeEMCAL, digit.getEnergy());
+    } else {
+      fillOptional1D(mDigitAmplitudeDCAL, digit.getEnergy());
+    }
+  } catch (o2::emcal::InvalidCellIDException& e) {
+    QcInfoLogger::GetInstance() << "Invalid cell ID: " << e.getCellID() << QcInfoLogger::endm;
+  }
+}
+
+void DigitsQcTask::DigitsHistograms::countEvent()
+{
+  mnumberEvents->Fill(1);
+}
+
+void DigitsQcTask::DigitsHistograms::startPublishing(o2::quality_control::core::ObjectsManager& manager)
+{
+  auto publishOptional = [&manager](TH1* hist) {
+    if (hist)
+      manager.startPublishing(hist);
+  };
+
+  publishOptional(mDigitTime);
+  publishOptional(mDigitTimeCalib);
+  publishOptional(mDigitAmplitude);
+  publishOptional(mDigitAmplitudeCalib);
+  publishOptional(mDigitAmpSupermodule);
+  publishOptional(mDigitAmpSupermoduleCalib);
+  publishOptional(mDigitTimeSupermodule);
+  publishOptional(mDigitTimeSupermoduleCalib);
+  publishOptional(mDigitAmplitudeEMCAL);
+  publishOptional(mDigitAmplitudeDCAL);
+  publishOptional(mDigitOccupancy);
+  publishOptional(mDigitOccupancyThr);
+  publishOptional(mIntegratedOccupancy);
+  publishOptional(mnumberEvents);
 }
 
 void DigitsQcTask::DigitsHistograms::reset()
@@ -342,16 +457,25 @@ void DigitsQcTask::DigitsHistograms::reset()
   //    h->Reset();
   //  }
 
-  mDigitTime->Reset();
-  mDigitTimeCalib->Reset();
-  mDigitAmplitude->Reset();
-  mDigitAmplitudeCalib->Reset();
-  mDigitAmplitudeEMCAL->Reset();
-  mDigitAmplitudeDCAL->Reset();
-  mDigitOccupancy->Reset();
-  mDigitOccupancyThr->Reset();
-  mIntegratedOccupancy->Reset();
-  mnumberEvents->Reset();
+  auto resetOptional = [](TH1* hist) {
+    if (hist)
+      hist->Reset();
+  };
+
+  resetOptional(mDigitTime);
+  resetOptional(mDigitTimeCalib);
+  resetOptional(mDigitAmplitude);
+  resetOptional(mDigitAmplitudeCalib);
+  resetOptional(mDigitAmpSupermodule);
+  resetOptional(mDigitAmpSupermoduleCalib);
+  resetOptional(mDigitTimeSupermodule);
+  resetOptional(mDigitTimeSupermoduleCalib);
+  resetOptional(mDigitAmplitudeEMCAL);
+  resetOptional(mDigitAmplitudeDCAL);
+  resetOptional(mDigitOccupancy);
+  resetOptional(mDigitOccupancyThr);
+  resetOptional(mIntegratedOccupancy);
+  resetOptional(mnumberEvents);
 }
 
 void DigitsQcTask::DigitsHistograms::clean()
@@ -369,35 +493,25 @@ void DigitsQcTask::DigitsHistograms::clean()
   //  delete h;
   // }
 
-  if (mDigitTime)
-    delete mDigitTime;
+  auto cleanOptional = [](TObject* hist) {
+    if (hist)
+      delete hist;
+  };
 
-  if (mDigitTimeCalib)
-    delete mDigitTimeCalib;
-
-  if (mDigitAmplitude)
-    delete mDigitAmplitude;
-
-  if (mDigitAmplitudeCalib)
-    delete mDigitAmplitudeCalib;
-
-  if (mDigitAmplitudeEMCAL)
-    delete mDigitAmplitudeEMCAL;
-
-  if (mDigitAmplitudeDCAL)
-    delete mDigitAmplitudeDCAL;
-
-  if (mDigitOccupancy)
-    delete mDigitOccupancy;
-
-  if (mDigitOccupancyThr)
-    delete mDigitOccupancyThr;
-
-  if (mIntegratedOccupancy)
-    delete mIntegratedOccupancy;
-
-  if (mnumberEvents)
-    delete mnumberEvents;
+  cleanOptional(mDigitTime);
+  cleanOptional(mDigitTimeCalib);
+  cleanOptional(mDigitAmplitude);
+  cleanOptional(mDigitAmplitudeCalib);
+  cleanOptional(mDigitAmpSupermodule);
+  cleanOptional(mDigitAmpSupermoduleCalib);
+  cleanOptional(mDigitTimeSupermodule);
+  cleanOptional(mDigitTimeSupermoduleCalib);
+  cleanOptional(mDigitAmplitudeEMCAL);
+  cleanOptional(mDigitAmplitudeDCAL);
+  cleanOptional(mDigitOccupancy);
+  cleanOptional(mDigitOccupancyThr);
+  cleanOptional(mIntegratedOccupancy);
+  cleanOptional(mnumberEvents);
 }
 
 } // namespace emcal


### PR DESCRIPTION
- Move filling of all hisstograms to a separate function
  fillHistograms of DigitsHistograms, this makes
  handling of optional histograms a lot easier
- Use lamdba functions for fill/reset/delete of
  optional histograms
- Disable all 2D histograms except occupancy for
  the LED events
- Add functions for easy access to task parameters