### PR TITLE
[QC-671] Set the activity in the MonitorObject earlier.

### DIFF
--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -144,7 +144,7 @@ class ObjectsManager
   size_t getNumberPublishedObjects();
 
   /**
-   * Returns the published MonitorObject specified by its name
+   * Returns the published MonitorObject specified by its index
    * @param index
    * @return A pointer to the MonitorObject.
    * @throw ObjectNotFoundError if the object is not found.
@@ -164,6 +164,9 @@ class ObjectsManager
    */
   void removeAllFromServiceDiscovery();
 
+  const Activity& getActivity() const;
+  void setActivity(const Activity& activity);
+
  private:
   std::unique_ptr<MonitorObjectCollection> mMonitorObjects;
   std::string mTaskName;
@@ -171,6 +174,7 @@ class ObjectsManager
   std::string mDetectorName;
   std::unique_ptr<ServiceDiscovery> mServiceDiscovery;
   bool mUpdateServiceDiscovery;
+  Activity mActivity;
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -59,6 +59,7 @@ void ObjectsManager::startPublishing(TObject* object)
   }
   auto* newObject = new MonitorObject(object, mTaskName, mTaskClass, mDetectorName);
   newObject->setIsOwner(false);
+  newObject->setActivity(mActivity);
   mMonitorObjects->Add(newObject);
   mUpdateServiceDiscovery = true;
 }
@@ -168,6 +169,21 @@ void ObjectsManager::setDisplayHint(TObject* obj, const std::string& hints)
 {
   MonitorObject* mo = getMonitorObject(obj->GetName());
   mo->addOrUpdateMetadata(gDisplayHintsKey, hints);
+}
+
+const Activity& ObjectsManager::getActivity() const
+{
+  return mActivity;
+}
+
+void ObjectsManager::setActivity(const Activity& activity)
+{
+  mActivity = activity;
+  // update the activity of all the objects
+  for (auto tobj : *mMonitorObjects) {
+    MonitorObject* mo = dynamic_cast<MonitorObject*>(tobj);
+    mo->setActivity(activity);
+  }
 }
 
 } // namespace o2::quality_control::core

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -308,6 +308,7 @@ void TaskRunner::startOfActivity()
   // Start activity in module's stask and update objectsManager
   Activity activity(mRunNumber, mTaskConfig.activityType, mTaskConfig.activityPeriodName, mTaskConfig.activityPassName, mTaskConfig.activityProvenance);
   ILOG(Info, Ops) << "Starting run " << mRunNumber << ENDM;
+  mObjectsManager->setActivity(activity);
   mCollector->setRunNumber(mRunNumber);
   mTask->startOfActivity(activity);
   mObjectsManager->updateServiceDiscovery();


### PR DESCRIPTION
Set the activity in the MonitorObject in the TaskRunner already instead of waiting to store in the CheckRunner.