### PR TITLE
[QC-630] Pass the host name to Data Sampling

### DIFF
--- a/Framework/src/runQC.cxx
+++ b/Framework/src/runQC.cxx
@@ -166,18 +166,18 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
       }
       case WorkflowType::Local: {
         ILOG(Info, Support) << "Creating a local QC topology." << ENDM;
+        auto host = config.options().get<std::string>("host").empty()
+                      ? boost::asio::ip::host_name()
+                      : config.options().get<std::string>("host");
 
         if (!config.options().get<bool>("no-data-sampling")) {
           ILOG(Info, Support) << "Generating Data Sampling" << ENDM;
-          DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+          DataSampling::GenerateInfrastructure(specs, qcConfigurationSource, 1, host);
         } else {
           ILOG(Info, Support) << "Omitting Data Sampling" << ENDM;
         }
 
         // Generation of the local QC topology (local QC tasks and their output proxies)
-        auto host = config.options().get<std::string>("host").empty()
-                      ? boost::asio::ip::host_name()
-                      : config.options().get<std::string>("host");
         quality_control::generateLocalInfrastructure(specs, qcConfigurationSource, host);
         break;
       }


### PR DESCRIPTION
...to allow for creating Data Sampling Policies only on specified machines.

needs https://github.com/AliceO2Group/AliceO2/pull/6812