### PR TITLE
QC-310: reconfigure checkrunner

### DIFF
--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -209,7 +209,7 @@ class CheckRunner : public framework::Task
 
   // General state
   std::string mDeviceName;
-  std::vector<Check> mChecks;
+  std::map<std::string, Check> mChecks;
   std::string mDetectorName;
   Activity mActivity;
   CheckRunnerConfig mConfig;

--- a/Framework/include/QualityControl/UpdatePolicyManager.h
+++ b/Framework/include/QualityControl/UpdatePolicyManager.h
@@ -122,6 +122,12 @@ class UpdatePolicyManager
    * @param policyHelper
    */
   void addPolicy(std::string actorName, UpdatePolicyType policyType, std::vector<std::string> objectNames, bool allObjects, bool policyHelper);
+
+  /**
+   * Remove all policies and reset revisions.
+   */
+  void reset();
+
   /**
    * Checks whether the given actor is ready or not.
    * @param actorName

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -212,6 +212,7 @@ void CheckRunner::init(framework::InitContext& iCtx)
     iCtx.services().get<CallbackService>().set(CallbackService::Id::Reset, [this]() { reset(); });
     iCtx.services().get<CallbackService>().set(CallbackService::Id::Stop, [this]() { stop(); });
 
+    updatePolicyManager.reset();
     for (auto& [checkName, check] : mChecks) {
       check.init();
       updatePolicyManager.addPolicy(check.getName(), check.getUpdatePolicyType(), check.getObjectsNames(), check.getAllObjectsOption(), false);

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -187,6 +187,7 @@ void CheckRunner::refreshConfig(InitContext& iCtx)
         // search if we have this check in this runner and replace it
         if (mChecks.find(checkSpec.checkName) != mChecks.end()) {
           auto checkConfig = Check::extractConfig(infrastructureSpec.common, checkSpec);
+          mChecks.erase(checkConfig.name);
           mChecks.emplace(checkConfig.name, checkConfig);
           ILOG(Debug, Devel) << "Check " << checkSpec.checkName << " has been updated" << ENDM;
         }

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -185,10 +185,10 @@ void CheckRunner::refreshConfig(InitContext& iCtx)
       // Topology changes are ignored: New checks are ignored. Removed checks are ignored.
       for (const auto& checkSpec : infrastructureSpec.checks) {
         // search if we have this check in this runner and replace it
-        if ( mChecks.find(checkSpec.checkName) != mChecks.end() ) {
+        if (mChecks.find(checkSpec.checkName) != mChecks.end()) {
           auto checkConfig = Check::extractConfig(infrastructureSpec.common, checkSpec);
           mChecks.emplace(checkConfig.name, checkConfig);
-          ILOG(Debug, Devel) << "Check "<< checkSpec.checkName << " has been updated" << ENDM;
+          ILOG(Debug, Devel) << "Check " << checkSpec.checkName << " has been updated" << ENDM;
         }
       }
     }

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -138,8 +138,8 @@ CheckRunner::CheckRunner(CheckRunnerConfig checkRunnerConfig, const std::vector<
     mTotalNumberMOStored(0),
     mTotalQOSent(0)
 {
-  for (const auto& checkConfig : checkConfigs) {
-    mChecks[checkConfig.name] = checkConfig;
+  for (auto& checkConfig : checkConfigs) {
+    mChecks.emplace(checkConfig.name, checkConfig);
   }
 }
 
@@ -187,7 +187,7 @@ void CheckRunner::refreshConfig(InitContext& iCtx)
         // search if we have this check in this runner and replace it
         if ( mChecks.find(checkSpec.checkName) != mChecks.end() ) {
           auto checkConfig = Check::extractConfig(infrastructureSpec.common, checkSpec);
-          mChecks[checkSpec.checkName] = checkConfig;
+          mChecks.emplace(checkConfig.name, checkConfig);
           ILOG(Debug, Devel) << "Check "<< checkSpec.checkName << " has been updated" << ENDM;
         }
       }

--- a/Framework/src/UpdatePolicyManager.cxx
+++ b/Framework/src/UpdatePolicyManager.cxx
@@ -183,4 +183,11 @@ std::ostream& operator<<(std::ostream& out, const UpdatePolicy& updatePolicy) //
   return out;
 }
 
+void UpdatePolicyManager::reset()
+{
+  mPoliciesByActor.clear();
+  mObjectsRevision.clear();
+  mGlobalRevision = 1;
+}
+
 } // namespace o2::quality_control::checker


### PR DESCRIPTION
We ignore the topology changes at this stage. We update (delete and rebuild) the checks that belong to the check runner.