### PR TITLE
[EMCAL-526] Add configurations for raw QC used at P2

### DIFF
--- a/Modules/EMCAL/etc/readout-stfb-remote.json
+++ b/Modules/EMCAL/etc/readout-stfb-remote.json
@@ -1,0 +1,63 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "emcccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+	    "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "RawTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::RawTask",
+        "moduleName": "QcEMCAL",
+        "detectorName": "EMC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "readout"
+        },
+        "location": "local",
+        "localMachines": [
+        	"localhost"
+        ],
+        "remoteMachine": "alio2-cr1-qc02.cern.ch",
+        "remotePort": "47702",
+        "mergingMode": "delta"
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "readout",
+      "active": "true",
+      "machines": [],
+      "query" : "readout:EMC/RAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/Modules/EMCAL/etc/readout-stfb.json
+++ b/Modules/EMCAL/etc/readout-stfb.json
@@ -1,0 +1,57 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "emcccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+	    "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "RawTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::RawTask",
+        "moduleName": "QcEMCAL",
+        "detectorName": "EMC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "readout"
+        },
+        "location": "remote"
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "readout",
+      "active": "true",
+      "machines": [],
+      "query" : "readout:EMC/RAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}


### PR DESCRIPTION
- readout-stfb.json: Raw QC from STF builder,
  no remote workflow (only 1 FLP)
- readout-stfb-remote.json: Raw QC from STF builder,
  remote workflow on alio2-cr1-qc02