### PR TITLE
[WIP] Qc offline task: clusters

### DIFF
--- a/Modules/ITS/CMakeLists.txt
+++ b/Modules/ITS/CMakeLists.txt
@@ -73,7 +73,7 @@ install(
 
 set(EXE_SRCS
     src/runITS.cxx
-    src/runITSClustersRootFileReader_Final.cxx)
+    src/runITSClustersRootFileReader.cxx)
 
 set(EXE_NAMES
     o2-qc-run-its

--- a/Modules/ITS/CMakeLists.txt
+++ b/Modules/ITS/CMakeLists.txt
@@ -1,4 +1,4 @@
-# ---- Library ----
+﻿# ---- Library ----
 
 add_library(O2QcITS
             src/ITSRawTask.cxx
@@ -72,22 +72,24 @@ install(
 # ---- Executables ----
 
 set(EXE_SRCS
-    src/runITS.cxx)
+    src/runITS.cxx
+    src/runITSClustersRootFileReader_Final.cxx)
 
 set(EXE_NAMES
-    o2-qc-run-its)
+    o2-qc-run-its
+    o2-qc-its-clusters-root-file-reader)
 
 # These were the original names before the convention changed. We will get rid
 # of them but for the time being we want to create symlinks to avoid confusion.
-set(EXE_OLD_NAMES
-    qcRunITS)
+#set(EXE_OLD_NAMES
+#    qcRunITS)
 
 list(LENGTH EXE_SRCS count)
 math(EXPR count "${count}-1")
 foreach(i RANGE ${count})
   list(GET EXE_SRCS ${i} src)
   list(GET EXE_NAMES ${i} name)
-  list(GET EXE_OLD_NAMES ${i} oldname)
+  #list(GET EXE_OLD_NAMES ${i} oldname)
   add_executable(${name} ${src})
   target_link_libraries(${name} PRIVATE O2QualityControl CURL::libcurl O2::ITSQCDataReaderWorkflow O2::DetectorsBase ROOT::Tree)
   install_symlink(${name} ${CMAKE_INSTALL_FULL_BINDIR}/${oldname})

--- a/Modules/ITS/src/runITSClustersRootFileReader.cxx
+++ b/Modules/ITS/src/runITSClustersRootFileReader.cxx
@@ -1,0 +1,151 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    runITSClustersRootFileReader.cxx
+/// \author  Kotliarov Artem
+
+/// This is an executable that reads clusters from a root file from disk and sends the data to QC via the Data Processing Layer.
+/// The code is inspired by a similar reader "runMFTClustersRootFileReader.cxx" (authors Guillermo Contreras, Tomas Herman, Katarina Krizkova Gajdosova, Diana Maria Krupova)
+
+/// Code run:
+/// o2-qc-its-clusters-root-file-reader --its-cluster-root-file => File_Name.root | o2-qc --config json://${QUALITYCONTROL_ROOT}/etc/itsCluster.json
+
+// C++
+#include <vector>
+// ROOT
+#include <TFile.h>
+#include <TTree.h>
+// O2
+#include <Framework/CallbackService.h>
+#include <Framework/ControlService.h>
+#include <Framework/runDataProcessing.h>
+#include <Framework/Task.h>
+#include <DataFormatsITSMFT/Cluster.h>
+#include <DataFormatsITSMFT/CompCluster.h>
+#include <DataFormatsITSMFT/ROFRecord.h>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::itsmft;
+
+class ITSClustersRootFileReader : public o2::framework::Task
+{
+
+ public:
+  void init(framework::InitContext& ic)
+  {
+    LOG(info) << " In ITSClustersRootFileReader::init ... entering ";
+
+    // open input file
+    auto filename = ic.options().get<std::string>("its-cluster-root-file");
+    mFile = std::make_unique<TFile>(filename.c_str(), "READ");
+    if (!mFile->IsOpen()) {
+      LOG(error) << "ITSClustersRootFileReader::init. Cannot open file: " << filename.c_str();
+      ic.services().get<ControlService>().endOfStream();
+      ic.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+      return;
+    }
+
+    // get TTree
+    mTree = (TTree*)mFile->Get("o2sim");
+    mTree->SetBranchAddress("ITSClusterComp", &pclusters);
+    mTree->SetBranchAddress("ITSClustersROF", &profs);
+
+    mNumberOfEntries = mTree->GetEntries();
+    if (mNumberOfEntries == 0) {
+      LOG(error) << "ITSClustersRootFileReader::init. No entries.";
+      ic.services().get<ControlService>().endOfStream();
+      ic.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+      return;
+    }
+  }
+
+  void run(framework::ProcessingContext& pc)
+  {
+
+    // Check if this is the last TF
+    if (mCurrentEntry == mNumberOfEntries) {
+      LOG(info) << " ITSClustersRootFileReader::run. End of file reached.";
+      pc.services().get<ControlService>().endOfStream();
+      pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+      return;
+    }
+
+    mTree->GetEntry(mCurrentEntry); // load Entry from TTree
+
+    // Prepare ROF output
+    std::vector<o2::itsmft::ROFRecord>* clusRofArr = new std::vector<o2::itsmft::ROFRecord>();
+    std::copy(rofs.begin(), rofs.end(), std::back_inserter(*clusRofArr));
+
+    // Prepare vector with clusters for all ROFs
+    std::vector<o2::itsmft::CompClusterExt>* clusArr = new std::vector<o2::itsmft::CompClusterExt>();
+
+    // Get number of rofs
+    mNumberOfROF = rofs.size();
+
+    for (unsigned int mCurrentROF = 0; mCurrentROF < mNumberOfROF; mCurrentROF++) {
+
+      // get clusters in current ROF
+      auto& rof = rofs[mCurrentROF];
+
+      // First cluster position in current ROF
+      unsigned int index = rof.getFirstEntry();
+
+      // Final cluster position in current ROF
+      unsigned int numberOfClustersInROF = rof.getNEntries();
+      unsigned int lastIndex = index + numberOfClustersInROF;
+
+      // Fill corresponding clusters
+      std::copy(clusters.begin() + index, clusters.begin() + lastIndex, std::back_inserter(*clusArr));
+    }
+
+    // Output vectors
+    pc.outputs().snapshot(Output{ "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe }, *clusArr);
+    pc.outputs().snapshot(Output{ "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe }, *clusRofArr);
+
+    // read a new entry in TTree
+    ++mCurrentEntry;
+  }
+
+ private:
+  std::unique_ptr<TFile> mFile = nullptr;                                   // file to be read
+  TTree* mTree = nullptr;                                                   // TTree object inside file
+  std::vector<o2::itsmft::ROFRecord> rofs, *profs = &rofs;                  // pointer to ROF branch
+  std::vector<o2::itsmft::CompClusterExt> clusters, *pclusters = &clusters; // pointer to Cluster branch
+
+  unsigned long mNumberOfEntries = 0; // number of entries from TTree
+  unsigned long mCurrentEntry = 0;    // index of current entry
+  unsigned long mNumberOfROF = 0;     // number of ROFs in current entry
+
+}; // end class definition
+
+WorkflowSpec defineDataProcessing(const ConfigContext&)
+{
+  WorkflowSpec specs; // To return the work flow
+
+  // Define the outputs
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back("ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
+
+  // The producer to generate data in the workflow
+  DataProcessorSpec producer{
+    "clusters-root-file-reader-ITS",
+    Inputs{},
+    outputs,
+    AlgorithmSpec{ adaptFromTask<ITSClustersRootFileReader>() },
+    Options{ { "its-cluster-root-file", VariantType::String, "o2clus_its.root", { "Name of the input file" } } }
+  };
+  specs.push_back(producer);
+
+  return specs;
+}


### PR DESCRIPTION
This is an executable that reads clusters from a root file on a disk and sends the data to QC. To run the code, one needs to add a new executable into the CMake file.