### PR TITLE
[EMCAL-526, EMCAL-527] Add histogram and checker for SM with max. amount of digits

### DIFF
--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -103,6 +103,7 @@ class DigitsQcTask final : public TaskInterface
   TH1* mEvCounterTFCALIB = nullptr; ///< Number of Events per timeframe per CALIB
   TH1* mTFPerCyclesTOT = nullptr;   ///< Number of Time Frame per cycles TOT
   TH1* mTFPerCycles = nullptr;      ///< Number of Time Frame per cycles per MonitorData
+  TH1* mDigitsMaxSM = nullptr;      ///< Supermodule with the largest amount of digits
 
   /// \brief Constructor
   DigitsQcTask() = default;


### PR DESCRIPTION
Monitor supermodule with max. amount of digits
(ideally uniformly distributed). Checker working
in the same way as payload checker in raw QC
(entries above truncated mean with robust
estimator)