### PR TITLE
[EMCAL-524, EMCAL-526] New histograms + fixes for input handling in downscaled modes

### DIFF
--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -92,6 +92,12 @@ class DigitsQcTask final : public TaskInterface
     void countEvent();
   };
 
+  TH1* mEvCounterTF = nullptr;      ///< Number of Events per timeframe
+  TH1* mEvCounterTFPHYS = nullptr;  ///< Number of Events per timeframe per PHYS
+  TH1* mEvCounterTFCALIB = nullptr; ///< Number of Events per timeframe per CALIB
+  TH1* mTFPerCyclesTOT = nullptr;   ///< Number of Time Frame per cycles TOT
+  TH1* mTFPerCycles = nullptr;      ///< Number of Time Frame per cycles per MonitorData
+
   /// \brief Constructor
   DigitsQcTask() = default;
   /// Destructor
@@ -143,6 +149,7 @@ class DigitsQcTask final : public TaskInterface
   o2::emcal::Geometry* mGeometry = nullptr;                    ///< EMCAL geometry
   o2::emcal::BadChannelMap* mBadChannelMap;                    ///< EMCAL channel map
   o2::emcal::TimeCalibrationParams* mTimeCalib;                ///< EMCAL time calib
+  int mTimeFramesPerCycles = 0;                                ///< TF per cycles
 };
 
 } // namespace emcal

--- a/Modules/EMCAL/include/EMCAL/RawTask.h
+++ b/Modules/EMCAL/include/EMCAL/RawTask.h
@@ -66,15 +66,6 @@ class RawTask final : public TaskInterface
   void endOfActivity(Activity& activity) override;
   void reset() override;
 
-  /// \brief Set the data origin
-  /// \param origin Data origin
-  ///
-  /// Normally data origin is EMC, however in case the
-  /// Task subscribes directly to readout or the origin
-  /// is different in the STFbuilder this needs to be handled
-  /// accordingly
-  void setDataOrigin(const std::string_view origin) { mDataOrigin = origin; }
-
   enum class EventType {
     CAL_EVENT,
     PHYS_EVENT
@@ -107,7 +98,6 @@ class RawTask final : public TaskInterface
   bool isLostTimeframe(framework::ProcessingContext& ctx) const;
 
   o2::emcal::Geometry* mGeometry = nullptr; ///< EMCAL geometry
-  std::string mDataOrigin = "EMC";
   TH1* mPayloadSize = nullptr;
   TH1* mMessageCounter = nullptr;
   TH1* mNumberOfSuperpagesPerMessage;

--- a/Modules/EMCAL/include/EMCAL/RawTask.h
+++ b/Modules/EMCAL/include/EMCAL/RawTask.h
@@ -115,6 +115,9 @@ class RawTask final : public TaskInterface
   TH1* mSuperpageCounter = nullptr;                                          ///< Counter for number of superpages
   TH1* mPageCounter = nullptr;                                               ///< Counter for number of pages (headers)
   TH1* mTotalDataVolume = nullptr;                                           ///< Total data volume
+  TH1* mNbunchPerChan = nullptr;                                             ///< Number of bunch per Channel
+  TH1* mNofADCsamples = nullptr;                                             ///< Number of ADC samples per Channel
+  TH1* mADCsize = nullptr;                                                   ///< ADC size per bunch
   std::array<TH1*, 20> mFECmaxCount;                                         ///< max number of hit channels
   std::array<TH1*, 20> mFECmaxID;                                            ///< FEC ID  max number of hit channels
   std::unordered_map<EventType, TProfile2D*> mRMS;                           ///< ADC rms for EMCAL+DCAL togheter

--- a/Modules/EMCAL/src/DigitsQcTask.cxx
+++ b/Modules/EMCAL/src/DigitsQcTask.cxx
@@ -48,10 +48,21 @@ DigitsQcTask::~DigitsQcTask()
   for (auto en : mHistogramContainer) {
     en.second.clean();
   }
+  if (mEvCounterTF)
+    delete mEvCounterTF;
+  if (mEvCounterTFPHYS)
+    delete mEvCounterTFPHYS;
+  if (mEvCounterTFCALIB)
+    delete mEvCounterTFCALIB;
+  if (mTFPerCycles)
+    delete mTFPerCycles;
+  if (mTFPerCyclesTOT)
+    delete mTFPerCyclesTOT;
 }
 
 void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
+  QcInfoLogger::GetInstance().setDetector("EMC");
   QcInfoLogger::GetInstance() << "initialize DigitsQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
   //define histograms
 
@@ -98,6 +109,31 @@ void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
     histos.startPublishing(*getObjectsManager());
     mHistogramContainer[trg] = histos;
   } //trigger type
+  //new histos`
+  mTFPerCyclesTOT = new TH1D("NumberOfTFperCycles_TOT", "NumberOfTFperCycles_TOT", 100, -0.5, 99.5); //
+  mTFPerCyclesTOT->GetXaxis()->SetTitle("NumberOfTFperCyclesTOT");
+  mTFPerCyclesTOT->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mTFPerCyclesTOT);
+
+  mTFPerCycles = new TH1D("NumberOfTFperCycles_1", "NumberOfTFperCycles_1", 1, -0.5, 1.5);
+  mTFPerCycles->GetXaxis()->SetTitle("NumberOfTFperCycles");
+  mTFPerCycles->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mTFPerCycles);
+
+  mEvCounterTF = new TH1D("NEventsPerTF", "NEventsPerTF", 100, -0.5, 99.5);
+  mEvCounterTF->GetXaxis()->SetTitle("NEventsPerTimeFrame");
+  mEvCounterTF->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mEvCounterTF);
+
+  mEvCounterTFPHYS = new TH1D("NEventsPerTFPHYS", "NEventsPerTFPHYS", 100, -0.5, 99.5);
+  mEvCounterTFPHYS->GetXaxis()->SetTitle("NEventsPerTimeFrame_PHYS");
+  mEvCounterTFPHYS->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mEvCounterTFPHYS);
+
+  mEvCounterTFCALIB = new TH1D("NEventsPerTFCALIB", "NEventsPerTFCALIB", 100, -0.5, 99.5);
+  mEvCounterTFCALIB->GetXaxis()->SetTitle("NEventsPerTimeFrame_CALIB");
+  mEvCounterTFCALIB->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mEvCounterTFCALIB);
 }
 
 void DigitsQcTask::startOfActivity(Activity& /*activity*/)
@@ -108,6 +144,7 @@ void DigitsQcTask::startOfActivity(Activity& /*activity*/)
 
 void DigitsQcTask::startOfCycle()
 {
+  mTimeFramesPerCycles = 0;
   QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
   std::map<std::string, std::string> metadata;
   mBadChannelMap = retrieveConditionAny<o2::emcal::BadChannelMap>("EMC/Calib/BadChannels", metadata);
@@ -123,7 +160,8 @@ void DigitsQcTask::startOfCycle()
 
 void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-
+  mTFPerCycles->Fill(1); //number of timeframe process per cycle
+  mTimeFramesPerCycles++;
   // check if we have payoad
   using MaskType_t = o2::emcal::BadChannelMap::MaskType_t;
 
@@ -166,6 +204,8 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
   //  QcInfoLogger::GetInstance() << "Received " << digitcontainer.size() << " digits " << AliceO2::InfoLogger::InfoLogger::endm;
   int eventcounter = 0;
+  int eventcounterCALIB = 0;
+  int eventcounterPHYS = 0;
   for (auto trg : combinedEvents) {
     if (!trg.getNumberOfObjects()) {
       continue;
@@ -178,8 +218,10 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     std::string trgClass;
     if (isPhysTrigger) {
       trgClass = "PHYS";
+      eventcounterPHYS++;
     } else if (isCalibTrigger) {
       trgClass = "CAL";
+      eventcounterCALIB++;
     } else {
       QcInfoLogger::GetInstance() << QcInfoLogger::Error << " Unmonitored trigger class requested " << AliceO2::InfoLogger::InfoLogger::endm;
       continue;
@@ -215,10 +257,15 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
     eventcounter++;
   }
+  mEvCounterTF->Fill(eventcounter);
+  mEvCounterTFPHYS->Fill(eventcounterPHYS);
+  mEvCounterTFCALIB->Fill(eventcounterCALIB);
+  //event counter per TimeFrame  (range 0-100) for the moment (parameter)
 }
 
 void DigitsQcTask::endOfCycle()
 {
+  mTFPerCyclesTOT->Fill(mTimeFramesPerCycles); // do not reset this histo
   QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
@@ -235,6 +282,14 @@ void DigitsQcTask::reset()
   for (auto cont : mHistogramContainer) {
     cont.second.reset();
   }
+  if (mEvCounterTF)
+    mEvCounterTF->Reset();
+  if (mEvCounterTFPHYS)
+    mEvCounterTFPHYS->Reset();
+  if (mEvCounterTFCALIB)
+    mEvCounterTFCALIB->Reset();
+  if (mTFPerCycles)
+    mTFPerCycles->Reset();
 }
 
 std::vector<DigitsQcTask::CombinedEvent> DigitsQcTask::buildCombinedEvents(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const
@@ -439,6 +494,10 @@ void DigitsQcTask::DigitsHistograms::startPublishing(o2::quality_control::core::
   publishOptional(mDigitOccupancyThr);
   publishOptional(mIntegratedOccupancy);
   publishOptional(mnumberEvents);
+  //  publishOptional(mEvCounterTF);
+  //  publishOptional(mEvCounterTFPHYS);
+  //  publishOptional(mEvCounterTFCALIB);
+  //  publishOptional(mTFPerCycles);
 }
 
 void DigitsQcTask::DigitsHistograms::reset()
@@ -476,6 +535,10 @@ void DigitsQcTask::DigitsHistograms::reset()
   resetOptional(mDigitOccupancyThr);
   resetOptional(mIntegratedOccupancy);
   resetOptional(mnumberEvents);
+  //  resetOptional(mEvCounterTF);
+  //  resetOptional(mEvCounterTFPHYS);
+  //  resetOptional(mEvCounterTFCALIB);
+  //  resetOptional(mTFPerCycles);
 }
 
 void DigitsQcTask::DigitsHistograms::clean()
@@ -512,6 +575,11 @@ void DigitsQcTask::DigitsHistograms::clean()
   cleanOptional(mDigitOccupancyThr);
   cleanOptional(mIntegratedOccupancy);
   cleanOptional(mnumberEvents);
+  //  cleanOptional(mEvCounterTF);
+  //  cleanOptional(mEvCounterTFPHYS);
+  //  cleanOptional(mEvCounterTFCALIB);
+  //  cleanOptional(mTFPerCycles);
+  //
 }
 
 } // namespace emcal


### PR DESCRIPTION
- New histograms requested in EMCAL-524 for the DigitsQC and EMCAL-526 for the raw QC
- Iteration over input container not steered via the the channel type because origin and descriptor
  change in case of downsampling, but instead using the binding which is the same for direct and downsampled channels. 