### PR TITLE
restore decoding error histo if requested (default=no)

### DIFF
--- a/Modules/TOF/include/TOF/TaskDigits.h
+++ b/Modules/TOF/include/TOF/TaskDigits.h
@@ -63,6 +63,7 @@ class TaskDigits final : public TaskInterface
   int fgNbinsToT = 100;                                  /// Number of bins in ToT plot
   float fgRangeMinToT = 0;                               /// Range min in ToT plot
   float fgRangeMaxToT = 48.8;                            /// Range max in ToT plot
+  bool fgDiagnostic = false;                             /// enable diagnostic plots
 
  private:
   // Event info
@@ -97,7 +98,7 @@ class TaskDigits final : public TaskInterface
 
   // std::shared_ptr<TH1F> mTOFRawsLTMHits = nullptr;          /// LTMs OR signals
   // std::shared_ptr<TH2F> mTOFrefMap = nullptr;               /// TOF enabled channel reference map
-  // std::shared_ptr<TH2I> mTOFDecodingErrors = nullptr;       /// Decoding error monitoring
+  std::shared_ptr<TH2I> mTOFDecodingErrors = nullptr; /// Decoding error monitoring
   // std::shared_ptr<TH1F> mTOFOrphansTime = nullptr;          /// TOF Raws - Orphans time (ns)
   // std::shared_ptr<TH2F> mTOFRawTimeVsTRM035 = nullptr;      /// TOF raws - Hit time vs TRM - crates 0 to 35
   // std::shared_ptr<TH2F> mTOFRawTimeVsTRM3671 = nullptr;     /// TOF raws - Hit time vs TRM - crates 36 to 72

--- a/Modules/TOF/tofdigits.json
+++ b/Modules/TOF/tofdigits.json
@@ -1,111 +1,119 @@
 {
-  "qc": {
-    "config": {
-      "database": {
-        "implementation": "CCDB",
-        "host": "ccdb-test.cern.ch:8080",
-        "username": "not_applicable",
-        "password": "not_applicable",
-        "name": "not_applicable"
+  "qc" : {
+    "config" : {
+      "database" : {
+        "implementation" : "CCDB",
+        "host" : "ccdb-test.cern.ch:8080",
+        "username" : "not_applicable",
+        "password" : "not_applicable",
+        "name" : "not_applicable"
       },
-      "Activity": {
-        "number": "42",
-        "type": "2"
+      "Activity" : {
+        "number" : "42",
+        "type" : "2"
       },
-      "monitoring": {
-        "url": "infologger:///debug?qc"
+      "monitoring" : {
+        "url" : "infologger:///debug?qc"
       },
-      "consul": {
-        "url": ""
+      "consul" : {
+        "url" : ""
       },
-      "conditionDB": {
-        "url": "ccdb-test.cern.ch:8080"
+      "conditionDB" : {
+        "url" : "ccdb-test.cern.ch:8080"
       }
     },
-    "tasks": {
-      "TaskDigits": {
-        "active": "true",
-        "className": "o2::quality_control_modules::tof::TaskDigits",
-        "moduleName": "QcTOF",
-        "detectorName": "TOF",
-        "cycleDurationSeconds": "10",
-        "maxNumberCycles": "-1",
-        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
-        "dataSource": {
-          "type": "dataSamplingPolicy",
-          "name": "tof-digits"
+    "tasks" : {
+      "TaskDigits" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::tof::TaskDigits",
+        "moduleName" : "QcTOF",
+        "detectorName" : "TOF",
+        "cycleDurationSeconds" : "10",
+        "maxNumberCycles" : "-1",
+        "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource" : {
+          "type" : "dataSamplingPolicy",
+          "name" : "tof-digits"
         },
-        "taskParameters": {
-          "nothing": "rien"
+        "taskParameters" : {
+          "Diagnostic" : "false"
         },
-        "location": "remote"
+        "location" : "remote"
       }
     },
-    "checks": {
-      "TOFRawsMulti": {
-        "active": "true",
-        "className": "o2::quality_control_modules::tof::CheckRawMultiplicity",
-        "moduleName": "QcTOF",
-        "policy": "OnAny",
-        "detectorName": "TOF",
-        "dataSource": [
+    "checks" : {
+      "TOFRawsMulti" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::tof::CheckRawMultiplicity",
+        "moduleName" : "QcTOF",
+        "policy" : "OnAny",
+        "detectorName" : "TOF",
+        "dataSource" : [
           {
-            "type": "Task",
-            "name": "TaskDigits",
-            "MOs": [
-              "TOFRawsMulti"
-            ]
+            "type" : "Task",
+            "name" : "TaskDigits",
+            "MOs" : ["TOFRawsMulti"]
           }
         ]
       },
-      "TOFRawsTime": {
-        "active": "true",
-        "className": "o2::quality_control_modules::tof::CheckRawTime",
-        "moduleName": "QcTOF",
-        "policy": "OnAny",
-        "detectorName": "TOF",
-        "dataSource": [
+      "TOFRawsTime" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::tof::CheckRawTime",
+        "moduleName" : "QcTOF",
+        "policy" : "OnAny",
+        "detectorName" : "TOF",
+        "dataSource" : [
           {
-            "type": "Task",
-            "name": "TaskDigits",
-            "MOs": [
-              "TOFRawsTime"
-            ]
+            "type" : "Task",
+            "name" : "TaskDigits",
+            "MOs" : ["TOFRawsTime"]
           }
         ]
       },
-      "TOFRawsToT": {
-        "active": "true",
-        "className": "o2::quality_control_modules::tof::CheckRawToT",
-        "moduleName": "QcTOF",
-        "policy": "OnAny",
-        "detectorName": "TOF",
-        "dataSource": [
+      "TOFRawsToT" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::tof::CheckRawToT",
+        "moduleName" : "QcTOF",
+        "policy" : "OnAny",
+        "detectorName" : "TOF",
+        "dataSource" : [
           {
-            "type": "Task",
-            "name": "TaskDigits",
-            "MOs": [
-              "TOFRawsToT"
-            ]
+            "type" : "Task",
+            "name" : "TaskDigits",
+            "MOs" : ["TOFRawsToT"]
           }
         ]
       }
     }
   },
-  "dataSamplingPolicies": [
-    {
-      "id": "tof-digits",
-      "active": "true",
-      "machines": [],
-      "query": "tofdigits:TOF/DIGITS/0;readoutwin:TOF/READOUTWINDOW/0",
-      "samplingConditions": [
-        {
-          "condition": "random",
-          "fraction": "0.1",
-          "seed": "1234"
-        }
-      ],
-      "blocking": "false"
-    }
-  ]
+         "dataSamplingPolicies" : [
+           {
+             "id" : "tof-digits",
+             "active" : "true",
+             "machines" : [],
+             "query" : "tofdigits:TOF/DIGITS/0;readoutwin:TOF/READOUTWINDOW/0",
+             "samplingConditions" : [
+               {
+                 "condition" : "random",
+                 "fraction" : "0.1",
+                 "seed" : "1234"
+               }
+             ],
+             "blocking" : "false"
+           },
+           {
+             "id" : "tof-digits-dia",
+             "active" : "true",
+             "machines" : [],
+             "query" : "tofdigits:TOF/DIGITS/0;readoutwin:TOF/READOUTWINDOW/0;patterns:TOF/PATTERNS",
+             "samplingConditions" : [
+               {
+                 "condition" : "random",
+                 "fraction" : "0.1",
+                 "seed" : "1234"
+               }
+             ],
+             "blocking" : "false"
+           }
+         ]
 }


### PR DESCRIPTION
@ercolessi @njacazio 
Add the possibility to require one additional histo (TRM errors) in TOF digit QC.
        "taskParameters": {
          "Diagnostic" : "false"
        },

if enabled it requires also this input to be added
patterns:TOF/PATTERNS

This is needed to check MC anchored to DATA (since we don't have this info from Raw QC there)