### PR TITLE
TRD reduce spectrum count

### DIFF
--- a/Modules/TRD/TRDQC.json
+++ b/Modules/TRD/TRDQC.json
@@ -1,0 +1,144 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "505618",
+        "type": "2",
+        "periodName": "",
+        "passName": "",
+        "provenance": "qc"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      },
+      "infologger": { "": "Configuration of the Infologger (optional).",
+        "filterDiscardDebug": "false",    "": "Set to 1 to discard debug and trace messages (default: false)",
+        "filterDiscardLevel": "2", "": "Message at this level or above are discarded (default: 21 - Trace)" 
+      }
+    },
+    "tasks": {
+      "RawDataTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::RawData",
+        "moduleName": "QcTRD",
+        "detectorName": "TRD",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD;rawstats:TRD/RAWSTATS"
+        },
+        "taskParameters": {
+          "peakregionstart": "7.0",
+          "peakregionend": "20.0",
+          "pulseheightpeaklower": "1.0",
+          "pulseheightpeakupper": "5.0"
+        },
+        "location": "remote",
+	"saveObjectsToFile":"qcrootobjects.root"
+      },
+      "DigitTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::DigitsTask",
+        "moduleName": "QcTRD",
+        "detectorName": "TRD",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD"
+        },
+        "taskParameters": {
+          "peakregionstart": "7.0",
+          "peakregionend": "20.0",
+          "pulseheightpeaklower": "1.0",
+          "pulseheightpeakupper": "5.0"
+        },
+        "location": "remote",
+	"saveObjectsToFile":"digitrootobjects.root"
+      },
+      "TrackletsTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::TrackletsTask",
+        "moduleName": "QcTRD",
+        "detectorName": "TRD",
+        "cycleDurationSeconds": "15",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "no comment",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD"
+        },
+        "taskParameters": {
+          "peakregionstart": "7.0",
+          "peakregionend": "20.0",
+          "pulseheightpeaklower": "1.0",
+          "pulseheightpeakupper": "5.0"
+        },
+        "location": "remote",
+	"saveObjectsToFile":"trackletobjects.root"
+      },
+      "PulseHeight": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::PulseHeight",
+        "moduleName": "QcTRD",
+        "detectorName": "TRD",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD;rawstats:TRD/RAWSTATS"
+        },
+        "taskParameters": {
+          "peakregionstart": "7.0",
+          "peakregionend": "20.0",
+          "pulseheightpeaklower": "1.0",
+          "pulseheightpeakupper": "5.0"
+        },
+        "location": "remote",
+	"saveObjectsToFile":"qcpulseheight.root"
+      }
+    },
+    "checks": {
+      "QcCheck": {
+        "active": "false",
+        "className": "o2::quality_control_modules::trd::RawDataCheck",
+        "moduleName": "QcTRD",
+        "policy": "OnAny",
+        "detectorName": "TRD",
+        "dataSource": [{
+          "type": "Task",
+          "name": "RawDataTask",
+          "MOs": ["trackletsperevent"]
+        }]
+      },
+      "PulseHeightCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::PulseHeightCheck",
+        "moduleName": "QcTRD",
+        "policy": "OnAny",
+        "detectorName": "TRD",
+        "dataSource": [{
+          "type": "Task",
+          "name": "RawDataTask",
+          "MOs": ["trackletsperevent"]
+        }]
+      }
+  },
+  "dataSamplingPolicies": [
+  ]
+}
+}

--- a/Modules/TRD/include/TRD/DigitsTask.h
+++ b/Modules/TRD/include/TRD/DigitsTask.h
@@ -21,6 +21,7 @@
 
 class TH1F;
 class TH2F;
+class TH1D;
 
 using namespace o2::quality_control::core;
 
@@ -59,7 +60,7 @@ class DigitsTask final : public TaskInterface
   std::shared_ptr<TH1F> mDigitHCID = nullptr;
   std::shared_ptr<TH1F> mParsingErrors = nullptr;
 
-  std::array<std::shared_ptr<TH1F>, 540> mClusterAmplitudeChamber;
+  std::shared_ptr<TH2F> mClusterAmplitudeChamber;
   std::array<std::shared_ptr<TH2F>, 6> mNClsLayer;        ///[layer]->Fill(sm - 0.5 + col / 144., startRow[istack]+row);
   std::shared_ptr<TH1D> mADCvalue;                        //->Fill(value);
   std::array<std::shared_ptr<TH1F>, 18> mADC;             //[sm]->Fill(value);
@@ -79,7 +80,6 @@ class DigitsTask final : public TaskInterface
   std::shared_ptr<TH1F> mClsAmpTb;                        //, "ClsAmpTb", "ClsAmpTb", 30, -0.5, 29.5);
   std::shared_ptr<TH1F> mClsAmpCh;                        //
   std::array<std::shared_ptr<TH2F>, 18> mClsDetAmp;       //[sm]->Fill(detLoc, sum);
-  std::array<std::shared_ptr<TH1F>, 540> mClsAmpChamber;  //[iChamber]->Fill(sum);
   std::shared_ptr<TH2F> mClsSector;                       //, "ClsSector", "ClsSector", nSMs, -0.5, 17.5, 500, -0.5, 999.5);
   std::shared_ptr<TH2F> mClsStack;                        //, "ClsStack", "ClsStack", 5, -0.5, 4.5, 500, -0.5, 999.5);
   std::array<std::shared_ptr<TH2F>, 18> mClsDetTime;      //[sm]->Fill(detLoc, time, sum);

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -191,14 +191,13 @@ namespace o2::quality_control_modules::trd
     mClsStack->SetTitle(";Stack;Amplitude");
 
     // local histos
-    for (int det = 0; det < 540; ++det) {
-      std::string label = fmt::format("clsAmp_{0}", det);
-      std::string title = fmt::format("Cluster Amplitude for chamber {0}", det);
-      mClusterAmplitudeChamber[det].reset(new TH1F(label.c_str(), title.c_str(), 300, -0.5, 299.5));
+      std::string label = fmt::format("clsAmp");
+      std::string title = fmt::format("Cluster Amplitude for chamber");
+      mClusterAmplitudeChamber.reset(new TH2F(label.c_str(), title.c_str(), 300, -0.5, 299.5,540,-0.5,539.5));
+
       //TODO come back to figure out proper names mClusterAmplitudeChamber[det]->GetXaxis()->SetTitle("PadRow");
-      //mClusterAmplitudeChamber[det]->GetYaxis()->SetTitle("Amplitude");
-      getObjectsManager()->startPublishing(mClusterAmplitudeChamber[det].get());
-    }
+      mClusterAmplitudeChamber[det]->GetYaxis()->SetTitle("Chmaber");
+      getObjectsManager()->startPublishing(mClusterAmplitudeChamber.get());
     for (int trgg = 0; trgg < 10; ++trgg) {
       if (trgg == 3) {
         std::string label = fmt::format("ClsChargeTbTrgg_{0}", trgg);
@@ -422,7 +421,7 @@ namespace o2::quality_control_modules::trd
                   if (time > mDriftRegion.first && time < mDriftRegion.second) {
                     mClsAmpDrift->Fill(sum);
                     mClsDetAmp[sm]->Fill(detLoc, sum);
-                    mClusterAmplitudeChamber[iChamber]->Fill(sum);
+                    mClusterAmplitudeChamber->Fill(sum,iChamber);
                   }
 
                   mClsSector->Fill(sm, sum);
@@ -458,11 +457,9 @@ namespace o2::quality_control_modules::trd
   void DigitsTask::endOfCycle()
   {
     ILOG(Info) << "endOfCycle" << ENDM;
-
+    TProfile *prof= mClusterAmplitudeChamber->ProfileY();
     for (Int_t det = 0; det < 540; det++) {
-      if (mClusterAmplitudeChamber[det]->GetEntries() > 0) {
-        mClsAmpCh->Fill(mClusterAmplitudeChamber[det]->GetMean());
-      }
+        mClsAmpCh->Fill(prof->GetBinContent(det));
     }
   }
 

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -191,13 +191,13 @@ namespace o2::quality_control_modules::trd
     mClsStack->SetTitle(";Stack;Amplitude");
 
     // local histos
-      std::string label = fmt::format("clsAmp");
-      std::string title = fmt::format("Cluster Amplitude for chamber");
-      mClusterAmplitudeChamber.reset(new TH2F(label.c_str(), title.c_str(), 300, -0.5, 299.5,540,-0.5,539.5));
+    std::string label = fmt::format("clsAmp");
+    std::string title = fmt::format("Cluster Amplitude for chamber");
+    mClusterAmplitudeChamber.reset(new TH2F(label.c_str(), title.c_str(), 300, -0.5, 299.5, 540, -0.5, 539.5));
 
-      //TODO come back to figure out proper names mClusterAmplitudeChamber[det]->GetXaxis()->SetTitle("PadRow");
-      mClusterAmplitudeChamber[det]->GetYaxis()->SetTitle("Chmaber");
-      getObjectsManager()->startPublishing(mClusterAmplitudeChamber.get());
+    //TODO come back to figure out proper names mClusterAmplitudeChamber[det]->GetXaxis()->SetTitle("PadRow");
+    mClusterAmplitudeChamber->GetYaxis()->SetTitle("Chamber");
+    getObjectsManager()->startPublishing(mClusterAmplitudeChamber.get());
     for (int trgg = 0; trgg < 10; ++trgg) {
       if (trgg == 3) {
         std::string label = fmt::format("ClsChargeTbTrgg_{0}", trgg);
@@ -421,7 +421,7 @@ namespace o2::quality_control_modules::trd
                   if (time > mDriftRegion.first && time < mDriftRegion.second) {
                     mClsAmpDrift->Fill(sum);
                     mClsDetAmp[sm]->Fill(detLoc, sum);
-                    mClusterAmplitudeChamber->Fill(sum,iChamber);
+                    mClusterAmplitudeChamber->Fill(sum, iChamber);
                   }
 
                   mClsSector->Fill(sm, sum);
@@ -457,9 +457,9 @@ namespace o2::quality_control_modules::trd
   void DigitsTask::endOfCycle()
   {
     ILOG(Info) << "endOfCycle" << ENDM;
-    TProfile *prof= mClusterAmplitudeChamber->ProfileY();
+    TProfile* prof = mClusterAmplitudeChamber->ProfileY();
     for (Int_t det = 0; det < 540; det++) {
-        mClsAmpCh->Fill(prof->GetBinContent(det));
+      mClsAmpCh->Fill(prof->GetBinContent(det));
     }
   }
 


### PR DESCRIPTION
Collapse the 540 cluster spectra, 1 for each chamber, into a singular 2d histogram.
This should lighten the load, we still end up with the same information.

Additonally add the currently used json file from my home directory to this github repo. Its sampling rate must be reduced still.