### PR TITLE
MCH: improved naming and location of digits task histograms

### DIFF
--- a/Modules/MUON/MCH/include/MCH/MergeableTH2Ratio.h
+++ b/Modules/MUON/MCH/include/MCH/MergeableTH2Ratio.h
@@ -66,12 +66,16 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
 
   void update()
   {
+    static constexpr double sOrbitLengthInNanoseconds = 3564 * 25;
+    static constexpr double sOrbitLengthInMicroseconds = sOrbitLengthInNanoseconds / 1000;
+    static constexpr double sOrbitLengthInMilliseconds = sOrbitLengthInMicroseconds / 1000;
     const char* name = this->GetName();
     const char* title = this->GetTitle();
     Reset();
     Divide(mhistoNum, mhistoDen);
     SetNameTitle(name, title);
-    Scale(1 / 87.5);
+    // convertion to KHz units
+    Scale(1. / sOrbitLengthInMilliseconds);
     SetOption("colz");
   }
 

--- a/Modules/MUON/MCH/src/PhysicsCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsCheck.cxx
@@ -61,7 +61,7 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
   for (auto& [moName, mo] : *moMap) {
 
     (void)moName;
-    if (mo->getName().find("QcMuonChambers_Occupancy_Elec") != std::string::npos) {
+    if (mo->getName().find("Occupancy_Elec") != std::string::npos) {
       auto* h = dynamic_cast<TH2F*>(mo->getObject());
       if (!h)
         return result;
@@ -69,14 +69,14 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
       if (h->GetEntries() == 0) {
         result = Quality::Medium;
       } else {
-        int nbinsx = 3; //h->GetXaxis()->GetNbins();
+        int nbinsx = h->GetXaxis()->GetNbins();
         int nbinsy = h->GetYaxis()->GetNbins();
         int nbad = 0;
         for (int i = 1; i <= nbinsx; i++) {
           for (int j = 1; j <= nbinsy; j++) {
             Float_t occ = h->GetBinContent(i, j);
             if (occ < minOccupancy || occ >= maxOccupancy) {
-              nbad += 1;
+              //nbad += 1;
               int ds_addr = (i % 40) - 1;
               int link_id = ((i - 1 - ds_addr) / 40) % 12;
               int fee_id = (i - 1 - ds_addr - 40 * link_id) / (12 * 40);
@@ -105,9 +105,11 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
   //std::cout<<"===================================="<<std::endl;
   //std::cout<<"PhysicsCheck::beautify() called"<<std::endl;
   //std::cout<<"===================================="<<std::endl;
-  if (mo->getName().find("QcMuonChambers_Occupancy_Elec") != std::string::npos) {
+  if (mo->getName().find("Occupancy_Elec") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
     h->SetDrawOption("colz");
+    h->SetMinimum(0);
+    h->SetMaximum(10);
     TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
     h->GetListOfFunctions()->Add(msg);
     msg->SetName(Form("%s_msg", mo->GetName()));

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -49,6 +49,11 @@ PhysicsTaskDigits::PhysicsTaskDigits() : TaskInterface() {}
 
 PhysicsTaskDigits::~PhysicsTaskDigits() {}
 
+static std::string getHistoPath(int deId)
+{
+  return fmt::format("ST{}/DE{}/", (deId - 100) / 200 + 1, deId);
+}
+
 void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
 {
   QcInfoLogger::GetInstance() << "initialize PhysicsTaskDigits" << AliceO2::InfoLogger::InfoLogger::endm;
@@ -68,28 +73,28 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   for (int feeid = 0; feeid < PhysicsTaskDigits::sMaxFeeId; feeid++) {
     for (int linkId = 0; linkId < PhysicsTaskDigits::sMaxLinkId; linkId++) {
       int index = PhysicsTaskDigits::sMaxLinkId * feeid + linkId;
-      mHistogramNHits[index] = new TH2F(TString::Format("QcMuonChambers_NHits_FEE%01d_LINK%02d", feeid, linkId),
-                                        TString::Format("QcMuonChambers - Number of hits (FEE link %02d)", index), PhysicsTaskDigits::sMaxDsId, 0, PhysicsTaskDigits::sMaxDsId, 64, 0, 64);
+      mHistogramNHits[index] = new TH2F(TString::Format("NHits_FEE%01d_LINK%02d", feeid, linkId),
+                                        TString::Format("Number of hits (FEE link %02d)", index), PhysicsTaskDigits::sMaxDsId, 0, PhysicsTaskDigits::sMaxDsId, 64, 0, 64);
     }
   }
 
   const uint32_t nElecXbins = PhysicsTaskDigits::sMaxFeeId * PhysicsTaskDigits::sMaxLinkId * PhysicsTaskDigits::sMaxDsId;
-  mHistogramNorbitsElec = new TH2F("QcMuonChambers_Norbits_Elec", "QcMuonChambers - Norbits", nElecXbins, 0, nElecXbins, 64, 0, 64);
+  mHistogramNorbitsElec = new TH2F("Norbits_Elec", "Norbits", nElecXbins, 0, nElecXbins, 64, 0, 64);
   mHistogramNorbitsElec->SetOption("colz");
   getObjectsManager()->startPublishing(mHistogramNorbitsElec);
-  mHistogramNHitsElec = new TH2F("QcMuonChambers_NHits_Elec", "QcMuonChambers - NHits", nElecXbins, 0, nElecXbins, 64, 0, 64);
+  mHistogramNHitsElec = new TH2F("NHits_Elec", "NHits", nElecXbins, 0, nElecXbins, 64, 0, 64);
   mHistogramNHitsElec->SetOption("colz");
   getObjectsManager()->startPublishing(mHistogramNHitsElec);
 
-  mHistogramOccupancyElec = new MergeableTH2Ratio("QcMuonChambers_Occupancy_Elec", "Occupancy (MHz)",
+  mHistogramOccupancyElec = new MergeableTH2Ratio("Occupancy_Elec", "Occupancy (KHz)",
                                                   mHistogramNHitsElec, mHistogramNorbitsElec);
   getObjectsManager()->startPublishing(mHistogramOccupancyElec);
   mHistogramOccupancyElec->SetOption("colz");
 
   // Histograms in detector coordinates
   for (auto de : o2::mch::raw::deIdsForAllMCH) {
-    TH1F* h = new TH1F(TString::Format("QcMuonChambers_ADCamplitude_DE%03d", de),
-                       TString::Format("QcMuonChambers - ADC amplitude (DE%03d)", de), 5000, 0, 5000);
+    TH1F* h = new TH1F(TString::Format("%sADCamplitude_DE%03d", getHistoPath(de).c_str(), de),
+                       TString::Format("ADC amplitude (DE%03d)", de), 5000, 0, 5000);
     mHistogramADCamplitudeDE.insert(make_pair(de, h));
 
     float Xsize = 40 * 5;
@@ -97,43 +102,43 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
     float Ysize = 50;
     float Ysize2 = Ysize / 2;
 
-    TH2F* h2n0 = new TH2F(TString::Format("QcMuonChambers_Nhits_DE%03d_B", de),
-                          TString::Format("QcMuonChambers - Number of hits (DE%03d B)", de), Xsize * 2, -Xsize2, Xsize2, Ysize * 2, -Ysize2, Ysize2);
+    TH2F* h2n0 = new TH2F(TString::Format("%sNhits_DE%03d_B", getHistoPath(de).c_str(), de),
+                          TString::Format("Number of hits (DE%03d B)", de), Xsize * 2, -Xsize2, Xsize2, Ysize * 2, -Ysize2, Ysize2);
     mHistogramNhitsDE[0].insert(make_pair(de, h2n0));
 
-    TH2F* h2n1 = new TH2F(TString::Format("QcMuonChambers_Nhits_DE%03d_NB", de),
-                          TString::Format("QcMuonChambers - Number of hits (DE%03d NB)", de), Xsize * 2, -Xsize2, Xsize2, Ysize * 2, -Ysize2, Ysize2);
+    TH2F* h2n1 = new TH2F(TString::Format("%sNhits_DE%03d_NB", getHistoPath(de).c_str(), de),
+                          TString::Format("Number of hits (DE%03d NB)", de), Xsize * 2, -Xsize2, Xsize2, Ysize * 2, -Ysize2, Ysize2);
     mHistogramNhitsDE[1].insert(make_pair(de, h2n1));
 
-    TH2F* h2d0 = new TH2F(TString::Format("QcMuonChambers_Norbits_DE%03d_B", de),
-                          TString::Format("QcMuonChambers - Number of orbits (DE%03d B)", de), Xsize * 2, -Xsize2, Xsize2, Ysize * 2, -Ysize2, Ysize2);
+    TH2F* h2d0 = new TH2F(TString::Format("%sNorbits_DE%03d_B", getHistoPath(de).c_str(), de),
+                          TString::Format("Number of orbits (DE%03d B)", de), Xsize * 2, -Xsize2, Xsize2, Ysize * 2, -Ysize2, Ysize2);
     mHistogramNorbitsDE[0].insert(make_pair(de, h2d0));
-    TH2F* h2d1 = new TH2F(TString::Format("QcMuonChambers_Norbits_DE%03d_NB", de),
-                          TString::Format("QcMuonChambers - Number of orbits (DE%03d NB)", de), Xsize * 2, -Xsize2, Xsize2, Ysize * 2, -Ysize2, Ysize2);
+    TH2F* h2d1 = new TH2F(TString::Format("%sNorbits_DE%03d_NB", getHistoPath(de).c_str(), de),
+                          TString::Format("Number of orbits (DE%03d NB)", de), Xsize * 2, -Xsize2, Xsize2, Ysize * 2, -Ysize2, Ysize2);
     mHistogramNorbitsDE[1].insert(make_pair(de, h2d1));
 
-    MergeableTH2Ratio* hm = new MergeableTH2Ratio(TString::Format("QcMuonChambers_Occupancy_B_XY_%03d", de),
-                                                  TString::Format("QcMuonChambers - Occupancy XY (DE%03d B) (MHz)", de), h2n0, h2d0);
+    MergeableTH2Ratio* hm = new MergeableTH2Ratio(TString::Format("%sOccupancy_B_XY_%03d", getHistoPath(de).c_str(), de),
+                                                  TString::Format("Occupancy XY (DE%03d B) (KHz)", de), h2n0, h2d0);
     mHistogramOccupancyDE[0].insert(make_pair(de, hm));
     getObjectsManager()->startPublishing(hm);
 
-    hm = new MergeableTH2Ratio(TString::Format("QcMuonChambers_Occupancy_NB_XY_%03d", de),
-                               TString::Format("QcMuonChambers - Occupancy XY (DE%03d NB) (MHz)", de), h2n1, h2d1);
+    hm = new MergeableTH2Ratio(TString::Format("%sOccupancy_NB_XY_%03d", getHistoPath(de).c_str(), de),
+                               TString::Format("Occupancy XY (DE%03d NB) (KHz)", de), h2n1, h2d1);
     mHistogramOccupancyDE[1].insert(make_pair(de, hm));
     getObjectsManager()->startPublishing(hm);
   }
 
-  mHistogramNHitsAllDE = new GlobalHistogram("QcMuonChambers_NHits_AllDE", "Number of hits");
+  mHistogramNHitsAllDE = new GlobalHistogram("NHits_AllDE", "Number of hits");
   mHistogramNHitsAllDE->init();
   mHistogramNHitsAllDE->SetOption("colz");
   getObjectsManager()->startPublishing(mHistogramNHitsAllDE);
 
-  mHistogramOrbitsAllDE = new GlobalHistogram("QcMuonChambers_Orbits_AllDE", "Number of orbits");
+  mHistogramOrbitsAllDE = new GlobalHistogram("Norbits_AllDE", "Number of orbits");
   mHistogramOrbitsAllDE->init();
   mHistogramOrbitsAllDE->SetOption("colz");
   getObjectsManager()->startPublishing(mHistogramOrbitsAllDE);
 
-  mHistogramOccupancyAllDE = new MergeableTH2Ratio("QcMuonChambers_Occupancy_AllDE", "Occupancy (MHz)",
+  mHistogramOccupancyAllDE = new MergeableTH2Ratio("Occupancy_AllDE", "Occupancy (KHz)",
                                                    mHistogramNHitsAllDE, mHistogramOrbitsAllDE);
   mHistogramOccupancyAllDE->SetOption("colz");
   getObjectsManager()->startPublishing(mHistogramOccupancyAllDE);
@@ -202,6 +207,8 @@ void PhysicsTaskDigits::plotDigit(const o2::mch::Digit& digit)
   if ((h != mHistogramADCamplitudeDE.end()) && (h->second != NULL)) {
     h->second->Fill(ADC);
   }
+
+  if (ADC < 100) return;
 
   // Fill NHits Elec Histogram and ADC distribution
   const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(de);

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -96,6 +96,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
     TH1F* h = new TH1F(TString::Format("%sADCamplitude_DE%03d", getHistoPath(de).c_str(), de),
                        TString::Format("ADC amplitude (DE%03d)", de), 5000, 0, 5000);
     mHistogramADCamplitudeDE.insert(make_pair(de, h));
+    getObjectsManager()->startPublishing(h);
 
     float Xsize = 40 * 5;
     float Xsize2 = Xsize / 2;
@@ -208,7 +209,9 @@ void PhysicsTaskDigits::plotDigit(const o2::mch::Digit& digit)
     h->second->Fill(ADC);
   }
 
-  if (ADC < 100) return;
+  if (ADC < 50) {
+    return;
+  }
 
   // Fill NHits Elec Histogram and ADC distribution
   const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(de);


### PR DESCRIPTION
The DE-specific occupancy histograms are moved into sub-folders, following the convention "STx/DExxx/".
This allows to only have global histograms in the root "QcTaskMCHDigits" folder.
Histogram names have also been shortened for better readability.