### PR TITLE
Cleanup MID Raw QC task

### DIFF
--- a/Modules/MUON/MID/CMakeLists.txt
+++ b/Modules/MUON/MID/CMakeLists.txt
@@ -2,66 +2,52 @@
 
 add_library(O2QcMID)
 
-target_sources(O2QcMID PUBLIC
-                src/RawQcCheck.cxx
-                src/RawQcTask.cxx
-                )
+target_sources(O2QcMID PRIVATE src/RawQcCheck.cxx src/RawQcTask.cxx)
 
 target_include_directories(
   O2QcMID
-  PUBLIC $<INSTALL_INTERFACE:include>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 target_link_libraries(O2QcMID PUBLIC O2QualityControl O2::MIDRaw O2::MIDQC)
 
-install(TARGETS O2QcMID
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  TARGETS O2QcMID
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-add_root_dictionary(O2QcMID
-                    HEADERS
-		            include/MID/RawQcCheck.h
-		            include/MID/RawQcTask.h
-                    LINKDEF include/MID/LinkDef.h
-                    BASENAME O2QcMID)
+add_root_dictionary(
+  O2QcMID
+  HEADERS include/MID/RawQcCheck.h include/MID/RawQcTask.h
+  LINKDEF include/MID/LinkDef.h
+  BASENAME O2QcMID)
 
 # ---- Test(s) ----
 
-#set(TEST_SRCS test/testQcMID.cxx)
+set(TEST_SRCS test/testQcMID.cxx)
 
-#foreach(test ${TEST_SRCS})
-#  get_filename_component(test_name ${test} NAME)
-#  string(REGEX REPLACE ".cxx" "" test_name ${test_name})
+foreach(test ${TEST_SRCS})
+  get_filename_component(test_name ${test} NAME)
+  string(REGEX REPLACE ".cxx" "" test_name ${test_name})
 
-#  add_executable(${test_name} ${test})
-#  target_link_libraries(${test_name}
-#                        PRIVATE O2QcMID Boost::unit_test_framework)
-#  add_test(NAME ${test_name} COMMAND ${test_name})
-#  set_property(TARGET ${test_name}
-#    PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
-#  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
-#endforeach()
+  add_executable(${test_name} ${test})
+  target_link_libraries(${test_name} PRIVATE O2QcMID Boost::unit_test_framework)
+  add_test(NAME ${test_name} COMMAND ${test_name})
+  set_property(TARGET ${test_name} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
+endforeach()
 
 # ---- Executables ----
 
-set(EXE_SRCS src/runMID.cxx)
+# set(EXE_SRCS src/runMID.cxx)
 
-set(EXE_NAMES o2-qc-run-mid)
+# set(EXE_NAMES o2-qc-run-mid)
 
-list(LENGTH EXE_SRCS count)
-math(EXPR count "${count}-1")
-foreach(i RANGE ${count})
-  list(GET EXE_SRCS ${i} src)
-  list(GET EXE_NAMES ${i} name)
-  add_executable(${name} ${src})
-  target_link_libraries(${name} PRIVATE O2QualityControl O2QcMID CURL::libcurl O2::MIDWorkflow O2::DetectorsBase)
-endforeach()
+# list(LENGTH EXE_SRCS count) math(EXPR count "${count}-1") foreach(i RANGE ${count}) list(GET EXE_SRCS ${i} src)
+# list(GET EXE_NAMES ${i} name) add_executable(${name} ${src}) target_link_libraries(${name} PRIVATE O2QualityControl
+# O2QcMID CURL::libcurl O2::MIDWorkflow O2::DetectorsBase) endforeach()
 
-install(
-  TARGETS ${EXE_NAMES}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+# install( TARGETS ${EXE_NAMES} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
-install(FILES mid-raw.json DESTINATION etc) 
+install(FILES mid-raw.json DESTINATION etc)

--- a/Modules/MUON/MID/include/MID/RawQcTask.h
+++ b/Modules/MUON/MID/include/MID/RawQcTask.h
@@ -52,21 +52,13 @@ class RawQcTask final : public TaskInterface
   void reset() override;
 
  private:
-  TH1F* mRawDataChecker = nullptr;
-  TH1F* mDetElemID = nullptr;
-
-  std::string mOutFilename;
-  std::string mFeeIdConfigFilename;
-  std::string mCrateMasksFilename;
-  std::string mElectronicsDelaysFilename;
-  bool mPerGBT;
-  bool mPerFeeId;
+  TH1F* mRawDataChecker{ nullptr };
 
   std::unique_ptr<o2::mid::Decoder> mDecoder{ nullptr };
-  o2::mid::RawDataChecker mChecker;
-  o2::mid::FEEIdConfig mFeeIdConfig;
-  o2::mid::ElectronicsDelay mElectronicsDelay;
-  o2::mid::CrateMasks mCrateMasks;
+  o2::mid::RawDataChecker mChecker{};
+  o2::mid::FEEIdConfig mFeeIdConfig{};
+  o2::mid::ElectronicsDelay mElectronicsDelay{};
+  o2::mid::CrateMasks mCrateMasks{};
 };
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/mid-raw.json
+++ b/Modules/MUON/MID/mid-raw.json
@@ -70,7 +70,7 @@
       "samplingConditions": [
         {
           "condition": "random",
-          "fraction": "1.0",
+          "fraction": "0.1",
           "seed": "1234"
         }
       ],

--- a/Modules/MUON/MID/mid-raw.json
+++ b/Modules/MUON/MID/mid-raw.json
@@ -36,29 +36,30 @@
           "name": "digits"
         },
         "taskParameters": {
-          "feeId-config-file": "",
+          "feeId-config-file": "/home/mid/daq_utils/config/feeId_mapper.txt",
           "crate-masks-file": "",
-          "electronics-delays-file": "",
-          "per-gbt": "false",
-          "per-feeId": "false",
-          "output-file": "./QCChecker-out.txt"
+          "electronics-delays-file": ""
         }
       }
     },
     "checks": {
       "QcCheckMID": {
         "active": "true",
-        "dataSource": [{
-          "type": "Task",
-          "name": "QcTestMID",
-          "MOs": ["mDetElemID"]
-        }],
         "className": "o2::quality_control_modules::mid::RawQcCheck",
         "moduleName": "QcMID",
         "detectorName": "MID",
-        "policy": "OnAny"
+        "policy": "OnAny",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "QcTestMID",
+            "MOs": [
+              "mDetElemID"
+            ]
+          }
+        ]
       }
-    }    
+    }
   },
   "dataSamplingPolicies": [
     {

--- a/Modules/MUON/MID/src/RawQcTask.cxx
+++ b/Modules/MUON/MID/src/RawQcTask.cxx
@@ -57,46 +57,25 @@ void RawQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   // Retrieve task parameters from the config file
   if (auto param = mCustomParameters.find("feeId-config-file"); param != mCustomParameters.end()) {
     ILOG(Info) << "Custom parameter - FEE Id config file: " << param->second << ENDM;
-    mFeeIdConfigFilename = param->second;
+    if (!param->second.empty()) {
+      mFeeIdConfig = o2::mid::FEEIdConfig(param->second.c_str());
+    }
   }
 
   if (auto param = mCustomParameters.find("crate-masks-file"); param != mCustomParameters.end()) {
     ILOG(Info) << "Custom parameter - Crate masks file: " << param->second << ENDM;
-    mCrateMasksFilename = param->second;
+    if (!param->second.empty()) {
+      mCrateMasks = o2::mid::CrateMasks(param->second.c_str());
+    }
   }
 
   if (auto param = mCustomParameters.find("electronics-delays-file"); param != mCustomParameters.end()) {
     ILOG(Info) << "Custom parameter - Electronics delays file: " << param->second << ENDM;
-    mElectronicsDelaysFilename = param->second;
+    if (!param->second.empty()) {
+      mElectronicsDelay = o2::mid::readElectronicsDelay(param->second.c_str());
+    }
   }
 
-  if (auto param = mCustomParameters.find("per-gbt"); param != mCustomParameters.end()) {
-    ILOG(Info) << "Custom parameter - Reading per GBT link: " << param->second << ENDM;
-    std::istringstream(param->second) >> std::boolalpha >> mPerGBT;
-  }
-
-  if (auto param = mCustomParameters.find("per-feeId"); param != mCustomParameters.end()) {
-    ILOG(Info) << "Custom parameter - Reading per FEE Id: " << param->second << ENDM;
-    std::istringstream(param->second) >> std::boolalpha >> mPerFeeId;
-  }
-
-  if (auto param = mCustomParameters.find("output-file"); param != mCustomParameters.end()) {
-    ILOG(Info) << "Custom parameter - Output file: " << param->second << ENDM;
-    mOutFilename = param->second;
-  }
-
-  // Decoder configuration inputs
-  if (!mFeeIdConfigFilename.empty()) {
-    mFeeIdConfig = o2::mid::FEEIdConfig(mFeeIdConfigFilename.c_str());
-  }
-
-  if (!mElectronicsDelaysFilename.empty()) {
-    mElectronicsDelay = o2::mid::readElectronicsDelay(mElectronicsDelaysFilename.c_str());
-  }
-
-  if (!mCrateMasksFilename.empty()) {
-    mCrateMasks = o2::mid::CrateMasks(mCrateMasksFilename.c_str());
-  }
   mChecker.init(mCrateMasks);
 
   // Histograms to be published
@@ -110,7 +89,6 @@ void RawQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 void RawQcTask::startOfActivity(Activity& /*activity*/)
 {
   ILOG(Info) << "startOfActivity" << ENDM;
-  mDetElemID->Reset();
 }
 
 void RawQcTask::startOfCycle()
@@ -122,22 +100,6 @@ void RawQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
   ILOG(Info) << "startOfDataMonitoring" << ENDM;
-
-  /* // FIXME
-  // Old version if called with runMID.cxx through o2-qc-run-mid
-  // To be included back
-
-  auto digits = ctx.inputs().get("digits");
-
-  // Get strip patterns and loop over them
-  gsl::span<const o2::mid::ColumnData> patterns = o2::framework::DataRefUtils::as<const o2::mid::ColumnData>(msg);
-
-  // Loop on stripPatterns
-  for (auto& col : patterns) {
-    int deIndex = col.deId;
-    mDetElemID->Fill(deIndex);
-  }
-  */
 
   o2::framework::DPLRawParser parser(ctx.inputs());
 


### PR DESCRIPTION
This PR removes some old executables and cleans up the MID QC Raw task, so that it can be used in an AliECS workflow.
Notice that the old executable conflicts with some O2 development. I therefore need to first merge this before pushing the modifications in O2, in order not to break QC compilation.
Notice also that, in the cleanup, I commented the code instead of removing it since I am not the QC developer. In this way the relevant people will more easily fix the executable and put it back.

The commits are intended to be atomic. Please do not squash them.