### PR TITLE
[EMCAL-524] Fix filling energy spectrum for DCAL supermodules

### DIFF
--- a/Modules/EMCAL/src/DigitsQcTask.cxx
+++ b/Modules/EMCAL/src/DigitsQcTask.cxx
@@ -465,7 +465,7 @@ void DigitsQcTask::DigitsHistograms::fillHistograms(const o2::emcal::Cell& digit
       fillOptional2D(mDigitAmpSupermoduleCalib, digit.getEnergy(), supermoduleID);
       fillOptional2D(mDigitTimeSupermoduleCalib, digit.getTimeStamp() - timecalib, supermoduleID);
     }
-    if (supermoduleID) {
+    if (supermoduleID < 12) {
       fillOptional1D(mDigitAmplitudeEMCAL, digit.getEnergy());
     } else {
       fillOptional1D(mDigitAmplitudeDCAL, digit.getEnergy());


### PR DESCRIPTION
Bug introduced in #792: Supemodule ID was not
checked against range, therefore all supermodules
treated as EMCAL supermodules.