### PR TITLE
[EMCAL-507] Remove custom end-of-payload check via EMCALBlockHeader

### DIFF
--- a/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
+++ b/Modules/EMCAL/include/EMCAL/DigitsQcTask.h
@@ -119,8 +119,6 @@ class DigitsQcTask final : public TaskInterface
   void endOfActivity(Activity& activity) override;
   void reset() override;
 
-  void setEndOfPayloadCheck(Bool_t doCheck) { mDoEndOfPayloadCheck = doCheck; }
-
   bool hasConfigValue(const std::string_view key);
   std::string getConfigValue(const std::string_view key);
   std::string getConfigValueLower(const std::string_view key);
@@ -151,7 +149,6 @@ class DigitsQcTask final : public TaskInterface
     };
   };
   std::vector<CombinedEvent> buildCombinedEvents(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const;
-  Bool_t mDoEndOfPayloadCheck = false;                         ///< Do old style end-of-payload check
   Bool_t mIgnoreTriggerTypes = false;                          ///< Do not differenciate between trigger types, treat all triggers as phys. triggers
   std::map<std::string, DigitsHistograms> mHistogramContainer; ///< Container with histograms per trigger class
   o2::emcal::Geometry* mGeometry = nullptr;                    ///< EMCAL geometry

--- a/Modules/EMCAL/src/DigitsQcTask.cxx
+++ b/Modules/EMCAL/src/DigitsQcTask.cxx
@@ -22,7 +22,6 @@
 #include <TH2.h>
 #include <TProfile2D.h>
 
-#include <DataFormatsEMCAL/EMCALBlockHeader.h>
 #include <DataFormatsEMCAL/TriggerRecord.h>
 #include <DataFormatsEMCAL/Digit.h>
 #include "QualityControl/QcInfoLogger.h"
@@ -177,15 +176,6 @@ void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
   mTimeFramesPerCycles++;
   // check if we have payoad
   using MaskType_t = o2::emcal::BadChannelMap::MaskType_t;
-
-  if (mDoEndOfPayloadCheck) {
-    auto dataref = ctx.inputs().get("emcal-digits");
-    auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
-    if (!emcheader->mHasPayload) {
-      ILOG(Info, Support) << "No more digits" << ENDM;
-      return;
-    }
-  }
 
   // Handling of inputs from multiple subevents (multiple FLPs)
   // Build maps of trigger records and cells according to the subspecification


### PR DESCRIPTION
End-of-payload check no longer needed, and
EMCALBlockHeader no longer published via the
RecoWorkflow.