### PR TITLE
Make sure that we don't have references to `consul-test` 

### DIFF
--- a/Framework/test/testObjectsManager.cxx
+++ b/Framework/test/testObjectsManager.cxx
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(duplicate_object_test)
 {
   Config config;
   config.taskName = "test";
-  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.consulUrl = "";
   ObjectsManager objectsManager(config.taskName, config.taskClass, config.detectorName, config.consulUrl, 0, true);
   TObjString s("content");
   objectsManager.startPublishing(&s);
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(is_being_published_test)
 {
   Config config;
   config.taskName = "test";
-  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.consulUrl = "";
   ObjectsManager objectsManager(config.taskName, config.taskClass, config.detectorName, config.consulUrl, 0, true);
   TObjString s("content");
   BOOST_CHECK(!objectsManager.isBeingPublished("content"));
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(getters_test)
 {
   Config config;
   config.taskName = "test";
-  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.consulUrl = "";
   ObjectsManager objectsManager(config.taskName, config.taskClass, config.detectorName, config.consulUrl, 0, true);
 
   TObjString s("content");
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(metadata_test)
 {
   Config config;
   config.taskName = "test";
-  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.consulUrl = "";
   ObjectsManager objectsManager(config.taskName, config.taskClass, config.detectorName, config.consulUrl, 0, true);
 
   TObjString s("content");
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(drawOptions_test)
 {
   Config config;
   config.taskName = "test";
-  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.consulUrl = "";
   ObjectsManager objectsManager(config.taskName, config.taskClass, config.detectorName, config.consulUrl, 0, true);
 
   TH1F h("histo", "h", 100, 0, 99);

--- a/Framework/test/testTrendingTask.json
+++ b/Framework/test/testTrendingTask.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/Benchmark/script/benchmarkPP.json
+++ b/Modules/Benchmark/script/benchmarkPP.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/CPV/etc/read-raw-from-file/pedestal-task-no-sampling.json
+++ b/Modules/CPV/etc/read-raw-from-file/pedestal-task-no-sampling.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/Common/etc/trfcollection-example.json
+++ b/Modules/Common/etc/trfcollection-example.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/Daq/daq.json
+++ b/Modules/Daq/daq.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/Daq/test/testQcDaq.cxx
+++ b/Modules/Daq/test/testQcDaq.cxx
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(instantiate_task)
 {
   DaqTask task;
   Config config;
-  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.consulUrl = "";
   config.taskName = "qcDaqTest";
   config.detectorName = "DAQ";
   auto manager = make_shared<ObjectsManager>(config.taskName, "DaqTask", config.detectorName, config.consulUrl, 0, true);

--- a/Modules/EMCAL/etc/digits.json
+++ b/Modules/EMCAL/etc/digits.json
@@ -16,7 +16,7 @@
           "url": "infologger:///debug?qc"
         },
         "consul": {
-          "url": "http://consul-test.cern.ch:8500"
+          "url": ""
         },
         "conditionDB": {
           "url": "ccdb-test.cern.ch:8080"

--- a/Modules/EMCAL/etc/readout-stfb-remote.json
+++ b/Modules/EMCAL/etc/readout-stfb-remote.json
@@ -16,7 +16,7 @@
 	    "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/EMCAL/etc/readout-stfb.json
+++ b/Modules/EMCAL/etc/readout-stfb.json
@@ -16,7 +16,7 @@
 	    "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/EMCAL/etc/readout.json
+++ b/Modules/EMCAL/etc/readout.json
@@ -16,7 +16,7 @@
 	    "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/Example/etc/analysisDerived.json
+++ b/Modules/Example/etc/analysisDerived.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/Example/etc/analysisDirect.json
+++ b/Modules/Example/etc/analysisDirect.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/Example/test/testQcExample.cxx
+++ b/Modules/Example/test/testQcExample.cxx
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(insantiate_task)
 {
   ExampleTask task;
   TaskRunnerConfig config;
-  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.consulUrl = "";
   config.taskName = "qcExampleTest";
   config.detectorName = "TST";
   auto manager = make_shared<ObjectsManager>(config.taskName, "ExampleTask", config.detectorName, config.consulUrl, 0, true);

--- a/Modules/FT0/ft0-basic-config.json
+++ b/Modules/FT0/ft0-basic-config.json
@@ -16,7 +16,7 @@
           "url": "infologger:///debug?METRIC"
         },
         "consul": {
-          "url": "http://consul-test.cern.ch:8500"
+          "url": ""
         },
         "conditionDB": {
           "url": "ccdb-test.cern.ch:8080"

--- a/Modules/FT0/ft0-calibration-config.json
+++ b/Modules/FT0/ft0-calibration-config.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?METRIC"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/FT0/ft0-multinode-config.json
+++ b/Modules/FT0/ft0-multinode-config.json
@@ -16,7 +16,7 @@
           "url": "infologger:///debug?qc"
         },
         "consul": {
-          "url": "http://consul-test.cern.ch:8500"
+          "url": ""
         },
         "conditionDB": {
           "url": "ccdb-test.cern.ch:8080"

--- a/Modules/FT0/ft0-postprocessing-config.json
+++ b/Modules/FT0/ft0-postprocessing-config.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/ITS/its.json
+++ b/Modules/ITS/its.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       }
     },
     "tasks": {

--- a/Modules/ITS/itsCluster.json
+++ b/Modules/ITS/itsCluster.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "188.184.2.55:8080"

--- a/Modules/ITS/itsEPN.json
+++ b/Modules/ITS/itsEPN.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/ITS/itsFLP.json
+++ b/Modules/ITS/itsFLP.json
@@ -16,7 +16,7 @@
                 "url": "infologger:///debug?qc"
             },
             "consul": {
-                "url": "http://consul-test.cern.ch:8500"
+                "url": ""
             },
             "conditionDB": {
                 "url": "ccdb-test.cern.ch:8080"

--- a/Modules/ITS/itsFee.json
+++ b/Modules/ITS/itsFee.json
@@ -16,7 +16,7 @@
                 "url": "infologger:///debug?qc"
             },
             "consul": {
-                "url": "http://consul-test.cern.ch:8500"
+                "url": ""
             },
             "conditionDB": {
                 "url": "ccdb-test.cern.ch:8080"

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -16,7 +16,7 @@
                 "url": "infologger:///debug?qc"
             },
             "consul": {
-                "url": "http://consul-test.cern.ch:8500"
+                "url": ""
             },
             "conditionDB": {
                 "url": "ccdb-test.cern.ch:8080"

--- a/Modules/ITS/itsNoisyPixel.json
+++ b/Modules/ITS/itsNoisyPixel.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/ITS/itsQCTrendingFhr.json
+++ b/Modules/ITS/itsQCTrendingFhr.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/ITS/itsQCTrendingThr.json
+++ b/Modules/ITS/itsQCTrendingThr.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/ITS/itsTrack.json
+++ b/Modules/ITS/itsTrack.json
@@ -16,7 +16,7 @@
         "url" : "infologger:///debug?qc"
       },
       "consul" : {
-        "url" : "http://consul-test.cern.ch:8500"
+        "url" : ""
       },
       "conditionDB" : {
         "url" : "ccdb-test.cern.ch:8080"

--- a/Modules/MFT/qc-mft-digit.json
+++ b/Modules/MFT/qc-mft-digit.json
@@ -16,7 +16,7 @@
         "url" : "infologger:///debug?qc"
       },
       "consul" : {
-        "url" : "http://consul-test.cern.ch:8500"
+        "url" : ""
       },
       "conditionDB" : {
         "url" : "ccdb-test.cern.ch:8080"

--- a/Modules/MFT/qc-mft-readout.json
+++ b/Modules/MFT/qc-mft-readout.json
@@ -16,7 +16,7 @@
         "url" : "infologger:///debug?qc"
       },
       "consul" : {
-        "url" : "http://consul-test.cern.ch:8500"
+        "url" : ""
       },
       "conditionDB" : {
         "url" : "ccdb-test.cern.ch:8080"

--- a/Modules/MUON/MID/mid-raw.json
+++ b/Modules/MUON/MID/mid-raw.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/PHOS/etc/phosCalibLED.json
+++ b/Modules/PHOS/etc/phosCalibLED.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/PHOS/etc/phosCalibPed.json
+++ b/Modules/PHOS/etc/phosCalibPed.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/PHOS/etc/phosClusters.json
+++ b/Modules/PHOS/etc/phosClusters.json
@@ -16,7 +16,7 @@
                 "url": "infologger:///debug?qc"
             },
             "consul": {
-                "url": "http://consul-test.cern.ch:8500"
+                "url": ""
             },
             "conditionDB": {
                 "url": "ccdb-test.cern.ch:8080"

--- a/Modules/PHOS/etc/phosPedestal.json
+++ b/Modules/PHOS/etc/phosPedestal.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/PHOS/etc/phosRaw.json
+++ b/Modules/PHOS/etc/phosRaw.json
@@ -16,7 +16,7 @@
                 "url": "infologger:///debug?qc"
             },
             "consul": {
-                "url": "http://consul-test.cern.ch:8500"
+                "url": ""
             },
             "conditionDB": {
                 "url": "ccdb-test.cern.ch:8080"

--- a/Modules/PHOS/etc/phosRawClu.json
+++ b/Modules/PHOS/etc/phosRawClu.json
@@ -16,7 +16,7 @@
                 "url": "infologger:///debug?qc"
             },
             "consul": {
-                "url": "http://consul-test.cern.ch:8500"
+                "url": ""
             },
             "conditionDB": {
                 "url": "ccdb-test.cern.ch:8080"

--- a/Modules/Skeleton/test/testQcSkeleton.cxx
+++ b/Modules/Skeleton/test/testQcSkeleton.cxx
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(instantiate_task)
 {
   SkeletonTask task;
   TaskRunnerConfig config;
-  config.consulUrl = "http://consul-test.cern.ch:8500";
+  config.consulUrl = "";
   config.taskName = "qcSkeletonTest";
   config.detectorName = "TST";
   auto manager = make_shared<ObjectsManager>(config.taskName, "SkeletonTask", config.detectorName, config.consulUrl, 0, true);

--- a/Modules/TOF/tofcosmics.json
+++ b/Modules/TOF/tofcosmics.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TOF/tofdigits.json
+++ b/Modules/TOF/tofdigits.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TOF/tofdigits_multinode.json
+++ b/Modules/TOF/tofdigits_multinode.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TOF/toffull.json
+++ b/Modules/TOF/toffull.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TOF/toffull_multinode.json
+++ b/Modules/TOF/toffull_multinode.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TOF/tofpostprocessdiagnosticpercrate.json
+++ b/Modules/TOF/tofpostprocessdiagnosticpercrate.json
@@ -16,7 +16,7 @@
           "url": "infologger:///debug?qc"
         },
         "consul": {
-          "url": "http://consul-test.cern.ch:8500"
+          "url": ""
         },
         "conditionDB": {
           "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TOF/tofraw.json
+++ b/Modules/TOF/tofraw.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TOF/tofraw_multinode.json
+++ b/Modules/TOF/tofraw_multinode.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCCalDetPublisher.json
+++ b/Modules/TPC/run/tpcQCCalDetPublisher.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCCheckTrending.json
+++ b/Modules/TPC/run/tpcQCCheckTrending.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCClusterChecker.json
+++ b/Modules/TPC/run/tpcQCClusterChecker.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCClusters_direct.json
+++ b/Modules/TPC/run/tpcQCClusters_direct.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCKrClusters_direct.json
+++ b/Modules/TPC/run/tpcQCKrClusters_direct.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCLaserTracks.json
+++ b/Modules/TPC/run/tpcQCLaserTracks.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCPID_direct.json
+++ b/Modules/TPC/run/tpcQCPID_direct.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCPID_sampled.json
+++ b/Modules/TPC/run/tpcQCPID_sampled.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCPadCalibrationCheck2D.json
+++ b/Modules/TPC/run/tpcQCPadCalibrationCheck2D.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCRawDigits_direct.json
+++ b/Modules/TPC/run/tpcQCRawDigits_direct.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCSimpleTrending.json
+++ b/Modules/TPC/run/tpcQCSimpleTrending.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCTasks_multinode.json
+++ b/Modules/TPC/run/tpcQCTasks_multinode.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCTrackingFromExternal_direct.json
+++ b/Modules/TPC/run/tpcQCTrackingFromExternal_direct.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCTracking_direct.json
+++ b/Modules/TPC/run/tpcQCTracking_direct.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCTracks_direct.json
+++ b/Modules/TPC/run/tpcQCTracks_direct.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCTracks_sampled.json
+++ b/Modules/TPC/run/tpcQCTracks_sampled.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"

--- a/Modules/TPC/run/tpcQCTrending.json
+++ b/Modules/TPC/run/tpcQCTrending.json
@@ -16,7 +16,7 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"


### PR DESCRIPTION
in the config files to avoid spamming the DNS server.