### PR TITLE
[EMCAL-526,EMCAL-527] Fix typo in histname

### DIFF
--- a/Modules/EMCAL/src/RawCheck.cxx
+++ b/Modules/EMCAL/src/RawCheck.cxx
@@ -44,14 +44,18 @@ Quality RawCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* m
       result = Quality::Bad;
     } // checker for the error type per SM
   }
-  if (mo->getName() == "BunchMinRawAmplutudeFull_PHYS" || mo->getName().find("RawAmplMinEMCAL") == 0) {
-    auto* h = dynamic_cast<TH1D*>(mo->getObject());
+  if (mo->getName().find("BunchMinRawAmplitude") == 0) {
+    auto* h = dynamic_cast<TH1*>(mo->getObject());
     Float_t totentries = h->Integral(10, 100); // Exclude dominant part of the channels for which the signal is in the noise range below pedestal
+    Float_t entriesBadRegion = h->Integral(20, 60);
+    int first = h->GetXaxis()->GetFirst(),
+        last = h->GetXaxis()->GetLast();
     h->GetXaxis()->SetRangeUser(20, 60);
     Int_t maxbin = h->GetMaximumBin();
+    h->GetXaxis()->SetRange(first, last);
     if (maxbin > 30 && maxbin < 50) {
-      Float_t entries = h->GetBinContent(maxbin + 1);
-      if (entries > 0.5 * totentries) {
+      //Float_t entries = h->GetBinContent(maxbin + 1);
+      if (entriesBadRegion > 0.5 * totentries) {
         result = Quality::Bad;
       }
     }
@@ -150,7 +154,7 @@ void RawCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
     }
     h->SetLineColor(kBlack);
   }
-  if (mo->getName() == "BunchMinRawAmplutudeFull_PHYS") {
+  if (mo->getName().find("BunchMinRawAmplitude") != std::string::npos) {
     auto* h = dynamic_cast<TH1*>(mo->getObject());
     TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
     h->GetListOfFunctions()->Add(msg);
@@ -174,7 +178,8 @@ void RawCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
     }
     h->SetLineColor(kBlack);
   }
-  if (mo->getName() == "FECidMaxChWithInput_perSM" || "PayloadSizeTFPerDDL") {
+  std::vector<std::string> payloadhists = { "FECidMaxChWithInput_perSM", "PayloadSizeTFPerDDL" };
+  if (std::find(payloadhists.begin(), payloadhists.end(), mo->getName()) != payloadhists.end()) {
     auto* h = dynamic_cast<TH1*>(mo->getObject());
     TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
     h->GetListOfFunctions()->Add(msg);

--- a/Modules/EMCAL/src/RawTask.cxx
+++ b/Modules/EMCAL/src/RawTask.cxx
@@ -313,17 +313,17 @@ void RawTask::initialize(o2::framework::InitContext& /*ctx*/)
     TH1D* histosRawMinEMCAL;
     TH1D* histosRawMinDCAL;
 
-    histosRawMinFull = new TH1D(Form("BunchMinRawAmplutudeFull_%s", histoStr[trg].Data()), Form("Bunch min raw amplitude EMCAL+DCAL (%s)", histoStr[trg].Data()), 100, 0., 100.);
+    histosRawMinFull = new TH1D(Form("BunchMinRawAmplitudeFull_%s", histoStr[trg].Data()), Form("Bunch min raw amplitude EMCAL+DCAL (%s)", histoStr[trg].Data()), 100, 0., 100.);
     histosRawMinFull->GetXaxis()->SetTitle("Min raw amplitude (ADC)");
     histosRawMinFull->GetYaxis()->SetTitle("Counts");
     getObjectsManager()->startPublishing(histosRawMinFull);
 
-    histosRawMinEMCAL = new TH1D(Form("BunchMinRawAmplutudeEMCAL_%s", histoStr[trg].Data()), Form("Bunch min raw amplitude EMCAL (%s)", histoStr[trg].Data()), 100, 0., 100.);
+    histosRawMinEMCAL = new TH1D(Form("BunchMinRawAmplitudeEMCAL_%s", histoStr[trg].Data()), Form("Bunch min raw amplitude EMCAL (%s)", histoStr[trg].Data()), 100, 0., 100.);
     histosRawMinEMCAL->GetXaxis()->SetTitle("Min raw amplitude (ADC)");
     histosRawMinEMCAL->GetYaxis()->SetTitle("Counts");
     getObjectsManager()->startPublishing(histosRawMinEMCAL);
 
-    histosRawMinDCAL = new TH1D(Form("BunchMinRawAmplutudeDCAL_%s", histoStr[trg].Data()), Form("Bunch min raw amplitude DCAL (%s)", histoStr[trg].Data()), 100, 0., 100.);
+    histosRawMinDCAL = new TH1D(Form("BunchMinRawAmplitudeDCAL_%s", histoStr[trg].Data()), Form("Bunch min raw amplitude DCAL (%s)", histoStr[trg].Data()), 100, 0., 100.);
     histosRawMinDCAL->GetXaxis()->SetTitle("Min raw amplitude (ADC)");
     histosRawMinDCAL->GetYaxis()->SetTitle("Counts");
     getObjectsManager()->startPublishing(histosRawMinDCAL);


### PR DESCRIPTION
Histos for the full surface (EMCAL, DCAL and
combined) by mistake used Amplutude instead
of Amplitude in the histogram name.

In addition fixing raw checker for the min. bunch
amplitude using the integral in the peak region
instead of the peak counts as criterion.