### PR TITLE
Allow for dropped messages in batch_test

### DIFF
--- a/Framework/script/o2-qc-batch-test.sh
+++ b/Framework/script/o2-qc-batch-test.sh
@@ -75,9 +75,9 @@ if (( $? != 0 )); then
 fi
 # try if it is a non empty histogram
 entries=`root -b -l -q -e 'TFile f("/tmp/batch_test_obj${UNIQUE_ID}.root"); TH1F *h = (TH1F*)f.Get("ccdb_object"); cout << h->GetEntries() << endl;' | tail -n 1`
-if [ $entries -ne 200 ] 2>/dev/null
+if [ $entries -lt 150 ] 2>/dev/null
 then
-  echo "The histogram of the QC Task does not have the expected 200 samples."
+  echo "The histogram of the QC Task has less than 150 (75%) of expected samples."
   delete_data
   exit 2
 fi


### PR DESCRIPTION
Dispatcher will be non-blocking soon, so we might see dropped messages in the tests. Let's just make sure there are not too many.