### PR TITLE
TPC: enable setting of conditionDB path for tasks

### DIFF
--- a/Modules/TPC/include/TPC/LaserTracks.h
+++ b/Modules/TPC/include/TPC/LaserTracks.h
@@ -43,7 +43,7 @@ class LaserTracks final : public quality_control::postprocessing::PostProcessing
   /// Configuration of a post-processing task. Can be overridden if user wants to retrieve the configuration of the task.
   /// \param name     Name of the task
   /// \param config   ConfigurationInterface with prefix set to ""
-  //void configure(std::string name, const boost::property_tree::ptree& config) override;
+  void configure(std::string name, const boost::property_tree::ptree& config) override;
   /// \brief Initialization of a post-processing task.
   /// Initialization of a post-processing task. User receives a Trigger which caused the initialization and a service
   /// registry with singleton interfaces.

--- a/Modules/TPC/src/CalDetPublisher.cxx
+++ b/Modules/TPC/src/CalDetPublisher.cxx
@@ -38,6 +38,8 @@ namespace o2::quality_control_modules::tpc
 
 void CalDetPublisher::configure(std::string name, const boost::property_tree::ptree& config)
 {
+  o2::tpc::CDBInterface::instance().setURL(config.get<std::string>("qc.config.conditionDB.url"));
+
   for (const auto& output : config.get_child("qc.postprocessing." + name + ".outputCalPadMaps")) {
     mOutputListMap.emplace_back(output.second.data());
   }

--- a/Modules/TPC/src/LaserTracks.cxx
+++ b/Modules/TPC/src/LaserTracks.cxx
@@ -31,6 +31,11 @@ using namespace o2::quality_control::postprocessing;
 namespace o2::quality_control_modules::tpc
 {
 
+void LaserTracks::configure(std::string name, const boost::property_tree::ptree& config)
+{
+  o2::tpc::CDBInterface::instance().setURL(config.get<std::string>("qc.config.conditionDB.url"));
+}
+
 void LaserTracks::initialize(Trigger, framework::ServiceRegistry&)
 {
   addAndPublish(getObjectsManager(),


### PR DESCRIPTION
 - LaserTracks
 - CalDetPublisher