### PR TITLE
TPC: add mergeable output for Clusters task

### DIFF
--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -43,6 +43,7 @@ add_root_dictionary(O2QcTPC
                             include/TPC/PadCalibrationCheck2D.h
                             include/TPC/Utility.h
                             include/TPC/RawDigits.h
+                            include/TPC/ClustersData.h
                             include/TPC/CheckOfTrendings.h
                             include/TPC/LaserTracks.h
                             include/TPC/LtrCalibReductor.h

--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -15,7 +15,8 @@ target_sources(O2QcTPC PRIVATE src/PID.cxx
                              src/RawDigits.cxx
                              src/CheckOfTrendings.cxx
                              src/LaserTracks.cxx
-                             src/LtrCalibReductor.cxx)
+                             src/LtrCalibReductor.cxx
+                             src/ClusterVisualizer.cxx)
 
 target_include_directories(
   O2QcTPC
@@ -47,6 +48,7 @@ add_root_dictionary(O2QcTPC
                             include/TPC/CheckOfTrendings.h
                             include/TPC/LaserTracks.h
                             include/TPC/LtrCalibReductor.h
+                            include/TPC/ClusterVisualizer.h
                     LINKDEF include/TPC/LinkDef.h
                     BASENAME O2QcTPC)
 
@@ -109,4 +111,6 @@ install(FILES run/tpcQCPID_sampled.json
               run/tpcQCCheckTrending.json
               run/tpcQCLaserTracks.json
               run/tpcQCTrending_laserCalib.json
+              run/tpcQCClusterVisualizer.json
+              run/tpcQCRawDigitVisualizer.json
         DESTINATION etc)

--- a/Modules/TPC/include/TPC/ClusterVisualizer.h
+++ b/Modules/TPC/include/TPC/ClusterVisualizer.h
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ClusterVisualizer.h
+/// \author Thomas Klemenz
+///
+
+#ifndef QUALITYCONTROL_CLUSTERVISUALIZER_H
+#define QUALITYCONTROL_CLUSTERVISUALIZER_H
+
+//O2 includes
+#include "CCDB/CcdbApi.h"
+
+// QC includes
+#include "QualityControl/PostProcessingInterface.h"
+
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <map>
+
+class TCanvas;
+class TPaveText;
+
+namespace o2::quality_control_modules::tpc
+{
+
+/// \brief Quality Control task for the calibration data of the TPC
+/// \author Thomas Klemenz
+class ClusterVisualizer final : public quality_control::postprocessing::PostProcessingInterface
+{
+ public:
+  /// \brief Constructor
+  ClusterVisualizer() = default;
+  /// \brief Destructor
+  ~ClusterVisualizer() = default;
+
+  /// \brief Configuration of a post-processing task.
+  /// Configuration of a post-processing task. Can be overridden if user wants to retrieve the configuration of the task.
+  /// \param name     Name of the task
+  /// \param config   ConfigurationInterface with prefix set to ""
+  void configure(std::string name, const boost::property_tree::ptree& config) override;
+  /// \brief Initialization of a post-processing task.
+  /// Initialization of a post-processing task. User receives a Trigger which caused the initialization and a service
+  /// registry with singleton interfaces.
+  /// \param trigger  Trigger which caused the initialization, for example Trigger::SOR
+  /// \param services Interface containing optional interfaces, for example DatabaseInterface
+  void initialize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
+  /// \brief Update of a post-processing task.
+  /// Update of a post-processing task. User receives a Trigger which caused the update and a service
+  /// registry with singleton interfaces.
+  /// \param trigger  Trigger which caused the initialization, for example Trigger::Period
+  /// \param services Interface containing optional interfaces, for example DatabaseInterface
+  void update(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
+  /// \brief Finalization of a post-processing task.
+  /// Finalization of a post-processing task. User receives a Trigger which caused the finalization and a service
+  /// registry with singleton interfaces.
+  /// \param trigger  Trigger which caused the initialization, for example Trigger::EOR
+  /// \param services Interface containing optional interfaces, for example DatabaseInterface
+  void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
+
+ private:
+  o2::ccdb::CcdbApi mCdbApi;
+  std::string mHost;
+  std::vector<std::vector<std::unique_ptr<TCanvas>>> mCalDetCanvasVec{}; ///< vector containing a vector of summary canvases for every CalDet object
+  std::vector<long> mTimestamps{};                                       ///< timestamps to look for specific data in the CCDB
+  std::vector<std::map<std::string, std::string>> mLookupMaps{};         ///< meta data to look for data in the CCDB
+  std::vector<std::map<std::string, std::string>> mStoreMaps{};          ///< meta data to be stored with the output in the QCDB
+  std::unordered_map<std::string, std::vector<float>> mRanges;           ///< histogram ranges configurable via config file
+  std::vector<std::string> mObservables{};
+  std::string mPath;
+  bool mIsClusters;
+};
+
+} // namespace o2::quality_control_modules::tpc
+
+#endif //QUALITYCONTROL_CLUSTERVISUALIZER_H

--- a/Modules/TPC/include/TPC/Clusters.h
+++ b/Modules/TPC/include/TPC/Clusters.h
@@ -19,10 +19,10 @@
 #define QC_MODULE_TPC_CLUSTERS_H
 
 // O2 includes
-#include "TPCQC/Clusters.h"
 #include "TPCQC/CalPadWrapper.h"
 
 // QC includes
+#include "TPC/ClustersData.h"
 #include "QualityControl/TaskInterface.h"
 
 class TCanvas;
@@ -54,7 +54,7 @@ class Clusters /*final*/ : public TaskInterface // todo add back the "final" whe
   void reset() override;
 
  private:
-  o2::tpc::qc::Clusters mQCClusters{};                         ///< O2 Cluster task to perform actions on cluster objects
+  ClustersData mQCClusters{};                                  ///< O2 Cluster task to perform actions on cluster objects
   std::vector<o2::tpc::qc::CalPadWrapper> mWrapperVector{};    ///< vector holding CalPad objects wrapped as TObjects; published on QCG; will be non-wrapped CalPad objects in the future
   std::vector<std::unique_ptr<TCanvas>> mNClustersCanvasVec{}; ///< summary canvases of the NClusters object
   std::vector<std::unique_ptr<TCanvas>> mQMaxCanvasVec{};      ///< summary canvases of the QMax object

--- a/Modules/TPC/include/TPC/Clusters.h
+++ b/Modules/TPC/include/TPC/Clusters.h
@@ -22,8 +22,8 @@
 #include "TPCQC/CalPadWrapper.h"
 
 // QC includes
-#include "TPC/ClustersData.h"
 #include "QualityControl/TaskInterface.h"
+#include "TPC/ClustersData.h"
 
 class TCanvas;
 
@@ -54,6 +54,7 @@ class Clusters /*final*/ : public TaskInterface // todo add back the "final" whe
   void reset() override;
 
  private:
+  bool mIsMergeable = true;
   ClustersData mQCClusters{};                                  ///< O2 Cluster task to perform actions on cluster objects
   std::vector<o2::tpc::qc::CalPadWrapper> mWrapperVector{};    ///< vector holding CalPad objects wrapped as TObjects; published on QCG; will be non-wrapped CalPad objects in the future
   std::vector<std::unique_ptr<TCanvas>> mNClustersCanvasVec{}; ///< summary canvases of the NClusters object

--- a/Modules/TPC/include/TPC/ClustersData.h
+++ b/Modules/TPC/include/TPC/ClustersData.h
@@ -35,21 +35,36 @@ namespace o2::quality_control_modules::tpc
 class ClustersData final : public TObject, public MergeInterface
 {
  public:
+  ClustersData()
+    : o2::mergers::MergeInterface(), TObject()
+  {
+  }
+
+  ClustersData(std::string_view nclName)
+    : o2::mergers::MergeInterface(), TObject(), mClusters{ nclName }
+  {
+  }
+
   ~ClustersData() final = default;
 
-  virtual void merge(MergeInterface* const other) final;
+  virtual void merge(MergeInterface* other) final;
 
   Clusters& getClusters() { return mClusters; }
 
+  void setName(std::string_view name) { mName = name.data(); }
+
+  virtual const char* GetName() const override { return mName.data(); }
+
  private:
   Clusters mClusters;
+  std::string mName;
 
   ClassDefOverride(ClustersData, 1);
 };
 
-inline void ClustersData::merge(MergeInterface* const other)
+inline void ClustersData::merge(MergeInterface* other)
 {
-  auto otherCl = dynamic_cast<const ClustersData* const>(other);
+  auto otherCl = dynamic_cast<ClustersData* const>(other);
   if (otherCl) {
     mClusters.merge(otherCl->mClusters);
   }

--- a/Modules/TPC/include/TPC/ClustersData.h
+++ b/Modules/TPC/include/TPC/ClustersData.h
@@ -1,0 +1,60 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Clusters.h
+/// \author Jens Wiechula
+/// \author Thomas Klemenz
+///
+
+#ifndef QC_MODULE_TPC_CLUSTERSDATA_H
+#define QC_MODULE_TPC_CLUSTERSDATA_H
+
+// ROOT includes
+#include "TObject.h"
+
+// O2 includes
+#include <Mergers/MergeInterface.h>
+#include <Rtypes.h>
+#include "TPCQC/Clusters.h"
+
+using o2::mergers::MergeInterface;
+using o2::tpc::qc::Clusters;
+
+namespace o2::quality_control_modules::tpc
+{
+
+class ClustersData final : public TObject, public MergeInterface
+{
+ public:
+  ~ClustersData() final = default;
+
+  virtual void merge(MergeInterface* const other) final;
+
+  Clusters& getClusters() { return mClusters; }
+
+ private:
+  Clusters mClusters;
+
+  ClassDefOverride(ClustersData, 1);
+};
+
+inline void ClustersData::merge(MergeInterface* const other)
+{
+  auto otherCl = dynamic_cast<const ClustersData* const>(other);
+  if (otherCl) {
+    mClusters.merge(otherCl->mClusters);
+  }
+}
+
+} // namespace o2::quality_control_modules::tpc
+
+#endif

--- a/Modules/TPC/include/TPC/LinkDef.h
+++ b/Modules/TPC/include/TPC/LinkDef.h
@@ -17,6 +17,7 @@
 #pragma link C++ class o2::quality_control_modules::tpc::LaserTracks+;
 #pragma link C++ class o2::quality_control_modules::tpc::LtrCalibReductor+;
 #pragma link C++ class o2::quality_control_modules::tpc::ClustersData+;
+#pragma link C++ class o2::quality_control_modules::tpc::ClusterVisualizer+;
 
 #pragma link C++ function o2::quality_control_modules::tpc::addAndPublish + ;
 #pragma link C++ function o2::quality_control_modules::tpc::toVector + ;

--- a/Modules/TPC/include/TPC/LinkDef.h
+++ b/Modules/TPC/include/TPC/LinkDef.h
@@ -16,6 +16,7 @@
 #pragma link C++ class o2::quality_control_modules::tpc::PadCalibrationCheck2D+;
 #pragma link C++ class o2::quality_control_modules::tpc::LaserTracks+;
 #pragma link C++ class o2::quality_control_modules::tpc::LtrCalibReductor+;
+#pragma link C++ class o2::quality_control_modules::tpc::ClustersData+;
 
 #pragma link C++ function o2::quality_control_modules::tpc::addAndPublish + ;
 #pragma link C++ function o2::quality_control_modules::tpc::toVector + ;

--- a/Modules/TPC/include/TPC/RawDigits.h
+++ b/Modules/TPC/include/TPC/RawDigits.h
@@ -19,13 +19,13 @@
 #define QC_MODULE_TPC_RAWDIGITS_H
 
 // O2 includes
-#include "TPCQC/Clusters.h"
 #include "TPCQC/CalPadWrapper.h"
 #include "TPCReconstruction/RawReaderCRU.h"
 #include "TPCWorkflow/CalibProcessingHelper.h"
 
 // QC includes
 #include "QualityControl/TaskInterface.h"
+#include "TPC/ClustersData.h"
 
 class TCanvas;
 
@@ -56,7 +56,8 @@ class RawDigits /*final*/ : public TaskInterface // todo add back the "final" wh
   void reset() override;
 
  private:
-  o2::tpc::qc::Clusters mRawDigitQC;                            ///< O2 Cluster task to perform actions on cluster objects
+  bool mIsMergeable = true;
+  ClustersData mRawDigitQC{ "N_RawDigits" };                    ///< O2 Cluster task to perform actions on cluster objects
   std::vector<o2::tpc::qc::CalPadWrapper> mWrapperVector{};     ///< vector holding CalPad objects wrapped as TObjects; published on QCG; will be non-wrapped CalPad objects in the future
   std::vector<std::unique_ptr<TCanvas>> mNRawDigitsCanvasVec{}; ///< summary canvases of the NRawDigits object
   std::vector<std::unique_ptr<TCanvas>> mQMaxCanvasVec{};       ///< summary canvases of the QMax object

--- a/Modules/TPC/run/tpcQCClusterVisualizer.json
+++ b/Modules/TPC/run/tpcQCClusterVisualizer.json
@@ -1,0 +1,83 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "postprocessing": {
+      "Clusters": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::ClusterVisualizer",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "timestamps_comment": [ "Put the timestamp of the corresponding file you want to look for in the timestamps array.",
+                                "You can either put a timestamp for every object or leave the array empty to take the latest file from the CCDB.",
+                                "An empty array to get the the latest version will be the main use case.",
+                                "The array is mapped to the output objects sequentially",
+                                "If you want to pick the latest file in the CCDB manually, you can use -1."
+        ],
+        "timestamps": [
+        ],
+        "lookupMetaData_comment": [ "With this array you can filter your search via meta data.",
+                                    "The array is mapped sequentially to the output objects.",
+                                    "If you leave only one entry in the array this is used for all objects in outputCalPadMaps and outputCalPads.",
+                                    "If you want no meta data simply remove 'keys' and 'values' completely and leave only {}",
+                                    "Every entry above (outputCalPads.size() + outputCalPadMaps.size()) is ignored.",
+                                    "The keys and values that are set by default are only there to serve as an example."
+        ],
+        "lookupMetaData": [
+          {
+          }
+        ],
+        "storeMetaData_comment": "For how-to, see 'lookupMetaData_comment'.",
+        "storeMetaData": [
+          {
+          }
+        ],
+        "histogramRanges_comment" : [ "nBins", "min", "max" ],
+        "histogramRanges": [
+          { "N_Clusters" : [ "100",  "0", "100"    ] },
+          { "Q_Max" :      [ "200",  "0", "200"    ] },
+          { "Q_Tot" :      [ "600",  "0", "600"    ] },
+          { "Sigma_Time" : [ "200",  "0", "2"      ] },
+          { "Sigma_Pad" :  [ "200",  "0", "2"      ] },
+          { "Time_Bin" :   [ "1000", "0", "100000" ] }
+        ],
+        "path_comment": "This is the path of the ClustersData object that shall be visualized.",
+        "path": "qc/TPC/MO/Clusters/ClusterData",
+        "dataType_comment": "This is the switch for 'RawDigits' or 'Clusters' task. Choose 'raw' or 'clusters'.",
+        "dataType": "clusters",
+        "initTrigger": [
+          "once"
+        ],
+        "updateTrigger_comment": "To trigger on a specific file being updated, use e.g. 'newobject:ccdb:TPC/Calib/Noise'",
+        "updateTrigger": [
+          "newobject:ccdb:qc/TPC/MO/Clusters/ClusterData"
+        ],
+        "stopTrigger_comment": [ "To keep the task running until it is stopped manually set the trigger on the update of a non-existing object, e.g. 'newobject:ccdb:TPC/ThisDoesNotExist'",
+                                 "There will be a end of run trigger implemented so the above workaround can be abandoned later." ],
+        "stopTrigger": [
+          "newobject:ccdb:TPC/ThisDoesNotExist"
+        ]
+      }
+    }
+  }
+}

--- a/Modules/TPC/run/tpcQCClusters_direct.json
+++ b/Modules/TPC/run/tpcQCClusters_direct.json
@@ -36,6 +36,7 @@
           "query" : "input:TPC/CLUSTERNATIVE"
         },
         "taskParameters": {
+          "mergeableOutput": "true",
           "NClustersNBins": "100",  "NClustersXMin": "0", "NClustersXMax": "100",
           "QmaxNBins":      "200",  "QmaxXMin":      "0", "QmaxXMax":      "200",
           "QtotNBins":      "600",  "QtotXMin":      "0", "QtotXMax":      "600",
@@ -43,7 +44,13 @@
           "SigmaTimeNBins": "200",  "SigmaTimeXMin": "0", "SigmaTimeXMax": "2",
           "TimeBinNBins":   "1000", "TimeBinXMin":   "0", "TimeBinXMax":   "100000"
         },
-        "location": "remote"
+        "location": "local",
+        "localMachines": [
+          "localhost"
+        ],
+        "remoteMachine": "localhost",
+        "remotePort": "32626",
+        "mergingMode": "delta"
       }
     }
   },

--- a/Modules/TPC/run/tpcQCRawDigitVisualizer.json
+++ b/Modules/TPC/run/tpcQCRawDigitVisualizer.json
@@ -1,0 +1,81 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "postprocessing": {
+      "RawDigits": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::ClusterVisualizer",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "timestamps_comment": [ "Put the timestamp of the corresponding file you want to look for in the timestamps array.",
+                                "You can either put a timestamp for every object or leave the array empty to take the latest file from the CCDB.",
+                                "An empty array to get the the latest version will be the main use case.",
+                                "The array is mapped to the output objects sequentially",
+                                "If you want to pick the latest file in the CCDB manually, you can use -1."
+        ],
+        "timestamps": [
+        ],
+        "lookupMetaData_comment": [ "With this array you can filter your search via meta data.",
+                                    "The array is mapped sequentially to the output objects.",
+                                    "If you leave only one entry in the array this is used for all objects in outputCalPadMaps and outputCalPads.",
+                                    "If you want no meta data simply remove 'keys' and 'values' completely and leave only {}",
+                                    "Every entry above (outputCalPads.size() + outputCalPadMaps.size()) is ignored.",
+                                    "The keys and values that are set by default are only there to serve as an example."
+        ],
+        "lookupMetaData": [
+          {
+          }
+        ],
+        "storeMetaData_comment": "For how-to, see 'lookupMetaData_comment'.",
+        "storeMetaData": [
+          {
+          }
+        ],
+        "histogramRanges_comment" : [ "nBins", "min", "max" ],
+        "histogramRanges": [
+          { "N_Clusters" :  [ "100",  "0", "100"    ] },
+          { "N_RawDigits" : [ "100",  "0", "100"    ] },
+          { "Q_Max" :       [ "200",  "0", "200"    ] },
+          { "Time_Bin" :    [ "1000", "0", "100000" ] }
+        ],
+        "path_comment": "This is the path of the RawDigitData object that shall be visualized.",
+        "path": "qc/TPC/MO/RawDigits/RawDigitData",
+        "dataType_comment": "This is the switch for 'RawDigits' or 'Clusters' task. Choose 'raw' or 'clusters'.",
+        "dataType": "raw",
+        "initTrigger": [
+          "once"
+        ],
+        "updateTrigger_comment": "To trigger on a specific file being updated, use e.g. 'newobject:ccdb:TPC/Calib/Noise'",
+        "updateTrigger": [
+          "newobject:ccdb:qc/TPC/MO/RawDigits/RawDigitData"
+        ],
+        "stopTrigger_comment": [ "To keep the task running until it is stopped manually set the trigger on the update of a non-existing object, e.g. 'newobject:ccdb:TPC/ThisDoesNotExist'",
+                                 "There will be a end of run trigger implemented so the above workaround can be abandoned later." ],
+        "stopTrigger": [
+          "newobject:ccdb:TPC/ThisDoesNotExist"
+        ]
+      }
+    }
+  }
+}

--- a/Modules/TPC/run/tpcQCRawDigits_direct.json
+++ b/Modules/TPC/run/tpcQCRawDigits_direct.json
@@ -28,18 +28,26 @@
         "className": "o2::quality_control_modules::tpc::RawDigits",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
-        "cycleDurationSeconds": "60",
+        "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
+        "resetAfterCycles": "5",
         "dataSource": {
           "type": "direct",
           "query" : "input:TPC/RAWDATA"
         },
         "taskParameters": {
+          "mergeableOutput": "true",
           "NRawDigitsNBins": "100",  "NRawDigitsXMin": "0", "NRawDigitsXMax": "100",
           "QmaxNBins":       "200",  "QmaxXMin":       "0", "QmaxXMax":       "200",
           "TimeBinNBins":    "1000", "TimeBinXMin":    "0", "TimeBinXMax":    "100000"
         },
-        "location": "remote"
+        "location": "local",
+        "localMachines": [
+          "localhost"
+        ],
+        "remoteMachine": "localhost",
+        "remotePort": "32627",
+        "mergingMode": "delta"
       }
     }
   },

--- a/Modules/TPC/src/ClusterVisualizer.cxx
+++ b/Modules/TPC/src/ClusterVisualizer.cxx
@@ -1,0 +1,206 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ClusterVisualizer.cxx
+/// \author Thomas Klemenz
+///
+
+// O2 includes
+#include "TPCBase/Painter.h"
+#include "TPCBase/CDBInterface.h"
+#include "TPCQC/Helpers.h"
+
+// QC includes
+#include "QualityControl/QcInfoLogger.h"
+#include "TPC/ClusterVisualizer.h"
+#include "TPC/Utility.h"
+#include "TPC/ClustersData.h"
+
+//root includes
+#include "TCanvas.h"
+#include "TPaveText.h"
+
+#include <fmt/format.h>
+#include <algorithm>
+
+using namespace o2::quality_control::postprocessing;
+
+namespace o2::quality_control_modules::tpc
+{
+
+void ClusterVisualizer::configure(std::string name, const boost::property_tree::ptree& config)
+{
+
+  for (const auto& timestamp : config.get_child("qc.postprocessing." + name + ".timestamps")) {
+    mTimestamps.emplace_back(std::stol(timestamp.second.data()));
+  }
+
+  std::vector<std::string> keyVec{};
+  std::vector<std::string> valueVec{};
+  for (const auto& data : config.get_child("qc.postprocessing." + name + ".lookupMetaData")) {
+    mLookupMaps.emplace_back(std::map<std::string, std::string>());
+    if (const auto& keys = data.second.get_child_optional("keys"); keys.has_value()) {
+      for (const auto& key : keys.value()) {
+        keyVec.emplace_back(key.second.data());
+      }
+    }
+    if (const auto& values = data.second.get_child_optional("values"); values.has_value()) {
+      for (const auto& value : values.value()) {
+        valueVec.emplace_back(value.second.data());
+      }
+    }
+    auto vecIter = 0;
+    if ((keyVec.size() > 0) && (keyVec.size() == valueVec.size())) {
+      for (const auto& key : keyVec) {
+        mLookupMaps.back().insert(std::pair<std::string, std::string>(key, valueVec.at(vecIter)));
+        vecIter++;
+      }
+    }
+    if (keyVec.size() != valueVec.size()) {
+      throw std::runtime_error("Number of keys and values for lookupMetaData are not matching");
+    }
+    keyVec.clear();
+    valueVec.clear();
+  }
+
+  for (const auto& data : config.get_child("qc.postprocessing." + name + ".storeMetaData")) {
+    mStoreMaps.emplace_back(std::map<std::string, std::string>());
+    if (const auto& keys = data.second.get_child_optional("keys"); keys.has_value()) {
+      for (const auto& key : keys.value()) {
+        keyVec.emplace_back(key.second.data());
+      }
+    }
+    if (const auto& values = data.second.get_child_optional("values"); values.has_value()) {
+      for (const auto& value : values.value()) {
+        valueVec.emplace_back(value.second.data());
+      }
+    }
+    auto vecIter = 0;
+    if ((keyVec.size() > 0) && (keyVec.size() == valueVec.size())) {
+      for (const auto& key : keyVec) {
+        mStoreMaps.back().insert(std::pair<std::string, std::string>(key, valueVec.at(vecIter)));
+        vecIter++;
+      }
+    }
+    if (keyVec.size() != valueVec.size()) {
+      throw std::runtime_error("Number of keys and values for storeMetaData are not matching");
+    }
+    keyVec.clear();
+    valueVec.clear();
+  }
+
+  for (const auto& entry : config.get_child("qc.postprocessing." + name + ".histogramRanges")) {
+    for (const auto& type : entry.second) {
+      for (const auto& value : type.second) {
+        mRanges[type.first].emplace_back(std::stof(value.second.data()));
+      }
+    }
+  }
+
+  mPath = config.get<std::string>("qc.postprocessing." + name + ".path");
+  mHost = config.get<std::string>("qc.config.conditionDB.url");
+
+  const auto type = config.get<std::string>("qc.postprocessing." + name + ".dataType");
+  if (type == "clusters") {
+    mIsClusters = true;
+    mObservables = {
+      "N_Clusters",
+      "Q_Max",
+      "Q_Tot",
+      "Sigma_Pad",
+      "Sigma_Time",
+      "Time_Bin"
+    };
+  } else if (type == "raw") {
+    mIsClusters = false;
+    mObservables = {
+      "N_RawDigits",
+      "Q_Max",
+      "Time_Bin"
+    };
+  } else {
+    throw std::runtime_error("No valid data type given. 'dataType' has to be either 'clusters' or 'raw'.");
+  }
+}
+
+void ClusterVisualizer::initialize(Trigger, framework::ServiceRegistry&)
+{
+  mCdbApi.init(mHost);
+
+  auto calDetIter = 0;
+  for (const auto& type : mObservables) {
+    mCalDetCanvasVec.emplace_back(std::vector<std::unique_ptr<TCanvas>>());
+    addAndPublish(getObjectsManager(),
+                  mCalDetCanvasVec.back(),
+                  { fmt::format("c_Sides_{}", type).data(),
+                    fmt::format("c_ROCs_{}_1D", type).data(),
+                    fmt::format("c_ROCs_{}_2D", type).data() },
+                  mStoreMaps.size() > 1 ? mStoreMaps.at(calDetIter) : mStoreMaps.at(0));
+    calDetIter++;
+  }
+}
+
+void ClusterVisualizer::update(Trigger t, framework::ServiceRegistry&)
+{
+  ILOG(Info, Support) << "Trigger type is: " << t.triggerType << ", the timestamp is " << t.timestamp << ENDM;
+
+  auto calDetIter = 0;
+
+  auto clusterData = mCdbApi.retrieveFromTFileAny<ClustersData>(mPath,
+                                                                mLookupMaps.size() > 1 ? mLookupMaps.at(calDetIter) : mLookupMaps.at(0),
+                                                                mTimestamps.size() > 0 ? mTimestamps.at(calDetIter) : -1);
+
+  auto& clusters = clusterData->getClusters();
+
+  auto& calDet = clusters.getNClusters();
+  auto vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
+  o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
+  calDetIter++;
+
+  calDet = clusters.getQMax();
+  vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
+  o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
+  calDetIter++;
+
+  calDet = clusters.getTimeBin();
+  vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
+  o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
+  calDetIter++;
+
+  if (mIsClusters) {
+    calDet = clusters.getQTot();
+    vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
+    o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
+    calDetIter++;
+
+    calDet = clusters.getSigmaPad();
+    vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
+    o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
+    calDetIter++;
+
+    calDet = clusters.getSigmaTime();
+    vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
+    o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
+    calDetIter++;
+  }
+}
+
+void ClusterVisualizer::finalize(Trigger, framework::ServiceRegistry&)
+{
+  for (const auto& calDetCanvasVec : mCalDetCanvasVec) {
+    for (const auto& canvas : calDetCanvasVec) {
+      getObjectsManager()->stopPublishing(canvas.get());
+    }
+  }
+}
+
+} // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/src/Clusters.cxx
+++ b/Modules/TPC/src/Clusters.cxx
@@ -34,28 +34,31 @@ namespace o2::quality_control_modules::tpc
 
 Clusters::Clusters() : TaskInterface()
 {
-  mWrapperVector.emplace_back(&mQCClusters.getNClusters());
-  mWrapperVector.emplace_back(&mQCClusters.getQMax());
-  mWrapperVector.emplace_back(&mQCClusters.getQTot());
-  mWrapperVector.emplace_back(&mQCClusters.getSigmaTime());
-  mWrapperVector.emplace_back(&mQCClusters.getSigmaPad());
-  mWrapperVector.emplace_back(&mQCClusters.getTimeBin());
+  auto& qcClusters = mQCClusters.getClusters();
+  mWrapperVector.emplace_back(&qcClusters.getNClusters());
+  mWrapperVector.emplace_back(&qcClusters.getQMax());
+  mWrapperVector.emplace_back(&qcClusters.getQTot());
+  mWrapperVector.emplace_back(&qcClusters.getSigmaTime());
+  mWrapperVector.emplace_back(&qcClusters.getSigmaPad());
+  mWrapperVector.emplace_back(&qcClusters.getTimeBin());
 }
 
 void Clusters::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Info, Support) << "initialize TPC Clusters QC task" << ENDM;
 
-  addAndPublish(getObjectsManager(), mNClustersCanvasVec, { "c_Sides_N_Clusters", "c_ROCs_N_Clusters_1D", "c_ROCs_N_Clusters_2D" });
-  addAndPublish(getObjectsManager(), mQMaxCanvasVec, { "c_Sides_Q_Max", "c_ROCs_Q_Max_1D", "c_ROCs_Q_Max_2D" });
-  addAndPublish(getObjectsManager(), mQTotCanvasVec, { "c_Sides_Q_Tot", "c_ROCs_Q_Tot_1D", "c_ROCs_Q_Tot_2D" });
-  addAndPublish(getObjectsManager(), mSigmaTimeCanvasVec, { "c_Sides_Sigma_Time", "c_ROCs_Sigma_Time_1D", "c_ROCs_Sigma_Time_2D" });
-  addAndPublish(getObjectsManager(), mSigmaPadCanvasVec, { "c_Sides_Sigma_Pad", "c_ROCs_Sigma_Pad_1D", "c_ROCs_Sigma_Pad_2D" });
-  addAndPublish(getObjectsManager(), mTimeBinCanvasVec, { "c_Sides_Time_Bin", "c_ROCs_Time_Bin_1D", "c_ROCs_Time_Bin_2D" });
+  //addAndPublish(getObjectsManager(), mNClustersCanvasVec, { "c_Sides_N_Clusters", "c_ROCs_N_Clusters_1D", "c_ROCs_N_Clusters_2D" });
+  //addAndPublish(getObjectsManager(), mQMaxCanvasVec, { "c_Sides_Q_Max", "c_ROCs_Q_Max_1D", "c_ROCs_Q_Max_2D" });
+  //addAndPublish(getObjectsManager(), mQTotCanvasVec, { "c_Sides_Q_Tot", "c_ROCs_Q_Tot_1D", "c_ROCs_Q_Tot_2D" });
+  //addAndPublish(getObjectsManager(), mSigmaTimeCanvasVec, { "c_Sides_Sigma_Time", "c_ROCs_Sigma_Time_1D", "c_ROCs_Sigma_Time_2D" });
+  //addAndPublish(getObjectsManager(), mSigmaPadCanvasVec, { "c_Sides_Sigma_Pad", "c_ROCs_Sigma_Pad_1D", "c_ROCs_Sigma_Pad_2D" });
+  //addAndPublish(getObjectsManager(), mTimeBinCanvasVec, { "c_Sides_Time_Bin", "c_ROCs_Time_Bin_1D", "c_ROCs_Time_Bin_2D" });
 
   for (auto& wrapper : mWrapperVector) {
     getObjectsManager()->startPublishing(&wrapper);
   }
+
+  getObjectsManager()->startPublishing(&mQCClusters);
 }
 
 void Clusters::startOfActivity(Activity& /*activity*/)
@@ -80,7 +83,7 @@ void Clusters::processClusterNative(o2::framework::InputRecord& inputs)
       const int nClusters = clusterIndex.nClusters[isector][irow];
       for (int icl = 0; icl < nClusters; ++icl) {
         const auto& cl = *(clusterIndex.clusters[isector][irow] + icl);
-        mQCClusters.processCluster(cl, o2::tpc::Sector(isector), irow);
+        mQCClusters.getClusters().processCluster(cl, o2::tpc::Sector(isector), irow);
       }
     }
   }
@@ -96,26 +99,26 @@ void Clusters::processKrClusters(o2::framework::InputRecord& inputs)
   for (auto const& inputRef : InputRecordWalker(inputs, filterKr)) {
     auto krClusters = inputs.get<gsl::span<o2::tpc::KrCluster>>(inputRef);
     for (const auto& cl : krClusters) {
-      mQCClusters.processCluster(cl, o2::tpc::Sector(cl.sector), int(cl.meanRow));
+      mQCClusters.getClusters().processCluster(cl, o2::tpc::Sector(cl.sector), int(cl.meanRow));
     }
   }
 }
 
 void Clusters::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  mQCClusters.denormalize();
+  mQCClusters.getClusters().denormalize();
 
   processClusterNative(ctx.inputs());
   processKrClusters(ctx.inputs());
 
   mQCClusters.normalize();
 
-  fillCanvases(mQCClusters.getNClusters(), mNClustersCanvasVec, mCustomParameters, "NClusters");
-  fillCanvases(mQCClusters.getQMax(), mQMaxCanvasVec, mCustomParameters, "Qmax");
-  fillCanvases(mQCClusters.getQTot(), mQTotCanvasVec, mCustomParameters, "Qtot");
-  fillCanvases(mQCClusters.getSigmaTime(), mSigmaTimeCanvasVec, mCustomParameters, "SigmaPad");
-  fillCanvases(mQCClusters.getSigmaPad(), mSigmaPadCanvasVec, mCustomParameters, "SigmaTime");
-  fillCanvases(mQCClusters.getTimeBin(), mTimeBinCanvasVec, mCustomParameters, "TimeBin");
+  //fillCanvases(mQCClusters.getNClusters(), mNClustersCanvasVec, mCustomParameters, "NClusters");
+  //fillCanvases(mQCClusters.getQMax(), mQMaxCanvasVec, mCustomParameters, "Qmax");
+  //fillCanvases(mQCClusters.getQTot(), mQTotCanvasVec, mCustomParameters, "Qtot");
+  //fillCanvases(mQCClusters.getSigmaTime(), mSigmaTimeCanvasVec, mCustomParameters, "SigmaPad");
+  //fillCanvases(mQCClusters.getSigmaPad(), mSigmaPadCanvasVec, mCustomParameters, "SigmaTime");
+  //fillCanvases(mQCClusters.getTimeBin(), mTimeBinCanvasVec, mCustomParameters, "TimeBin");
 }
 
 void Clusters::endOfCycle()
@@ -134,14 +137,14 @@ void Clusters::reset()
 
   ILOG(Info, Support) << "Resetting the canvases" << ENDM;
 
-  mQCClusters.reset();
+  mQCClusters.getClusters().reset();
 
-  clearCanvases(mNClustersCanvasVec);
-  clearCanvases(mQMaxCanvasVec);
-  clearCanvases(mQTotCanvasVec);
-  clearCanvases(mSigmaTimeCanvasVec);
-  clearCanvases(mSigmaPadCanvasVec);
-  clearCanvases(mTimeBinCanvasVec);
+  //clearCanvases(mNClustersCanvasVec);
+  //clearCanvases(mQMaxCanvasVec);
+  //clearCanvases(mQTotCanvasVec);
+  //clearCanvases(mSigmaTimeCanvasVec);
+  //clearCanvases(mSigmaPadCanvasVec);
+  //clearCanvases(mTimeBinCanvasVec);
 }
 
 } // namespace o2::quality_control_modules::tpc


### PR DESCRIPTION
The Clusters task now has the option to use mergeable output to be able to run the task locally and do only the merging on the remote node. For the visualization of the merged output the post-processing task `ClusterVisualizer` is needed.

The Clusters task can still be run in the exact same way before if needed.

An exemplary json file for mergeable output in a local Clusters task is `Modules/TPC/run/tpcQCClusters_direct.json`. The `taskParameter` `mergeableOutput` has to be set to true (false is default even if the option is completely omitted). 