### PR TITLE
[QC-443] Give only ptrees to Data Sampling

### DIFF
--- a/Framework/include/QualityControl/InfrastructureSpecReader.h
+++ b/Framework/include/QualityControl/InfrastructureSpecReader.h
@@ -34,12 +34,12 @@ class InfrastructureSpecReader
  public:
   /// \brief Reads the full QC configuration file.
   // todo remove configurationSource when it is possible
-  static InfrastructureSpec readInfrastructureSpec(const boost::property_tree::ptree&, const std::string& configurationSource);
+  static InfrastructureSpec readInfrastructureSpec(const boost::property_tree::ptree& wholeTree, const std::string& configurationSource);
 
   // readers for separate parts
-  static CommonSpec readCommonSpec(const boost::property_tree::ptree& config, const std::string& configurationSource);
-  static TaskSpec readTaskSpec(std::string taskName, const boost::property_tree::ptree& taskSpec, const std::string& configurationSource);
-  static DataSourceSpec readDataSourceSpec(const boost::property_tree::ptree& dataSourceSpec, const std::string& configurationSource);
+  static CommonSpec readCommonSpec(const boost::property_tree::ptree& commonTree, const std::string& configurationSource);
+  static TaskSpec readTaskSpec(std::string taskName, const boost::property_tree::ptree& taskTree, const boost::property_tree::ptree& wholeTree);
+  static DataSourceSpec readDataSourceSpec(const boost::property_tree::ptree& dataSourceTree, const boost::property_tree::ptree& wholeTree);
 
   static std::string validateDetectorName(std::string name);
 };

--- a/Framework/src/InfrastructureSpecReader.cxx
+++ b/Framework/src/InfrastructureSpecReader.cxx
@@ -26,10 +26,10 @@ using namespace o2::framework;
 namespace o2::quality_control::core
 {
 
-InfrastructureSpec InfrastructureSpecReader::readInfrastructureSpec(const boost::property_tree::ptree& config, const std::string& configurationSource)
+InfrastructureSpec InfrastructureSpecReader::readInfrastructureSpec(const boost::property_tree::ptree& wholeTree, const std::string& configurationSource)
 {
   InfrastructureSpec spec;
-  const auto& qcTree = config.get_child("qc");
+  const auto& qcTree = wholeTree.get_child("qc");
   if (qcTree.find("config") != qcTree.not_found()) {
     spec.common = readCommonSpec(qcTree.get_child("config"), configurationSource);
   } else {
@@ -39,32 +39,32 @@ InfrastructureSpec InfrastructureSpecReader::readInfrastructureSpec(const boost:
     const auto& tasksTree = qcTree.get_child("tasks");
     spec.tasks.reserve(tasksTree.size());
     for (const auto& [taskName, taskConfig] : tasksTree) {
-      spec.tasks.push_back(readTaskSpec(taskName, taskConfig, configurationSource));
+      spec.tasks.push_back(readTaskSpec(taskName, taskConfig, wholeTree));
     }
   }
   return spec;
 }
 
-CommonSpec InfrastructureSpecReader::readCommonSpec(const boost::property_tree::ptree& config, const std::string& configurationSource)
+CommonSpec InfrastructureSpecReader::readCommonSpec(const boost::property_tree::ptree& commonTree, const std::string& configurationSource)
 {
   CommonSpec spec;
-  for (const auto& [key, value] : config.get_child("database")) {
+  for (const auto& [key, value] : commonTree.get_child("database")) {
     spec.database.emplace(key, value.get_value<std::string>());
   }
-  spec.activityNumber = config.get<int>("Activity.number", spec.activityNumber);
-  spec.activityType = config.get<int>("Activity.type", spec.activityType);
-  spec.monitoringUrl = config.get<std::string>("monitoring.url", spec.monitoringUrl);
-  spec.consulUrl = config.get<std::string>("consul.url", spec.consulUrl);
-  spec.conditionDBUrl = config.get<std::string>("conditionDB.url", spec.conditionDBUrl);
-  spec.infologgerFilterDiscardDebug = config.get<bool>("infologger.filterDiscardDebug", spec.infologgerFilterDiscardDebug);
-  spec.infologgerDiscardLevel = config.get<int>("infologger.filterDiscardLevel", spec.infologgerDiscardLevel);
+  spec.activityNumber = commonTree.get<int>("Activity.number", spec.activityNumber);
+  spec.activityType = commonTree.get<int>("Activity.type", spec.activityType);
+  spec.monitoringUrl = commonTree.get<std::string>("monitoring.url", spec.monitoringUrl);
+  spec.consulUrl = commonTree.get<std::string>("consul.url", spec.consulUrl);
+  spec.conditionDBUrl = commonTree.get<std::string>("conditionDB.url", spec.conditionDBUrl);
+  spec.infologgerFilterDiscardDebug = commonTree.get<bool>("infologger.filterDiscardDebug", spec.infologgerFilterDiscardDebug);
+  spec.infologgerDiscardLevel = commonTree.get<int>("infologger.filterDiscardLevel", spec.infologgerDiscardLevel);
 
   spec.configurationSource = configurationSource;
 
   return spec;
 }
 
-TaskSpec InfrastructureSpecReader::readTaskSpec(std::string taskName, const boost::property_tree::ptree& config, const std::string& configurationSource)
+TaskSpec InfrastructureSpecReader::readTaskSpec(std::string taskName, const boost::property_tree::ptree& taskTree, const boost::property_tree::ptree& wholeTree)
 {
   static std::unordered_map<std::string, TaskLocationSpec> const taskLocationFromString = {
     { "local", TaskLocationSpec::Local },
@@ -74,52 +74,52 @@ TaskSpec InfrastructureSpecReader::readTaskSpec(std::string taskName, const boos
   TaskSpec ts;
 
   ts.taskName = taskName;
-  ts.className = config.get<std::string>("className");
-  ts.moduleName = config.get<std::string>("moduleName");
-  ts.detectorName = config.get<std::string>("detectorName");
-  ts.cycleDurationSeconds = config.get<int>("cycleDurationSeconds");
-  ts.dataSource = readDataSourceSpec(config.get_child("dataSource"), configurationSource);
+  ts.className = taskTree.get<std::string>("className");
+  ts.moduleName = taskTree.get<std::string>("moduleName");
+  ts.detectorName = taskTree.get<std::string>("detectorName");
+  ts.cycleDurationSeconds = taskTree.get<int>("cycleDurationSeconds");
+  ts.dataSource = readDataSourceSpec(taskTree.get_child("dataSource"), wholeTree);
 
-  ts.active = config.get<bool>("active", ts.active);
-  ts.maxNumberCycles = config.get<int>("maxNumberCycles", ts.maxNumberCycles);
-  ts.resetAfterCycles = config.get<size_t>("resetAfterCycles", ts.resetAfterCycles);
-  ts.saveObjectsToFile = config.get<std::string>("saveObjectsToFile", ts.saveObjectsToFile);
-  if (config.count("taskParameters") > 0) {
-    for (const auto& [key, value] : config.get_child("taskParameters")) {
+  ts.active = taskTree.get<bool>("active", ts.active);
+  ts.maxNumberCycles = taskTree.get<int>("maxNumberCycles", ts.maxNumberCycles);
+  ts.resetAfterCycles = taskTree.get<size_t>("resetAfterCycles", ts.resetAfterCycles);
+  ts.saveObjectsToFile = taskTree.get<std::string>("saveObjectsToFile", ts.saveObjectsToFile);
+  if (taskTree.count("taskParameters") > 0) {
+    for (const auto& [key, value] : taskTree.get_child("taskParameters")) {
       ts.customParameters.emplace(key, value.get_value<std::string>());
     }
   }
 
-  bool multinodeSetup = config.find("location") != config.not_found();
-  ts.location = taskLocationFromString.at(config.get<std::string>("location", "remote"));
-  if (config.count("localMachines") > 0) {
-    for (const auto& [key, value] : config.get_child("localMachines")) {
+  bool multinodeSetup = taskTree.find("location") != taskTree.not_found();
+  ts.location = taskLocationFromString.at(taskTree.get<std::string>("location", "remote"));
+  if (taskTree.count("localMachines") > 0) {
+    for (const auto& [key, value] : taskTree.get_child("localMachines")) {
       ts.localMachines.emplace_back(value.get_value<std::string>());
     }
   }
-  if (multinodeSetup && config.count("remoteMachine") > 0) {
+  if (multinodeSetup && taskTree.count("remoteMachine") > 0) {
     ILOG(Warning, Trace)
       << "No remote machine was specified for a multinode QC setup."
          " This is fine if running with AliECS, but it will fail in standalone mode."
       << ENDM;
   }
-  ts.remoteMachine = config.get<std::string>("remoteMachine", ts.remoteMachine);
-  if (multinodeSetup && config.count("remotePort") > 0) {
+  ts.remoteMachine = taskTree.get<std::string>("remoteMachine", ts.remoteMachine);
+  if (multinodeSetup && taskTree.count("remotePort") > 0) {
     ILOG(Warning, Trace)
       << "No remote port was specified for a multinode QC setup."
          " This is fine if running with AliECS, but it might fail in standalone mode."
       << ENDM;
   }
-  ts.remotePort = config.get<uint16_t>("remotePort", ts.remotePort);
-  ts.localControl = config.get<std::string>("localControl", ts.localControl);
-  ts.mergingMode = config.get<std::string>("mergingMode", ts.mergingMode);
-  ts.mergerCycleMultiplier = config.get<int>("mergerCycleMultiplier", ts.mergerCycleMultiplier);
+  ts.remotePort = taskTree.get<uint16_t>("remotePort", ts.remotePort);
+  ts.localControl = taskTree.get<std::string>("localControl", ts.localControl);
+  ts.mergingMode = taskTree.get<std::string>("mergingMode", ts.mergingMode);
+  ts.mergerCycleMultiplier = taskTree.get<int>("mergerCycleMultiplier", ts.mergerCycleMultiplier);
 
   return ts;
 }
 
-DataSourceSpec InfrastructureSpecReader::readDataSourceSpec(const boost::property_tree::ptree& dataSourceSpec,
-                                                            const std::string& configurationSource)
+DataSourceSpec InfrastructureSpecReader::readDataSourceSpec(const boost::property_tree::ptree& dataSourceTree,
+                                                            const boost::property_tree::ptree& wholeTree)
 {
   static std::unordered_map<std::string, DataSourceType> const dataSourceTypeFromString = {
     // fixme: the convention is inconsistent and it should be fixed in coordination with configuration files
@@ -133,18 +133,18 @@ DataSourceSpec InfrastructureSpecReader::readDataSourceSpec(const boost::propert
   };
 
   DataSourceSpec dss;
-  dss.type = dataSourceTypeFromString.at(dataSourceSpec.get<std::string>("type"));
+  dss.type = dataSourceTypeFromString.at(dataSourceTree.get<std::string>("type"));
 
   switch (dss.type) {
     case DataSourceType::DataSamplingPolicy: {
-      auto name = dataSourceSpec.get<std::string>("name");
+      auto name = dataSourceTree.get<std::string>("name");
       dss.typeSpecificParams.insert({ "name", name });
-      dss.inputs = DataSampling::InputSpecsForPolicy(configurationSource, name); //fixme: add a method which takes a ptree, then i can remove configurationSource
+      dss.inputs = DataSampling::InputSpecsForPolicy(wholeTree.get_child("dataSamplingPolicies"), name);
       break;
     }
     case DataSourceType::Direct: {
-      dss.typeSpecificParams.insert({ "query", dataSourceSpec.get<std::string>("query") });
-      auto inputsQuery = dataSourceSpec.get<std::string>("query");
+      dss.typeSpecificParams.insert({ "query", dataSourceTree.get<std::string>("query") });
+      auto inputsQuery = dataSourceTree.get<std::string>("query");
       dss.inputs = DataDescriptorQueryBuilder::parse(inputsQuery.c_str());
       break;
     }
@@ -152,11 +152,11 @@ DataSourceSpec InfrastructureSpecReader::readDataSourceSpec(const boost::propert
     case DataSourceType::PostProcessingTask:
     case DataSourceType::Check:
     case DataSourceType::Aggregator:
-      dss.typeSpecificParams.insert({ "name", dataSourceSpec.get<std::string>("name") });
+      dss.typeSpecificParams.insert({ "name", dataSourceTree.get<std::string>("name") });
       break;
     case DataSourceType::ExternalTask:
-      dss.typeSpecificParams.insert({ "name", dataSourceSpec.get<std::string>("name") });
-      dss.typeSpecificParams.insert({ "query", dataSourceSpec.get<std::string>("query") });
+      dss.typeSpecificParams.insert({ "name", dataSourceTree.get<std::string>("name") });
+      dss.typeSpecificParams.insert({ "query", dataSourceTree.get<std::string>("query") });
       break;
     case DataSourceType::Invalid:
       // todo: throw?

--- a/Framework/src/runAdvanced.cxx
+++ b/Framework/src/runAdvanced.cxx
@@ -38,11 +38,8 @@
 ///   \endcode
 
 #include <Framework/CompletionPolicyHelpers.h>
-#include <Framework/DataSpecUtils.h>
 #include <DataSampling/DataSampling.h>
 #include "QualityControl/InfrastructureGenerator.h"
-#include "QualityControl/QcInfoLogger.h"
-#include "QualityControl/AdvancedWorkflow.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -73,11 +70,17 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 }
 
 #include <Framework/runDataProcessing.h>
+#include <Framework/DataSpecUtils.h>
+#include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
+#include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/AdvancedWorkflow.h"
 
 using namespace o2;
 using namespace o2::header;
 using namespace o2::quality_control::core;
 using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
+using namespace o2::configuration;
 
 WorkflowSpec defineDataProcessing(ConfigContext const& config)
 {
@@ -93,7 +96,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   WorkflowSpec specs = getFullProcessingTopology();
 
   if (!noQC) {
-    DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+    auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+    auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+    DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
     // Generation of the remote QC topology (for the QC servers)
     quality_control::generateStandaloneInfrastructure(specs, qcConfigurationSource);
   }

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -68,6 +68,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 #include <Framework/runDataProcessing.h>
 #include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
 
 #include "QualityControl/CheckRunner.h"
 #include "QualityControl/InfrastructureGenerator.h"
@@ -80,6 +81,7 @@ std::string getConfigPath(const ConfigContext& config);
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::configuration;
 using namespace o2::quality_control::checker;
 using namespace std::chrono;
 
@@ -96,7 +98,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
   ILOG(Info, Ops) << "Using config file '" << qcConfigurationSource << "'" << ENDM;
 
   // Generation of Data Sampling infrastructure
-  DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+  auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+  auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+  DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
 
   // Generation of the QC topology (one task, one checker in this case)
   quality_control::generateStandaloneInfrastructure(specs, qcConfigurationSource);

--- a/Framework/src/runQC.cxx
+++ b/Framework/src/runQC.cxx
@@ -28,12 +28,15 @@
 
 #include <boost/asio/ip/host_name.hpp>
 #include <DataSampling/DataSampling.h>
+#include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
 #include "QualityControl/InfrastructureGenerator.h"
 #include "QualityControl/QcInfoLogger.h"
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::utilities;
+using namespace o2::configuration;
 
 // The customize() functions are used to declare the executable arguments and to specify custom completion and channel
 // configuration policies. They have to be above `#include "Framework/runDataProcessing.h"` - that header checks if
@@ -157,7 +160,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
 
         if (!config.options().get<bool>("no-data-sampling")) {
           ILOG(Info, Support) << "Generating Data Sampling" << ENDM;
-          DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+          auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+          auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+          DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
         } else {
           ILOG(Info, Support) << "Omitting Data Sampling" << ENDM;
         }
@@ -169,7 +174,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
 
         if (!config.options().get<bool>("no-data-sampling")) {
           ILOG(Info, Support) << "Generating Data Sampling" << ENDM;
-          DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+          auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+          auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+          DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
         } else {
           ILOG(Info, Support) << "Omitting Data Sampling" << ENDM;
         }
@@ -192,7 +199,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
         ILOG(Info, Support) << "Creating a local batch QC workflow." << ENDM;
         if (!config.options().get<bool>("no-data-sampling")) {
           ILOG(Info, Support) << "Generating Data Sampling" << ENDM;
-          DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+          auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+          auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+          DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
         } else {
           ILOG(Info, Support) << "Omitting Data Sampling" << ENDM;
         }

--- a/Framework/test/testCheckWorkflow.cxx
+++ b/Framework/test/testCheckWorkflow.cxx
@@ -44,11 +44,14 @@ void customize(std::vector<CompletionPolicy>& policies)
 #include "QualityControl/runnerUtils.h"
 #include <Framework/runDataProcessing.h>
 #include <Framework/ControlService.h>
+#include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
 #include <set>
 #include <vector>
 
 using namespace o2::quality_control::core;
 using namespace o2::quality_control::checker;
+using namespace o2::configuration;
 
 /**
  * Test description
@@ -140,7 +143,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   ILOG(Info) << "Using config file '" << qcConfigurationSource << "'" << ENDM;
 
   // Generation of Data Sampling infrastructure
-  DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+  auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+  auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+  DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
 
   // Generation of the QC topology (one task, one checker in this case)
   quality_control::generateStandaloneInfrastructure(specs, qcConfigurationSource);

--- a/Framework/test/testTaskRunner.cxx
+++ b/Framework/test/testTaskRunner.cxx
@@ -59,8 +59,9 @@ BOOST_AUTO_TEST_CASE(test_factory)
 
   BOOST_CHECK_EQUAL(taskRunner.name, "QC-TASK-RUNNER-abcTask");
 
+  auto dataSamplingTree = ConfigurationFactory::getConfiguration(configFilePath)->getRecursive("dataSamplingPolicies");
   BOOST_REQUIRE_EQUAL(taskRunner.inputs.size(), 2);
-  BOOST_CHECK_EQUAL(taskRunner.inputs[0], DataSampling::InputSpecsForPolicy(configFilePath, "tpcclust").at(0));
+  BOOST_CHECK_EQUAL(taskRunner.inputs[0], DataSampling::InputSpecsForPolicy(dataSamplingTree, "tpcclust").at(0));
   BOOST_CHECK(taskRunner.inputs[1].lifetime == Lifetime::Timer);
 
   BOOST_REQUIRE_EQUAL(taskRunner.outputs.size(), 1);
@@ -84,13 +85,13 @@ BOOST_AUTO_TEST_CASE(test_task_runner_static)
 BOOST_AUTO_TEST_CASE(test_task_runner)
 {
   std::string configFilePath = std::string("json://") + getTestDataDirectory() + "testSharedConfig.json";
-
   TaskRunner qcTask{ getTaskConfig(configFilePath, "abcTask", 0) };
 
   BOOST_CHECK_EQUAL(qcTask.getDeviceName(), "QC-TASK-RUNNER-abcTask");
 
+  auto dataSamplingTree = ConfigurationFactory::getConfiguration(configFilePath)->getRecursive("dataSamplingPolicies");
   BOOST_REQUIRE_EQUAL(qcTask.getInputsSpecs().size(), 2);
-  BOOST_CHECK_EQUAL(qcTask.getInputsSpecs()[0], DataSampling::InputSpecsForPolicy(configFilePath, "tpcclust").at(0));
+  BOOST_CHECK_EQUAL(qcTask.getInputsSpecs()[0], DataSampling::InputSpecsForPolicy(dataSamplingTree, "tpcclust").at(0));
   BOOST_CHECK(qcTask.getInputsSpecs()[1].lifetime == Lifetime::Timer);
 
   BOOST_CHECK_EQUAL(qcTask.getOutputSpec(), (OutputSpec{ { "mo" }, "QC", "abcTask-mo", 0 }));

--- a/Framework/test/testWorkflow.cxx
+++ b/Framework/test/testWorkflow.cxx
@@ -32,10 +32,13 @@ void customize(std::vector<CompletionPolicy>& policies)
 #include "QualityControl/runnerUtils.h"
 #include <Framework/runDataProcessing.h>
 #include <Framework/ControlService.h>
+#include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
 #include <TH1F.h>
 
 using namespace o2::quality_control::core;
 using namespace o2::quality_control::checker;
+using namespace o2::configuration;
 
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
@@ -60,7 +63,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   ILOG(Info) << "Using config file '" << qcConfigurationSource << "'" << ENDM;
 
   // Generation of Data Sampling infrastructure
-  DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+  auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+  auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+  DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
 
   // Generation of the QC topology (one task, one checker in this case)
   quality_control::generateStandaloneInfrastructure(specs, qcConfigurationSource);

--- a/Modules/EMCAL/src/runQCEMCALDigits.cxx
+++ b/Modules/EMCAL/src/runQCEMCALDigits.cxx
@@ -12,20 +12,15 @@
 #include <string>
 #include <TH1.h>
 
-#if __has_include(<Framework/DataSampling.h>)
-#include <Framework/DataSampling.h>
-using namespace o2::framework;
-// TODO bring back full namespaces after the migration
-#else
 #include <DataSampling/DataSampling.h>
-using namespace o2::utilities;
-#endif
 #include <DataFormatsEMCAL/Digit.h>
 #include <DataFormatsEMCAL/Cell.h>
 #include <EMCALWorkflow/PublisherSpec.h>
 #include "QualityControl/InfrastructureGenerator.h"
 #include "QualityControl/CheckRunner.h"
 #include "QualityControl/CheckRunnerFactory.h"
+
+using namespace o2::utilities;
 
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
@@ -57,6 +52,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 }
 
 #include "Framework/runDataProcessing.h"
+#include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
+
+using namespace o2::configuration;
 
 std::string getConfigPath(const o2::framework::ConfigContext& config);
 
@@ -106,14 +105,18 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
 
   if (!config.options().get<bool>("local") && !config.options().get<bool>("remote")) {
     ILOG(Info, Support) << "Creating a standalone QC topology." << ENDM;
-    o2::quality_control::generateStandaloneInfrastructure(specs, qcConfigurationSource);
+    auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+    auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+    DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
   }
 
   if (config.options().get<bool>("local")) {
     ILOG(Info, Support) << "Creating a local QC topology." << ENDM;
 
     // Generation of Data Sampling infrastructure
-    DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+    auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+    auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+    DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
 
     // Generation of the local QC topology (local QC tasks and their output proxies)
     o2::quality_control::generateLocalInfrastructure(specs, qcConfigurationSource, config.options().get<std::string>("host"));

--- a/Modules/ITS/src/runITS.cxx
+++ b/Modules/ITS/src/runITS.cxx
@@ -19,16 +19,12 @@
 /// \brief This is an executable to run the ITS QC Task.
 ///
 
-#if __has_include(<Framework/DataSampling.h>)
-#include <Framework/DataSampling.h>
-#else
 #include <DataSampling/DataSampling.h>
-using namespace o2::utilities;
-#endif
 #include "QualityControl/InfrastructureGenerator.h"
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::utilities;
 
 void customize(std::vector<CompletionPolicy>& policies)
 {
@@ -54,8 +50,10 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 #include <memory>
 #include <random>
 
-#include "Framework/runDataProcessing.h"
+#include <Framework/runDataProcessing.h>
 
+#include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
 #include "QualityControl/Check.h"
 #include "QualityControl/InfrastructureGenerator.h"
 #include "QualityControl/runnerUtils.h"
@@ -65,6 +63,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 std::string getConfigPath(const ConfigContext& config);
 
+using namespace o2::configuration;
 using namespace o2::framework;
 using namespace o2::quality_control::checker;
 using namespace std::chrono;
@@ -84,7 +83,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
   LOG(INFO) << "Using config file '" << qcConfigurationSource << "'";
 
   // Generation of Data Sampling infrastructure
-  DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+  auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+  auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+  DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
 
   // Generation of the QC topology (one task, one checker in this case)
   quality_control::generateStandaloneInfrastructure(specs, qcConfigurationSource);

--- a/Modules/MUON/MID/src/runMID.cxx
+++ b/Modules/MUON/MID/src/runMID.cxx
@@ -15,20 +15,12 @@
 /// \brief This is an executable to run the MID QC Task (see the ITS code).
 ///
 
-//#include "Framework/DataSampling.h"
-//#include "DataSampling/DataSampling.h"
-//#include "QualityControl/InfrastructureGenerator.h"
-
-#if __has_include(<Framework/DataSampling.h>)
-#include <Framework/DataSampling.h>
-#else
 #include <DataSampling/DataSampling.h>
-using namespace o2::utilities;
-#endif
 #include "QualityControl/InfrastructureGenerator.h"
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::utilities;
 
 void customize(std::vector<CompletionPolicy>& policies)
 {
@@ -54,7 +46,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 #include <memory>
 #include <random>
 
-#include "Framework/runDataProcessing.h"
+#include <Framework/runDataProcessing.h>
+#include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
 
 #include "QualityControl/Check.h"
 #include "QualityControl/InfrastructureGenerator.h"
@@ -67,6 +61,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 std::string getConfigPath(const ConfigContext& config);
 
 using namespace o2::framework;
+using namespace o2::configuration;
 using namespace o2::quality_control::checker;
 using namespace std::chrono;
 
@@ -84,7 +79,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
   LOG(INFO) << "Using config file '" << qcConfigurationSource << "'";
 
   // Generation of Data Sampling infrastructure
-  DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+  auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+  auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+  DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
 
   // Generation of the QC topology (one task, one checker in this case)
   quality_control::generateStandaloneInfrastructure(specs, qcConfigurationSource);

--- a/Modules/PHOS/src/runQCPHOSRaw.cxx
+++ b/Modules/PHOS/src/runQCPHOSRaw.cxx
@@ -18,6 +18,7 @@
 #include "QualityControl/InfrastructureGenerator.h"
 #include "QualityControl/CheckRunner.h"
 #include "QualityControl/CheckRunnerFactory.h"
+using namespace o2::utilities;
 
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
@@ -48,7 +49,11 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
                                                                                       " machines, can be omitted for the local development" } });
 }
 
-#include "Framework/runDataProcessing.h"
+#include <Framework/runDataProcessing.h>
+#include <Configuration/ConfigurationFactory.h>
+#include <Configuration/ConfigurationInterface.h>
+
+using namespace o2::configuration;
 
 std::string getConfigPath(const o2::framework::ConfigContext& config);
 
@@ -68,7 +73,9 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
 
     LOG(INFO) << "Local GenerateInfrastructure";
     // Generation of Data Sampling infrastructure
-    o2::utilities::DataSampling::GenerateInfrastructure(specs, qcConfigurationSource);
+    auto configInterface = ConfigurationFactory::getConfiguration(qcConfigurationSource);
+    auto dataSamplingTree = configInterface->getRecursive("dataSamplingPolicies");
+    DataSampling::GenerateInfrastructure(specs, dataSamplingTree);
 
     LOG(INFO) << "Local: generateLocalInfrastructure";
     // Generation of the local QC topology (local QC tasks)

--- a/Modules/TPC/run/runTPCQCTrackReader.cxx
+++ b/Modules/TPC/run/runTPCQCTrackReader.cxx
@@ -20,16 +20,12 @@
 // for some reason, if the 'customize' functions are below the other includes,
 // the options are not added to the workflow.
 // So the structure should be kept as it is
-#if __has_include(<Framework/DataSampling.h>)
-#include <Framework/DataSampling.h>
-#else
 #include <DataSampling/DataSampling.h>
-using namespace o2::utilities;
-#endif
 #include "QualityControl/InfrastructureGenerator.h"
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::utilities;
 
 void customize(std::vector<CompletionPolicy>& policies)
 {


### PR DESCRIPTION
Another step towards configuration push and general isolation from `ConfigurationInterface`.

Needs https://github.com/AliceO2Group/AliceO2/pull/6813