### PR TITLE
New plots in ITS track task + new post-processing online or tracks

### DIFF
--- a/Modules/GLO/src/VertexingQcTask.cxx
+++ b/Modules/GLO/src/VertexingQcTask.cxx
@@ -144,10 +144,10 @@ void VertexingQcTask::monitorData(o2::framework::ProcessingContext& ctx)
       }
     }
     for (const auto& lbl : mcLbl) {
-      auto header = mMCReader.getMCEventHeader(lbl.getSourceID(), lbl.getEventID());
       if (lbl.getSourceID() != 0) { // using only underlying event,  which is source 0
         continue;
       }
+      auto header = mMCReader.getMCEventHeader(lbl.getSourceID(), lbl.getEventID());
       auto mult = header.GetNPrim();
       auto nVertices = mMapEvIDSourceID[{ lbl.getEventID(), lbl.getSourceID() }];
       if (nVertices == 1) {

--- a/Modules/ITS/CMakeLists.txt
+++ b/Modules/ITS/CMakeLists.txt
@@ -4,9 +4,9 @@ add_library(O2QcITS
             src/ITSRawTask.cxx
             src/TrendingTaskITSThr.cxx
             src/TrendingTaskITSFhr.cxx
-            src/TrendingTaskITSTracks.cxx            
+            src/TrendingTaskITSTracks.cxx                                    
             src/TrendingTaskConfigITS.cxx
-            src/TH2XlineReductor.cxx           
+            src/TH2XlineReductor.cxx
             src/ITSFhrTask.cxx
             src/ITSFeeTask.cxx
             src/ITSClusterTask.cxx
@@ -46,7 +46,7 @@ add_root_dictionary(O2QcITS
                     HEADERS include/ITS/ITSRawTask.h
                             include/ITS/TrendingTaskITSThr.h
                             include/ITS/TrendingTaskITSFhr.h
-                            include/ITS/TrendingTaskITSTracks.h                            
+                            include/ITS/TrendingTaskITSTracks.h                                                        
                             include/ITS/TH2XlineReductor.h
                             include/ITS/ITSFhrTask.h
                             include/ITS/ITSFeeTask.h
@@ -103,7 +103,7 @@ install(FILES
         its.json
         itsQCTrendingThr.json
         itsQCTrendingFhr.json
-        itsQCTrendingTracks.json        
+        itsQCTrendingTracks.json                
         itsFhr.json
         itsFee.json
         itsCluster.json

--- a/Modules/ITS/CMakeLists.txt
+++ b/Modules/ITS/CMakeLists.txt
@@ -6,8 +6,7 @@ add_library(O2QcITS
             src/TrendingTaskITSFhr.cxx
             src/TrendingTaskITSTracks.cxx            
             src/TrendingTaskConfigITS.cxx
-            src/TH2XlineReductor.cxx
-            src/TH1XlineReductor.cxx            
+            src/TH2XlineReductor.cxx           
             src/ITSFhrTask.cxx
             src/ITSFeeTask.cxx
             src/ITSClusterTask.cxx
@@ -19,7 +18,7 @@ add_library(O2QcITS
             src/ITSFeeCheck.cxx
             )
 
-target_sources(O2QcITS PRIVATE src/TH2XlineReductor.cxx src/TH1XlineReductor.cxx)
+target_sources(O2QcITS PRIVATE src/TH2XlineReductor.cxx)
 
 target_include_directories(
   O2QcITS
@@ -49,7 +48,6 @@ add_root_dictionary(O2QcITS
                             include/ITS/TrendingTaskITSFhr.h
                             include/ITS/TrendingTaskITSTracks.h                            
                             include/ITS/TH2XlineReductor.h
-                            include/ITS/TH1XlineReductor.h                            
                             include/ITS/ITSFhrTask.h
                             include/ITS/ITSFeeTask.h
                             include/ITS/ITSClusterTask.h

--- a/Modules/ITS/CMakeLists.txt
+++ b/Modules/ITS/CMakeLists.txt
@@ -4,8 +4,10 @@ add_library(O2QcITS
             src/ITSRawTask.cxx
             src/TrendingTaskITSThr.cxx
             src/TrendingTaskITSFhr.cxx
+            src/TrendingTaskITSTracks.cxx            
             src/TrendingTaskConfigITS.cxx
             src/TH2XlineReductor.cxx
+            src/TH1XlineReductor.cxx            
             src/ITSFhrTask.cxx
             src/ITSFeeTask.cxx
             src/ITSClusterTask.cxx
@@ -17,7 +19,7 @@ add_library(O2QcITS
             src/ITSFeeCheck.cxx
             )
 
-target_sources(O2QcITS PRIVATE src/TH2XlineReductor.cxx)
+target_sources(O2QcITS PRIVATE src/TH2XlineReductor.cxx src/TH1XlineReductor.cxx)
 
 target_include_directories(
   O2QcITS
@@ -45,7 +47,9 @@ add_root_dictionary(O2QcITS
                     HEADERS include/ITS/ITSRawTask.h
                             include/ITS/TrendingTaskITSThr.h
                             include/ITS/TrendingTaskITSFhr.h
+                            include/ITS/TrendingTaskITSTracks.h                            
                             include/ITS/TH2XlineReductor.h
+                            include/ITS/TH1XlineReductor.h                            
                             include/ITS/ITSFhrTask.h
                             include/ITS/ITSFeeTask.h
                             include/ITS/ITSClusterTask.h
@@ -104,6 +108,7 @@ install(FILES
         its.json
         itsQCTrendingThr.json
         itsQCTrendingFhr.json
+        itsQCTrendingTracks.json        
         itsFhr.json
         itsFee.json
         itsCluster.json

--- a/Modules/ITS/CMakeLists.txt
+++ b/Modules/ITS/CMakeLists.txt
@@ -8,7 +8,6 @@ add_library(O2QcITS
             src/TrendingTaskITSTracks.cxx
             src/TrendingTaskConfigITS.cxx
             src/TH2XlineReductor.cxx
-            src/TH1XlineReductor.cxx
             src/ITSFhrTask.cxx
             src/ITSFeeTask.cxx
             src/ITSClusterTask.cxx
@@ -20,7 +19,7 @@ add_library(O2QcITS
             src/ITSFeeCheck.cxx
             )
 
-target_sources(O2QcITS PRIVATE src/TH2XlineReductor.cxx src/TH1XlineReductor.cxx)
+target_sources(O2QcITS PRIVATE src/TH2XlineReductor.cxx)
 
 target_include_directories(
   O2QcITS
@@ -51,7 +50,6 @@ add_root_dictionary(O2QcITS
                             include/ITS/TrendingTaskITSCluster.h
                             include/ITS/TrendingTaskITSTracks.h
                             include/ITS/TH2XlineReductor.h
-                            include/ITS/TH1XlineReductor.h
                             include/ITS/ITSFhrTask.h
                             include/ITS/ITSFeeTask.h
                             include/ITS/ITSClusterTask.h

--- a/Modules/ITS/include/ITS/ITSTrackTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackTask.h
@@ -60,8 +60,6 @@ class ITSTrackTask : public TaskInterface
   TH1D* hNClusters;
   TH1D* hTrackEta;
   TH1D* hTrackPhi;
-  TH1D* hOccupancyROF;
-  TH1D* hClusterUsage;
   TH2D* hAngularDistribution;
   TH2D* hVertexCoordinates;
   TH2D* hVertexRvsZ;

--- a/Modules/ITS/include/ITS/ITSTrackTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackTask.h
@@ -67,12 +67,17 @@ class ITSTrackTask : public TaskInterface
   TH2D* hVertexRvsZ;
   TH1D* hVertexZ;
   TH1D* hVertexContributors;
+  TH1D* hAssociatedClusterFraction;
+  TH1D* hNtracks;
+  TH2D* hNClustersPerTrackEta;
+  
   std::string mRunNumber;
   std::string mRunNumberPath;
 
   float mVertexXYsize;
   float mVertexZsize;
   float mVertexRsize;
+  Int_t mNtracksMAX;
   Int_t mNTracks = 0;
   Int_t mNRofs = 0;
 

--- a/Modules/ITS/include/ITS/ITSTrackTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackTask.h
@@ -68,7 +68,7 @@ class ITSTrackTask : public TaskInterface
   TH1D* hAssociatedClusterFraction;
   TH1D* hNtracks;
   TH2D* hNClustersPerTrackEta;
-  
+
   std::string mRunNumber;
   std::string mRunNumberPath;
 

--- a/Modules/ITS/include/ITS/LinkDef.h
+++ b/Modules/ITS/include/ITS/LinkDef.h
@@ -6,7 +6,9 @@
 #pragma link C++ class o2::quality_control_modules::its::ITSRawTask + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSThr + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSFhr + ;
+#pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSTracks + ;
 #pragma link C++ class o2::quality_control_modules::its::TH2XlineReductor + ;
+#pragma link C++ class o2::quality_control_modules::its::TH1XlineReductor + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSFhrTask + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSFeeTask + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSClusterTask + ;

--- a/Modules/ITS/include/ITS/LinkDef.h
+++ b/Modules/ITS/include/ITS/LinkDef.h
@@ -9,7 +9,6 @@
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSCluster + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSTracks + ;
 #pragma link C++ class o2::quality_control_modules::its::TH2XlineReductor + ;
-#pragma link C++ class o2::quality_control_modules::its::TH1XlineReductor + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSFhrTask + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSFeeTask + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSClusterTask + ;

--- a/Modules/ITS/include/ITS/LinkDef.h
+++ b/Modules/ITS/include/ITS/LinkDef.h
@@ -8,7 +8,6 @@
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSFhr + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSTracks + ;
 #pragma link C++ class o2::quality_control_modules::its::TH2XlineReductor + ;
-#pragma link C++ class o2::quality_control_modules::its::TH1XlineReductor + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSFhrTask + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSFeeTask + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSClusterTask + ;

--- a/Modules/ITS/include/ITS/TrendingTaskITSTracks.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSTracks.h
@@ -1,0 +1,101 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    TrendingTaskITSTracks.h
+/// \author  Ivan Ravasenga on the structure from Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_TRENDINGTASKITSTRACKS_H
+#define QUALITYCONTROL_TRENDINGTASKITSTRACKS_H
+
+#include "ITS/TrendingTaskConfigITS.h"
+#include "QualityControl/PostProcessingInterface.h"
+#include "QualityControl/Reductor.h"
+
+#include <TAxis.h>
+#include <TColor.h>
+#include <TGraph.h>
+#include <TLegend.h>
+#include <TTree.h>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace o2::quality_control::repository
+{
+class DatabaseInterface;
+}
+
+namespace o2::quality_control::postprocessing
+{
+
+/// \brief  A post-processing task which trends values, stores them in a TTree
+/// and produces plots.
+///
+/// A post-processing task which trends objects inside QC database (QCDB). It
+/// extracts some values of one or multiple
+/// objects using the Reductor classes, then stores them inside a TTree. One can
+/// generate plots out the TTree - the
+/// class exposes the TTree::Draw interface to the user. The TTree and plots are
+/// stored in the QCDB. The class is
+/// configured with configuration files, see Framework/postprocessing.json as an
+/// example.
+///
+/// \author Ivan Ravasenga on the structure from Piotr Konopka
+class TrendingTaskITSTracks : public PostProcessingInterface
+{
+ public:
+  TrendingTaskITSTracks() = default;
+  ~TrendingTaskITSTracks() override = default;
+
+  void configure(std::string name,
+                 const boost::property_tree::ptree& config) override;
+  void initialize(Trigger, framework::ServiceRegistry&) override;
+  void update(Trigger, framework::ServiceRegistry&) override;
+  void finalize(Trigger, framework::ServiceRegistry&) override;
+
+  // other functions (mainly style)
+  void SetLegendStyle(TLegend* leg);
+  void SetGraphStyle(TGraph* g, int col, int mkr);
+  void SetGraphNameAndAxes(TGraph* g, std::string name, std::string title,
+                           std::string xtitle, std::string ytitle, double ymin,
+                           double ymax, std::vector<std::string> runlist);
+  void PrepareLegend(TLegend* leg, int layer);
+
+ private:
+  struct MetaData {
+    Int_t runNumber = 0;
+  };
+
+  void trendValues(repository::DatabaseInterface& qcdb);
+  void storePlots(repository::DatabaseInterface& qcdb);
+  void storeTrend(repository::DatabaseInterface& qcdb);
+
+  TrendingTaskConfigITS mConfig;
+  MetaData mMetaData;
+  UInt_t mTime;
+  std::unique_ptr<TTree> mTrend;
+  std::vector<std::string> runlist;
+  Int_t ntreeentries = 0;
+  std::unordered_map<std::string, std::unique_ptr<Reductor>> mReductors;
+
+  const int col[4] = { 1, 2, 3, 4};
+  const int mkr[4] = { 8, 16, 24, 32};
+  static constexpr int NTRENDSTRACKS = 4;
+  const std::string trendtitles[NTRENDSTRACKS] = { "NCluster mean", "NCluster rms", "Occupancy ROF", "Cluster Usage"};
+  const std::string trendnames[NTRENDSTRACKS] = { "NCluster mean", "NCluster rms", "Occupancy ROF", "Cluster Usage"};
+  const std::string ytitles[NTRENDSTRACKS] = {"NCluster mean", "NCluster rms", "Occupancy ROF", "Cluster Usage"};
+};
+
+} // namespace o2::quality_control::postprocessing
+
+#endif // QUALITYCONTROL_TRENDINGTASKITSTRACKS_H

--- a/Modules/ITS/include/ITS/TrendingTaskITSTracks.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSTracks.h
@@ -88,12 +88,12 @@ class TrendingTaskITSTracks : public PostProcessingInterface
   Int_t ntreeentries = 0;
   std::unordered_map<std::string, std::unique_ptr<Reductor>> mReductors;
 
-  const int col[4] = { 1, 2, 3, 4};
-  const int mkr[4] = { 8, 16, 24, 32};
+  const int col[4] = { 1, 2, 3, 4 };
+  const int mkr[4] = { 8, 16, 24, 32 };
   static constexpr int NTRENDSTRACKS = 4;
-  const std::string trendtitles[NTRENDSTRACKS] = { "NCluster mean", "NCluster stddev"};
-  const std::string trendnames[NTRENDSTRACKS] = { "NCluster mean", "NCluster stddev"};
-  const std::string ytitles[NTRENDSTRACKS] = {"NCluster mean", "NCluster stddev"};
+  const std::string trendtitles[NTRENDSTRACKS] = { "NCluster mean", "NCluster stddev" };
+  const std::string trendnames[NTRENDSTRACKS] = { "NCluster mean", "NCluster stddev" };
+  const std::string ytitles[NTRENDSTRACKS] = { "NCluster mean", "NCluster stddev" };
 };
 
 } // namespace o2::quality_control::postprocessing

--- a/Modules/ITS/include/ITS/TrendingTaskITSTracks.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSTracks.h
@@ -91,9 +91,9 @@ class TrendingTaskITSTracks : public PostProcessingInterface
   const int col[4] = { 1, 2, 3, 4};
   const int mkr[4] = { 8, 16, 24, 32};
   static constexpr int NTRENDSTRACKS = 4;
-  const std::string trendtitles[NTRENDSTRACKS] = { "NCluster mean", "NCluster rms", "Occupancy ROF", "Cluster Usage"};
-  const std::string trendnames[NTRENDSTRACKS] = { "NCluster mean", "NCluster rms", "Occupancy ROF", "Cluster Usage"};
-  const std::string ytitles[NTRENDSTRACKS] = {"NCluster mean", "NCluster rms", "Occupancy ROF", "Cluster Usage"};
+  const std::string trendtitles[NTRENDSTRACKS] = { "NCluster mean", "NCluster stddev"};
+  const std::string trendnames[NTRENDSTRACKS] = { "NCluster mean", "NCluster stddev"};
+  const std::string ytitles[NTRENDSTRACKS] = {"NCluster mean", "NCluster stddev"};
 };
 
 } // namespace o2::quality_control::postprocessing

--- a/Modules/ITS/itsQCTrendingTracks.json
+++ b/Modules/ITS/itsQCTrendingTracks.json
@@ -50,7 +50,7 @@
           "userorcontrol"
         ],
         "updateTrigger": [
-          "10 seconds"
+          "60 seconds"
         ],
         "stopTrigger": [
           "userorcontrol"

--- a/Modules/ITS/itsQCTrendingTracks.json
+++ b/Modules/ITS/itsQCTrendingTracks.json
@@ -35,70 +35,13 @@
             "names": ["NClusters"],
             "reductorName": "o2::quality_control_modules::common::TH1Reductor",
             "moduleName": "QcITS"
-          },
-          {
-            "type": "repository",
-            "paths": ["qc/ITS/MO/ITSTrackTask/EtaDistribution"],
-            "names": ["Eta"],
-            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
-            "moduleName": "QcITS"
-          },
-          {
-            "type": "repository",
-            "paths": ["qc/ITS/MO/ITSTrackTask/PhiDistribution"],
-            "names": ["Phi"],
-            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
-            "moduleName": "QcITS"
-          },      
-          {
-            "type": "repository",
-            "paths": ["qc/ITS/MO/ITSTrackTask/OccupancyROF"],
-            "names": ["OccupancyROF"],
-            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
-            "moduleName": "QcITS"
-          },    
-          {
-            "type": "repository",
-            "paths": ["qc/ITS/MO/ITSTrackTask/ClusterUsage"],
-            "names": ["ClusterUsage"],
-            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
-            "moduleName": "QcITS"
-          }    
-          
+          }  
         ],
         "plots": [
           {
             "names": ["NClusters_mean", "NClusters_stddev"],
             "title": ["Average NClusters trend", "Stddev NClusters trend"],
             "varexp": ["NClusters.mean:ntreeentries", "NClusters.stddev:ntreeentries"],
-            "selection": "",
-            "option": "PL"
-          }, 
-          {
-            "names": ["Eta_mean", "Eta_stddev"],
-            "title": ["Average Eta trend", "Stddev Eta trend"],
-            "varexp": ["Eta.mean:ntreeentries", "Eta.stddev:ntreeentries"],
-            "selection": "",
-            "option": "PL"
-          },
-          {
-            "names": ["Phi_mean", "Phi_stddev"],
-            "title": ["Average Phi trend", "Stddev Phi trend"],
-            "varexp": ["Phi.mean:ntreeentries", "Phi.stddev:ntreeentries"],
-            "selection": "",
-            "option": "PL"
-          },  
-          {
-            "names": ["OccupancyROF_mean", "OccupancyROF_stddev"],
-            "title": ["Average OccupancyROF trend", "Stddev OccupancyROF trend"],
-            "varexp": ["OccupancyROF.mean:ntreeentries", "OccupancyROF.stddev:ntreeentries"],
-            "selection": "",
-            "option": "PL"
-          },  
-          {
-            "names": ["ClusterUsage_mean", "ClusterUsage_stddev"],
-            "title": ["Average ClusterUsage trend", "Stddev ClusterUsage trend"],
-            "varexp": ["ClusterUsage.mean:ntreeentries", "ClusterUsage.stddev:ntreeentries"],
             "selection": "",
             "option": "PL"
           }

--- a/Modules/ITS/itsQCTrendingTracks.json
+++ b/Modules/ITS/itsQCTrendingTracks.json
@@ -1,0 +1,118 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "postprocessing": {
+      "ITSqcTracks": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::TrendingTaskITSTracks",
+        "moduleName": "QualityControl",
+        "detectorName": "ITS",
+        "dataSources": [
+          {
+            "type": "repository",
+            "paths": ["qc/ITS/MO/ITSTrackTask/NClusters"],
+            "names": ["NClusters"],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcITS"
+          },
+          {
+            "type": "repository",
+            "paths": ["qc/ITS/MO/ITSTrackTask/EtaDistribution"],
+            "names": ["Eta"],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcITS"
+          },
+          {
+            "type": "repository",
+            "paths": ["qc/ITS/MO/ITSTrackTask/PhiDistribution"],
+            "names": ["Phi"],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcITS"
+          },      
+          {
+            "type": "repository",
+            "paths": ["qc/ITS/MO/ITSTrackTask/OccupancyROF"],
+            "names": ["OccupancyROF"],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcITS"
+          },    
+          {
+            "type": "repository",
+            "paths": ["qc/ITS/MO/ITSTrackTask/ClusterUsage"],
+            "names": ["ClusterUsage"],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcITS"
+          }    
+          
+        ],
+        "plots": [
+          {
+            "names": ["NClusters_mean", "NClusters_stddev"],
+            "title": ["Average NClusters trend", "Stddev NClusters trend"],
+            "varexp": ["NClusters.mean:ntreeentries", "NClusters.stddev:ntreeentries"],
+            "selection": "",
+            "option": "PL"
+          }, 
+          {
+            "names": ["Eta_mean", "Eta_stddev"],
+            "title": ["Average Eta trend", "Stddev Eta trend"],
+            "varexp": ["Eta.mean:ntreeentries", "Eta.stddev:ntreeentries"],
+            "selection": "",
+            "option": "PL"
+          },
+          {
+            "names": ["Phi_mean", "Phi_stddev"],
+            "title": ["Average Phi trend", "Stddev Phi trend"],
+            "varexp": ["Phi.mean:ntreeentries", "Phi.stddev:ntreeentries"],
+            "selection": "",
+            "option": "PL"
+          },  
+          {
+            "names": ["OccupancyROF_mean", "OccupancyROF_stddev"],
+            "title": ["Average OccupancyROF trend", "Stddev OccupancyROF trend"],
+            "varexp": ["OccupancyROF.mean:ntreeentries", "OccupancyROF.stddev:ntreeentries"],
+            "selection": "",
+            "option": "PL"
+          },  
+          {
+            "names": ["ClusterUsage_mean", "ClusterUsage_stddev"],
+            "title": ["Average ClusterUsage trend", "Stddev ClusterUsage trend"],
+            "varexp": ["ClusterUsage.mean:ntreeentries", "ClusterUsage.stddev:ntreeentries"],
+            "selection": "",
+            "option": "PL"
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "10 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    }
+  }
+}

--- a/Modules/ITS/itsTrack.json
+++ b/Modules/ITS/itsTrack.json
@@ -56,7 +56,7 @@
         "dataSource" : [ {
           "type" : "Task",
           "name" : "ITSTrackTask",
-          "MOs" : ["NClusters","PhiDistribution","AngularDistribution","ClusterUsage","EtaDistribution","VertexCoordinates","VertexRvsZ","VertexZ"]
+          "MOs" : ["NClusters","PhiDistribution","AngularDistribution","EtaDistribution","VertexCoordinates","VertexRvsZ","VertexZ"]
         } ]
       }
     }

--- a/Modules/ITS/itsTrack.json
+++ b/Modules/ITS/itsTrack.json
@@ -40,7 +40,8 @@
           "runNumberPath" : "/home/its/QC/workdir/infiles/RunNumber.dat",
 	  "vertexXYsize" : "0.1",
 	  "vertexZsize": "15",
-	  "vertexRsize": "0.1"
+	  "vertexRsize": "0.1",
+	  "NtracksMAX"  : "100"
         }
 
       }

--- a/Modules/ITS/src/ITSTrackCheck.cxx
+++ b/Modules/ITS/src/ITSTrackCheck.cxx
@@ -62,12 +62,6 @@ Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
         result = result.getLevel() + 1e2;
     }
 
-    if (iter->second->getName() == "ClusterUsage") {
-      auto* h = dynamic_cast<TH1D*>(iter->second->getObject());
-      if (h->GetMaximum() < 0.1)
-        result = result.getLevel() + 1e3;
-    }
-
     if (iter->second->getName() == "EtaDistribution") {
       auto* h = dynamic_cast<TH1D*>(iter->second->getObject());
       if (abs(h->GetBinCenter(h->GetMaximumBin())) > 0.5)
@@ -174,25 +168,6 @@ void ITSTrackCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
     }
 
     auto* msg = new TLatex(positionX, positionY, Form("#bf{#splitline{%s}{%s}}", text[0].Data(), text[1].Data()));
-    msg->SetTextColor(textColor);
-    msg->SetTextSize(0.08);
-    msg->SetTextFont(43);
-    msg->SetNDC();
-    h->GetListOfFunctions()->Add(msg);
-  }
-
-  if (mo->getName() == "ClusterUsage") {
-    auto* h = dynamic_cast<TH1D*>(mo->getObject());
-    int histoQuality = getDigit(checkResult.getLevel(), 4);
-    if (histoQuality == 0) {
-      text[0] = "Quality::GOOD";
-      textColor = kGreen;
-    } else {
-      text[0] = "INFO: fraction of clusters below 0.1";
-      text[1] = "call expert";
-      textColor = kRed;
-    }
-    auto* msg = new TLatex(0.15, 0.7, Form("#bf{#splitline{%s}{%s}}", text[0].Data(), text[1].Data()));
     msg->SetTextColor(textColor);
     msg->SetTextSize(0.08);
     msg->SetTextFont(43);

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -37,18 +37,14 @@ ITSTrackTask::ITSTrackTask() : TaskInterface()
 
 ITSTrackTask::~ITSTrackTask()
 {
-
   delete hNClusters;
   delete hTrackEta;
   delete hTrackPhi;
-  delete hOccupancyROF;
-  delete hClusterUsage;
   delete hAngularDistribution;
   delete hVertexCoordinates;
   delete hVertexRvsZ;
   delete hVertexZ;
   delete hVertexContributors;
-  
   delete hAssociatedClusterFraction;
   delete hNtracks;
   delete hNClustersPerTrackEta; 
@@ -123,10 +119,9 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
       vEta.emplace_back(Eta);
       vPhi.emplace_back(out.getPhi());
       
-      hNClustersPerTrackEta->Fill(track.getNumberOfClusters(),Eta);
+      hNClustersPerTrackEta->Fill(Eta,track.getNumberOfClusters());
       nClusterCntTrack += track.getNumberOfClusters();   
     }
-    tClusterMap->Fill();
 
     auto clusters_in_frame = ROF.getROFData(clusArr);
     nClusterCnt = clusters_in_frame.size();
@@ -145,10 +140,8 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
   mNRofs += rofArr.size();
 
   if (mNRofs >= NROFOCCUPANCY) {
-    hOccupancyROF->SetBinContent(1, 1. * mNTracks / mNRofs);
     mNTracks = 0;
     mNRofs = 0;
-    hClusterUsage->SetBinContent(1, 1. * mNClustersInTracks / mNClusters);
     mNClustersInTracks = 0;
     mNClusters = 0;
   }
@@ -183,8 +176,6 @@ void ITSTrackTask::reset()
   hNClusters->Reset();
   hTrackPhi->Reset();
   hTrackEta->Reset();
-  hOccupancyROF->Reset();
-  hClusterUsage->Reset();
 
   hVertexCoordinates->Reset();
   hVertexRvsZ->Reset();
@@ -194,7 +185,7 @@ void ITSTrackTask::reset()
   hAssociatedClusterFraction->Reset();
   hNtracks->Reset();
   hNClustersPerTrackEta->Reset();
-  
+
 }
 
 void ITSTrackTask::createAllHistos()
@@ -230,20 +221,6 @@ void ITSTrackTask::createAllHistos()
   addObject(hTrackPhi);
   formatAxes(hTrackPhi, "#phi", "counts", 1, 1.10);
   hTrackPhi->SetStats(0);
-
-  hOccupancyROF = new TH1D("OccupancyROF", "OccupancyROF", 1, 0, 1);
-  hOccupancyROF->SetTitle("Track occupancy in ROF");
-  addObject(hOccupancyROF);
-  formatAxes(hOccupancyROF, "", "nTracks/ROF", 1, 1.10);
-  hOccupancyROF->SetStats(0);
-  hOccupancyROF->SetBit(TH1::kIsAverage);
-
-  hClusterUsage = new TH1D("ClusterUsage", "ClusterUsage", 1, 0, 1);
-  hClusterUsage->SetTitle("Fraction of clusters used in tracking");
-  addObject(hClusterUsage);
-  formatAxes(hClusterUsage, "", "nCluster in track / Total cluster", 1, 1.10);
-  hClusterUsage->SetStats(0);
-  hClusterUsage->SetBit(TH1::kIsAverage);
 
   hVertexCoordinates = new TH2D("VertexCoordinates", "VertexCoordinates", 1000, -1. * mVertexXYsize, mVertexXYsize, 1000, -1 * mVertexXYsize, mVertexXYsize);
   hVertexCoordinates->SetTitle("Coordinates of track vertex");
@@ -281,10 +258,10 @@ void ITSTrackTask::createAllHistos()
   formatAxes(hNtracks, "", "# of tracks ", 1, 1.10);
   hNtracks->SetStats(0);
 
-  hNClustersPerTrackEta = new TH2D("NClustersPerTrackEta", "NClustersPerTrackEta", 50, 0, 10, 30, -1.5, 1.5);
-  hNClustersPerTrackEta->SetTitle("NClusters Per Track vs Eta");
+  hNClustersPerTrackEta = new TH2D("NClustersPerTrackEta", "NClustersPerTrackEta", 30, -1.5, 1.5, 13, 1.5, 14.5);
+  hNClustersPerTrackEta->SetTitle("Eta vs NClusters Per Track");
   addObject(hNClustersPerTrackEta);
-  formatAxes(hNClustersPerTrackEta, "# of Clusters per Track", "#Eta", 1, 1.10);
+  formatAxes(hNClustersPerTrackEta, "#eta", "# of Clusters per Track", 1, 1.10);
   hNClustersPerTrackEta->SetStats(0);
   
 }

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -252,13 +252,13 @@ void ITSTrackTask::createAllHistos()
   formatAxes(hAssociatedClusterFraction, "", "Clusters in track / Clusters", 1, 1.10);
   hAssociatedClusterFraction->SetStats(0);
   
-  hNtracks = new TH1D("Ntracks", "Ntracks", mNtracksMAX, 0, mNtracksMAX);
+  hNtracks = new TH1D("Ntracks", "Ntracks", (int)mNtracksMAX, 0, mNtracksMAX);
   hNtracks->SetTitle("The number of tracks event by event");
   addObject(hNtracks);
   formatAxes(hNtracks, "", "# of tracks ", 1, 1.10);
   hNtracks->SetStats(0);
 
-  hNClustersPerTrackEta = new TH2D("NClustersPerTrackEta", "NClustersPerTrackEta", 30, -1.5, 1.5, 13, 1.5, 14.5);
+  hNClustersPerTrackEta = new TH2D("NClustersPerTrackEta", "NClustersPerTrackEta", 300, -1.5, 1.5, 13, 1.5, 14.5);
   hNClustersPerTrackEta->SetTitle("Eta vs NClusters Per Track");
   addObject(hNClustersPerTrackEta);
   formatAxes(hNClustersPerTrackEta, "#eta", "# of Clusters per Track", 1, 1.10);

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -47,7 +47,7 @@ ITSTrackTask::~ITSTrackTask()
   delete hVertexContributors;
   delete hAssociatedClusterFraction;
   delete hNtracks;
-  delete hNClustersPerTrackEta; 
+  delete hNClustersPerTrackEta;
 }
 
 void ITSTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
@@ -59,7 +59,7 @@ void ITSTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
   mVertexXYsize = std::stof(mCustomParameters["vertexXYsize"]);
   mVertexZsize = std::stof(mCustomParameters["vertexZsize"]);
   mVertexRsize = std::stof(mCustomParameters["vertexRsize"]);
-  mNtracksMAX  = std::stof(mCustomParameters["NtracksMAX"]);
+  mNtracksMAX = std::stof(mCustomParameters["NtracksMAX"]);
   mDoTTree = std::stoi(mCustomParameters["doTTree"]);
 
   createAllHistos();
@@ -99,10 +99,10 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
     vEta.clear();
     vPhi.clear();
 
-    int ntrackCnt =0;
-    int nClusterCntTrack =0;
-    int nClusterCnt =0;
-        
+    int ntrackCnt = 0;
+    int nClusterCntTrack = 0;
+    int nClusterCnt = 0;
+
     for (int itrack = ROF.getFirstEntry(); itrack < ROF.getFirstEntry() + ROF.getNEntries(); itrack++) {
 
       auto& track = trackArr[itrack];
@@ -118,18 +118,18 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
       vMap.emplace_back(track.getPattern());
       vEta.emplace_back(Eta);
       vPhi.emplace_back(out.getPhi());
-      
-      hNClustersPerTrackEta->Fill(Eta,track.getNumberOfClusters());
-      nClusterCntTrack += track.getNumberOfClusters();   
+
+      hNClustersPerTrackEta->Fill(Eta, track.getNumberOfClusters());
+      nClusterCntTrack += track.getNumberOfClusters();
     }
 
     auto clusters_in_frame = ROF.getROFData(clusArr);
     nClusterCnt = clusters_in_frame.size();
-    ntrackCnt   = ROF.getNEntries();
-    
-    float clusterRatio = nClusterCnt >0 ? nClusterCntTrack/nClusterCnt : -1;
+    ntrackCnt = ROF.getNEntries();
+
+    float clusterRatio = nClusterCnt > 0 ? nClusterCntTrack / nClusterCnt : -1;
     hAssociatedClusterFraction->Fill(clusterRatio);
-    hNtracks->Fill(ntrackCnt);    
+    hNtracks->Fill(ntrackCnt);
 
     if (mDoTTree)
       tClusterMap->Fill();
@@ -181,11 +181,10 @@ void ITSTrackTask::reset()
   hVertexRvsZ->Reset();
   hVertexZ->Reset();
   hVertexContributors->Reset();
-  
+
   hAssociatedClusterFraction->Reset();
   hNtracks->Reset();
   hNClustersPerTrackEta->Reset();
-
 }
 
 void ITSTrackTask::createAllHistos()
@@ -245,13 +244,13 @@ void ITSTrackTask::createAllHistos()
   addObject(hVertexContributors);
   formatAxes(hVertexContributors, "Number of contributors for vertex", "Counts", 1, 1.10);
   hVertexContributors->SetStats(0);
-  
+
   hAssociatedClusterFraction = new TH1D("AssociatedClusterFraction", "AssociatedClusterFraction", 100, 0, 1);
   hAssociatedClusterFraction->SetTitle("The fraction of clusters in tracking event by event");
   addObject(hAssociatedClusterFraction);
   formatAxes(hAssociatedClusterFraction, "", "Clusters in track / Clusters", 1, 1.10);
   hAssociatedClusterFraction->SetStats(0);
-  
+
   hNtracks = new TH1D("Ntracks", "Ntracks", (int)mNtracksMAX, 0, mNtracksMAX);
   hNtracks->SetTitle("The number of tracks event by event");
   addObject(hNtracks);
@@ -263,7 +262,6 @@ void ITSTrackTask::createAllHistos()
   addObject(hNClustersPerTrackEta);
   formatAxes(hNClustersPerTrackEta, "#eta", "# of Clusters per Track", 1, 1.10);
   hNClustersPerTrackEta->SetStats(0);
-  
 }
 
 void ITSTrackTask::addObject(TObject* aObject)

--- a/Modules/ITS/src/TrendingTaskITSTracks.cxx
+++ b/Modules/ITS/src/TrendingTaskITSTracks.cxx
@@ -29,7 +29,7 @@ using namespace o2::quality_control::core;
 using namespace o2::quality_control::postprocessing;
 
 void TrendingTaskITSTracks::configure(std::string name,
-                                   const boost::property_tree::ptree& config)
+                                      const boost::property_tree::ptree& config)
 {
   mConfig = TrendingTaskConfigITS(name, config);
 }
@@ -108,7 +108,7 @@ void TrendingTaskITSTracks::trendValues(repository::DatabaseInterface& qcdb)
       auto mo = qcdb.retrieveMO(dataSource.path, "");
       if (!count) {
         std::map<std::string, std::string> entryMetadata = mo->getMetadataMap(); //full list of metadata as a map
-        mMetaData.runNumber = (entryMetadata["Run"]!="") ? std::stoi(entryMetadata["Run"]) : 0;                   //get and set run number
+        mMetaData.runNumber = std::stoi(entryMetadata["RunNumber"]);             //get and set run number
         ntreeentries = (Int_t)mTrend->GetEntries() + 1;
         runlist.push_back(std::to_string(mMetaData.runNumber));
       }
@@ -116,11 +116,11 @@ void TrendingTaskITSTracks::trendValues(repository::DatabaseInterface& qcdb)
       if (obj) {
         mReductors[dataSource.name]->update(obj);
       }
-    }else if (dataSource.type == "repository-quality") {
+    } else if (dataSource.type == "repository-quality") {
       auto qo = qcdb.retrieveQO(dataSource.path + "/" + dataSource.name);
       if (qo) {
         mReductors[dataSource.name]->update(qo.get());
-      } 
+      }
     } else {
       ILOGE << "Unknown type of data source '" << dataSource.type << "'.";
     }
@@ -143,19 +143,19 @@ void TrendingTaskITSTracks::storePlots(repository::DatabaseInterface& qcdb)
     int add = 0;
     double ymin = -10.;
     double ymax = +10.;
-    if(plot.name.find("mean") != std::string::npos){
+    if (plot.name.find("mean") != std::string::npos) {
       add = 0;
       ymin = 0.;
-      ymax = 15.;  
-    } else if(plot.name.find("stddev") != std::string::npos){
+      ymax = 15.;
+    } else if (plot.name.find("stddev") != std::string::npos) {
       add = 1;
       ymin = 0.;
-      ymax = 5.;  
+      ymax = 5.;
     }
 
     bool isrun = plot.varexp.find("ntreeentries") != std::string::npos ? true : false; // vs run or vs time
     long int n = mTrend->Draw(plot.varexp.c_str(), plot.selection.c_str(),
-                              "goff"); 
+                              "goff");
 
     double* x = mTrend->GetV2();
     double* y = mTrend->GetV1();
@@ -176,7 +176,6 @@ void TrendingTaskITSTracks::storePlots(repository::DatabaseInterface& qcdb)
     // after and getting a segfault.
     delete g;
   } // end loop on plots
-
 }
 
 void TrendingTaskITSTracks::SetLegendStyle(TLegend* leg)
@@ -194,9 +193,9 @@ void TrendingTaskITSTracks::SetGraphStyle(TGraph* g, int col, int mkr)
 }
 
 void TrendingTaskITSTracks::SetGraphNameAndAxes(TGraph* g, std::string name,
-                                             std::string title, std::string xtitle,
-                                             std::string ytitle, double ymin,
-                                             double ymax, std::vector<std::string> runlist)
+                                                std::string title, std::string xtitle,
+                                                std::string ytitle, double ymin,
+                                                double ymax, std::vector<std::string> runlist)
 {
   g->SetTitle(title.c_str());
   g->SetName(name.c_str());
@@ -225,5 +224,4 @@ void TrendingTaskITSTracks::SetGraphNameAndAxes(TGraph* g, std::string name,
 
 void TrendingTaskITSTracks::PrepareLegend(TLegend* leg, int layer)
 {
-
 }

--- a/Modules/ITS/src/TrendingTaskITSTracks.cxx
+++ b/Modules/ITS/src/TrendingTaskITSTracks.cxx
@@ -1,0 +1,239 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    TrendingTaskITSTracks.cxx
+/// \author  Ivan Ravasenga on the structure from Piotr Konopka
+///
+
+#include "ITS/TrendingTaskITSTracks.h"
+#include "QualityControl/RootClassFactory.h"
+#include "QualityControl/DatabaseInterface.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/Reductor.h"
+#include <TCanvas.h>
+#include <TH1.h>
+#include <TDatime.h>
+
+using namespace o2::quality_control;
+using namespace o2::quality_control::core;
+using namespace o2::quality_control::postprocessing;
+
+void TrendingTaskITSTracks::configure(std::string name,
+                                   const boost::property_tree::ptree& config)
+{
+  mConfig = TrendingTaskConfigITS(name, config);
+}
+
+void TrendingTaskITSTracks::initialize(Trigger, framework::ServiceRegistry&)
+{
+  // Preparing data structure of TTree
+  mTrend = std::make_unique<TTree>(); // todo: retrieve last TTree, so we
+                                      // continue trending. maybe do it
+                                      // optionally?
+  mTrend->SetName(PostProcessingInterface::getName().c_str());
+  mTrend->Branch("runNumber", &mMetaData.runNumber);
+  mTrend->Branch("ntreeentries", &ntreeentries);
+  mTrend->Branch("time", &mTime);
+
+  for (const auto& source : mConfig.dataSources) {
+    std::unique_ptr<Reductor> reductor(root_class_factory::create<Reductor>(
+      source.moduleName, source.reductorName));
+    mTrend->Branch(source.name.c_str(), reductor->getBranchAddress(),
+                   reductor->getBranchLeafList());
+    mReductors[source.name] = std::move(reductor);
+  }
+}
+
+// todo: see if OptimizeBaskets() indeed helps after some time
+void TrendingTaskITSTracks::update(Trigger, framework::ServiceRegistry& services)
+{
+  auto& qcdb = services.get<repository::DatabaseInterface>();
+
+  trendValues(qcdb);
+
+  storePlots(qcdb);
+  storeTrend(qcdb);
+}
+
+void TrendingTaskITSTracks::finalize(Trigger, framework::ServiceRegistry& services)
+{
+  auto& qcdb = services.get<repository::DatabaseInterface>();
+
+  trendValues(qcdb);
+
+  storePlots(qcdb);
+  storeTrend(qcdb);
+}
+
+void TrendingTaskITSTracks::storeTrend(repository::DatabaseInterface& qcdb)
+{
+  ILOG(Info, Support) << "Storing the trend, entries: " << mTrend->GetEntries() << ENDM;
+
+  auto mo = std::make_shared<core::MonitorObject>(mTrend.get(), getName(),
+                                                  mConfig.className,
+                                                  mConfig.detectorName);
+  mo->setIsOwner(false);
+  qcdb.storeMO(mo);
+}
+
+void TrendingTaskITSTracks::trendValues(repository::DatabaseInterface& qcdb)
+{
+  // We use current date and time. This for planned processing (not history). We
+  // still might need to use the objects
+  // timestamps in the end, but this would become ambiguous if there is more
+  // than one data source.
+  mTime = TDatime().Convert();
+  // todo get run number when it is available. consider putting it inside
+  // monitor object's metadata (this might be not
+  //  enough if we trend across runs).
+  mMetaData.runNumber = 0;
+  int count = 0;
+
+  for (auto& dataSource : mConfig.dataSources) {
+    //std::cout<<"TrendingTaskITSTracks dataSource type "<<dataSource.name<<" "<<dataSource.type<<std::endl;
+    // todo: make it agnostic to MOs, QOs or other objects. Let the reductor
+    // cast to whatever it needs.
+    if (dataSource.type == "repository") {
+      // auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name);
+      auto mo = qcdb.retrieveMO(dataSource.path, "");
+      if (!count) {
+        std::map<std::string, std::string> entryMetadata = mo->getMetadataMap(); //full list of metadata as a map
+        mMetaData.runNumber = (entryMetadata["Run"]!="") ? std::stoi(entryMetadata["Run"]) : 0;                   //get and set run number
+        ntreeentries = (Int_t)mTrend->GetEntries() + 1;
+        runlist.push_back(std::to_string(mMetaData.runNumber));
+      }
+      TObject* obj = mo ? mo->getObject() : nullptr;
+      if (obj) {
+        mReductors[dataSource.name]->update(obj);
+      }
+    }else if (dataSource.type == "repository-quality") {
+      auto qo = qcdb.retrieveQO(dataSource.path + "/" + dataSource.name);
+      if (qo) {
+        mReductors[dataSource.name]->update(qo.get());
+      } 
+    } else {
+      ILOGE << "Unknown type of data source '" << dataSource.type << "'.";
+    }
+    count++;
+  }
+  mTrend->Fill();
+}
+
+void TrendingTaskITSTracks::storePlots(repository::DatabaseInterface& qcdb)
+{
+  ILOG(Info, Support) << "Generating and storing " << mConfig.plots.size() << " plots."
+                      << ENDM;
+  //
+  // Create and save trends for each stave
+  //
+  int countplots = 0;
+  int ilay = 0;
+  for (const auto& plot : mConfig.plots) {
+
+    int add = 0;
+    double ymin = -10.;
+    double ymax = +10.;
+    if(plot.name.find("mean") != std::string::npos){
+      add = 0;
+      ymin = 0.;
+      ymax = 15.;  
+    } else if(plot.name.find("rms") != std::string::npos){
+      add = 1;
+      ymin = 0.;
+      ymax = 5.;  
+    } else if(plot.name.find("ROF") != std::string::npos){
+      add = 2;
+      ymin = 0.;
+      ymax = 1.;  
+    } else if(plot.name.find("Usage") != std::string::npos){
+      add = 3;
+      ymin = 0.;
+      ymax = 20.;  
+    }
+
+    bool isrun = plot.varexp.find("ntreeentries") != std::string::npos ? true : false; // vs run or vs time
+    long int n = mTrend->Draw(plot.varexp.c_str(), plot.selection.c_str(),
+                              "goff"); // plot.option.c_str());
+    double* x = mTrend->GetV2();
+    double* y = mTrend->GetV1();
+
+    // post processing plot
+    //TGraph* g = new TGraph(n, mTrend->GetV2(), mTrend->GetV1());
+    TGraph* g = new TGraph(n, x, y);
+    SetGraphStyle(g, col[add], mkr[add]);
+    //double ymin = plot.name.find("rms") != std::string::npos ? -1. : -10.;
+
+    //double ymax = plot.name.find("rms") != std::string::npos ? +1. : +10.;
+    SetGraphNameAndAxes(g, plot.name, plot.title, isrun ? "run" : "time", ytitles[add], ymin,
+                        ymax, runlist);
+    ILOG(Info, Support) << " Saving " << plot.name << " to CCDB " << ENDM;
+    auto mo = std::make_shared<MonitorObject>(g, mConfig.taskName, "o2::quality_control_modules::its::TrendingTaskITSTracks",
+                                              mConfig.detectorName);
+    mo->setIsOwner(false);
+    qcdb.storeMO(mo);
+
+    // It should delete everything inside. Confirmed by trying to delete histo
+    // after and getting a segfault.
+    delete g;
+  } // end loop on plots
+
+}
+
+void TrendingTaskITSTracks::SetLegendStyle(TLegend* leg)
+{
+  leg->SetTextFont(42);
+  leg->SetLineColor(kWhite);
+  leg->SetFillColor(0);
+}
+
+void TrendingTaskITSTracks::SetGraphStyle(TGraph* g, int col, int mkr)
+{
+  g->SetLineColor(col);
+  g->SetMarkerStyle(mkr);
+  g->SetMarkerColor(col);
+}
+
+void TrendingTaskITSTracks::SetGraphNameAndAxes(TGraph* g, std::string name,
+                                             std::string title, std::string xtitle,
+                                             std::string ytitle, double ymin,
+                                             double ymax, std::vector<std::string> runlist)
+{
+  g->SetTitle(title.c_str());
+  g->SetName(name.c_str());
+
+  g->GetXaxis()->SetTitle(xtitle.c_str());
+  g->GetYaxis()->SetTitle(ytitle.c_str());
+  g->GetYaxis()->SetRangeUser(ymin, ymax);
+
+  if (xtitle.find("time") != std::string::npos) {
+    g->GetXaxis()->SetTimeDisplay(1);
+    // It deals with highly congested dates labels
+    g->GetXaxis()->SetNdivisions(505);
+    // Without this it would show dates in order of 2044-12-18 on the day of
+    // 2019-12-19.
+    g->GetXaxis()->SetTimeOffset(0.0);
+    g->GetXaxis()->SetTimeFormat("%Y-%m-%d %H:%M");
+  }
+  if (xtitle.find("run") != std::string::npos) {
+    g->GetXaxis()->SetNdivisions(505); // It deals with highly congested dates labels
+    for (int ipoint = 0; ipoint < g->GetN(); ipoint++) {
+      g->GetXaxis()->SetBinLabel(g->GetXaxis()->FindBin(ipoint + 1.), runlist[ipoint].c_str());
+      g->GetXaxis()->LabelsOption("v");
+    }
+  }
+}
+
+void TrendingTaskITSTracks::PrepareLegend(TLegend* leg, int layer)
+{
+
+}

--- a/Modules/ITS/src/TrendingTaskITSTracks.cxx
+++ b/Modules/ITS/src/TrendingTaskITSTracks.cxx
@@ -147,33 +147,22 @@ void TrendingTaskITSTracks::storePlots(repository::DatabaseInterface& qcdb)
       add = 0;
       ymin = 0.;
       ymax = 15.;  
-    } else if(plot.name.find("rms") != std::string::npos){
+    } else if(plot.name.find("stddev") != std::string::npos){
       add = 1;
       ymin = 0.;
       ymax = 5.;  
-    } else if(plot.name.find("ROF") != std::string::npos){
-      add = 2;
-      ymin = 0.;
-      ymax = 1.;  
-    } else if(plot.name.find("Usage") != std::string::npos){
-      add = 3;
-      ymin = 0.;
-      ymax = 20.;  
     }
 
     bool isrun = plot.varexp.find("ntreeentries") != std::string::npos ? true : false; // vs run or vs time
     long int n = mTrend->Draw(plot.varexp.c_str(), plot.selection.c_str(),
-                              "goff"); // plot.option.c_str());
+                              "goff"); 
     double* x = mTrend->GetV2();
     double* y = mTrend->GetV1();
 
     // post processing plot
-    //TGraph* g = new TGraph(n, mTrend->GetV2(), mTrend->GetV1());
     TGraph* g = new TGraph(n, x, y);
     SetGraphStyle(g, col[add], mkr[add]);
-    //double ymin = plot.name.find("rms") != std::string::npos ? -1. : -10.;
 
-    //double ymax = plot.name.find("rms") != std::string::npos ? +1. : +10.;
     SetGraphNameAndAxes(g, plot.name, plot.title, isrun ? "run" : "time", ytitles[add], ymin,
                         ymax, runlist);
     ILOG(Info, Support) << " Saving " << plot.name << " to CCDB " << ENDM;


### PR DESCRIPTION
This PR includes 3 new plots for the ITS track task:
- distribution event by event of the fraction of clusters into tracks
- distribution event by event of the number of tracks per ROF
- 2D distribution of the number of clusters per track vs eta

In addition, new online post-processing for tracks (v0, to be extended in the near future)
