### PR TITLE
FT0/FV0: Add BcOrbitMap for each PM module in DigitQcTask

### DIFF
--- a/Modules/FT0/include/FT0/DigitQcTask.h
+++ b/Modules/FT0/include/FT0/DigitQcTask.h
@@ -54,6 +54,7 @@ class DigitQcTask final : public TaskInterface
   void endOfCycle() override;
   void endOfActivity(Activity& activity) override;
   void reset() override;
+  constexpr static std::size_t sOrbitsPerTF = 256;
 
  private:
   // three ways of computing cycle duration:
@@ -95,6 +96,7 @@ class DigitQcTask final : public TaskInterface
   std::array<o2::InteractionRecord, o2::ft0::Constants::sNCHANNELS_PM> mStateLastIR2Ch;
   std::map<int, std::string> mMapDigitTrgNames;
   std::map<o2::ft0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
+  std::map<std::string, std::vector<int>> mMapPmModuleChannels; // PM name to its channels
   std::unique_ptr<TH1F> mHistNumADC;
   std::unique_ptr<TH1F> mHistNumCFD;
 
@@ -124,6 +126,7 @@ class DigitQcTask final : public TaskInterface
   std::map<unsigned int, TH1F*> mMapHistPMbits;
   std::map<unsigned int, TH2F*> mMapHistAmpVsTime;
   std::map<unsigned int, TH2F*> mMapTrgBcOrbit;
+  std::map<std::string, TH2F*> mMapPmModuleBcOrbit;
 };
 
 } // namespace o2::quality_control_modules::ft0

--- a/Modules/FV0/include/FV0/DigitQcTask.h
+++ b/Modules/FV0/include/FV0/DigitQcTask.h
@@ -102,6 +102,7 @@ class DigitQcTask final : public TaskInterface
   std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
   std::map<int, std::string> mMapDigitTrgNames;
   std::map<int, std::string> mMapChTrgNames;
+  std::map<std::string, std::vector<int>> mMapPmModuleChannels; // PM name to its channels
   std::unique_ptr<TH1F> mHistNumADC;
   std::unique_ptr<TH1F> mHistNumCFD;
 
@@ -139,6 +140,7 @@ class DigitQcTask final : public TaskInterface
   std::map<unsigned int, TH1F*> mMapHistPMbits;
   std::map<unsigned int, TH2F*> mMapHistAmpVsTime;
   std::map<unsigned int, TH2F*> mMapTrgBcOrbit;
+  std::map<std::string, TH2F*> mMapPmModuleBcOrbit;
 };
 
 } // namespace o2::quality_control_modules::fv0

--- a/Modules/FV0/src/DigitQcTask.cxx
+++ b/Modules/FV0/src/DigitQcTask.cxx
@@ -16,13 +16,14 @@
 
 #include <TCanvas.h>
 #include <TH1.h>
-
 #include <TROOT.h>
 
 #include "QualityControl/QcInfoLogger.h"
 #include "FV0/DigitQcTask.h"
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
+
+#include <DataFormatsFV0/LookUpTable.h>
 
 namespace o2::quality_control_modules::fv0
 {
@@ -156,6 +157,34 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
       mListHistGarbage->Add(pairTrgBcOrbit.first->second);
     }
   }
+
+  char* p;
+  for (const auto& lutEntry : o2::fv0::SingleLUT::Instance().getVecMetadataFEE()) {
+    int chId = std::strtol(lutEntry.mChannelID.c_str(), &p, 10);
+    if (*p) {
+      // lutEntry.mChannelID is not a number
+      continue;
+    }
+    auto moduleName = lutEntry.mModuleName;
+    if (mMapPmModuleChannels.find(moduleName) != mMapPmModuleChannels.end()) {
+      mMapPmModuleChannels[moduleName].push_back(chId);
+    } else {
+      std::vector<int> vChId = {
+        chId,
+      };
+      mMapPmModuleChannels.insert({ moduleName, vChId });
+    }
+  }
+
+  for (const auto& entry : mMapPmModuleChannels) {
+    auto pairModuleBcOrbit = mMapPmModuleBcOrbit.insert({ entry.first, new TH2F(Form("BcOrbitMap_%s", entry.first.c_str()), Form("BC-orbit map for %s;Orbit;BC", entry.first.c_str()), 256, 0, 256, 3564, 0, 3564) });
+    if (pairModuleBcOrbit.second) {
+      getObjectsManager()->startPublishing(pairModuleBcOrbit.first->second);
+      pairModuleBcOrbit.first->second->SetOption("colz");
+      mListHistGarbage->Add(pairModuleBcOrbit.first->second);
+    }
+  }
+
   mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistSumAmpA = std::make_unique<TH1F>("SumAmpA", "Sum of amplitudes(TCM), side A;", 1000, 0, 1e4);
@@ -211,7 +240,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
     }
   }
 
-  rebinFromConfig();
+  rebinFromConfig(); // after all histos are created
 
   getObjectsManager()->startPublishing(mHistTime2Ch.get());
   getObjectsManager()->startPublishing(mHistAmp2Ch.get());
@@ -273,6 +302,9 @@ void DigitQcTask::startOfActivity(Activity& activity)
     entry.second->Reset();
   }
   for (auto& entry : mMapTrgBcOrbit) {
+    entry.second->Reset();
+  }
+  for (auto& entry : mMapPmModuleBcOrbit) {
     entry.second->Reset();
   }
 }
@@ -346,6 +378,15 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
       for (auto& entry : mMapTrgBcOrbit) {
         if (digit.getTriggers().triggerSignals & (1 << entry.first)) {
           entry.second->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
+        }
+      }
+    }
+
+    for (auto& entry : mMapPmModuleChannels) {
+      for (const auto& chData : vecChData) {
+        if (std::find(entry.second.begin(), entry.second.end(), ch_data::getChId(chData)) != entry.second.end()) {
+          mMapPmModuleBcOrbit[entry.first]->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
+          break;
         }
       }
     }
@@ -443,6 +484,9 @@ void DigitQcTask::reset()
     entry.second->Reset();
   }
   for (auto& entry : mMapTrgBcOrbit) {
+    entry.second->Reset();
+  }
+  for (auto& entry : mMapPmModuleBcOrbit) {
     entry.second->Reset();
   }
 }


### PR DESCRIPTION
If still possible we would love to have this on our FLP for pilot beams.
We discovered the need for these plots during yesterday tests.