### PR TITLE
Use merge base of PR HEAD and current master for formatting

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # To get the merge base, we need the full history.
+          fetch-depth: 0
       - name: Install prerequisites
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -18,13 +20,13 @@ jobs:
           sudo apt install -y clang-format-11
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
           sudo update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-11 100
-      - name: Run clang-foramt on changed files
+      - name: Run clang-format on changed files
         run: |
           set -x
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git fetch origin pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}
-          BASE_COMMIT=$(git rev-parse ${{ github.event.pull_request.base.sha }})
-          COMMIT_FILES=$(git diff --diff-filter=d --name-only ${BASE_COMMIT} | grep -E -- '\.cxx|\.h' | grep -i -v LinkDef) || true ;# avoid failures if nothing is greped
+          BASE_COMMIT=$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})
+          COMMIT_FILES=$(git diff --diff-filter=d --name-only "$BASE_COMMIT" -- '*.cxx' '*.h' ':!*LinkDef*')
           if [ "$COMMIT_FILES" == "" ]; then
             exit 0 ;# nothing to check
           fi


### PR DESCRIPTION
This avoids clang-format complaining about files that were changed on master between where the PR branches off and now.