### PR TITLE
[QC-443] Represent Checks configuration as C++ structures

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -78,7 +78,8 @@ add_library(O2QualityControl
   src/Calculators.cxx
   src/DataSourceSpec.cxx
   src/RootFileSink.cxx
-  src/RootFileSource.cxx)
+  src/RootFileSource.cxx
+  src/UpdatePolicyType.cxx)
 
 target_include_directories(
   O2QualityControl

--- a/Framework/include/QualityControl/Aggregator.h
+++ b/Framework/include/QualityControl/Aggregator.h
@@ -22,7 +22,7 @@
 // QC
 #include "QualityControl/QualityObject.h"
 #include "QualityControl/CheckConfig.h"
-#include "QualityObject.h"
+#include "QualityControl/UpdatePolicyType.h"
 // config
 #include <boost/property_tree/ptree_fwd.hpp>
 
@@ -36,6 +36,7 @@ namespace o2::quality_control::checker
 
 class AggregatorInterface;
 
+// todo: it can be replaced DataSourceType
 enum AggregatorSourceType { check,
                             aggregator };
 
@@ -73,7 +74,7 @@ class Aggregator
   o2::quality_control::core::QualityObjectsType aggregate(core::QualityObjectsMapType& qoMap);
 
   const std::string& getName() const;
-  std::string getPolicyName() const;
+  UpdatePolicyType getUpdatePolicyType() const;
   std::vector<std::string> getObjectsNames() const;
   bool getAllObjectsOption() const;
   std::vector<AggregatorSource> getSources();

--- a/Framework/include/QualityControl/AggregatorRunner.h
+++ b/Framework/include/QualityControl/AggregatorRunner.h
@@ -91,7 +91,7 @@ class AggregatorRunner : public framework::Task
    * @param configurationSource Path to configuration
    * @param checkRunnerOutputs List of checkRunners' output that it will take as inputs.
    */
-  AggregatorRunner(const std::string& configurationSource, const vector<framework::OutputSpec> checkRunnerOutputs);
+  AggregatorRunner(const std::string& configurationSource, const std::vector<framework::OutputSpec> checkRunnerOutputs);
 
   /// Destructor
   ~AggregatorRunner() override;

--- a/Framework/include/QualityControl/AggregatorRunnerFactory.h
+++ b/Framework/include/QualityControl/AggregatorRunnerFactory.h
@@ -30,7 +30,7 @@ class AggregatorRunnerFactory
   AggregatorRunnerFactory() = default;
   virtual ~AggregatorRunnerFactory() = default;
 
-  static framework::DataProcessorSpec create(const vector<framework::OutputSpec>& checkerRunnerOutputs, const std::string& configurationSource);
+  static framework::DataProcessorSpec create(const std::vector<framework::OutputSpec>& checkerRunnerOutputs, const std::string& configurationSource);
   static void customizeInfrastructure(std::vector<framework::CompletionPolicy>& policies);
 };
 

--- a/Framework/include/QualityControl/Check.h
+++ b/Framework/include/QualityControl/Check.h
@@ -27,6 +27,8 @@
 #include "QualityControl/CheckInterface.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/CheckConfig.h"
+#include "QualityControl/CommonSpec.h"
+#include "QualityControl/CheckSpec.h"
 
 namespace o2::quality_control::checker
 {
@@ -49,7 +51,7 @@ class Check
    * @param checkName Check name from the configuration
    * @param configurationSource Path to configuration
    */
-  Check(std::string checkName, std::string configurationSource);
+  Check(CheckConfig config);
 
   /**
    * \brief Initialize the check state
@@ -68,36 +70,28 @@ class Check
   void updateRevision(unsigned int revision);
 
   const std::string& getName() const { return mCheckConfig.name; };
-  o2::framework::OutputSpec getOutputSpec() const { return mOutputSpec; };
-  o2::framework::Inputs getInputs() const { return mInputs; };
+  o2::framework::OutputSpec getOutputSpec() const { return mCheckConfig.qoSpec; };
+  o2::framework::Inputs getInputs() const { return mCheckConfig.inputSpecs; };
 
   //TODO: Unique Input string
-  static o2::header::DataDescription createCheckerDataDescription(const std::string taskName);
+  static o2::header::DataDescription createCheckerDataDescription(const std::string& taskName);
 
   // For testing purpose
   void setCheckInterface(CheckInterface* checkInterface) { mCheckInterface = checkInterface; };
 
-  std::string getPolicyName() const;
+  UpdatePolicyType getUpdatePolicyType() const;
   std::vector<std::string> getObjectsNames() const;
   bool getAllObjectsOption() const;
 
- private:
-  void initConfig(std::string checkName);
+  // todo: probably make CheckFactory
+  static CheckConfig extractConfig(const CommonSpec&, const CheckSpec&);
 
+ private:
   void beautify(std::map<std::string, std::shared_ptr<MonitorObject>>& moMap, Quality quality);
 
-  std::string mConfigurationSource;
   o2::quality_control::core::QcInfoLogger& mLogger;
   CheckConfig mCheckConfig;
   CheckInterface* mCheckInterface = nullptr;
-  size_t mNumberOfTaskSources;
-
-  // DPL information
-  o2::framework::Inputs mInputs;
-  std::vector<std::string> mInputsStringified;
-  o2::framework::OutputSpec mOutputSpec;
-
-  bool mBeautify = true;
 };
 
 } // namespace o2::quality_control::checker

--- a/Framework/include/QualityControl/CheckConfig.h
+++ b/Framework/include/QualityControl/CheckConfig.h
@@ -20,6 +20,9 @@
 #include <string>
 #include <unordered_map>
 
+#include <Framework/DataProcessorSpec.h>
+#include "QualityControl/UpdatePolicyType.h"
+
 namespace o2::quality_control::checker
 {
 
@@ -30,9 +33,12 @@ struct CheckConfig {
   std::string className;
   std::string detectorName = "MISC"; // intended to be the 3 letters code;
   std::unordered_map<std::string, std::string> customParameters = {};
-  std::string policyType = "OnAny";
-  std::vector<std::string> objectNames;
+  UpdatePolicyType policyType = UpdatePolicyType::OnAny;
+  std::vector<std::string> objectNames{}; // fixme: if object names are empty, allObjects are true, consider reducing to one var
   bool allObjects = false;
+  bool allowBeautify = false;
+  framework::Inputs inputSpecs{};
+  framework::OutputSpec qoSpec{ "XXX", "INVALID" };
 };
 
 } // namespace o2::quality_control::checker

--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -40,6 +40,7 @@
 #include "QualityControl/Check.h"
 #include "QualityControl/UpdatePolicyManager.h"
 #include "QualityControl/Activity.h"
+#include "QualityControl/CheckRunnerConfig.h"
 
 namespace o2::quality_control::core
 {
@@ -83,11 +84,10 @@ class CheckRunner : public framework::Task
    * Depending on the constructor, it can be a single check device or a group check device.
    * Group check assumes that the input of the checks is the same!
    *
-   * @param checkName Check name from the configuration
-   * @param checkNames List of check names, that operate on the same inputs.
-   * @param configurationSource Path to configuration
+   * @param checkRunnerConfig configuration of CheckRunner
+   * @param checkConfigs configuration of all Checks that should run in this data processor
    */
-  CheckRunner(std::vector<Check> checks, std::string configurationSource);
+  CheckRunner(CheckRunnerConfig, const std::vector<CheckConfig>& checkConfigs);
 
   /**
    * \brief CheckRunner constructor
@@ -95,10 +95,10 @@ class CheckRunner : public framework::Task
    * Create a sink for the Input. It is expected to receive Monitor Object to store.
    * It will not run any checks on a given input.
    *
+   * @param checkRunnerConfig configuration of CheckRunner
    * @param input Monitor Object input spec.
-   * @param configSource Path to configuration
    */
-  CheckRunner(o2::framework::InputSpec input, std::string configurationSource);
+  CheckRunner(CheckRunnerConfig, o2::framework::InputSpec input);
 
   /// Destructor
   ~CheckRunner() override;
@@ -116,11 +116,8 @@ class CheckRunner : public framework::Task
   std::string getDeviceName() { return mDeviceName; };
 
   /// \brief Unified DataDescription naming scheme for all checkers
-  static o2::header::DataDescription createCheckRunnerDataDescription(const std::string taskName);
-  static o2::framework::Inputs createInputSpec(const std::string checkName, const std::string configSource);
-
   static std::string createCheckRunnerIdString() { return "QC-CHECK-RUNNER"; };
-  static std::string createCheckRunnerName(std::vector<Check> checks);
+  static std::string createCheckRunnerName(const std::vector<CheckConfig>& checks);
   static std::string createSinkCheckRunnerName(o2::framework::InputSpec input);
   static std::string createCheckRunnerFacility(std::string deviceName);
 
@@ -161,7 +158,7 @@ class CheckRunner : public framework::Task
    *
    * \param checks List of all checks
    */
-  static o2::framework::Outputs collectOutputs(const std::vector<Check>& checks);
+  static o2::framework::Outputs collectOutputs(const std::vector<CheckConfig>& checks);
 
   inline void initDatabase();
   inline void initMonitoring();
@@ -178,7 +175,7 @@ class CheckRunner : public framework::Task
    *
    * \param input_string String intended to be hashed
    */
-  static std::size_t hash(std::string input_string);
+  static std::size_t hash(const std::string& inputString);
 
   /**
    * \brief Massage/Prepare data from the Context and store it in the cache.
@@ -206,11 +203,11 @@ class CheckRunner : public framework::Task
   std::string mDeviceName;
   std::vector<Check> mChecks;
   Activity mActivity;
+  CheckRunnerConfig mConfig;
   o2::quality_control::core::QcInfoLogger& mLogger;
   std::shared_ptr<o2::quality_control::repository::DatabaseInterface> mDatabase;
   std::unordered_set<std::string> mInputStoreSet;
   std::vector<std::shared_ptr<MonitorObject>> mMonitorObjectStoreVector;
-  std::shared_ptr<o2::configuration::ConfigurationInterface> mConfigFile;
   UpdatePolicyManager updatePolicyManager;
 
   // DPL

--- a/Framework/include/QualityControl/CheckRunnerConfig.h
+++ b/Framework/include/QualityControl/CheckRunnerConfig.h
@@ -1,0 +1,39 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CheckRunnerConfig.h
+/// \author Piotr Konopka
+///
+#ifndef QUALITYCONTROL_CHECKRUNNERCONFIG_H
+#define QUALITYCONTROL_CHECKRUNNERCONFIG_H
+
+#include <string>
+#include <unordered_map>
+
+namespace o2::quality_control::checker
+{
+
+struct CheckRunnerConfig {
+  std::unordered_map<std::string, std::string> database;
+  std::string consulUrl{};
+  std::string monitoringUrl{};
+  bool infologgerFilterDiscardDebug = false;
+  int infologgerDiscardLevel = 21;
+  int fallbackRunNumber = 0;
+  std::string fallbackPeriodName{};
+  std::string fallbackPassName{};
+  std::string fallbackProvenance{};
+};
+
+} // namespace o2::quality_control::checker
+
+#endif //QUALITYCONTROL_CHECKRUNNERCONFIG_H

--- a/Framework/include/QualityControl/CheckRunnerFactory.h
+++ b/Framework/include/QualityControl/CheckRunnerFactory.h
@@ -22,6 +22,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include <Framework/CompletionPolicy.h>
 #include "QualityControl/Check.h"
+#include "QualityControl/CheckRunnerConfig.h"
 
 namespace o2::framework
 {
@@ -38,7 +39,7 @@ class CheckRunnerFactory
   CheckRunnerFactory() = default;
   virtual ~CheckRunnerFactory() = default;
 
-  framework::DataProcessorSpec create(std::vector<Check> checks, std::string configurationSource, std::vector<std::string> storeVector = {});
+  static framework::DataProcessorSpec create(CheckRunnerConfig checkRunnerConfig, std::vector<CheckConfig> checkConfigs, std::vector<std::string> storeVector = {});
 
   /*
    * \brief Create a CheckRunner sink DPL device.
@@ -48,7 +49,9 @@ class CheckRunnerFactory
    * @param input InputSpec with the content to store
    * @param configurationSource
    */
-  framework::DataProcessorSpec createSinkDevice(o2::framework::InputSpec input, std::string configurationSource);
+  static framework::DataProcessorSpec createSinkDevice(CheckRunnerConfig checkRunnerConfig, o2::framework::InputSpec input);
+
+  static CheckRunnerConfig extractConfig(const CommonSpec&);
 
   static void customizeInfrastructure(std::vector<framework::CompletionPolicy>& policies);
 };

--- a/Framework/include/QualityControl/CheckSpec.h
+++ b/Framework/include/QualityControl/CheckSpec.h
@@ -1,0 +1,59 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QUALITYCONTROL_CHECKSPEC_H
+#define QUALITYCONTROL_CHECKSPEC_H
+
+///
+/// \file   CheckSpec.h
+/// \author Piotr Konopka
+///
+
+#include <string>
+
+#include "QualityControl/DataSourceSpec.h"
+#include "QualityControl/UpdatePolicyType.h"
+
+namespace o2::quality_control::checker
+{
+
+/// \brief Specification of a Check, which should map the JSON configuration structure.
+struct CheckSpec {
+  // default, invalid spec
+  CheckSpec() = default;
+
+  // minimal valid spec
+  CheckSpec(std::string checkName, std::string className, std::string moduleName, std::string detectorName,
+            std::vector<core::DataSourceSpec> dataSources, UpdatePolicyType updatePolicySpec)
+    : checkName(std::move(checkName)),
+      className(std::move(className)),
+      moduleName(std::move(moduleName)),
+      detectorName(std::move(detectorName)),
+      dataSources(std::move(dataSources)),
+      updatePolicy(updatePolicySpec)
+  {
+  }
+
+  // basic
+  std::string checkName = "Invalid";
+  std::string className = "Invalid";
+  std::string moduleName = "Invalid";
+  std::string detectorName = "DET";
+  std::vector<core::DataSourceSpec> dataSources;
+  UpdatePolicyType updatePolicy = UpdatePolicyType::OnAny;
+  // advanced
+  bool active = true;
+  std::unordered_map<std::string, std::string> customParameters = {};
+};
+
+} // namespace o2::quality_control::checker
+
+#endif //QUALITYCONTROL_CHECKSPEC_H

--- a/Framework/include/QualityControl/DataSourceSpec.h
+++ b/Framework/include/QualityControl/DataSourceSpec.h
@@ -37,7 +37,7 @@ enum class DataSourceType {
 
 // this should allow us to represent all data sources which come from DPL (and maybe CCDB).
 struct DataSourceSpec {
-  explicit DataSourceSpec(DataSourceType type = DataSourceType::Invalid, std::unordered_map<std::string, std::string> params = {});
+  explicit DataSourceSpec(DataSourceType type = DataSourceType::Invalid);
 
   // todo: use c++20 concepts when available
   template <class... Args, class Enable = std::enable_if_t<(... && std::is_convertible_v<Args, DataSourceType>)>>
@@ -47,8 +47,9 @@ struct DataSourceSpec {
   }
 
   DataSourceType type;
-  std::unordered_map<std::string, std::string> typeSpecificParams;
+  std::string name;
   std::vector<framework::InputSpec> inputs;
+  std::vector<std::string> subInputs; // can be MO or QO names
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/ExternalTaskSpec.h
+++ b/Framework/include/QualityControl/ExternalTaskSpec.h
@@ -1,0 +1,39 @@
+#include <utility>
+
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QUALITYCONTROL_EXTERNALTASKSPEC_H
+#define QUALITYCONTROL_EXTERNALTASKSPEC_H
+
+///
+/// \file   ExternalTaskSpec.h
+/// \author Piotr Konopka
+///
+
+namespace o2::quality_control::core
+{
+
+struct ExternalTaskSpec {
+  ExternalTaskSpec() = default;
+
+  ExternalTaskSpec(std::string taskName, std::string query, bool active = true) : taskName(std::move(taskName)), query(std::move(query)), active(active)
+  {
+  }
+
+  std::string taskName;
+  std::string query;
+  bool active = true;
+};
+
+} // namespace o2::quality_control::core
+
+#endif //QUALITYCONTROL_EXTERNALTASKSPEC_H

--- a/Framework/include/QualityControl/InfrastructureGenerator.h
+++ b/Framework/include/QualityControl/InfrastructureGenerator.h
@@ -32,6 +32,8 @@ namespace o2::quality_control
 namespace core
 {
 
+struct InfrastructureSpec;
+
 /// \brief A factory class which can generate QC topologies given a configuration file.
 ///
 /// A factory class which can generate QC topologies given a configuration file (example in Framework/basic.json and
@@ -199,8 +201,8 @@ class InfrastructureGenerator
                               std::string mergingMode,
                               size_t resetAfterCycles,
                               std::string monitoringUrl);
-  static vector<framework::OutputSpec> generateCheckRunners(framework::WorkflowSpec& workflow, std::string configurationSource);
-  static void generateAggregator(framework::WorkflowSpec& workflow, std::string configurationSource, vector<framework::OutputSpec>& checkRunnerOutputs);
+  static std::vector<framework::OutputSpec> generateCheckRunners(framework::WorkflowSpec& workflow, const InfrastructureSpec& infrastructureSpec);
+  static void generateAggregator(framework::WorkflowSpec& workflow, std::string configurationSource, std::vector<framework::OutputSpec>& checkRunnerOutputs);
   static void generatePostProcessing(framework::WorkflowSpec& workflow, std::string configurationSource);
 };
 

--- a/Framework/include/QualityControl/InfrastructureSpec.h
+++ b/Framework/include/QualityControl/InfrastructureSpec.h
@@ -18,6 +18,9 @@
 
 #include "QualityControl/CommonSpec.h"
 #include "QualityControl/TaskSpec.h"
+#include "QualityControl/CheckSpec.h"
+#include "QualityControl/PostProcessingTaskSpec.h"
+#include "QualityControl/ExternalTaskSpec.h"
 
 #include <vector>
 
@@ -27,6 +30,9 @@ namespace o2::quality_control::core
 struct InfrastructureSpec {
   CommonSpec common;
   std::vector<TaskSpec> tasks;
+  std::vector<checker::CheckSpec> checks;
+  std::vector<PostProcessingTaskSpec> postProcessingTasks;
+  std::vector<ExternalTaskSpec> externalTasks;
   // todo: add other actors
 };
 

--- a/Framework/include/QualityControl/InfrastructureSpecReader.h
+++ b/Framework/include/QualityControl/InfrastructureSpecReader.h
@@ -20,6 +20,8 @@
 #include "QualityControl/TaskSpec.h"
 #include "QualityControl/CommonSpec.h"
 #include "QualityControl/DataSourceSpec.h"
+#include "QualityControl/CheckSpec.h"
+#include "QualityControl/PostProcessingTaskSpec.h"
 #include <boost/property_tree/ptree_fwd.hpp>
 
 namespace o2::quality_control::core
@@ -40,6 +42,9 @@ class InfrastructureSpecReader
   static CommonSpec readCommonSpec(const boost::property_tree::ptree& commonTree, const std::string& configurationSource);
   static TaskSpec readTaskSpec(std::string taskName, const boost::property_tree::ptree& taskTree, const boost::property_tree::ptree& wholeTree);
   static DataSourceSpec readDataSourceSpec(const boost::property_tree::ptree& dataSourceTree, const boost::property_tree::ptree& wholeTree);
+  static checker::CheckSpec readCheckSpec(std::string checkName, const boost::property_tree::ptree& checkTree, const boost::property_tree::ptree& wholeTree);
+  static PostProcessingTaskSpec readPostProcessingTaskSpec(std::string ppTaskName, const boost::property_tree::ptree& ppTaskTree, const boost::property_tree::ptree& wholeTree);
+  static ExternalTaskSpec readExternalTaskSpec(std::string externalTaskName, const boost::property_tree::ptree& externalTaskTree, const boost::property_tree::ptree& wholeTree);
 
   static std::string validateDetectorName(std::string name);
 };

--- a/Framework/include/QualityControl/PostProcessingConfig.h
+++ b/Framework/include/QualityControl/PostProcessingConfig.h
@@ -31,16 +31,16 @@ struct PostProcessingConfig {
   PostProcessingConfig() = default;
   PostProcessingConfig(std::string name, const boost::property_tree::ptree& config);
   ~PostProcessingConfig() = default;
-  std::string taskName = "";
-  std::string moduleName = "";
-  std::string className = "";
+  std::string taskName;
+  std::string moduleName;
+  std::string className;
   std::string detectorName = "MISC";
   std::vector<std::string> initTriggers = {};
   std::vector<std::string> updateTriggers = {};
   std::vector<std::string> stopTriggers = {};
-  std::string qcdbUrl = "";
-  std::string ccdbUrl = "";
-  std::string consulUrl = "";
+  std::string qcdbUrl;
+  std::string ccdbUrl;
+  std::string consulUrl;
 };
 
 } // namespace o2::quality_control::postprocessing

--- a/Framework/include/QualityControl/PostProcessingTaskSpec.h
+++ b/Framework/include/QualityControl/PostProcessingTaskSpec.h
@@ -1,0 +1,55 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QUALITYCONTROL_POSTPROCESSINGTASKSPEC_H
+#define QUALITYCONTROL_POSTPROCESSINGTASKSPEC_H
+
+///
+/// \file   PostProcessingTaskSpec.h
+/// \author Piotr Konopka
+///
+
+#include <boost/property_tree/ptree.hpp>
+#include <string>
+#include <vector>
+
+namespace o2::quality_control::core
+{
+
+struct PostProcessingTaskSpec {
+  // default, invalid spec
+  PostProcessingTaskSpec() = default;
+
+  // minimal valid spec
+  PostProcessingTaskSpec(std::string taskName, std::string className, std::string moduleName, std::string detectorName)
+    : taskName(std::move(taskName)),
+      className(std::move(className)),
+      moduleName(std::move(moduleName)),
+      detectorName(std::move(detectorName))
+  {
+  }
+
+  // basic
+  std::string taskName = "Invalid";
+  std::string className = "Invalid";
+  std::string moduleName = "Invalid";
+  std::string detectorName = "Invalid";
+  std::vector<std::string> initTriggers;
+  std::vector<std::string> updateTriggers;
+  std::vector<std::string> stopTriggers;
+  // advanced
+  bool active = true;
+  boost::property_tree::ptree tree = {}; // todo see if it can be avoided
+};
+
+} // namespace o2::quality_control::core
+
+#endif //QUALITYCONTROL_POSTPROCESSINGTASKSPEC_H

--- a/Framework/include/QualityControl/TaskRunnerConfig.h
+++ b/Framework/include/QualityControl/TaskRunnerConfig.h
@@ -51,7 +51,7 @@ struct TaskRunnerConfig {
   std::string activityPeriodName = "";
   std::string activityPassName = "";
   std::string activityProvenance = "qc";
-  int defaultRunNumber = 0;
+  int fallbackRunNumber = 0;
   std::string configurationSource{};
 };
 

--- a/Framework/include/QualityControl/TaskSpec.h
+++ b/Framework/include/QualityControl/TaskSpec.h
@@ -1,8 +1,9 @@
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
-// See http://alice-o2.web.cern.ch/license for full licensing information.
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/Framework/include/QualityControl/UpdatePolicyManager.h
+++ b/Framework/include/QualityControl/UpdatePolicyManager.h
@@ -23,6 +23,8 @@
 #include <functional>
 #include <iosfwd>
 
+#include "QualityControl/UpdatePolicyType.h"
+
 namespace o2::quality_control::checker
 {
 
@@ -119,7 +121,7 @@ class UpdatePolicyManager
    * @param allObjects
    * @param policyHelper
    */
-  void addPolicy(std::string actorName, std::string policyType, std::vector<std::string> objectNames, bool allObjects, bool policyHelper);
+  void addPolicy(std::string actorName, UpdatePolicyType policyType, std::vector<std::string> objectNames, bool allObjects, bool policyHelper);
   /**
    * Checks whether the given actor is ready or not.
    * @param actorName

--- a/Framework/include/QualityControl/UpdatePolicyType.h
+++ b/Framework/include/QualityControl/UpdatePolicyType.h
@@ -1,0 +1,39 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QUALITYCONTROL_UPDATEPOLICYTYPE_H
+#define QUALITYCONTROL_UPDATEPOLICYTYPE_H
+
+///
+/// \file   UpdatePolicyType.h
+/// \author Piotr Konopka
+///
+
+#include <string>
+
+namespace o2::quality_control::checker
+{
+
+enum class UpdatePolicyType {
+  OnAny,
+  OnAnyNonZero,
+  OnAll,
+  OnEachSeparately,
+  OnGlobalAny
+};
+
+struct UpdatePolicyTypeUtils {
+  static UpdatePolicyType FromString(const std::string&);
+  static std::string ToString(UpdatePolicyType);
+};
+
+} // namespace o2::quality_control::checker
+#endif //QUALITYCONTROL_UPDATEPOLICYTYPE_H

--- a/Framework/include/QualityControl/runnerUtils.h
+++ b/Framework/include/QualityControl/runnerUtils.h
@@ -64,6 +64,7 @@ inline bool hasChecks(std::string configSource)
   return config->getRecursive("qc").count("checks") > 0;
 }
 
+// todo: delete those four once QC-443 is done (or in the process)
 inline int computeRunNumber(const framework::ServiceRegistry& services, const boost::property_tree::ptree& config)
 { // Determine run number
   int run = 0;
@@ -108,7 +109,7 @@ inline std::string computeProvenance(const boost::property_tree::ptree& config)
   return provenance;
 }
 
-inline int computeRunNumber(const framework::ServiceRegistry& services, int defaultRunNumber = 0)
+inline int computeRunNumber(const framework::ServiceRegistry& services, int fallbackRunNumber = 0)
 { // Determine run number
   int run = 0;
   try {
@@ -121,9 +122,35 @@ inline int computeRunNumber(const framework::ServiceRegistry& services, int defa
                            "   using the one from the config file or 0 as a last resort."
                         << ENDM;
   }
-  run = run > 0 /* found it in service */ ? run : defaultRunNumber;
+  run = run > 0 /* found it in service */ ? run : fallbackRunNumber;
   ILOG(Debug, Devel) << "Run number returned by computeRunNumber (default) : " << run << ENDM;
   return run;
+}
+
+inline std::string computePeriodName(const framework::ServiceRegistry& services, const std::string& fallbackPeriodName = "")
+{ // Determine period
+  std::string periodName;
+  periodName = services.get<framework::RawDeviceService>().device()->fConfig->GetProperty<std::string>("periodName", "unspecified");
+  ILOG(Info, Devel) << "Got this property periodName from RawDeviceService: '" << periodName << "'" << ENDM;
+  periodName = periodName != "unspecified" /* found it in service */ ? periodName : fallbackPeriodName;
+  ILOG(Debug, Devel) << "Period Name returned by computePeriodName : " << periodName << ENDM;
+  return periodName;
+}
+
+inline std::string computePassName(const std::string& fallbackPassName = "")
+{
+  std::string passName;
+  passName = fallbackPassName;
+  ILOG(Debug, Devel) << "Period Name returned by computePassName : " << passName << ENDM;
+  return passName;
+}
+
+inline std::string computeProvenance(const std::string& fallbackProvenance = "")
+{
+  std::string provenance;
+  provenance = fallbackProvenance;
+  ILOG(Debug, Devel) << "Period Name returned by computeProvenance : " << provenance << ENDM;
+  return provenance;
 }
 
 } // namespace o2::quality_control::core

--- a/Framework/src/Aggregator.cxx
+++ b/Framework/src/Aggregator.cxx
@@ -18,6 +18,7 @@
 #include "QualityControl/Aggregator.h"
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/AggregatorInterface.h"
+#include "QualityControl/UpdatePolicyType.h"
 #include <Common/Exceptions.h>
 
 using namespace o2::quality_control::checker;
@@ -31,7 +32,7 @@ Aggregator::Aggregator(const std::string& aggregatorName, const boost::property_
 {
   mAggregatorConfig.name = aggregatorName;
   mAggregatorConfig.moduleName = configuration.get<std::string>("moduleName", "");
-  mAggregatorConfig.policyType = configuration.get<std::string>("policy", "");
+  mAggregatorConfig.policyType = UpdatePolicyTypeUtils::FromString(configuration.get<std::string>("policy", ""));
   mAggregatorConfig.className = configuration.get<std::string>("className", "");
   mAggregatorConfig.detectorName = configuration.get<std::string>("detectorName", "");
 
@@ -55,7 +56,7 @@ Aggregator::Aggregator(const std::string& aggregatorName, const boost::property_
       if (dataSource.count("QOs") == 0) {
         ILOG(Info, Devel) << "      (no QOs specified, we take all)" << ENDM;
         mAggregatorConfig.allObjects = true;
-        mAggregatorConfig.policyType = "_OnGlobalAny";
+        mAggregatorConfig.policyType = UpdatePolicyType::OnGlobalAny;
       } else {
         for (const auto& qoName : dataSource.get_child("QOs")) {
           auto name = std::string(sourceName + "/" + qoName.second.get_value<std::string>());
@@ -89,7 +90,7 @@ void Aggregator::init()
   ILOG(Info, Ops) << mAggregatorConfig.name << ": Module " << mAggregatorConfig.moduleName << AliceO2::InfoLogger::InfoLogger::endm;
   ILOG(Info, Ops) << mAggregatorConfig.name << ": Class " << mAggregatorConfig.className << AliceO2::InfoLogger::InfoLogger::endm;
   ILOG(Info, Ops) << mAggregatorConfig.name << ": Detector " << mAggregatorConfig.detectorName << AliceO2::InfoLogger::InfoLogger::endm;
-  ILOG(Info, Ops) << mAggregatorConfig.name << ": Policy " << mAggregatorConfig.policyType << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Ops) << mAggregatorConfig.name << ": Policy " << UpdatePolicyTypeUtils::ToString(mAggregatorConfig.policyType) << AliceO2::InfoLogger::InfoLogger::endm;
   ILOG(Info, Ops) << mAggregatorConfig.name << ": QualityObjects : " << AliceO2::InfoLogger::InfoLogger::endm;
   for (const auto& moname : mAggregatorConfig.objectNames) {
     ILOG(Info, Ops) << mAggregatorConfig.name << "   - " << moname << AliceO2::InfoLogger::InfoLogger::endm;
@@ -140,7 +141,7 @@ QualityObjectsType Aggregator::aggregate(QualityObjectsMapType& qoMap)
       quality,
       mAggregatorConfig.name + "/" + qualityName,
       mAggregatorConfig.detectorName,
-      mAggregatorConfig.policyType));
+      UpdatePolicyTypeUtils::ToString(mAggregatorConfig.policyType)));
   }
   return qualityObjects;
 }
@@ -150,7 +151,7 @@ const std::string& Aggregator::getName() const
   return mAggregatorConfig.name;
 }
 
-std::string Aggregator::getPolicyName() const
+UpdatePolicyType Aggregator::getUpdatePolicyType() const
 {
   return mAggregatorConfig.policyType;
 }

--- a/Framework/src/AggregatorRunner.cxx
+++ b/Framework/src/AggregatorRunner.cxx
@@ -44,7 +44,7 @@ const auto current_diagnostic = boost::current_exception_diagnostic_information;
 namespace o2::quality_control::checker
 {
 
-AggregatorRunner::AggregatorRunner(const std::string& configurationSource, const vector<framework::OutputSpec> checkRunnerOutputs)
+AggregatorRunner::AggregatorRunner(const std::string& configurationSource, const std::vector<framework::OutputSpec> checkRunnerOutputs)
   : mDeviceName(createAggregatorRunnerName()),
     mTotalNumberObjectsReceived(0)
 {
@@ -234,7 +234,7 @@ void AggregatorRunner::initAggregators()
           auto aggregator = make_shared<Aggregator>(aggregatorName, aggregatorConfig);
           aggregator->init();
           updatePolicyManager.addPolicy(aggregator->getName(),
-                                        aggregator->getPolicyName(),
+                                        aggregator->getUpdatePolicyType(),
                                         aggregator->getObjectsNames(),
                                         aggregator->getAllObjectsOption(),
                                         false);

--- a/Framework/src/AggregatorRunnerFactory.cxx
+++ b/Framework/src/AggregatorRunnerFactory.cxx
@@ -31,7 +31,7 @@ using namespace o2::framework;
 namespace o2::quality_control::checker
 {
 
-DataProcessorSpec AggregatorRunnerFactory::create(const vector<OutputSpec>& checkerRunnerOutputs, const std::string& configurationSource)
+DataProcessorSpec AggregatorRunnerFactory::create(const std::vector<OutputSpec>& checkerRunnerOutputs, const std::string& configurationSource)
 {
   AggregatorRunner aggregator{ configurationSource, checkerRunnerOutputs };
 

--- a/Framework/src/CheckRunnerFactory.cxx
+++ b/Framework/src/CheckRunnerFactory.cxx
@@ -30,9 +30,9 @@ namespace o2::quality_control::checker
 
 using namespace o2::framework;
 
-DataProcessorSpec CheckRunnerFactory::create(std::vector<Check> checks, std::string configurationSource, std::vector<std::string> storeVector)
+DataProcessorSpec CheckRunnerFactory::create(CheckRunnerConfig checkRunnerConfig, std::vector<CheckConfig> checkConfigs, std::vector<std::string> storeVector)
 {
-  CheckRunner qcCheckRunner{ checks, configurationSource };
+  CheckRunner qcCheckRunner{ std::move(checkRunnerConfig), std::move(checkConfigs) };
   qcCheckRunner.setTaskStoreSet({ storeVector.begin(), storeVector.end() });
 
   DataProcessorSpec newCheckRunner{ qcCheckRunner.getDeviceName(),
@@ -44,9 +44,9 @@ DataProcessorSpec CheckRunnerFactory::create(std::vector<Check> checks, std::str
   return newCheckRunner;
 }
 
-DataProcessorSpec CheckRunnerFactory::createSinkDevice(o2::framework::InputSpec input, std::string configurationSource)
+DataProcessorSpec CheckRunnerFactory::createSinkDevice(CheckRunnerConfig checkRunnerConfig, o2::framework::InputSpec input)
 {
-  CheckRunner qcCheckRunner{ input, configurationSource };
+  CheckRunner qcCheckRunner{ std::move(checkRunnerConfig), input };
   qcCheckRunner.setTaskStoreSet({ DataSpecUtils::label(input) });
 
   DataProcessorSpec newCheckRunner{ qcCheckRunner.getDeviceName(),
@@ -68,6 +68,21 @@ void CheckRunnerFactory::customizeInfrastructure(std::vector<framework::Completi
   auto callback = CompletionPolicyHelpers::consumeWhenAny().callback;
 
   policies.emplace_back("checkerCompletionPolicy", matcher, callback);
+}
+
+CheckRunnerConfig CheckRunnerFactory::extractConfig(const CommonSpec& commonSpec)
+{
+  return {
+    commonSpec.database,
+    commonSpec.consulUrl,
+    commonSpec.monitoringUrl,
+    commonSpec.infologgerFilterDiscardDebug,
+    commonSpec.infologgerDiscardLevel,
+    commonSpec.activityNumber,
+    commonSpec.activityPeriodName,
+    commonSpec.activityPassName,
+    commonSpec.activityProvenance
+  };
 }
 
 } // namespace o2::quality_control::checker

--- a/Framework/src/DataSourceSpec.cxx
+++ b/Framework/src/DataSourceSpec.cxx
@@ -21,8 +21,8 @@ namespace o2::quality_control::core
 
 // todo make DataSourceUtils
 
-DataSourceSpec::DataSourceSpec(DataSourceType type, std::unordered_map<std::string, std::string> params)
-  : type(type), typeSpecificParams(std::move(params))
+DataSourceSpec::DataSourceSpec(DataSourceType type)
+  : type(type)
 {
   // todo: validation?
 }

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -21,7 +21,6 @@
 
 // O2
 #include <Common/Exceptions.h>
-#include <Configuration/ConfigurationFactory.h>
 #include <Monitoring/MonitoringFactory.h>
 #include <DataSampling/DataSampling.h>
 
@@ -29,13 +28,8 @@
 #include <Framework/CompletionPolicyHelpers.h>
 #include <Framework/TimesliceIndex.h>
 #include <Framework/DataSpecUtils.h>
-#include <Framework/DataDescriptorQueryBuilder.h>
 #include <Framework/InputRecordWalker.h>
 #include <Framework/InputSpan.h>
-#include <Framework/RawDeviceService.h>
-
-#include <fairlogger/Logger.h>
-#include <FairMQDevice.h>
 
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/TaskFactory.h"
@@ -213,7 +207,7 @@ void TaskRunner::endOfStream(framework::EndOfStreamContext& eosContext)
 
 void TaskRunner::start(const ServiceRegistry& services)
 {
-  mRunNumber = o2::quality_control::core::computeRunNumber(services, mTaskConfig.defaultRunNumber);
+  mRunNumber = o2::quality_control::core::computeRunNumber(services, mTaskConfig.fallbackRunNumber);
 
   try {
     startOfActivity();

--- a/Framework/src/UpdatePolicyManager.cxx
+++ b/Framework/src/UpdatePolicyManager.cxx
@@ -61,94 +61,99 @@ void UpdatePolicyManager::updateObjectRevision(std::string objectName)
   updateObjectRevision(objectName, mGlobalRevision);
 }
 
-void UpdatePolicyManager::addPolicy(std::string actorName, std::string policyType, std::vector<std::string> objectNames, bool allObjects, bool policyHelper)
+void UpdatePolicyManager::addPolicy(std::string actorName, UpdatePolicyType policyType, std::vector<std::string> objectNames, bool allObjects, bool policyHelper)
 {
   UpdatePolicyFunctionType policy;
-  if (policyType == "OnAll") {
-    /** 
-     * Run check if all MOs are updated 
-     */
-    policy = [&, actorName]() {
-      for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
-        if (mObjectsRevision.count(objectName) == 0 || mObjectsRevision.at(objectName) <= mPoliciesByActor.at(actorName).revision) {
-          return false;
-        }
-      }
-      return true;
-    };
-  } else if (policyType == "OnAnyNonZero") {
-    /**
-     * Return true if any declared MOs were updated
-     * Guarantee that all declared MOs are available
-     */
-    policy = [&, actorName]() {
-      if (!mPoliciesByActor.at(actorName).policyHelperFlag) {
-        // Check if all monitor objects are available
+  switch (policyType) {
+    case UpdatePolicyType::OnAll: {
+      /**
+       * Run check if all MOs are updated
+       */
+      policy = [&, actorName]() {
         for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
-          if (!mObjectsRevision.count(objectName)) {
+          if (mObjectsRevision.count(objectName) == 0 || mObjectsRevision.at(objectName) <= mPoliciesByActor.at(actorName).revision) {
             return false;
           }
         }
-        // From now on all MOs are available
-        mPoliciesByActor.at(actorName).policyHelperFlag = true;
-      }
-
-      for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
-        if (mObjectsRevision[objectName] > mPoliciesByActor.at(actorName).revision) {
-          return true;
-        }
-      }
-      return false;
-    };
-
-  } else if (policyType == "OnEachSeparately") {
-    /**
-     * Return true if any declared object were updated.
-     * This is the same behaviour as OnAny.
-     */
-    policy = [&, actorName]() {
-      if (mPoliciesByActor.at(actorName).allInputObjects) {
         return true;
-      }
+      };
+      break;
+    }
+    case UpdatePolicyType::OnAnyNonZero: {
+      /**
+       * Return true if any declared MOs were updated
+       * Guarantee that all declared MOs are available
+       */
+      policy = [&, actorName]() {
+        if (!mPoliciesByActor.at(actorName).policyHelperFlag) {
+          // Check if all monitor objects are available
+          for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
+            if (!mObjectsRevision.count(objectName)) {
+              return false;
+            }
+          }
+          // From now on all MOs are available
+          mPoliciesByActor.at(actorName).policyHelperFlag = true;
+        }
 
-      for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
-        if (mObjectsRevision.count(objectName) && mObjectsRevision[objectName] > mPoliciesByActor.at(actorName).revision) {
+        for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
+          if (mObjectsRevision[objectName] > mPoliciesByActor.at(actorName).revision) {
+            return true;
+          }
+        }
+        return false;
+      };
+      break;
+    }
+    case UpdatePolicyType::OnEachSeparately: {
+      /**
+        * Return true if any declared object were updated.
+        * This is the same behaviour as OnAny.
+        */
+      policy = [&, actorName]() {
+        if (mPoliciesByActor.at(actorName).allInputObjects) {
           return true;
         }
-      }
-      return false;
-    };
 
-  } else if (policyType == "_OnGlobalAny") {
-    /**
-     * Return true if any MOs were updated.
-     * Inner policy - used for `"MOs": "all"`
-     * Might return true even if MO is not used in Check
-     */
-
-    policy = []() {
-      // Expecting check of this policy only if any change
-      return true;
-    };
-
-  } else if (policyType == "OnAny") {
-    /**
-     * Default behaviour
-     *
-     * Run check if any declared MOs are updated
-     * Does not guarantee to contain all declared MOs 
-     */
-    policy = [&, actorName]() {
-      for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
-        if (mObjectsRevision.count(objectName) && mObjectsRevision[objectName] > mPoliciesByActor.at(actorName).revision) {
-          return true;
+        for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
+          if (mObjectsRevision.count(objectName) && mObjectsRevision[objectName] > mPoliciesByActor.at(actorName).revision) {
+            return true;
+          }
         }
-      }
-      return false;
-    };
-  } else {
-    ILOG(Fatal, Ops) << "No policy named '" << policyType << "'" << ENDM;
-    BOOST_THROW_EXCEPTION(FatalException() << errinfo_details("No policy named '" + policyType + "'"));
+        return false;
+      };
+      break;
+    }
+    case UpdatePolicyType::OnGlobalAny: {
+      /**
+       * Return true if any MOs were updated.
+       * Inner policy - used for `"MOs": "all"`
+       * Might return true even if MO is not used in Check
+       */
+
+      policy = []() {
+        // Expecting check of this policy only if any change
+        return true;
+      };
+      break;
+    }
+    case UpdatePolicyType::OnAny: {
+      /**
+       * Default behaviour
+       *
+       * Run check if any declared MOs are updated
+       * Does not guarantee to contain all declared MOs
+       */
+      policy = [&, actorName]() {
+        for (const auto& objectName : mPoliciesByActor.at(actorName).inputObjects) {
+          if (mObjectsRevision.count(objectName) && mObjectsRevision[objectName] > mPoliciesByActor.at(actorName).revision) {
+            return true;
+          }
+        }
+        return false;
+      };
+      break;
+    }
   }
 
   mPoliciesByActor[actorName] = { actorName, policy, objectNames, allObjects, policyHelper };

--- a/Framework/src/UpdatePolicyType.cxx
+++ b/Framework/src/UpdatePolicyType.cxx
@@ -1,0 +1,49 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   UpdatePolicyType.cxx
+/// \author Piotr Konopka
+///
+
+#include "QualityControl/UpdatePolicyType.h"
+
+#include <unordered_map>
+
+namespace o2::quality_control::checker
+{
+
+UpdatePolicyType UpdatePolicyTypeUtils::FromString(const std::string& str)
+{
+  static std::unordered_map<std::string, UpdatePolicyType> const updatePolicyTypeFromString = {
+    { "OnAny", UpdatePolicyType::OnAny },
+    { "OnAnyNonZero", UpdatePolicyType::OnAnyNonZero },
+    { "OnAll", UpdatePolicyType::OnAll },
+    { "OnEachSeparately", UpdatePolicyType::OnEachSeparately },
+    { "OnGlobalAny", UpdatePolicyType::OnGlobalAny }
+  };
+
+  return updatePolicyTypeFromString.at(str);
+}
+
+std::string UpdatePolicyTypeUtils::ToString(UpdatePolicyType policyType)
+{
+  static std::unordered_map<UpdatePolicyType, std::string> const stringFromUpdatePolicyType = {
+    { UpdatePolicyType::OnAny, "OnAny" },
+    { UpdatePolicyType::OnAnyNonZero, "OnAnyNonZero" },
+    { UpdatePolicyType::OnAll, "OnAll" },
+    { UpdatePolicyType::OnEachSeparately, "OnEachSeparately" },
+    { UpdatePolicyType::OnGlobalAny, "OnGlobalAny" }
+  };
+  return stringFromUpdatePolicyType.at(policyType);
+}
+
+} // namespace o2::quality_control::checker

--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -110,7 +110,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
     DataProcessorSpec printer{
       "printer",
       Inputs{
-        { "checked-mo", "QC", CheckRunner::createCheckRunnerDataDescription(getFirstCheckName(qcConfigurationSource)), 0 } },
+        { "checked-mo", "QC", Check::createCheckerDataDescription(getFirstCheckName(qcConfigurationSource)), 0 } },
       Outputs{},
       adaptFromTask<o2::quality_control::example::ExampleQualityPrinterSpec>()
     };

--- a/Framework/test/testCheckRunner.cxx
+++ b/Framework/test/testCheckRunner.cxx
@@ -30,10 +30,6 @@ using namespace o2::header;
 
 BOOST_AUTO_TEST_CASE(test_check_runner_static)
 {
-  BOOST_CHECK(CheckRunner::createCheckRunnerDataDescription("qwertyuiop") == DataDescription("qwertyuiop-chk"));
-  BOOST_CHECK(CheckRunner::createCheckRunnerDataDescription("012345678901234567890") == DataDescription("012345678901-chk"));
-  BOOST_CHECK_THROW(CheckRunner::createCheckRunnerDataDescription(""), AliceO2::Common::FatalException);
-
   // facility name
   BOOST_CHECK(CheckRunner::createCheckRunnerFacility(CheckRunner::createCheckRunnerIdString() + "-test") == "check/test");
   BOOST_CHECK(CheckRunner::createCheckRunnerFacility(CheckRunner::createCheckRunnerIdString() + "-abcdefghijklmnopqrstuvwxyz") == "check/abcdefghijklmnopqrstuvwxyz");

--- a/Framework/test/testPolicyManager.cxx
+++ b/Framework/test/testPolicyManager.cxx
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(test_basic_isready)
   UpdatePolicyManager updatePolicyManager;
 
   // init
-  updatePolicyManager.addPolicy("actor1", "OnAny", { "object1" }, false, false);
+  updatePolicyManager.addPolicy("actor1", UpdatePolicyType::OnAny, { "object1" }, false, false);
 
   // this is like 1 iteration of the run() :
   // get new data
@@ -61,10 +61,10 @@ BOOST_AUTO_TEST_CASE(test_basic_isready2)
   UpdatePolicyManager updatePolicyManager;
 
   // init
-  updatePolicyManager.addPolicy("actor1", "OnAny", { "object1", "object2" }, false, false);
-  updatePolicyManager.addPolicy("actor2", "OnAny", { "object2", "object3" }, false, false);
-  updatePolicyManager.addPolicy("actor3", "OnAny", {}, false, false); // no objects listed
-  updatePolicyManager.addPolicy("actor4", "OnAny", {}, true, false);  // allMOs set
+  updatePolicyManager.addPolicy("actor1", UpdatePolicyType::OnAny, { "object1", "object2" }, false, false);
+  updatePolicyManager.addPolicy("actor2", UpdatePolicyType::OnAny, { "object2", "object3" }, false, false);
+  updatePolicyManager.addPolicy("actor3", UpdatePolicyType::OnAny, {}, false, false); // no objects listed
+  updatePolicyManager.addPolicy("actor4", UpdatePolicyType::OnAny, {}, true, false);  // allMOs set
 
   // this is like 1 iteration of the run() :
   // get new data
@@ -114,10 +114,10 @@ BOOST_AUTO_TEST_CASE(test_check_policy_OnAll)
   UpdatePolicyManager updatePolicyManager;
 
   // init
-  updatePolicyManager.addPolicy("actor1", "OnAll", { "object1", "object2" }, false, false);
-  updatePolicyManager.addPolicy("actor2", "OnAll", { "object2", "object3" }, false, false);
-  //  updatePolicyManager.addPolicy("actor3", "OnAll", { }, false, false);
-  //  updatePolicyManager.addPolicy("actor4", "OnAll", { }, true, false);
+  updatePolicyManager.addPolicy("actor1", UpdatePolicyType::OnAll, { "object1", "object2" }, false, false);
+  updatePolicyManager.addPolicy("actor2", UpdatePolicyType::OnAll, { "object2", "object3" }, false, false);
+  //  updatePolicyManager.addPolicy("actor3", UpdatePolicyType::OnAll, { }, false, false);
+  //  updatePolicyManager.addPolicy("actor4", UpdatePolicyType::OnAll, { }, true, false);
 
   // iteration 1 of run() : get object1
   // get new data
@@ -178,8 +178,8 @@ BOOST_AUTO_TEST_CASE(test_check_policy_OnAny)
   UpdatePolicyManager updatePolicyManager;
 
   // init
-  updatePolicyManager.addPolicy("actor1", "OnAny", { "object1", "object2" }, false, false);
-  updatePolicyManager.addPolicy("actor2", "OnAny", { "object2", "object3" }, false, false);
+  updatePolicyManager.addPolicy("actor1", UpdatePolicyType::OnAny, { "object1", "object2" }, false, false);
+  updatePolicyManager.addPolicy("actor2", UpdatePolicyType::OnAny, { "object2", "object3" }, false, false);
 
   // iteration 1 of run() : get object1
   // get new data
@@ -235,8 +235,8 @@ BOOST_AUTO_TEST_CASE(test_check_policy_OnAnyNonZero)
   UpdatePolicyManager updatePolicyManager;
 
   // init
-  updatePolicyManager.addPolicy("actor1", "OnAnyNonZero", { "object1", "object2" }, false, false);
-  updatePolicyManager.addPolicy("actor2", "OnAnyNonZero", { "object2", "object3" }, false, false);
+  updatePolicyManager.addPolicy("actor1", UpdatePolicyType::OnAnyNonZero, { "object1", "object2" }, false, false);
+  updatePolicyManager.addPolicy("actor2", UpdatePolicyType::OnAnyNonZero, { "object2", "object3" }, false, false);
 
   // iteration 1 of run() : get object1
   // get new data
@@ -291,8 +291,8 @@ BOOST_AUTO_TEST_CASE(test_check_policy_OnEachSeparately)
   UpdatePolicyManager updatePolicyManager;
 
   // init
-  updatePolicyManager.addPolicy("actor1", "OnEachSeparately", { "object1", "object2" }, false, false);
-  updatePolicyManager.addPolicy("actor2", "OnEachSeparately", { "object2", "object3" }, false, false);
+  updatePolicyManager.addPolicy("actor1", UpdatePolicyType::OnEachSeparately, { "object1", "object2" }, false, false);
+  updatePolicyManager.addPolicy("actor2", UpdatePolicyType::OnEachSeparately, { "object2", "object3" }, false, false);
 
   // iteration 1 of run() : get object1
   // get new data
@@ -348,9 +348,7 @@ BOOST_AUTO_TEST_CASE(test_errors)
   UpdatePolicyManager updatePolicyManager;
 
   // init
-  BOOST_CHECK_THROW(
-    updatePolicyManager.addPolicy("actor1", "OnTheMoon", { "object1", "object2" }, false, false), FatalException);
-  updatePolicyManager.addPolicy("actor2", "OnEachSeparately", { "object2", "object3" }, false, false);
+  updatePolicyManager.addPolicy("actor2", UpdatePolicyType::OnEachSeparately, { "object2", "object3" }, false, false);
 
   // get new data
   updatePolicyManager.updateObjectRevision("object3");

--- a/Framework/test/testWorkflow.cxx
+++ b/Framework/test/testWorkflow.cxx
@@ -74,7 +74,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   DataProcessorSpec receiver{
     "receiver",
     Inputs{
-      { "checked-mo", "QC", CheckRunner::createCheckRunnerDataDescription(getFirstCheckName(qcConfigurationSource)), 0 } },
+      { "checked-mo", "QC", Check::createCheckerDataDescription(getFirstCheckName(qcConfigurationSource)), 0 } },
     Outputs{},
     AlgorithmSpec{
       [](ProcessingContext& pctx) {

--- a/doc/ModulesDevelopment.md
+++ b/doc/ModulesDevelopment.md
@@ -319,7 +319,7 @@ A Check is a function that determines the quality of the Monitor Objects produce
     * _OnEachSeparately_ - Triggers separately for EACH of the listed objects whenever one of them changes.
     * In case the list of monitor objects is empty, the policy is simply ignored and the `check` will be triggered whenever a new MonitorObject is received.
 * __dataSource__ - declaration of the `check` input
-    * _type_ - currently only supported is _Task_
+    * _type_ - currently only supported are _Task_ and _ExternalTask_
     * _name_ - name of the _Task_
     * _MOs_ - list of MonitorObjects names or can be omitted to mean that all objects should be taken.
 


### PR DESCRIPTION
Includes also PostProcessingTaskSpec and ExternalTaskSpec, but these are only
used by CheckRunners so far.

Not the last PR for this issue...