### PR TITLE
[EMCAL-524] Add task parameter ignoring the trigger type

### DIFF
--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -145,6 +145,7 @@ class DigitsQcTask final : public TaskInterface
   };
   std::vector<CombinedEvent> buildCombinedEvents(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const;
   Bool_t mDoEndOfPayloadCheck = false;                         ///< Do old style end-of-payload check
+  Bool_t mIgnoreTriggerTypes = false;                          ///< Do not differenciate between trigger types, treat all triggers as phys. triggers
   std::map<std::string, DigitsHistograms> mHistogramContainer; ///< Container with histograms per trigger class
   o2::emcal::Geometry* mGeometry = nullptr;                    ///< EMCAL geometry
   o2::emcal::BadChannelMap* mBadChannelMap;                    ///< EMCAL channel map

--- a/Modules/EMCAL/src/DigitsQcTask.cxx
+++ b/Modules/EMCAL/src/DigitsQcTask.cxx
@@ -85,6 +85,7 @@ void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   auto hasAmpVsCell = get_bool(getConfigValueLower("hasAmpVsCell")),
        hasTimeVsCell = get_bool(getConfigValueLower("hasTimeVsCell")),
        hasCalib2D = get_bool(getConfigValueLower("hasHistValibVsCell"));
+  mIgnoreTriggerTypes = get_bool(getConfigValue("ignoreTriggers"));
   double threshold = hasConfigValue("threshold") ? get_double(getConfigValue("threshold")) : 0.5;
 
   if (hasAmpVsCell) {
@@ -219,7 +220,8 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
     //trigger type
     auto triggertype = trg.mTriggerType;
-    bool isPhysTrigger = triggertype & o2::trigger::PhT, isCalibTrigger = triggertype & o2::trigger::Cal;
+    bool isPhysTrigger = mIgnoreTriggerTypes || (triggertype & o2::trigger::PhT),
+         isCalibTrigger = (!mIgnoreTriggerTypes) && (triggertype & o2::trigger::Cal);
     std::string trgClass;
     if (isPhysTrigger) {
       trgClass = "PHYS";


### PR DESCRIPTION
- Task parameter "ignoreTriggers" (bool) steers
  whether trigger type is ignored or not
- If set to true (trigger type ignored) all triggers will
  be treated as physics triggers
Mainly of relevance for running the QC on CTF data
which currently does not have the trigger type
encoded.