### PR TITLE
[QC-627] Set proper ownership of MO collection after deserialization

### DIFF
--- a/Framework/include/QualityControl/MonitorObjectCollection.h
+++ b/Framework/include/QualityControl/MonitorObjectCollection.h
@@ -30,6 +30,9 @@ class MonitorObjectCollection : public TObjArray, public mergers::MergeInterface
   ~MonitorObjectCollection() = default;
 
   void merge(mergers::MergeInterface* const other) override;
+
+  void postDeserialization() override;
+
   ClassDefOverride(MonitorObjectCollection, 0);
 };
 

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -243,11 +243,12 @@ void CheckRunner::prepareCacheData(framework::InputRecord& inputRecord)
 
       // We don't know what we receive, so we test for an array and then try a tobject.
       // If we received a tobject, it gets encapsulated in the tobjarray.
-      shared_ptr<const TObjArray> array = nullptr;
-      shared_ptr<const TObject> tobj = inputRecord.get<TObject*>(input.binding.c_str());
+      shared_ptr<TObjArray> array = nullptr;
+      auto tobj = DataRefUtils::as<TObject>(dataRef);
       // if the object has not been found, it will raise an exception that we just let go.
       if (tobj->InheritsFrom("TObjArray")) {
-        array = dynamic_pointer_cast<const TObjArray>(tobj);
+        array.reset(dynamic_cast<TObjArray*>(tobj.release()));
+        array->SetOwner(false);
         mLogger << AliceO2::InfoLogger::InfoLogger::Info << "CheckRunner " << mDeviceName
                 << " received an array with " << array->GetEntries()
                 << " entries from " << input.binding << ENDM;

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -53,7 +53,7 @@ ObjectsManager::~ObjectsManager() = default;
 
 void ObjectsManager::startPublishing(TObject* object)
 {
-  if (mMonitorObjects->FindObject(object->GetName()) != 0) {
+  if (mMonitorObjects->FindObject(object->GetName()) != nullptr) {
     ILOG(Warning, Support) << "Object is already being published (" << object->GetName() << ")" << ENDM;
     BOOST_THROW_EXCEPTION(DuplicateObjectError() << errinfo_object_name(object->GetName()));
   }


### PR DESCRIPTION
This fixes the leaks reported in QC-627. The problem was that `MonitorObjects` in `MonitorObjectCollection` were indeed deleted, but they did not own the contained objects, so those were not.

As far as I could see, ROOT does not offer any method which allows to correct ownership after deserialization, so I added one in https://github.com/AliceO2Group/AliceO2/pull/6811 and made sure it is executed after the received objects are unpacked.
In `CheckRunner` we used to assume that `TObjArray` is always non-owning, I had to fix that.