### PR TITLE
[QC-654] Fix QC multinode setup test

### DIFF
--- a/Framework/multinode-test.json.in
+++ b/Framework/multinode-test.json.in
@@ -112,7 +112,7 @@
         "localhost"
       ],
       "port": "@UNIQUE_PORT_2@",
-      "query": "random0:TST/RAWDATA/0;random1:TST/RAWDATA/1",
+      "query": "random0:TST/RAWDATA",
       "samplingConditions": [
         {
           "condition": "random",


### PR DESCRIPTION
Dispatcher tries to avoid having multiple inputs which cover the same range. Here it optimized "TST/RAWDATA/*", "TST/RAWDATA/0" and "TST/RAWDATA/1" into just "TST/RAWDATA/*". Thus, on rare occasions messages of different subspecs would be concatenated into one multipart (when they would synchronise perfectly). Then, because Dispatcher matches only the first part to a Policy for performance reasons, it would try to publish TST/RAWDATA/1 on an output which accepts only TST/RAWDATA/0.

This seems to be a very exotic case and I would just avoid invoking this behaviour instead of providing a safety mechanism, which could noticeably slow down the Dispatchers performance.