### PR TITLE
TOF: Add MOs for TOF asynch QC

### DIFF
--- a/Modules/TOF/include/TOF/TOFMatchedTracks.h
+++ b/Modules/TOF/include/TOF/TOFMatchedTracks.h
@@ -26,6 +26,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 
 class TH1F;
+class TH2F;
 class TEfficiency;
 
 namespace o2::quality_control_modules::tof
@@ -83,12 +84,15 @@ class TOFMatchedTracks final : public TaskInterface
   bool mVerbose = false;
   TH1F* mInTracksPt[trkType::SIZE] = {};
   TH1F* mInTracksEta[trkType::SIZE] = {};
+  TH2F* mInTracks2DPtEta[trkType::SIZE] = {};
   TH1F* mMatchedTracksPt[trkType::SIZE] = {};
   TH1F* mMatchedTracksEta[trkType::SIZE] = {};
+  TH2F* mMatchedTracks2DPtEta[trkType::SIZE] = {};
   TH1F* mFakeMatchedTracksPt[trkType::SIZE] = {};
   TH1F* mFakeMatchedTracksEta[trkType::SIZE] = {};
   TEfficiency* mEffPt[trkType::SIZE] = {};
   TEfficiency* mEffEta[trkType::SIZE] = {};
+  TEfficiency* mEff2DPtEta[trkType::SIZE] = {};
   TEfficiency* mFakeFractionTracksPt[trkType::SIZE] = {};  // fraction of fakes among the matched tracks vs pT
   TEfficiency* mFakeFractionTracksEta[trkType::SIZE] = {}; // fraction of fakes among the matched tracks vs Eta
 

--- a/Modules/TOF/include/TOF/TOFMatchedTracks.h
+++ b/Modules/TOF/include/TOF/TOFMatchedTracks.h
@@ -79,7 +79,7 @@ class TOFMatchedTracks final : public TaskInterface
   // ITS-TPC-TOF
   gsl::span<const o2::dataformats::TrackTPCITS> mITSTPCTracks;
   gsl::span<const o2::dataformats::MatchInfoTOF> mITSTPCTOFMatches;
- 
+
   bool mUseMC = false;
   bool mVerbose = false;
   TH1F* mInTracksPt[trkType::SIZE] = {};

--- a/Modules/TOF/include/TOF/TOFMatchedTracks.h
+++ b/Modules/TOF/include/TOF/TOFMatchedTracks.h
@@ -94,6 +94,7 @@ class TOFMatchedTracks final : public TaskInterface
   TH2F* mDeltaZPhi[trkType::SIZE] = {};
   TH2F* mDeltaXEta[trkType::SIZE] = {};
   TH2F* mDeltaXPhi[trkType::SIZE] = {};
+  TH1F* mTOFChi2[trkType::SIZE] = {};
   TEfficiency* mEffPt[trkType::SIZE] = {};
   TEfficiency* mEffEta[trkType::SIZE] = {};
   TEfficiency* mEff2DPtEta[trkType::SIZE] = {};

--- a/Modules/TOF/include/TOF/TOFMatchedTracks.h
+++ b/Modules/TOF/include/TOF/TOFMatchedTracks.h
@@ -79,7 +79,7 @@ class TOFMatchedTracks final : public TaskInterface
   // ITS-TPC-TOF
   gsl::span<const o2::dataformats::TrackTPCITS> mITSTPCTracks;
   gsl::span<const o2::dataformats::MatchInfoTOF> mITSTPCTOFMatches;
-
+ 
   bool mUseMC = false;
   bool mVerbose = false;
   TH1F* mInTracksPt[trkType::SIZE] = {};
@@ -90,6 +90,10 @@ class TOFMatchedTracks final : public TaskInterface
   TH2F* mMatchedTracks2DPtEta[trkType::SIZE] = {};
   TH1F* mFakeMatchedTracksPt[trkType::SIZE] = {};
   TH1F* mFakeMatchedTracksEta[trkType::SIZE] = {};
+  TH2F* mDeltaZEta[trkType::SIZE] = {};
+  TH2F* mDeltaZPhi[trkType::SIZE] = {};
+  TH2F* mDeltaXEta[trkType::SIZE] = {};
+  TH2F* mDeltaXPhi[trkType::SIZE] = {};
   TEfficiency* mEffPt[trkType::SIZE] = {};
   TEfficiency* mEffEta[trkType::SIZE] = {};
   TEfficiency* mEff2DPtEta[trkType::SIZE] = {};

--- a/Modules/TOF/src/TOFMatchedTracks.cxx
+++ b/Modules/TOF/src/TOFMatchedTracks.cxx
@@ -144,7 +144,7 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
     mDeltaZPhi[i] = new TH2F(Form("mDeltaZPhi%s", title[i].c_str()), Form("mDeltaZPhi (trkType: %s); #phi; #Delta z (cm); counts", title[i].c_str()), 100, .0f, 6.3f, 100, -10.f, 10.f);
     mDeltaXEta[i] = new TH2F(Form("mDeltaXEta%s", title[i].c_str()), Form("mDeltaXEta (trkType: %s); #eta; #Delta x (cm); counts", title[i].c_str()), 100, -1.0f, 1.0f, 100, -10.f, 10.f);
     mDeltaXPhi[i] = new TH2F(Form("mDeltaXPhi%s", title[i].c_str()), Form("mDeltaXPhi (trkType: %s); #phi; #Delta x (cm); counts", title[i].c_str()), 100, .0f, 6.3f, 100, -10.f, 10.f);
-    mTOFChi2[i] = new TH1F(Form("mTOFChi2%s", title[i].c_str()), Form("mTOFChi2 (trkType: %s); #Chi^{2}; counts", title[i].c_str()), 100, 0.f, 10.f);
+    mTOFChi2[i] = new TH1F(Form("mTOFChi2%s", title[i].c_str()), Form("mTOFChi2 (trkType: %s); #chi^{2}; counts", title[i].c_str()), 100, 0.f, 10.f);
   }
 
   // initialize B field and geometry for track selection
@@ -243,11 +243,11 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
       LOG(debug) << "NUM UNCONS: track with eta " << trk.getEta() << " and pt " << trk.getPt() << " ACCEPTED for numerator, UNCONS";
       mMatchedTracksPt[trkType::UNCONS]->Fill(trk.getPt());
       mMatchedTracksEta[trkType::UNCONS]->Fill(trk.getEta());
-      mMatchedTracks2DPtEta[trkType::UNCONS]->Fill(trk.getPt(),trk.getEta());
-      mDeltaZEta[trkType::UNCONS]->Fill(trk.getEta(),trkDz);
-      mDeltaZPhi[trkType::UNCONS]->Fill(trk.getPhi(),trkDz);
-      mDeltaXEta[trkType::UNCONS]->Fill(trk.getEta(),trkDx);
-      mDeltaXPhi[trkType::UNCONS]->Fill(trk.getPhi(),trkDx);
+      mMatchedTracks2DPtEta[trkType::UNCONS]->Fill(trk.getPt(), trk.getEta());
+      mDeltaZEta[trkType::UNCONS]->Fill(trk.getEta(), trkDz);
+      mDeltaZPhi[trkType::UNCONS]->Fill(trk.getPhi(), trkDz);
+      mDeltaXEta[trkType::UNCONS]->Fill(trk.getEta(), trkDx);
+      mDeltaXPhi[trkType::UNCONS]->Fill(trk.getPhi(), trkDx);
       mTOFChi2[trkType::UNCONS]->Fill(trkchi2);
       if (mUseMC) {
         auto lbl = mRecoCont.getTrackMCLabel(gTrackId);
@@ -281,11 +281,11 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
                  << " gid: " << gTrackId << " TPC gid =" << trk.getRefTPC();
       mMatchedTracksPt[trkType::CONSTR]->Fill(trkTPC.getPt());
       mMatchedTracksEta[trkType::CONSTR]->Fill(trkTPC.getEta());
-      mMatchedTracks2DPtEta[trkType::CONSTR]->Fill(trk.getPt(),trk.getEta());
-      mDeltaZEta[trkType::CONSTR]->Fill(trk.getEta(),trkDz);
-      mDeltaZPhi[trkType::CONSTR]->Fill(trk.getPhi(),trkDz);
-      mDeltaXEta[trkType::CONSTR]->Fill(trk.getEta(),trkDx);
-      mDeltaXPhi[trkType::CONSTR]->Fill(trk.getPhi(),trkDx);
+      mMatchedTracks2DPtEta[trkType::CONSTR]->Fill(trk.getPt(), trk.getEta());
+      mDeltaZEta[trkType::CONSTR]->Fill(trk.getEta(), trkDz);
+      mDeltaZPhi[trkType::CONSTR]->Fill(trk.getPhi(), trkDz);
+      mDeltaXEta[trkType::CONSTR]->Fill(trk.getEta(), trkDx);
+      mDeltaXPhi[trkType::CONSTR]->Fill(trk.getPhi(), trkDx);
       mTOFChi2[trkType::CONSTR]->Fill(trkchi2);
       if (mUseMC) {
         auto lbl = mRecoCont.getTrackMCLabel(gTrackId);
@@ -316,7 +316,7 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
                    << " gid: " << gid;
         this->mInTracksPt[trkType::UNCONS]->Fill(trk.getPt());
         this->mInTracksEta[trkType::UNCONS]->Fill(trk.getEta());
-        this->mInTracks2DPtEta[trkType::UNCONS]->Fill(trk.getPt(),trk.getEta());
+        this->mInTracks2DPtEta[trkType::UNCONS]->Fill(trk.getPt(), trk.getEta());
       } else if constexpr (isTPCTOFTrack<decltype(trk)>()) {
         const auto& tpcTrack = mTPCTracks[mTPCTOFMatches[trk.getRefMatch()].getTrackRef().getIndex()];
         if (!selectTrack(tpcTrack)) {
@@ -326,7 +326,7 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
         LOG(debug) << "DEN UNCONS: track with eta " << tpcTrack.getEta() << " and pT " << tpcTrack.getPt() << " ACCEPTED for denominator UNCONS, TPCTOF track";
         this->mInTracksPt[trkType::UNCONS]->Fill(tpcTrack.getPt());
         this->mInTracksEta[trkType::UNCONS]->Fill(tpcTrack.getEta());
-        this->mInTracks2DPtEta[trkType::UNCONS]->Fill(tpcTrack.getPt(),tpcTrack.getEta());
+        this->mInTracks2DPtEta[trkType::UNCONS]->Fill(tpcTrack.getPt(), tpcTrack.getEta());
       }
     }
     // In case of ITS-TPC-TOF, the ITS-TPC tracks contain also the ITS-TPC-TOF
@@ -339,7 +339,7 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
       LOG(debug) << "DEN CONSTR: track with eta " << tpcTrack.getEta() << " and pT " << tpcTrack.getPt() << " ACCEPTED for denominator CONSTR, ITSTPC track";
       this->mInTracksPt[trkType::CONSTR]->Fill(tpcTrack.getPt());
       this->mInTracksEta[trkType::CONSTR]->Fill(tpcTrack.getEta());
-      this->mInTracks2DPtEta[trkType::CONSTR]->Fill(tpcTrack.getPt(),tpcTrack.getEta());
+      this->mInTracks2DPtEta[trkType::CONSTR]->Fill(tpcTrack.getPt(), tpcTrack.getEta());
     }
     return true;
   };

--- a/Modules/TOF/src/TOFMatchedTracks.cxx
+++ b/Modules/TOF/src/TOFMatchedTracks.cxx
@@ -18,6 +18,7 @@
 
 #include <TCanvas.h>
 #include <TH1.h>
+#include <TH2.h>
 #include <TEfficiency.h>
 
 #include "QualityControl/QcInfoLogger.h"
@@ -44,14 +45,17 @@ TOFMatchedTracks::~TOFMatchedTracks()
   for (int i = 0; i < trkType::SIZE; ++i) {
     delete mMatchedTracksPt[i];
     delete mMatchedTracksEta[i];
+    delete mMatchedTracks2DPtEta[i];
     if (mUseMC) {
       delete mFakeMatchedTracksPt[i];
       delete mFakeMatchedTracksEta[i];
     }
     delete mInTracksPt[i];
     delete mInTracksEta[i];
+    delete mInTracks2DPtEta[i];
     delete mEffPt[i];
     delete mEffEta[i];
+    delete mEff2DPtEta[i];
   }
 }
 
@@ -118,8 +122,10 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
   for (int i = 0; i < trkType::SIZE; ++i) {
     mInTracksPt[i] = new TH1F(Form("mInTracksPt_%s", title[i].c_str()), Form("mInTracksPt (trkType: %s); #it{p}_{T}; counts", title[i].c_str()), 100, 0.f, 20.f);
     mInTracksEta[i] = new TH1F(Form("mInTracksEta_%s", title[i].c_str()), Form("mInTracksEta (trkType: %s); #eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
+    mInTracks2DPtEta[i] = new TH2F(Form("mInTracks2DPtEta_%s", title[i].c_str()), Form("mInTracks2DPtEta (trkType: %s); #it{p}_{T}; #eta; counts", title[i].c_str()), 100, 0.f, 20.f, 100, -1.0f, 1.0f);
     mMatchedTracksPt[i] = new TH1F(Form("mMatchedTracksPt_%s", title[i].c_str()), Form("mMatchedTracksPt (trkType: %s); #it{p}_{T}; counts", title[i].c_str()), 100, 0.f, 20.f);
     mMatchedTracksEta[i] = new TH1F(Form("mMatchedTracksEta_%s", title[i].c_str()), Form("mMatchedTracksEta (trkType: %s); #eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
+    mMatchedTracks2DPtEta[i] = new TH2F(Form("mMatchedTracks2DPtEta_%s", title[i].c_str()), Form("mMatchedTracks2DPtEta (trkType: %s); #it{p}_{T}; #eta; counts", title[i].c_str()), 100, 0.f, 20.f, 100, -1.0f, 1.0f);
     if (mUseMC) {
       mFakeMatchedTracksPt[i] = new TH1F(Form("mFakeMatchedTracksPt_%s", title[i].c_str()), Form("mFakeMatchedTracksPt (trkType: %s); #it{p}_{T}; counts", title[i].c_str()), 100, 0.f, 20.f);
       mFakeMatchedTracksEta[i] = new TH1F(Form("mFakeMatchedTracksEta_%s", title[i].c_str()), Form("mFakeMatchedTracksEta (trkType: %s); #eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
@@ -128,6 +134,7 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
     }
     mEffPt[i] = new TEfficiency(Form("mEffPt_%s", title[i].c_str()), Form("Efficiency vs Pt (trkType: %s); #it{p}_{T}; Eff", title[i].c_str()), 100, 0.f, 20.f);
     mEffEta[i] = new TEfficiency(Form("mEffEta_%s", title[i].c_str()), Form("Efficiency vs Eta (trkType: %s); #eta; Eff", title[i].c_str()), 100, -1.f, 1.f);
+    mEff2DPtEta[i] = new TEfficiency(Form("mEff2DPtEta_%s", title[i].c_str()), Form("Efficiency vs Pt vs Eta (trkType: %s); #it{p}_{T}; #eta; Eff", title[i].c_str()), 100, 0.f, 20.f, 100, -1.0f, 1.0f);
   }
 
   // initialize B field and geometry for track selection
@@ -138,8 +145,10 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
   if (mSrc[GID::Source::TPCTOF] == 1) {
     getObjectsManager()->startPublishing(mInTracksPt[trkType::UNCONS]);
     getObjectsManager()->startPublishing(mInTracksEta[trkType::UNCONS]);
+    getObjectsManager()->startPublishing(mInTracks2DPtEta[trkType::UNCONS]);
     getObjectsManager()->startPublishing(mMatchedTracksPt[trkType::UNCONS]);
     getObjectsManager()->startPublishing(mMatchedTracksEta[trkType::UNCONS]);
+    getObjectsManager()->startPublishing(mMatchedTracks2DPtEta[trkType::UNCONS]);
     if (mUseMC) {
       getObjectsManager()->startPublishing(mFakeMatchedTracksPt[trkType::UNCONS]);
       getObjectsManager()->startPublishing(mFakeMatchedTracksEta[trkType::UNCONS]);
@@ -148,13 +157,16 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
     }
     getObjectsManager()->startPublishing(mEffPt[trkType::UNCONS]);
     getObjectsManager()->startPublishing(mEffEta[trkType::UNCONS]);
+    getObjectsManager()->startPublishing(mEff2DPtEta[trkType::UNCONS]);
   }
 
   if (mSrc[GID::Source::ITSTPCTOF] == 1) {
     getObjectsManager()->startPublishing(mInTracksPt[trkType::CONSTR]);
     getObjectsManager()->startPublishing(mInTracksEta[trkType::CONSTR]);
+    getObjectsManager()->startPublishing(mInTracks2DPtEta[trkType::CONSTR]);
     getObjectsManager()->startPublishing(mMatchedTracksPt[trkType::CONSTR]);
     getObjectsManager()->startPublishing(mMatchedTracksEta[trkType::CONSTR]);
+    getObjectsManager()->startPublishing(mMatchedTracks2DPtEta[trkType::CONSTR]);
     if (mUseMC) {
       getObjectsManager()->startPublishing(mFakeMatchedTracksPt[trkType::CONSTR]);
       getObjectsManager()->startPublishing(mFakeMatchedTracksEta[trkType::CONSTR]);
@@ -163,6 +175,7 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
     }
     getObjectsManager()->startPublishing(mEffPt[trkType::CONSTR]);
     getObjectsManager()->startPublishing(mEffEta[trkType::CONSTR]);
+    getObjectsManager()->startPublishing(mEff2DPtEta[trkType::CONSTR]);
   }
 }
 
@@ -207,6 +220,7 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
       LOG(debug) << "NUM UNCONS: track with eta " << trk.getEta() << " and pt " << trk.getPt() << " ACCEPTED for numerator, UNCONS";
       mMatchedTracksPt[trkType::UNCONS]->Fill(trk.getPt());
       mMatchedTracksEta[trkType::UNCONS]->Fill(trk.getEta());
+      mMatchedTracks2DPtEta[trkType::UNCONS]->Fill(trk.getPt(),trk.getEta());
       if (mUseMC) {
         auto lbl = mRecoCont.getTrackMCLabel(gTrackId);
         if (lbl.isFake()) {
@@ -236,6 +250,7 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
                  << " gid: " << gTrackId << " TPC gid =" << trk.getRefTPC();
       mMatchedTracksPt[trkType::CONSTR]->Fill(trkTPC.getPt());
       mMatchedTracksEta[trkType::CONSTR]->Fill(trkTPC.getEta());
+      mMatchedTracks2DPtEta[trkType::CONSTR]->Fill(trk.getPt(),trk.getEta());
       if (mUseMC) {
         auto lbl = mRecoCont.getTrackMCLabel(gTrackId);
         if (lbl.isFake()) {
@@ -265,6 +280,7 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
                    << " gid: " << gid;
         this->mInTracksPt[trkType::UNCONS]->Fill(trk.getPt());
         this->mInTracksEta[trkType::UNCONS]->Fill(trk.getEta());
+        this->mInTracks2DPtEta[trkType::UNCONS]->Fill(trk.getPt(),trk.getEta());
       } else if constexpr (isTPCTOFTrack<decltype(trk)>()) {
         const auto& tpcTrack = mTPCTracks[mTPCTOFMatches[trk.getRefMatch()].getTrackRef().getIndex()];
         if (!selectTrack(tpcTrack)) {
@@ -274,6 +290,7 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
         LOG(debug) << "DEN UNCONS: track with eta " << tpcTrack.getEta() << " and pT " << tpcTrack.getPt() << " ACCEPTED for denominator UNCONS, TPCTOF track";
         this->mInTracksPt[trkType::UNCONS]->Fill(tpcTrack.getPt());
         this->mInTracksEta[trkType::UNCONS]->Fill(tpcTrack.getEta());
+        this->mInTracks2DPtEta[trkType::UNCONS]->Fill(tpcTrack.getPt(),tpcTrack.getEta());
       }
     }
     // In case of ITS-TPC-TOF, the ITS-TPC tracks contain also the ITS-TPC-TOF
@@ -286,6 +303,7 @@ void TOFMatchedTracks::monitorData(o2::framework::ProcessingContext& ctx)
       LOG(debug) << "DEN CONSTR: track with eta " << tpcTrack.getEta() << " and pT " << tpcTrack.getPt() << " ACCEPTED for denominator CONSTR, ITSTPC track";
       this->mInTracksPt[trkType::CONSTR]->Fill(tpcTrack.getPt());
       this->mInTracksEta[trkType::CONSTR]->Fill(tpcTrack.getEta());
+      this->mInTracks2DPtEta[trkType::CONSTR]->Fill(tpcTrack.getPt(),tpcTrack.getEta());
     }
     return true;
   };
@@ -359,7 +377,9 @@ void TOFMatchedTracks::endOfCycle()
     if (!mEffPt[trkType::UNCONS]->SetTotalHistogram(*mInTracksPt[trkType::UNCONS], "f") || // all total have to be forcely replaced, or the passed from previous processing may have incompatible number of entries
         !mEffPt[trkType::UNCONS]->SetPassedHistogram(*mMatchedTracksPt[trkType::UNCONS], "") ||
         !mEffEta[trkType::UNCONS]->SetTotalHistogram(*mInTracksEta[trkType::UNCONS], "f") ||
-        !mEffEta[trkType::UNCONS]->SetPassedHistogram(*mMatchedTracksEta[trkType::UNCONS], "")) {
+        !mEffEta[trkType::UNCONS]->SetPassedHistogram(*mMatchedTracksEta[trkType::UNCONS], "") ||
+        !mEff2DPtEta[trkType::UNCONS]->SetTotalHistogram(*mInTracks2DPtEta[trkType::UNCONS], "f") ||
+        !mEff2DPtEta[trkType::UNCONS]->SetPassedHistogram(*mMatchedTracks2DPtEta[trkType::UNCONS], "")) {
       ILOG(Fatal, Support) << "Something went wrong in defining the efficiency histograms, UNCONS!!";
     }
     if (mUseMC) {
@@ -375,7 +395,9 @@ void TOFMatchedTracks::endOfCycle()
     if (!mEffPt[trkType::CONSTR]->SetTotalHistogram(*mInTracksPt[trkType::CONSTR], "f") ||
         !mEffPt[trkType::CONSTR]->SetPassedHistogram(*mMatchedTracksPt[trkType::CONSTR], "") ||
         !mEffEta[trkType::CONSTR]->SetTotalHistogram(*mInTracksEta[trkType::CONSTR], "f") ||
-        !mEffEta[trkType::CONSTR]->SetPassedHistogram(*mMatchedTracksEta[trkType::CONSTR], "")) {
+        !mEffEta[trkType::CONSTR]->SetPassedHistogram(*mMatchedTracksEta[trkType::CONSTR], "") ||
+        !mEff2DPtEta[trkType::CONSTR]->SetTotalHistogram(*mInTracks2DPtEta[trkType::CONSTR], "f") ||
+        !mEff2DPtEta[trkType::CONSTR]->SetPassedHistogram(*mMatchedTracks2DPtEta[trkType::CONSTR], "")) {
       ILOG(Fatal, Support) << "Something went wrong in defining the efficiency histograms, CONSTR!!";
     }
     if (mUseMC) {
@@ -433,12 +455,14 @@ void TOFMatchedTracks::reset()
   for (int i = 0; i < trkType::SIZE; ++i) {
     mMatchedTracksPt[i]->Reset();
     mMatchedTracksEta[i]->Reset();
+    mMatchedTracks2DPtEta[i]->Reset();
     if (mUseMC) {
       mFakeMatchedTracksPt[i]->Reset();
       mFakeMatchedTracksEta[i]->Reset();
     }
     mInTracksPt[i]->Reset();
     mInTracksEta[i]->Reset();
+    mInTracks2DPtEta[i]->Reset();
   }
 }
 

--- a/Modules/TOF/src/TOFMatchedTracks.cxx
+++ b/Modules/TOF/src/TOFMatchedTracks.cxx
@@ -116,18 +116,18 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
 
   std::array<std::string, 2> title{ "UNCONS", "CONSTR" };
   for (int i = 0; i < trkType::SIZE; ++i) {
-    mInTracksPt[i] = new TH1F(Form("mInTracksPt_%s", title[i].c_str()), Form("mInTracksPt (trkType: %s); Pt; counts", title[i].c_str()), 100, 0.f, 20.f);
-    mInTracksEta[i] = new TH1F(Form("mInTracksEta_%s", title[i].c_str()), Form("mInTracksEta (trkType: %s); Eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
-    mMatchedTracksPt[i] = new TH1F(Form("mMatchedTracksPt_%s", title[i].c_str()), Form("mMatchedTracksPt (trkType: %s); Pt; counts", title[i].c_str()), 100, 0.f, 20.f);
-    mMatchedTracksEta[i] = new TH1F(Form("mMatchedTracksEta_%s", title[i].c_str()), Form("mMatchedTracksEta (trkType: %s); Eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
+    mInTracksPt[i] = new TH1F(Form("mInTracksPt_%s", title[i].c_str()), Form("mInTracksPt (trkType: %s); #it{p}_{T}; counts", title[i].c_str()), 100, 0.f, 20.f);
+    mInTracksEta[i] = new TH1F(Form("mInTracksEta_%s", title[i].c_str()), Form("mInTracksEta (trkType: %s); #eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
+    mMatchedTracksPt[i] = new TH1F(Form("mMatchedTracksPt_%s", title[i].c_str()), Form("mMatchedTracksPt (trkType: %s); #it{p}_{T}; counts", title[i].c_str()), 100, 0.f, 20.f);
+    mMatchedTracksEta[i] = new TH1F(Form("mMatchedTracksEta_%s", title[i].c_str()), Form("mMatchedTracksEta (trkType: %s); #eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
     if (mUseMC) {
-      mFakeMatchedTracksPt[i] = new TH1F(Form("mFakeMatchedTracksPt_%s", title[i].c_str()), Form("mFakeMatchedTracksPt (trkType: %s); Pt; counts", title[i].c_str()), 100, 0.f, 20.f);
-      mFakeMatchedTracksEta[i] = new TH1F(Form("mFakeMatchedTracksEta_%s", title[i].c_str()), Form("mFakeMatchedTracksEta (trkType: %s); Eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
-      mFakeFractionTracksPt[i] = new TEfficiency(Form("mFakeFractionPt_%s", title[i].c_str()), Form("Fraction of fake matches vs Pt (trkType: %s); Pt; Eff", title[i].c_str()), 100, 0.f, 20.f);
-      mFakeFractionTracksEta[i] = new TEfficiency(Form("mFakeFractionEta_%s", title[i].c_str()), Form("Fraction of fake matches vs Eta (trkType: %s); Eta; Eff", title[i].c_str()), 100, -1.0f, 1.0f);
+      mFakeMatchedTracksPt[i] = new TH1F(Form("mFakeMatchedTracksPt_%s", title[i].c_str()), Form("mFakeMatchedTracksPt (trkType: %s); #it{p}_{T}; counts", title[i].c_str()), 100, 0.f, 20.f);
+      mFakeMatchedTracksEta[i] = new TH1F(Form("mFakeMatchedTracksEta_%s", title[i].c_str()), Form("mFakeMatchedTracksEta (trkType: %s); #eta; counts", title[i].c_str()), 100, -1.0f, 1.0f);
+      mFakeFractionTracksPt[i] = new TEfficiency(Form("mFakeFractionPt_%s", title[i].c_str()), Form("Fraction of fake matches vs Pt (trkType: %s); #it{p}_{T}; Eff", title[i].c_str()), 100, 0.f, 20.f);
+      mFakeFractionTracksEta[i] = new TEfficiency(Form("mFakeFractionEta_%s", title[i].c_str()), Form("Fraction of fake matches vs Eta (trkType: %s); #eta; Eff", title[i].c_str()), 100, -1.0f, 1.0f);
     }
-    mEffPt[i] = new TEfficiency(Form("mEffPt_%s", title[i].c_str()), Form("Efficiency vs Pt (trkType: %s); Pt; Eff", title[i].c_str()), 100, 0.f, 20.f);
-    mEffEta[i] = new TEfficiency(Form("mEffEta_%s", title[i].c_str()), Form("Efficiency vs Eta (trkType: %s); Eta; Eff", title[i].c_str()), 100, -1.f, 1.f);
+    mEffPt[i] = new TEfficiency(Form("mEffPt_%s", title[i].c_str()), Form("Efficiency vs Pt (trkType: %s); #it{p}_{T}; Eff", title[i].c_str()), 100, 0.f, 20.f);
+    mEffEta[i] = new TEfficiency(Form("mEffEta_%s", title[i].c_str()), Form("Efficiency vs Eta (trkType: %s); #eta; Eff", title[i].c_str()), 100, -1.f, 1.f);
   }
 
   // initialize B field and geometry for track selection


### PR DESCRIPTION
Hi @chiarazampolli, @njacazio and @noferini I added few histograms which were discussed in the last weeks:
- 3D efficiencies vs pT vs eta 
- Delta x and Delta z vs eta and phi
- chi2 distribution 
Please let me know if you have any comments!

I leave this WIP since I am having issues with publishing the 3D efficiencies on the qcg (says "JSROOT was unable to draw this object". I will write an email to the experts.
This was tested and you find the output in https://qcg-test.cern.ch/?page=objectTree