### PR TITLE
[QC-668]  Tune down modules logging.

### DIFF
--- a/Modules/EMCAL/src/RawTask.cxx
+++ b/Modules/EMCAL/src/RawTask.cxx
@@ -178,8 +178,8 @@ void RawTask::initialize(o2::framework::InitContext& /*ctx*/)
   context.setField(infoCONTEXT::FieldName::Facility, "QC");
   context.setField(infoCONTEXT::FieldName::System, "QC");
   context.setField(infoCONTEXT::FieldName::Detector, "EMC");
-  QcInfoLogger::GetInstance().setContext(context);
-  QcInfoLogger::GetInstance() << "initialize RawTask" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG_INST.setContext(context);
+  ILOG(Info, Support) << "initialize RawTask" << ENDM;
 
   // initialize geometry
   if (!mGeometry)
@@ -446,13 +446,13 @@ void RawTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void RawTask::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  QcInfoLogger::GetInstance() << "startOfActivity" << ENDM;
   reset();
 }
 
 void RawTask::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  QcInfoLogger::GetInstance() << "startOfCycle" << ENDM;
 }
 
 void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
@@ -471,7 +471,7 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
   // The type DataOrigin allows only conversion of char arrays with size 4, not char *, therefore
   // the origin string has to be converted manually to the char array and checked for length.
   if (mDataOrigin.size() > 4) {
-    QcInfoLogger::GetInstance() << QcInfoLogger::Error << "No valid data origin" << mDataOrigin << ", cannot process" << QcInfoLogger::endm;
+    ILOG(Error, Support) << "No valid data origin" << mDataOrigin << ", cannot process" << QcInfoLogger::endm;
     return;
   }
   char dataOrigin[4];
@@ -481,7 +481,7 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
     return;
 
   Int_t nPagesMessage = 0, nSuperpagesMessage = 0;
-  QcInfoLogger::GetInstance() << QcInfoLogger::Debug << " Processing message " << mNumberOfMessages << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Debug, Support) << " Processing message " << mNumberOfMessages << ENDM;
   mNumberOfMessages++;
   mMessageCounter->Fill(1); //for expert
 
@@ -500,11 +500,11 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (rawData.header != nullptr && rawData.payload != nullptr) {
       const auto* header = header::get<header::DataHeader*>(rawData.header);
       // get payload of a specific input, which is a char array.
-      QcInfoLogger::GetInstance() << QcInfoLogger::Debug << "Processing superpage " << mNumberOfSuperpages << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Debug, Support) << "Processing superpage " << mNumberOfSuperpages << ENDM;
       mNumberOfSuperpages++;
       nSuperpagesMessage++;
       mSuperpageCounter->Fill(1); //for expert
-      QcInfoLogger::GetInstance() << QcInfoLogger::Debug << " EMCAL Reading Payload size: " << header->payloadSize << " for " << header->dataOrigin << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Debug, Support) << " EMCAL Reading Payload size: " << header->payloadSize << " for " << header->dataOrigin << ENDM;
 
       //fill the histogram with payload sizes
       mPayloadSize->Fill(header->payloadSize);         //for expert
@@ -523,7 +523,7 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
 
       while (rawreader.hasNext()) {
 
-        QcInfoLogger::GetInstance() << QcInfoLogger::Debug << " Processing page " << mNumberOfPages << AliceO2::InfoLogger::InfoLogger::endm;
+        ILOG(Debug, Support) << " Processing page " << mNumberOfPages << ENDM;
         mNumberOfPages++;
         nPagesMessage++;
         mPageCounter->Fill(1); //expert
@@ -547,7 +547,7 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
           mPayloadSizePerDDL_1D->Fill(feeID, payLoadSize / 1024.); //for shifter
         }
         if (!(isPhysTrigger || isCalibTrigger)) {
-          QcInfoLogger::GetInstance() << QcInfoLogger::Error << " Unmonitored trigger class requested " << AliceO2::InfoLogger::InfoLogger::endm;
+          ILOG(Error, Support) << " Unmonitored trigger class requested " << ENDM;
           continue;
         }
 
@@ -621,7 +621,7 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
               break;
           }
           errormessage << " in Supermodule " << feeID;
-          QcInfoLogger::GetInstance() << QcInfoLogger::Error << " EMCAL raw task: " << errormessage.str() << AliceO2::InfoLogger::InfoLogger::endm;
+          ILOG(Error, Support) << " EMCAL raw task: " << errormessage.str() << ENDM;
           //fill histograms  with error types
           mErrorTypeAltro->Fill(feeID, errornum); //for shifter
           continue;
@@ -643,7 +643,7 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
             rowOnline = mapping.getRow(chan.getHardwareAddress());
             chType = mapping.getChannelType(chan.getHardwareAddress());
           } catch (o2::emcal::Mapper::AddressNotFoundException& err) {
-            QcInfoLogger::GetInstance() << QcInfoLogger::Error << "DDL " << feeID << ": " << err.what() << QcInfoLogger::endm;
+            ILOG(Error, Support) << "DDL " << feeID << ": " << err.what() << QcInfoLogger::endm;
             mErrorTypeAltro->Fill(feeID, 8);
             continue;
           }
@@ -779,21 +779,21 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void RawTask::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  QcInfoLogger::GetInstance() << "endOfCycle" << ENDM;
 }
 
 void RawTask::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
-  QcInfoLogger::GetInstance() << "Total amount of messages: " << mNumberOfMessages << AliceO2::InfoLogger::InfoLogger::endm;
-  QcInfoLogger::GetInstance() << "Total amount of superpages: " << mNumberOfSuperpages << ", pages: " << mNumberOfPages << AliceO2::InfoLogger::InfoLogger::endm;
+  QcInfoLogger::GetInstance() << "endOfActivity" << ENDM;
+  QcInfoLogger::GetInstance() << "Total amount of messages: " << mNumberOfMessages << ENDM;
+  QcInfoLogger::GetInstance() << "Total amount of superpages: " << mNumberOfSuperpages << ", pages: " << mNumberOfPages << ENDM;
 }
 
 void RawTask::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  QcInfoLogger::GetInstance() << "Resetting the histogram" << ENDM;
   EventType triggers[2] = { EventType::CAL_EVENT, EventType::PHYS_EVENT };
 
   for (const auto& trg : triggers) {

--- a/Modules/FT0/src/OutOfBunchCollTask.cxx
+++ b/Modules/FT0/src/OutOfBunchCollTask.cxx
@@ -74,7 +74,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
   const auto* bcPattern = mCcdbApi.retrieveFromTFileAny<o2::BunchFilling>("GLO/GRP/BunchFilling", metadata, -1, &headers);
   if (!bcPattern) {
     ILOG(Error, Support) << "\nMO \"BunchFilling\" NOT retrieved!!!\n"
-                << ENDM;
+                         << ENDM;
   }
   const int nBc = 3564;
   const int nOrbits = 256;
@@ -89,7 +89,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
     auto hBcOrbitMapTrg = (TH2F*)mo->getObject();
     if (!hBcOrbitMapTrg) {
       ILOG(Error, Support) << "\nMO \"" << moName << "\" NOT retrieved!!!\n"
-                  << ENDM;
+                           << ENDM;
     }
     entry.second->Reset();
     // scale bc pattern by vmax to make sure the difference is non positive

--- a/Modules/FT0/src/OutOfBunchCollTask.cxx
+++ b/Modules/FT0/src/OutOfBunchCollTask.cxx
@@ -73,7 +73,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
   std::map<std::string, std::string> headers;
   const auto* bcPattern = mCcdbApi.retrieveFromTFileAny<o2::BunchFilling>("GLO/GRP/BunchFilling", metadata, -1, &headers);
   if (!bcPattern) {
-    ILOG(Error) << "\nMO \"BunchFilling\" NOT retrieved!!!\n"
+    ILOG(Error, Support) << "\nMO \"BunchFilling\" NOT retrieved!!!\n"
                 << ENDM;
   }
   const int nBc = 3564;
@@ -88,7 +88,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
     auto mo = mDatabase->retrieveMO("qc/FT0/MO/DigitQcTask/", moName);
     auto hBcOrbitMapTrg = (TH2F*)mo->getObject();
     if (!hBcOrbitMapTrg) {
-      ILOG(Error) << "\nMO \"" << moName << "\" NOT retrieved!!!\n"
+      ILOG(Error, Support) << "\nMO \"" << moName << "\" NOT retrieved!!!\n"
                   << ENDM;
     }
     entry.second->Reset();

--- a/Modules/FT0/src/TriggerQcTask.cxx
+++ b/Modules/FT0/src/TriggerQcTask.cxx
@@ -268,7 +268,7 @@ void TriggerQcTask::monitorData(o2::framework::ProcessingContext& ctx)
           digit.mTriggers.amplC, int(sumAmplC / 8),
           digit.mTriggers.timeA, avgTimeA,
           digit.mTriggers.timeC, avgTimeC, vtxPos);
-        ILOG(Info) << msg << ENDM;
+        ILOG(Info, Support) << msg << ENDM;
       }
     }
   }

--- a/Modules/FV0/src/BasicPPTask.cxx
+++ b/Modules/FV0/src/BasicPPTask.cxx
@@ -110,13 +110,13 @@ void BasicPPTask::update(Trigger, framework::ServiceRegistry&)
   auto mo = mDatabase->retrieveMO("qc/FV0/MO/DigitQcTask/", "Triggers");
   auto hTriggers = (TH1F*)mo->getObject();
   if (!hTriggers) {
-    ILOG(Error) << "MO \"Triggers\" NOT retrieved!!!" << ENDM;
+    ILOG(Error, Support) << "MO \"Triggers\" NOT retrieved!!!" << ENDM;
   }
 
   auto mo2 = mDatabase->retrieveMO("qc/FV0/MO/DigitQcTask/", mCycleDurationMoName);
   auto hCycleDuration = (TH1D*)mo2->getObject();
   if (!hCycleDuration) {
-    ILOG(Error) << "MO \"" << mCycleDurationMoName << "\" NOT retrieved!!!" << ENDM;
+    ILOG(Error, Support) << "MO \"" << mCycleDurationMoName << "\" NOT retrieved!!!" << ENDM;
   }
 
   double cycleDurationMS = 0;
@@ -131,7 +131,7 @@ void BasicPPTask::update(Trigger, framework::ServiceRegistry&)
 
   double eps = 1e-8;
   if (cycleDurationMS < eps) {
-    ILOG(Warning) << "cycle duration = " << cycleDurationMS << " ms, almost zero - cannot compute trigger rates!" << ENDM;
+    ILOG(Warning, Support) << "cycle duration = " << cycleDurationMS << " ms, almost zero - cannot compute trigger rates!" << ENDM;
   } else {
     mRateMinBias->SetPoint(n, n, hTriggers->GetBinContent(hTriggers->GetXaxis()->FindBin("MinBias")) / cycleDurationMS);
     mRateOuterRing->SetPoint(n, n, hTriggers->GetBinContent(hTriggers->GetXaxis()->FindBin("OuterRing")) / cycleDurationMS);
@@ -163,13 +163,13 @@ void BasicPPTask::update(Trigger, framework::ServiceRegistry&)
   auto mo3 = mDatabase->retrieveMO("qc/FV0/MO/DigitQcTask/", "AmpPerChannel");
   auto hAmpPerChannel = (TH2D*)mo3->getObject();
   if (!hAmpPerChannel) {
-    ILOG(Error) << "\nMO \"AmpPerChannel\" NOT retrieved!!!\n"
+    ILOG(Error, Support) << "\nMO \"AmpPerChannel\" NOT retrieved!!!\n"
                 << ENDM;
   }
   auto mo4 = mDatabase->retrieveMO("qc/FV0/MO/DigitQcTask/", "TimePerChannel");
   auto hTimePerChannel = (TH2D*)mo4->getObject();
   if (!hTimePerChannel) {
-    ILOG(Error) << "\nMO \"TimePerChannel\" NOT retrieved!!!\n"
+    ILOG(Error, Support) << "\nMO \"TimePerChannel\" NOT retrieved!!!\n"
                 << ENDM;
   }
 

--- a/Modules/FV0/src/BasicPPTask.cxx
+++ b/Modules/FV0/src/BasicPPTask.cxx
@@ -164,13 +164,13 @@ void BasicPPTask::update(Trigger, framework::ServiceRegistry&)
   auto hAmpPerChannel = (TH2D*)mo3->getObject();
   if (!hAmpPerChannel) {
     ILOG(Error, Support) << "\nMO \"AmpPerChannel\" NOT retrieved!!!\n"
-                << ENDM;
+                         << ENDM;
   }
   auto mo4 = mDatabase->retrieveMO("qc/FV0/MO/DigitQcTask/", "TimePerChannel");
   auto hTimePerChannel = (TH2D*)mo4->getObject();
   if (!hTimePerChannel) {
     ILOG(Error, Support) << "\nMO \"TimePerChannel\" NOT retrieved!!!\n"
-                << ENDM;
+                         << ENDM;
   }
 
   mAmpl = hAmpPerChannel->ProfileX("MeanAmplPerChannel");

--- a/Modules/FV0/src/DigitQcTask.cxx
+++ b/Modules/FV0/src/DigitQcTask.cxx
@@ -49,16 +49,16 @@ void DigitQcTask::rebinFromConfig()
     vector<std::string> tokenizedBinning;
     boost::split(tokenizedBinning, binning, boost::is_any_of(","));
     if (tokenizedBinning.size() == 3) { // TH1
-      ILOG(Debug) << "config: rebinning TH1 " << hName << " -> " << binning << ENDM;
+      ILOG(Debug, Support) << "config: rebinning TH1 " << hName << " -> " << binning << ENDM;
       auto htmp = (TH1F*)gROOT->FindObject(hName.data());
       htmp->SetBins(std::atof(tokenizedBinning[0].c_str()), std::atof(tokenizedBinning[1].c_str()), std::atof(tokenizedBinning[2].c_str()));
     } else if (tokenizedBinning.size() == 6) { // TH2
       auto htmp = (TH2F*)gROOT->FindObject(hName.data());
-      ILOG(Debug) << "config: rebinning TH2 " << hName << " -> " << binning << ENDM;
+      ILOG(Debug, Support) << "config: rebinning TH2 " << hName << " -> " << binning << ENDM;
       htmp->SetBins(std::atof(tokenizedBinning[0].c_str()), std::atof(tokenizedBinning[1].c_str()), std::atof(tokenizedBinning[2].c_str()),
                     std::atof(tokenizedBinning[3].c_str()), std::atof(tokenizedBinning[4].c_str()), std::atof(tokenizedBinning[5].c_str()));
     } else {
-      ILOG(Warning) << "config: invalid binning parameter: " << hName << " -> " << binning << ENDM;
+      ILOG(Warning, Support) << "config: invalid binning parameter: " << hName << " -> " << binning << ENDM;
     }
   };
 
@@ -75,7 +75,7 @@ void DigitQcTask::rebinFromConfig()
         rebinHisto(hNameCur, binning);
       }
     } else if (!gROOT->FindObject(hName.data())) {
-      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
+      ILOG(Warning, Support) << "config: histogram named \"" << hName << "\" not found" << ENDM;
       continue;
     } else {
       rebinHisto(hName, binning);
@@ -437,7 +437,7 @@ void DigitQcTask::endOfCycle()
   mHistCycleDurationNTF->SetEntries(mTfCounter);
   mHistCycleDuration->SetBinContent(1., mTimeSum);
   mHistCycleDuration->SetEntries(mTimeSum);
-  ILOG(Debug) << "Cycle duration: NTF=" << mTfCounter << ", range = " << (mTimeMaxNS - mTimeMinNS) / 1e6 / mTfCounter << " ms/TF, sum = " << mTimeSum / 1e6 / mTfCounter << " ms/TF" << ENDM;
+  ILOG(Debug, Support) << "Cycle duration: NTF=" << mTfCounter << ", range = " << (mTimeMaxNS - mTimeMinNS) / 1e6 / mTfCounter << " ms/TF, sum = " << mTimeSum / 1e6 / mTfCounter << " ms/TF" << ENDM;
 }
 
 void DigitQcTask::endOfActivity(Activity& /*activity*/)

--- a/Modules/FV0/src/OutOfBunchCollTask.cxx
+++ b/Modules/FV0/src/OutOfBunchCollTask.cxx
@@ -74,7 +74,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
   const auto* bcPattern = mCcdbApi.retrieveFromTFileAny<o2::BunchFilling>("GLO/GRP/BunchFilling", metadata, -1, &headers);
   if (!bcPattern) {
     ILOG(Error, Support) << "\nMO \"BunchFilling\" NOT retrieved!!!\n"
-                << ENDM;
+                         << ENDM;
   }
   const int nBc = 3564;
   const int nOrbits = 256;
@@ -89,7 +89,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
     auto hBcOrbitMapTrg = (TH2F*)mo->getObject();
     if (!hBcOrbitMapTrg) {
       ILOG(Error, Support) << "\nMO \"" << moName << "\" NOT retrieved!!!\n"
-                  << ENDM;
+                           << ENDM;
     }
     entry.second->Reset();
     // scale bc pattern by vmax to make sure the difference is non positive

--- a/Modules/FV0/src/OutOfBunchCollTask.cxx
+++ b/Modules/FV0/src/OutOfBunchCollTask.cxx
@@ -73,7 +73,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
   std::map<std::string, std::string> headers;
   const auto* bcPattern = mCcdbApi.retrieveFromTFileAny<o2::BunchFilling>("GLO/GRP/BunchFilling", metadata, -1, &headers);
   if (!bcPattern) {
-    ILOG(Error) << "\nMO \"BunchFilling\" NOT retrieved!!!\n"
+    ILOG(Error, Support) << "\nMO \"BunchFilling\" NOT retrieved!!!\n"
                 << ENDM;
   }
   const int nBc = 3564;
@@ -88,7 +88,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
     auto mo = mDatabase->retrieveMO("qc/FV0/MO/DigitQcTask/", moName);
     auto hBcOrbitMapTrg = (TH2F*)mo->getObject();
     if (!hBcOrbitMapTrg) {
-      ILOG(Error) << "\nMO \"" << moName << "\" NOT retrieved!!!\n"
+      ILOG(Error, Support) << "\nMO \"" << moName << "\" NOT retrieved!!!\n"
                   << ENDM;
     }
     entry.second->Reset();

--- a/Modules/FV0/src/TriggerQcTask.cxx
+++ b/Modules/FV0/src/TriggerQcTask.cxx
@@ -30,7 +30,7 @@ unsigned int TriggerQcTask::getModeParameter(std::string paramName, unsigned int
     // if parameter was provided check which option was chosen
     for (const auto& choice : choices) {
       if (param->second == choice.second) {
-        ILOG(Debug) << "setting \"" << paramName << "\" to: \"" << choice.second << "\"" << ENDM;
+        ILOG(Debug, Support) << "setting \"" << paramName << "\" to: \"" << choice.second << "\"" << ENDM;
         return choice.first;
       }
     }
@@ -41,11 +41,11 @@ unsigned int TriggerQcTask::getModeParameter(std::string paramName, unsigned int
       allowedValues += choice.second;
       allowedValues += "\", ";
     }
-    ILOG(Warning) << "Provided value (\"" << param->second << "\") for parameter \"" << paramName << "\" is not allowed. Allowed values are: " << allowedValues << " setting \"" << paramName << "\" to default value: \"" << choices[defaultVal] << "\"" << ENDM;
+    ILOG(Warning, Support) << "Provided value (\"" << param->second << "\") for parameter \"" << paramName << "\" is not allowed. Allowed values are: " << allowedValues << " setting \"" << paramName << "\" to default value: \"" << choices[defaultVal] << "\"" << ENDM;
     return defaultVal;
   } else {
     // param not provided - use default
-    ILOG(Debug) << "Setting \"" << paramName << "\" to default value: \"" << choices[defaultVal] << "\"" << ENDM;
+    ILOG(Debug, Support) << "Setting \"" << paramName << "\" to default value: \"" << choices[defaultVal] << "\"" << ENDM;
     return defaultVal;
   }
 }
@@ -54,10 +54,10 @@ int TriggerQcTask::getNumericalParameter(std::string paramName, int defaultVal)
 {
   if (auto param = mCustomParameters.find(paramName); param != mCustomParameters.end()) {
     float val = stoi(param->second);
-    ILOG(Debug) << "Setting \"" << paramName << "\" to: " << val << ENDM;
+    ILOG(Debug, Support) << "Setting \"" << paramName << "\" to: " << val << ENDM;
     return val;
   } else {
-    ILOG(Debug) << "Setting \"" << paramName << "\" to default value: " << defaultVal << ENDM;
+    ILOG(Debug, Support) << "Setting \"" << paramName << "\" to default value: " << defaultVal << ENDM;
     return defaultVal;
   }
 }
@@ -197,7 +197,7 @@ void TriggerQcTask::monitorData(o2::framework::ProcessingContext& ctx)
           digit.mTriggers.amplA, int(sumAmplInner + sumAmplOuter),
           int(sumAmplInner),
           int(sumAmplOuter));
-        ILOG(Info) << msg << ENDM;
+        ILOG(Info, Support) << msg << ENDM;
       }
     }
   }

--- a/Modules/HMPID/src/HmpidTask.cxx
+++ b/Modules/HMPID/src/HmpidTask.cxx
@@ -53,11 +53,11 @@ Int_t NumCycles = 0;
 
 void HmpidTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info) << "initialize HmpidTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  ILOG(Info, Support) << "initialize HmpidTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
 
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
   if (auto param = mCustomParameters.find("myOwnKey"); param != mCustomParameters.end()) {
-    ILOG(Info) << "Custom parameter - myOwnKey: " << param->second << ENDM;
+    ILOG(Info, Support) << "Custom parameter - myOwnKey: " << param->second << ENDM;
   }
 
   hPedestalMean = new TH1F("hPedestalMean", "Pedestal Mean", 2000, 0, 2000);
@@ -97,7 +97,7 @@ void HmpidTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void HmpidTask::startOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "startOfActivity" << ENDM;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
   hPedestalMean->Reset();
   hPedestalSigma->Reset();
 
@@ -108,7 +108,7 @@ void HmpidTask::startOfActivity(Activity& /*activity*/)
 
 void HmpidTask::startOfCycle()
 {
-  ILOG(Info) << "startOfCycle" << ENDM;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void HmpidTask::monitorData(o2::framework::ProcessingContext& ctx)
@@ -129,7 +129,7 @@ void HmpidTask::monitorData(o2::framework::ProcessingContext& ctx)
       }
       mDecoder->setUpStream(ptrToPayload, (long int)header->payloadSize);
       if (!mDecoder->decodeBufferFast()) {
-        ILOG(Error) << "Error decoding the Superpage !" << ENDM;
+        ILOG(Error, Support) << "Error decoding the Superpage !" << ENDM;
       }
 
       // Double_t ddl[14], EventSize[14], BusyTime[14];
@@ -176,19 +176,19 @@ void HmpidTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void HmpidTask::endOfCycle()
 {
-  ILOG(Info) << "endOfCycle" << ENDM;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void HmpidTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "endOfActivity" << ENDM;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void HmpidTask::reset()
 {
   // clean all the monitor objects here
 
-  ILOG(Info) << "Resetting the histogram" << ENDM;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
   hPedestalMean->Reset();
   hPedestalSigma->Reset();
   hBusyTime->ResetAttFill();

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -79,7 +79,7 @@ ITSClusterTask::~ITSClusterTask()
 void ITSClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
 
-  QcInfoLogger::GetInstance() << "initialize ITSClusterTask" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize ITSClusterTask" << ENDM;
 
   getJsonParameters();
 
@@ -102,12 +102,12 @@ void ITSClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void ITSClusterTask::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
 }
 
 void ITSClusterTask::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
@@ -117,7 +117,7 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   int difference;
   start = std::chrono::high_resolution_clock::now();
 
-  QcInfoLogger::GetInstance() << "START DOING QC General" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "START DOING QC General" << ENDM;
   auto clusArr = ctx.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compclus");
   auto clusRofArr = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clustersrof");
 
@@ -200,18 +200,18 @@ void ITSClusterTask::endOfCycle()
         getObjectsManager()->addMetadata(mPublishedObjects.at(iObj)->GetName(), "Run", runNumber);
       mRunNumber = runNumber;
     }
-    QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "endOfCycle" << ENDM;
   }
 }
 
 void ITSClusterTask::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void ITSClusterTask::reset()
 {
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
   for (Int_t iLayer = 0; iLayer < NLayer; iLayer++) {
     if (!mEnableLayers[iLayer])
       continue;

--- a/Modules/ITS/src/ITSFeeTask.cxx
+++ b/Modules/ITS/src/ITSFeeTask.cxx
@@ -51,7 +51,7 @@ ITSFeeTask::~ITSFeeTask()
 
 void ITSFeeTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info) << "Initializing the ITSFeeTask" << ENDM;
+  ILOG(Info, Support) << "Initializing the ITSFeeTask" << ENDM;
   createFeePlots();
   setPlotsFormat();
 }
@@ -151,7 +151,7 @@ void ITSFeeTask::startOfActivity(Activity& activity)
   mRunNumber = activity.mId;
 }
 
-void ITSFeeTask::startOfCycle() { ILOG(Info) << "startOfCycle" << ENDM; }
+void ITSFeeTask::startOfCycle() { ILOG(Info, Support) << "startOfCycle" << ENDM; }
 
 void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
@@ -225,12 +225,12 @@ void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void ITSFeeTask::endOfCycle()
 {
-  ILOG(Info) << "endOfCycle" << ENDM;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void ITSFeeTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "endOfActivity" << ENDM;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void ITSFeeTask::resetGeneralPlots()
@@ -242,7 +242,7 @@ void ITSFeeTask::resetGeneralPlots()
 void ITSFeeTask::reset()
 {
   resetGeneralPlots();
-  ILOG(Info) << "Reset" << ENDM;
+  ILOG(Info, Support) << "Reset" << ENDM;
 }
 
 } // namespace o2::quality_control_modules::its

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -80,7 +80,7 @@ ITSFhrTask::~ITSFhrTask()
 
 void ITSFhrTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info) << "initialize ITSFhrTask" << ENDM;
+  ILOG(Info, Support) << "initialize ITSFhrTask" << ENDM;
   getParameters();
   o2::base::GeometryManager::loadGeometry(mGeomPath.c_str());
   mGeom = o2::its::GeometryTGeo::Instance();
@@ -353,7 +353,7 @@ void ITSFhrTask::startOfActivity(Activity& activity)
   reset();
 }
 
-void ITSFhrTask::startOfCycle() { ILOG(Info) << "startOfCycle" << ENDM; }
+void ITSFhrTask::startOfCycle() { ILOG(Info, Support) << "startOfCycle" << ENDM; }
 
 void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
@@ -693,13 +693,13 @@ void ITSFhrTask::getParameters()
 
 void ITSFhrTask::endOfCycle()
 {
-  ILOG(Debug) << "average process time == " << (double)mAverageProcessTime / mTFCount << ENDM;
-  ILOG(Info) << "endOfCycle" << ENDM;
+  ILOG(Debug, Support) << "average process time == " << (double)mAverageProcessTime / mTFCount << ENDM;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void ITSFhrTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "endOfActivity" << ENDM;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void ITSFhrTask::resetGeneralPlots()
@@ -769,7 +769,7 @@ void ITSFhrTask::reset()
     }
   }
 
-  ILOG(Info) << "Reset" << ENDM;
+  ILOG(Info, Support) << "Reset" << ENDM;
 }
 
 void ITSFhrTask::getStavePoint(int layer, int stave, double* px, double* py)

--- a/Modules/ITS/src/ITSNoisyPixelTask.cxx
+++ b/Modules/ITS/src/ITSNoisyPixelTask.cxx
@@ -239,7 +239,7 @@ void ITSNoisyPixelTask::monitorData(o2::framework::ProcessingContext& ctx)
   end = std::chrono::high_resolution_clock::now();
   difference = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
   mTotalTimeInQCTask += difference;
-  ILOG(Info) << "Time in QC Noisy Pixel Task:  " << difference << ENDM;
+  ILOG(Info, Support) << "Time in QC Noisy Pixel Task:  " << difference << ENDM;
 }
 
 void ITSNoisyPixelTask::endOfCycle()

--- a/Modules/ITS/src/ITSRawTask.cxx
+++ b/Modules/ITS/src/ITSRawTask.cxx
@@ -204,7 +204,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
 
   int ResetDecision = ctx.inputs().get<int>("in");
   ILOG(Info, Support) << "Reset Histogram Decision = " << ResetDecision
-                              << AliceO2::InfoLogger::InfoLogger::endm;
+                      << AliceO2::InfoLogger::InfoLogger::endm;
   if (ResetDecision == 1) {
     reset();
   }
@@ -221,7 +221,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
 
   for (int i = 0; i < NError; i++) {
     ILOG(Info, Support) << " i = " << i << "   Error = " << mErrors[i] << "   ErrorPre = " << mErrorPre[i]
-                                << "   ErrorPerFile = " << mErrorPerFile[i] << AliceO2::InfoLogger::InfoLogger::endm;
+                        << "   ErrorPerFile = " << mErrorPerFile[i] << AliceO2::InfoLogger::InfoLogger::endm;
     hErrorPlots->SetBinContent(i + 1, mErrors[i]);
     hErrorFile->SetBinContent((FileID + 1 + (EPID - 4) * 12), i + 1, mErrorPerFile[i]);
   }
@@ -343,7 +343,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
   end = std::chrono::high_resolution_clock::now();
   difference = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
   ILOG(Info, Support) << "Time After Loop = " << difference / 1000.0 << "s"
-                              << AliceO2::InfoLogger::InfoLogger::endm;
+                      << AliceO2::InfoLogger::InfoLogger::endm;
   timefout << "Time After Loop = " << difference / 1000.0 << "s" << std::endl;
 
   ILOG(Info, Support) << "NEventDone = " << mNEvent << AliceO2::InfoLogger::InfoLogger::endm;
@@ -355,7 +355,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
   difference = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
   TotalHisTime = TotalHisTime + difference;
   ILOG(Info, Support) << "Time in Histogram = " << difference / 1000.0 << "s"
-                              << AliceO2::InfoLogger::InfoLogger::endm;
+                      << AliceO2::InfoLogger::InfoLogger::endm;
   timefout << "Time in Histogram = " << difference / 1000.0 << "s" << std::endl;
 
   if (mNEvent == 0 && ChipID == 0 && row == 0 && col == 0 && mYellowed == 0) {
@@ -664,7 +664,7 @@ void ITSRawTask::updateFile(int aRunID, int aEpID, int aFileID)
   if (RunIDPre != aRunID || FileIDPre != aFileID) {
     TString FileName = Form("infiles/run000%d/data-ep%d-link%d", aRunID, aEpID, aFileID);
     ILOG(Info, Support) << "For the Moment: RunID = " << aRunID << "  FileID = " << aFileID
-                                << AliceO2::InfoLogger::InfoLogger::endm;
+                        << AliceO2::InfoLogger::InfoLogger::endm;
     hFileNameInfo->Fill(0.5);
     hFileNameInfo->SetTitle(Form("Current File Name: %s", FileName.Data()));
     mTotalFileDone = mTotalFileDone + 1;

--- a/Modules/ITS/src/ITSRawTask.cxx
+++ b/Modules/ITS/src/ITSRawTask.cxx
@@ -107,12 +107,12 @@ ITSRawTask::~ITSRawTask()
 
 void ITSRawTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize ITSRawTask" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize ITSRawTask" << AliceO2::InfoLogger::InfoLogger::endm;
 
   o2::its::GeometryTGeo* geom = o2::its::GeometryTGeo::Instance();
   geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::L2G));
   int numOfChips = geom->getNumberOfChips();
-  QcInfoLogger::GetInstance() << "numOfChips = " << numOfChips << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "numOfChips = " << numOfChips << AliceO2::InfoLogger::InfoLogger::endm;
   setNChips(numOfChips);
 
   for (int i = 0; i < NError; i++) {
@@ -158,7 +158,7 @@ void ITSRawTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   publishHistos();
 
-  QcInfoLogger::GetInstance() << "DONE Inititing Publication = " << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "DONE Inititing Publication = " << AliceO2::InfoLogger::InfoLogger::endm;
 
   bulb->SetFillColor(kRed);
   mTotalFileDone = 0;
@@ -169,12 +169,12 @@ void ITSRawTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void ITSRawTask::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ITSRawTask::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
@@ -193,7 +193,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
 
   ofstream timefout2("HisTimeLoop.dat", ios::app);
 
-  QcInfoLogger::GetInstance() << "BEEN HERE BRO" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "BEEN HERE BRO" << AliceO2::InfoLogger::InfoLogger::endm;
 
   int FileID = ctx.inputs().get<int>("File");
   int EPID = ctx.inputs().get<int>("EP");
@@ -203,7 +203,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
   //Will Fix Later//
 
   int ResetDecision = ctx.inputs().get<int>("in");
-  QcInfoLogger::GetInstance() << "Reset Histogram Decision = " << ResetDecision
+  ILOG(Info, Support) << "Reset Histogram Decision = " << ResetDecision
                               << AliceO2::InfoLogger::InfoLogger::endm;
   if (ResetDecision == 1) {
     reset();
@@ -220,7 +220,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
 
   for (int i = 0; i < NError; i++) {
-    QcInfoLogger::GetInstance() << " i = " << i << "   Error = " << mErrors[i] << "   ErrorPre = " << mErrorPre[i]
+    ILOG(Info, Support) << " i = " << i << "   Error = " << mErrors[i] << "   ErrorPre = " << mErrorPre[i]
                                 << "   ErrorPerFile = " << mErrorPerFile[i] << AliceO2::InfoLogger::InfoLogger::endm;
     hErrorPlots->SetBinContent(i + 1, mErrors[i]);
     hErrorFile->SetBinContent((FileID + 1 + (EPID - 4) * 12), i + 1, mErrorPerFile[i]);
@@ -233,7 +233,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
 
   difference = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-  //	QcInfoLogger::GetInstance() << "Before Loop = " << difference/1000.0 << "s" <<  AliceO2::InfoLogger::InfoLogger::endm;
+  //	ILOG(Info, Support) << "Before Loop = " << difference/1000.0 << "s" <<  AliceO2::InfoLogger::InfoLogger::endm;
   timefout << "Before Loop  = " << difference / 1000.0 << "s" << std::endl;
   int i = 0;
   for (auto&& pixeldata : digits) {
@@ -256,12 +256,12 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (mCounted < mTotalCounted) {
       end = std::chrono::high_resolution_clock::now();
       difference = std::chrono::duration_cast<std::chrono::nanoseconds>(end - startLoop).count();
-      //	QcInfoLogger::GetInstance() << "Before Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
+      //	ILOG(Info, Support) << "Before Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
       timefout2 << "Getting Value Time  = " << difference << "ns" << std::endl;
     }
 
     if (mNEvent % 1000000 == 0 && mNEvent > 0) {
-      QcInfoLogger::GetInstance() << "ChipID = " << ChipID << "  col = " << col << "  row = " << row << "  mNEvent = " << mNEvent << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Info, Support) << "ChipID = " << ChipID << "  col = " << col << "  row = " << row << "  mNEvent = " << mNEvent << AliceO2::InfoLogger::InfoLogger::endm;
     }
     // wouldnt this update this update the text for every digit in events 1000, 2000 ... ?
     if (mNEvent % 1000 == 0 || mNEventPre != mNEvent) {
@@ -272,7 +272,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (mCounted < mTotalCounted) {
       end = std::chrono::high_resolution_clock::now();
       difference = std::chrono::duration_cast<std::chrono::nanoseconds>(end - startLoop).count();
-      //	QcInfoLogger::GetInstance() << "Before Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
+      //	ILOG(Info, Support) << "Before Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
       timefout2 << "Before Geo  = " << difference << "ns" << std::endl;
     }
 
@@ -289,7 +289,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (mCounted < mTotalCounted) {
       end = std::chrono::high_resolution_clock::now();
       difference = std::chrono::duration_cast<std::chrono::nanoseconds>(end - startLoop).count();
-      //	QcInfoLogger::GetInstance() << "After Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
+      //	ILOG(Info, Support) << "After Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
       timefout2 << "After Geo =  " << difference << "ns" << std::endl;
     }
 
@@ -309,14 +309,14 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (mCounted < mTotalCounted) {
       end = std::chrono::high_resolution_clock::now();
       difference = std::chrono::duration_cast<std::chrono::nanoseconds>(end - startLoop).count();
-      //	QcInfoLogger::GetInstance() << "After Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
+      //	ILOG(Info, Support) << "After Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
       timefout2 << "Fill HitMaps =  " << difference << "ns" << std::endl;
     }
 
     if (mCounted < mTotalCounted) {
       end = std::chrono::high_resolution_clock::now();
       difference = std::chrono::duration_cast<std::chrono::nanoseconds>(end - startLoop).count();
-      //	QcInfoLogger::GetInstance() << "After Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
+      //	ILOG(Info, Support) << "After Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
       timefout2 << "Before glo etaphi =  " << difference << "ns" << std::endl;
     }
 
@@ -327,7 +327,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (mCounted < mTotalCounted) {
       end = std::chrono::high_resolution_clock::now();
       difference = std::chrono::duration_cast<std::chrono::nanoseconds>(end - startLoop).count();
-      //	QcInfoLogger::GetInstance() << "After Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
+      //	ILOG(Info, Support) << "After Geo = " << difference << "ns" <<  AliceO2::InfoLogger::InfoLogger::endm;
       timefout2 << "After glo etaphi =  " << difference << "ns" << std::endl;
       mCounted = mCounted + 1;
     }
@@ -342,19 +342,19 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
   //cout << "EndUpdateOcc " << NEventPre <<endl;
   end = std::chrono::high_resolution_clock::now();
   difference = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-  QcInfoLogger::GetInstance() << "Time After Loop = " << difference / 1000.0 << "s"
+  ILOG(Info, Support) << "Time After Loop = " << difference / 1000.0 << "s"
                               << AliceO2::InfoLogger::InfoLogger::endm;
   timefout << "Time After Loop = " << difference / 1000.0 << "s" << std::endl;
 
-  QcInfoLogger::GetInstance() << "NEventDone = " << mNEvent << AliceO2::InfoLogger::InfoLogger::endm;
-  QcInfoLogger::GetInstance() << "Test  " << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "NEventDone = " << mNEvent << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Test  " << AliceO2::InfoLogger::InfoLogger::endm;
 
   digits.clear();
 
   end = std::chrono::high_resolution_clock::now();
   difference = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
   TotalHisTime = TotalHisTime + difference;
-  QcInfoLogger::GetInstance() << "Time in Histogram = " << difference / 1000.0 << "s"
+  ILOG(Info, Support) << "Time in Histogram = " << difference / 1000.0 << "s"
                               << AliceO2::InfoLogger::InfoLogger::endm;
   timefout << "Time in Histogram = " << difference / 1000.0 << "s" << std::endl;
 
@@ -367,7 +367,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
 void ITSRawTask::addObject(TObject* aObject, bool published)
 {
   if (!aObject) {
-    QcInfoLogger::GetInstance() << "ERROR: trying to add non-existent object" << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "ERROR: trying to add non-existent object" << AliceO2::InfoLogger::InfoLogger::endm;
     return;
   }
   m_objects.push_back(aObject);
@@ -643,8 +643,8 @@ void ITSRawTask::getProcessStatus(int aInfoFile, int& aFileFinish)
   //cout<<"aInfoFile = "<<aInfoFile<<endl;
   FileRest = (aInfoFile - aFileFinish) / 10;
 
-  QcInfoLogger::GetInstance() << "FileFinish = " << aFileFinish << AliceO2::InfoLogger::InfoLogger::endm;
-  QcInfoLogger::GetInstance() << "FileRest = " << FileRest << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "FileFinish = " << aFileFinish << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "FileRest = " << FileRest << AliceO2::InfoLogger::InfoLogger::endm;
 
   if (aFileFinish == 0) {
     bulb->SetFillColor(kGreen);
@@ -663,7 +663,7 @@ void ITSRawTask::updateFile(int aRunID, int aEpID, int aFileID)
   static int RunIDPre = 0, FileIDPre = 0;
   if (RunIDPre != aRunID || FileIDPre != aFileID) {
     TString FileName = Form("infiles/run000%d/data-ep%d-link%d", aRunID, aEpID, aFileID);
-    QcInfoLogger::GetInstance() << "For the Moment: RunID = " << aRunID << "  FileID = " << aFileID
+    ILOG(Info, Support) << "For the Moment: RunID = " << aRunID << "  FileID = " << aFileID
                                 << AliceO2::InfoLogger::InfoLogger::endm;
     hFileNameInfo->Fill(0.5);
     hFileNameInfo->SetTitle(Form("Current File Name: %s", FileName.Data()));
@@ -683,18 +683,18 @@ void ITSRawTask::updateFile(int aRunID, int aEpID, int aFileID)
 
 void ITSRawTask::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ITSRawTask::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ITSRawTask::reset()
 {
   // clean all the monitor objects here
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
 
   mTotalFileDone = 0;
   ptNFile->Clear();
@@ -704,7 +704,7 @@ void ITSRawTask::reset()
   resetHitmaps();
   resetOccupancyPlots();
 
-  QcInfoLogger::GetInstance() << "DONE the histogram Resetting" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "DONE the histogram Resetting" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 // reset method for all plots that are supposed to be reset once

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -46,7 +46,7 @@ ITSTrackTask::~ITSTrackTask()
 void ITSTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
 
-  QcInfoLogger::GetInstance() << "initialize ITSTrackTask" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize ITSTrackTask" << AliceO2::InfoLogger::InfoLogger::endm;
 
   mRunNumberPath = mCustomParameters["runNumberPath"];
 
@@ -64,18 +64,18 @@ void ITSTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void ITSTrackTask::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ITSTrackTask::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
-  QcInfoLogger::GetInstance() << "START DOING QC General" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "START DOING QC General" << AliceO2::InfoLogger::InfoLogger::endm;
   auto trackArr = ctx.inputs().get<gsl::span<o2::its::TrackITS>>("tracks");
   auto rofArr = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("rofs");
   auto clusArr = ctx.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compclus");
@@ -124,18 +124,18 @@ void ITSTrackTask::endOfCycle()
         getObjectsManager()->addMetadata(mPublishedObjects.at(iObj)->GetName(), "Run", runNumber);
       mRunNumber = runNumber;
     }
-    QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
   }
 }
 
 void ITSTrackTask::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ITSTrackTask::reset()
 {
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
   hAngularDistribution->Reset();
   hNClusters->Reset();
   hTrackPhi->Reset();

--- a/Modules/MUON/MCH/src/DecodingErrorsTask.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsTask.cxx
@@ -77,7 +77,7 @@ static void setAxisLabels(TH2F* hErrors)
 
 void DecodingErrorsTask::initialize(o2::framework::InitContext& /*ic*/)
 {
-  ILOG(Info) << "initialize DecodingErrorsTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  ILOG(Info, Support) << "initialize DecodingErrorsTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
 
   mElec2Det = createElec2DetMapper<ElectronicMapperGenerated>();
   mFee2Solar = createFeeLink2SolarMapper<ElectronicMapperGenerated>();
@@ -89,13 +89,13 @@ void DecodingErrorsTask::initialize(o2::framework::InitContext& /*ic*/)
 
 void DecodingErrorsTask::startOfActivity(Activity& activity)
 {
-  ILOG(Info) << "startOfActivity : " << activity.mId << ENDM;
+  ILOG(Info, Support) << "startOfActivity : " << activity.mId << ENDM;
   mHistogramErrors->Reset();
 }
 
 void DecodingErrorsTask::startOfCycle()
 {
-  ILOG(Info) << "startOfCycle" << ENDM;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void DecodingErrorsTask::decodeTF(framework::ProcessingContext& pc)
@@ -141,7 +141,7 @@ void DecodingErrorsTask::decodeReadout(const o2::framework::DataRef& input)
 
 void DecodingErrorsTask::decodeBuffer(gsl::span<const std::byte> buf)
 {
-  ILOG(Debug) << "Start of new buffer" << ENDM;
+  ILOG(Debug, Support) << "Start of new buffer" << ENDM;
 
   size_t bufSize = buf.size();
   size_t pageStart = 0;
@@ -195,7 +195,7 @@ void DecodingErrorsTask::decodePage(gsl::span<const std::byte> page)
 
   auto& rdhAny = *reinterpret_cast<RDH*>(const_cast<std::byte*>(&(page[0])));
   int feeId = o2::raw::RDHUtils::getFEEID(rdhAny) & 0x7F;
-  ILOG(Debug) << "Received " << nErrors << " from " << feeId << ENDM;
+  ILOG(Debug, Support) << "Received " << nErrors << " from " << feeId << ENDM;
 }
 
 void DecodingErrorsTask::monitorData(o2::framework::ProcessingContext& ctx)
@@ -222,12 +222,12 @@ void DecodingErrorsTask::saveHistograms()
 
 void DecodingErrorsTask::endOfCycle()
 {
-  ILOG(Info) << "endOfCycle" << ENDM;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void DecodingErrorsTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "endOfActivity" << ENDM;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 
 #ifdef QC_MCH_SAVE_TEMP_ROOTFILE
   saveHistograms();
@@ -238,7 +238,7 @@ void DecodingErrorsTask::reset()
 {
   // clean all the monitor objects here
 
-  ILOG(Info) << "Resetting the histogram" << ENDM;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
   mHistogramErrors->Reset();
 }
 

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -57,7 +57,7 @@ PedestalsTask::~PedestalsTask()
 
 void PedestalsTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize PedestalsTask" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize PedestalsTask" << AliceO2::InfoLogger::InfoLogger::endm;
 
   mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
   mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
@@ -120,12 +120,12 @@ void PedestalsTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void PedestalsTask::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void PedestalsTask::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void PedestalsTask::fill_noise_distributions()
@@ -298,7 +298,7 @@ void PedestalsTask::PlotPedestalDE(uint16_t solarID, uint8_t dsID, uint8_t chann
 
 void PedestalsTask::monitorDataPedestals(o2::framework::ProcessingContext& ctx)
 {
-  QcInfoLogger::GetInstance() << "Plotting pedestals" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Plotting pedestals" << AliceO2::InfoLogger::InfoLogger::endm;
   using ChannelPedestal = o2::mch::calibration::MCHChannelCalibrator::ChannelPedestal;
 
   auto pedestals = ctx.inputs().get<gsl::span<ChannelPedestal>>("pedestals");
@@ -350,7 +350,7 @@ void PedestalsTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void PedestalsTask::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 
   mHistogramPedestalsMCH->set(mHistogramPedestalsXY[0], mHistogramPedestalsXY[1], true);
   mHistogramNoiseMCH->set(mHistogramNoiseXY[0], mHistogramNoiseXY[1], true);
@@ -359,7 +359,7 @@ void PedestalsTask::endOfCycle()
 void PedestalsTask::endOfActivity(Activity& /*activity*/)
 {
   printf("PedestalsTask::endOfActivity() called\n");
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 
 #ifdef QC_MCH_SAVE_TEMP_ROOTFILE
   save_histograms();
@@ -370,7 +370,7 @@ void PedestalsTask::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
   mPedestalProcessor.reset();
 }
 

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -51,7 +51,7 @@ PhysicsTaskDigits::~PhysicsTaskDigits() {}
 
 void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize PhysicsTaskDigits" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize PhysicsTaskDigits" << AliceO2::InfoLogger::InfoLogger::endm;
 
   mElec2DetMapper = createElec2DetMapper<ElectronicMapperGenerated>();
   mDet2ElecMapper = createDet2ElecMapper<ElectronicMapperGenerated>();
@@ -142,12 +142,12 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
 
 void PhysicsTaskDigits::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void PhysicsTaskDigits::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void PhysicsTaskDigits::monitorData(o2::framework::ProcessingContext& ctx)
@@ -156,7 +156,7 @@ void PhysicsTaskDigits::monitorData(o2::framework::ProcessingContext& ctx)
   auto digits = ctx.inputs().get<gsl::span<o2::mch::Digit>>("digits");
   auto orbits = ctx.inputs().get<gsl::span<uint64_t>>("orbits");
   if (orbits.empty()) {
-    QcInfoLogger::GetInstance() << "WARNING: empty orbits vector" << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "WARNING: empty orbits vector" << AliceO2::InfoLogger::InfoLogger::endm;
     return;
   }
 
@@ -309,7 +309,7 @@ void PhysicsTaskDigits::updateOrbits()
 
 void PhysicsTaskDigits::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 
   updateOrbits();
 
@@ -334,7 +334,7 @@ void PhysicsTaskDigits::endOfCycle()
 
 void PhysicsTaskDigits::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 
 #ifdef QC_MCH_SAVE_TEMP_ROOTFILE
   TFile f("mch-qc-digits.root", "RECREATE");
@@ -381,7 +381,7 @@ void PhysicsTaskDigits::endOfActivity(Activity& /*activity*/)
 void PhysicsTaskDigits::reset()
 {
   // clean all the monitor objects here
-  QcInfoLogger::GetInstance() << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 } // namespace muonchambers

--- a/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
@@ -53,7 +53,7 @@ PhysicsTaskPreclusters::~PhysicsTaskPreclusters() {}
 
 void PhysicsTaskPreclusters::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize PhysicsTaskPreclusters" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize PhysicsTaskPreclusters" << AliceO2::InfoLogger::InfoLogger::endm;
 
   for (auto de : o2::mch::raw::deIdsForAllMCH) {
 
@@ -138,12 +138,12 @@ void PhysicsTaskPreclusters::initialize(o2::framework::InitContext& /*ctx*/)
 
 void PhysicsTaskPreclusters::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void PhysicsTaskPreclusters::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void PhysicsTaskPreclusters::monitorData(o2::framework::ProcessingContext& ctx)
@@ -394,18 +394,18 @@ void PhysicsTaskPreclusters::printPrecluster(gsl::span<const o2::mch::Digit> pre
   bool isWide[2];
   CoG(preClusterDigits, Xcog, Ycog, isWide);
 
-  QcInfoLogger::GetInstance() << "\n\n\n====================\n"
+  ILOG(Info, Support) << "\n\n\n====================\n"
                               << "[pre-cluster] nDigits = " << preClusterDigits.size() << "  charge = " << chargeSum[0] << " " << chargeSum[1] << "   CoG = " << Xcog << "," << Ycog << AliceO2::InfoLogger::InfoLogger::endm;
   for (auto& d : preClusterDigits) {
     float X = segment.padPositionX(d.getPadID());
     float Y = segment.padPositionY(d.getPadID());
     bool bend = !segment.isBendingPad(d.getPadID());
-    QcInfoLogger::GetInstance() << fmt::format("  DE {:4d}  PAD {:5d}  ADC {:6d}  TIME ({})",
+    ILOG(Info, Support) << fmt::format("  DE {:4d}  PAD {:5d}  ADC {:6d}  TIME ({})",
                                                d.getDetID(), d.getPadID(), d.getADC(), d.getTime())
                                 << "\n"
                                 << fmt::format("  CATHODE {}  PAD_XY {:+2.2f} , {:+2.2f}", (int)bend, X, Y) << AliceO2::InfoLogger::InfoLogger::endm;
   }
-  QcInfoLogger::GetInstance() << "\n====================\n\n"
+  ILOG(Info, Support) << "\n====================\n\n"
                               << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
@@ -475,14 +475,14 @@ void PhysicsTaskPreclusters::computePseudoEfficiency()
 
 void PhysicsTaskPreclusters::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 
   computePseudoEfficiency();
 }
 
 void PhysicsTaskPreclusters::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 
 #ifdef QC_MCH_SAVE_TEMP_ROOTFILE
   computePseudoEfficiency();
@@ -550,7 +550,7 @@ void PhysicsTaskPreclusters::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 } // namespace muonchambers

--- a/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
@@ -395,18 +395,18 @@ void PhysicsTaskPreclusters::printPrecluster(gsl::span<const o2::mch::Digit> pre
   CoG(preClusterDigits, Xcog, Ycog, isWide);
 
   ILOG(Info, Support) << "\n\n\n====================\n"
-                              << "[pre-cluster] nDigits = " << preClusterDigits.size() << "  charge = " << chargeSum[0] << " " << chargeSum[1] << "   CoG = " << Xcog << "," << Ycog << AliceO2::InfoLogger::InfoLogger::endm;
+                      << "[pre-cluster] nDigits = " << preClusterDigits.size() << "  charge = " << chargeSum[0] << " " << chargeSum[1] << "   CoG = " << Xcog << "," << Ycog << AliceO2::InfoLogger::InfoLogger::endm;
   for (auto& d : preClusterDigits) {
     float X = segment.padPositionX(d.getPadID());
     float Y = segment.padPositionY(d.getPadID());
     bool bend = !segment.isBendingPad(d.getPadID());
     ILOG(Info, Support) << fmt::format("  DE {:4d}  PAD {:5d}  ADC {:6d}  TIME ({})",
-                                               d.getDetID(), d.getPadID(), d.getADC(), d.getTime())
-                                << "\n"
-                                << fmt::format("  CATHODE {}  PAD_XY {:+2.2f} , {:+2.2f}", (int)bend, X, Y) << AliceO2::InfoLogger::InfoLogger::endm;
+                                       d.getDetID(), d.getPadID(), d.getADC(), d.getTime())
+                        << "\n"
+                        << fmt::format("  CATHODE {}  PAD_XY {:+2.2f} , {:+2.2f}", (int)bend, X, Y) << AliceO2::InfoLogger::InfoLogger::endm;
   }
   ILOG(Info, Support) << "\n====================\n\n"
-                              << AliceO2::InfoLogger::InfoLogger::endm;
+                      << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 //_________________________________________________________________________________________________

--- a/Modules/MUON/MID/src/DigitsQcTask.cxx
+++ b/Modules/MUON/MID/src/DigitsQcTask.cxx
@@ -53,7 +53,7 @@ DigitsQcTask::~DigitsQcTask()
 
 void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info) << "initialize DigitsQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  ILOG(Info, Support) << "initialize DigitsQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
 
   // Histograms to be published
   mHitsMapB = new TH2F("HitsMapB", "Hits Map - bending plane", MID_NDE, 0, MID_NDE, MID_NCOL, 0, MID_NCOL);
@@ -105,12 +105,12 @@ void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void DigitsQcTask::startOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "startOfActivity" << ENDM;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
 }
 
 void DigitsQcTask::startOfCycle()
 {
-  ILOG(Info) << "startOfCycle" << ENDM;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 static int countColumnDataHits(const o2::mid::ColumnData& digit, int id)
@@ -157,7 +157,7 @@ static std::pair<uint32_t, uint32_t> getROFSize(const o2::mid::ROFRecord& rof, g
 
 void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  ILOG(Info) << "startOfDataMonitoring" << ENDM;
+  ILOG(Info, Support) << "startOfDataMonitoring" << ENDM;
 
   auto digits = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("digits");
   auto rofs = ctx.inputs().get<gsl::span<o2::mid::ROFRecord>>("digitrofs");
@@ -203,7 +203,7 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void DigitsQcTask::endOfCycle()
 {
-  ILOG(Info) << "endOfCycle" << ENDM;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 
   mOccupancyMapB->update();
   mOccupancyMapNB->update();
@@ -211,14 +211,14 @@ void DigitsQcTask::endOfCycle()
 
 void DigitsQcTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "endOfActivity" << ENDM;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void DigitsQcTask::reset()
 {
   // clean all the monitor objects here
 
-  ILOG(Info) << "Resetting the histogram" << ENDM;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
 }
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/src/RawQcTask.cxx
+++ b/Modules/MUON/MID/src/RawQcTask.cxx
@@ -52,25 +52,25 @@ RawQcTask::~RawQcTask()
 
 void RawQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info) << "initialize RawQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  ILOG(Info, Support) << "initialize RawQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
 
   // Retrieve task parameters from the config file
   if (auto param = mCustomParameters.find("feeId-config-file"); param != mCustomParameters.end()) {
-    ILOG(Info) << "Custom parameter - FEE Id config file: " << param->second << ENDM;
+    ILOG(Info, Support) << "Custom parameter - FEE Id config file: " << param->second << ENDM;
     if (!param->second.empty()) {
       mFeeIdConfig = o2::mid::FEEIdConfig(param->second.c_str());
     }
   }
 
   if (auto param = mCustomParameters.find("crate-masks-file"); param != mCustomParameters.end()) {
-    ILOG(Info) << "Custom parameter - Crate masks file: " << param->second << ENDM;
+    ILOG(Info, Support) << "Custom parameter - Crate masks file: " << param->second << ENDM;
     if (!param->second.empty()) {
       mCrateMasks = o2::mid::CrateMasks(param->second.c_str());
     }
   }
 
   if (auto param = mCustomParameters.find("electronics-delays-file"); param != mCustomParameters.end()) {
-    ILOG(Info) << "Custom parameter - Electronics delays file: " << param->second << ENDM;
+    ILOG(Info, Support) << "Custom parameter - Electronics delays file: " << param->second << ENDM;
     if (!param->second.empty()) {
       mElectronicsDelay = o2::mid::readElectronicsDelay(param->second.c_str());
     }
@@ -88,18 +88,18 @@ void RawQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void RawQcTask::startOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "startOfActivity" << ENDM;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
 }
 
 void RawQcTask::startOfCycle()
 {
-  ILOG(Info) << "startOfCycle" << ENDM;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void RawQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
-  ILOG(Info) << "startOfDataMonitoring" << ENDM;
+  ILOG(Info, Support) << "startOfDataMonitoring" << ENDM;
 
   o2::framework::DPLRawParser parser(ctx.inputs());
 
@@ -108,7 +108,7 @@ void RawQcTask::monitorData(o2::framework::ProcessingContext& ctx)
   if (!mDecoder) {
     auto const* rdhPtr = reinterpret_cast<const o2::header::RDHAny*>(parser.begin().raw());
     mDecoder = createDecoder(*rdhPtr, true, mElectronicsDelay, mCrateMasks, mFeeIdConfig);
-    ILOG(Info) << "Created decoder" << ENDM;
+    ILOG(Info, Support) << "Created decoder" << ENDM;
   }
 
   mDecoder->clear();
@@ -123,32 +123,32 @@ void RawQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
   mChecker.clear();
   if (!mChecker.process(mDecoder->getData(), mDecoder->getROFRecords(), dummy)) {
-    //ILOG(Info) << mChecker.getDebugMessage() << ENDM;
+    //ILOG(Info, Support) << mChecker.getDebugMessage() << ENDM;
     mRawDataChecker->Fill("Faulty", mChecker.getNEventsFaulty());
   }
 
-  ILOG(Info) << "Number of busy raised: " << mChecker.getNBusyRaised() << ENDM;
-  ILOG(Info) << "Fraction of faulty events: " << mChecker.getNEventsFaulty() << " / " << mChecker.getNEventsProcessed() << ENDM;
-  ILOG(Info) << "Counts: " << count << ENDM;
+  ILOG(Info, Support) << "Number of busy raised: " << mChecker.getNBusyRaised() << ENDM;
+  ILOG(Info, Support) << "Fraction of faulty events: " << mChecker.getNEventsFaulty() << " / " << mChecker.getNEventsProcessed() << ENDM;
+  ILOG(Info, Support) << "Counts: " << count << ENDM;
 
   mRawDataChecker->Fill("Processed", mChecker.getNEventsProcessed());
 }
 
 void RawQcTask::endOfCycle()
 {
-  ILOG(Info) << "endOfCycle" << ENDM;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void RawQcTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info) << "endOfActivity" << ENDM;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void RawQcTask::reset()
 {
   // clean all the monitor objects here
 
-  ILOG(Info) << "Resetting the histogram" << ENDM;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
   mRawDataChecker->Reset();
 }
 

--- a/Modules/PHOS/src/CalibQcTask.cxx
+++ b/Modules/PHOS/src/CalibQcTask.cxx
@@ -47,23 +47,23 @@ void CalibQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   context.setField(infoCONTEXT::FieldName::System, "QC");
   context.setField(infoCONTEXT::FieldName::Detector, "PHS");
   QcInfoLogger::GetInstance().setContext(context);
-  QcInfoLogger::GetInstance() << "initialize CalibQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize CalibQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
 
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
   if (auto param = mCustomParameters.find("pedestal"); param != mCustomParameters.end()) {
-    QcInfoLogger::GetInstance() << "Working in pedestal mode " << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "Working in pedestal mode " << AliceO2::InfoLogger::InfoLogger::endm;
     if (param->second.find("on") != std::string::npos) {
       mMode = 1;
     }
   }
   if (auto param = mCustomParameters.find("LED"); param != mCustomParameters.end()) {
-    QcInfoLogger::GetInstance() << "Working in LED mode " << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "Working in LED mode " << AliceO2::InfoLogger::InfoLogger::endm;
     if (param->second.find("on") != std::string::npos) {
       mMode = 2;
     }
   }
   if (auto param = mCustomParameters.find("BadMap"); param != mCustomParameters.end()) {
-    QcInfoLogger::GetInstance() << "Working in BadMap mode " << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "Working in BadMap mode " << AliceO2::InfoLogger::InfoLogger::endm;
     if (param->second.find("on") != std::string::npos) {
       mMode = 0;
     }
@@ -138,13 +138,13 @@ void CalibQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void CalibQcTask::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
   reset();
 }
 
 void CalibQcTask::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void CalibQcTask::monitorData(o2::framework::ProcessingContext& ctx)
@@ -168,19 +168,19 @@ void CalibQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void CalibQcTask::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void CalibQcTask::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void CalibQcTask::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
   for (int i = NHIST2D; i--;) {
     if (mHist2D[i]) {
       mHist2D[i]->Reset();

--- a/Modules/PHOS/src/ClusterQcTask.cxx
+++ b/Modules/PHOS/src/ClusterQcTask.cxx
@@ -54,11 +54,11 @@ void ClusterQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   context.setField(infoCONTEXT::FieldName::System, "QC");
   context.setField(infoCONTEXT::FieldName::Detector, "PHS");
   QcInfoLogger::GetInstance().setContext(context);
-  QcInfoLogger::GetInstance() << "initialize ClusterQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize ClusterQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
 
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
   if (auto param = mCustomParameters.find("myOwnKey"); param != mCustomParameters.end()) {
-    QcInfoLogger::GetInstance() << "Custom parameter - myOwnKey : " << param->second << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "Custom parameter - myOwnKey : " << param->second << AliceO2::InfoLogger::InfoLogger::endm;
   }
 
   //read alignment to calculate cluster global coordinates
@@ -120,13 +120,13 @@ void ClusterQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void ClusterQcTask::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
   reset();
 }
 
 void ClusterQcTask::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ClusterQcTask::monitorData(o2::framework::ProcessingContext& ctx)
@@ -184,18 +184,18 @@ void ClusterQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void ClusterQcTask::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ClusterQcTask::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void ClusterQcTask::reset()
 {
   // clean all the monitor objects here
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
   for (int i = kNhist1D; i--;) {
     if (mHist1D[i]) {
       mHist1D[i]->Reset();

--- a/Modules/PHOS/src/RawQcTask.cxx
+++ b/Modules/PHOS/src/RawQcTask.cxx
@@ -56,23 +56,23 @@ void RawQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   context.setField(infoCONTEXT::FieldName::System, "QC");
   context.setField(infoCONTEXT::FieldName::Detector, "PHS");
   QcInfoLogger::GetInstance().setContext(context);
-  QcInfoLogger::GetInstance() << "initialize RawQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize RawQcTask" << AliceO2::InfoLogger::InfoLogger::endm;
 
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
   if (auto param = mCustomParameters.find("pedestal"); param != mCustomParameters.end()) {
-    QcInfoLogger::GetInstance() << "Working in pedestal mode " << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "Working in pedestal mode " << AliceO2::InfoLogger::InfoLogger::endm;
     if (param->second.find("on") != std::string::npos) {
       mMode = 1;
     }
   }
   if (auto param = mCustomParameters.find("LED"); param != mCustomParameters.end()) {
-    QcInfoLogger::GetInstance() << "Working in LED mode " << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "Working in LED mode " << AliceO2::InfoLogger::InfoLogger::endm;
     if (param->second.find("on") != std::string::npos) {
       mMode = 2;
     }
   }
   if (auto param = mCustomParameters.find("physics"); param != mCustomParameters.end()) {
-    QcInfoLogger::GetInstance() << "Working in physics mode " << AliceO2::InfoLogger::InfoLogger::endm;
+    ILOG(Info, Support) << "Working in physics mode " << AliceO2::InfoLogger::InfoLogger::endm;
     if (param->second.find("on") != std::string::npos) {
       mMode = 0;
     }
@@ -114,13 +114,13 @@ void RawQcTask::InitHistograms()
 
 void RawQcTask::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
   reset();
 }
 
 void RawQcTask::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
   if (mMode == 1) {   //Pedestals
     if (mFinalized) { //means were already calculated
       for (Int_t mod = 0; mod < 4; mod++) {
@@ -190,7 +190,7 @@ void RawQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void RawQcTask::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
   if (mMode == 1) {   //Pedestals
     if (mFinalized) { //means were already calculated
       return;
@@ -262,7 +262,7 @@ void RawQcTask::endOfCycle()
 void RawQcTask::endOfActivity(Activity& /*activity*/)
 {
   endOfCycle();
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
 void RawQcTask::reset()
@@ -270,7 +270,7 @@ void RawQcTask::reset()
   // clean all the monitor objects here
   mFinalized = false;
 
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
   for (int i = kNhist1D; i--;) {
     if (mHist1D[i]) {
       mHist1D[i]->Reset();

--- a/Modules/TOF/src/TaskCosmics.cxx
+++ b/Modules/TOF/src/TaskCosmics.cxx
@@ -62,15 +62,15 @@ void TaskCosmics::initialize(o2::framework::InitContext& /*ctx*/)
   // Set task parameters from JSON
   if (auto param = mCustomParameters.find("SelDeltaTSignalRegion"); param != mCustomParameters.end()) {
     mSelDeltaTSignalRegion = atoi(param->second.c_str());
-    LOG(info) << "Set SelDeltaTSignalRegion to " << mSelDeltaTSignalRegion << " ps";
+    ILOG(Info, Support) << "Set SelDeltaTSignalRegion to " << mSelDeltaTSignalRegion << " ps";
   }
   if (auto param = mCustomParameters.find("SelDeltaTBackgroundRegion"); param != mCustomParameters.end()) {
     mSelDeltaTBackgroundRegion = atoi(param->second.c_str());
-    LOG(info) << "Set SelDeltaTBackgroundRegion to " << mSelDeltaTBackgroundRegion << " ps";
+    ILOG(Info, Support) << "Set SelDeltaTBackgroundRegion to " << mSelDeltaTBackgroundRegion << " ps";
   }
   if (auto param = mCustomParameters.find("SelMinLength"); param != mCustomParameters.end()) {
     mSelMinLength = atoi(param->second.c_str());
-    LOG(info) << "Set SelMinLength to " << mSelMinLength << " cm";
+    ILOG(Info, Support) << "Set SelMinLength to " << mSelMinLength << " cm";
   }
 
   mHistoCrate1.reset(new TH1F("Crate1", "Crate1;Crate of first hit;Counts", 72, 0, 72));

--- a/Modules/TOF/src/TaskRaw.cxx
+++ b/Modules/TOF/src/TaskRaw.cxx
@@ -321,7 +321,7 @@ void TaskRaw::initialize(o2::framework::InitContext& /*ctx*/)
   // Set task parameters from JSON
   if (auto param = mCustomParameters.find("DecoderCONET"); param != mCustomParameters.end()) {
     if (param->second == "True") {
-      LOG(info) << "Rig for DecoderCONET";
+      ILOG(Info, Support) << "Rig for DecoderCONET";
       mDecoderRaw.setDecoderCONET(kTRUE);
     }
   }

--- a/Modules/TPC/src/Clusters.cxx
+++ b/Modules/TPC/src/Clusters.cxx
@@ -44,7 +44,7 @@ Clusters::Clusters() : TaskInterface()
 
 void Clusters::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize TPC Clusters QC task" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize TPC Clusters QC task" << ENDM;
 
   addAndPublish(getObjectsManager(), mNClustersCanvasVec, { "c_Sides_N_Clusters", "c_ROCs_N_Clusters_1D", "c_ROCs_N_Clusters_2D" });
   addAndPublish(getObjectsManager(), mQMaxCanvasVec, { "c_Sides_Q_Max", "c_ROCs_Q_Max_1D", "c_ROCs_Q_Max_2D" });
@@ -60,12 +60,12 @@ void Clusters::initialize(o2::framework::InitContext& /*ctx*/)
 
 void Clusters::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
 }
 
 void Clusters::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void Clusters::processClusterNative(o2::framework::InputRecord& inputs)
@@ -120,19 +120,19 @@ void Clusters::monitorData(o2::framework::ProcessingContext& ctx)
 
 void Clusters::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void Clusters::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void Clusters::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Resetting the canvases" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the canvases" << ENDM;
 
   mQCClusters.reset();
 

--- a/Modules/TPC/src/PID.cxx
+++ b/Modules/TPC/src/PID.cxx
@@ -40,7 +40,7 @@ PID::~PID()
 
 void PID::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize TPC PID QC task" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize TPC PID QC task" << ENDM;
 
   mQCPID.initializeHistograms();
   //o2::tpc::qc::helpers::setStyleHistogram1D(mQCPID.getHistograms1D());
@@ -59,20 +59,20 @@ void PID::initialize(o2::framework::InitContext& /*ctx*/)
 
 void PID::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
   mQCPID.resetHistograms();
 }
 
 void PID::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void PID::monitorData(o2::framework::ProcessingContext& ctx)
 {
   using TrackType = std::vector<o2::tpc::TrackTPC>;
   auto tracks = ctx.inputs().get<TrackType>("inputTracks");
-  //QcInfoLogger::GetInstance() << "monitorData: " << tracks.size() << AliceO2::InfoLogger::InfoLogger::endm;
+  //ILOG(Info, Support) << "monitorData: " << tracks.size() << ENDM;
 
   for (auto const& track : tracks) {
     mQCPID.processTrack(track);
@@ -84,19 +84,19 @@ void PID::monitorData(o2::framework::ProcessingContext& ctx)
 
 void PID::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void PID::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void PID::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
   mQCPID.resetHistograms();
 }
 

--- a/Modules/TPC/src/RawDigits.cxx
+++ b/Modules/TPC/src/RawDigits.cxx
@@ -36,7 +36,7 @@ RawDigits::RawDigits() : TaskInterface()
 
 void RawDigits::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize TPC RawDigits QC task" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize TPC RawDigits QC task" << ENDM;
 
   mRawReader.createReader("");
 
@@ -56,12 +56,12 @@ void RawDigits::initialize(o2::framework::InitContext& /*ctx*/)
 
 void RawDigits::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
 }
 
 void RawDigits::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void RawDigits::monitorData(o2::framework::ProcessingContext& ctx)
@@ -80,19 +80,19 @@ void RawDigits::monitorData(o2::framework::ProcessingContext& ctx)
 
 void RawDigits::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void RawDigits::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void RawDigits::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
 
   mRawDigitQC.reset();
 

--- a/Modules/TPC/src/Tracking.cxx
+++ b/Modules/TPC/src/Tracking.cxx
@@ -54,7 +54,7 @@ Tracking::~Tracking()
 
 void Tracking::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize TPC Tracking QC task" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize TPC Tracking QC task" << ENDM;
   mOutputMode = o2::tpc::qc::Tracking::outputMergeable;
   mQCTracking.initialize(mOutputMode);
 
@@ -77,13 +77,13 @@ void Tracking::initialize(o2::framework::InitContext& /*ctx*/)
 
 void Tracking::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
   mQCTracking.resetHistograms();
 }
 
 void Tracking::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void Tracking::monitorData(o2::framework::ProcessingContext& ctx)
@@ -99,19 +99,19 @@ void Tracking::monitorData(o2::framework::ProcessingContext& ctx)
 
 void Tracking::endOfCycle()
 {
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void Tracking::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void Tracking::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
   mQCTracking.resetHistograms();
 }
 

--- a/Modules/TPC/src/Tracks.cxx
+++ b/Modules/TPC/src/Tracks.cxx
@@ -35,7 +35,7 @@ namespace o2::quality_control_modules::tpc
 
 void Tracks::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  QcInfoLogger::GetInstance() << "initialize TPC Tracks QC task" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "initialize TPC Tracks QC task" << ENDM;
 
   mQCTracks.initializeHistograms();
   o2::tpc::qc::helpers::setStyleHistogram2D(mQCTracks.getHistograms2D());
@@ -55,13 +55,13 @@ void Tracks::initialize(o2::framework::InitContext& /*ctx*/)
 
 void Tracks::startOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "startOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
   mQCTracks.resetHistograms();
 }
 
 void Tracks::startOfCycle()
 {
-  QcInfoLogger::GetInstance() << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
 }
 
 void Tracks::monitorData(o2::framework::ProcessingContext& ctx)
@@ -70,7 +70,7 @@ void Tracks::monitorData(o2::framework::ProcessingContext& ctx)
   auto tracks = ctx.inputs().get<TrackType>("inputTracks");
   //using TracksType = gsl::span<o2::tpc::TrackTPC>;
   //const auto tracks = ctx.inputs().get<TracksType>("inputTracks");
-  //QcInfoLogger::GetInstance() << "monitorData: " << tracks.size() << AliceO2::InfoLogger::InfoLogger::endm;
+  //ILOG(Info, Support) << "monitorData: " << tracks.size() << ENDM;
 
   for (auto const& track : tracks) {
     mQCTracks.processTrack(track);
@@ -81,19 +81,19 @@ void Tracks::monitorData(o2::framework::ProcessingContext& ctx)
 void Tracks::endOfCycle()
 {
   mQCTracks.processEndOfCycle();
-  QcInfoLogger::GetInstance() << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
 }
 
 void Tracks::endOfActivity(Activity& /*activity*/)
 {
-  QcInfoLogger::GetInstance() << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
 }
 
 void Tracks::reset()
 {
   // clean all the monitor objects here
 
-  QcInfoLogger::GetInstance() << "Resetting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
   mQCTracks.resetHistograms();
 }
 


### PR DESCRIPTION
The modules, and in particular the monitorData method, must specify severity and level for their logs.
It is important to allow the proper filtering, at the source or not, of the logs. 

@mfasDa 
@afurs 
@aferrero2707 
@JianLIUhep 
@wiechula 
Could you check my changes ? 
