### PR TITLE
TPC: Cluster task bug fix

### DIFF
--- a/Modules/TPC/run/tpcQCClusterVisualizer.json
+++ b/Modules/TPC/run/tpcQCClusterVisualizer.json
@@ -72,10 +72,8 @@
         "updateTrigger": [
           "newobject:ccdb:qc/TPC/MO/Clusters/ClusterData"
         ],
-        "stopTrigger_comment": [ "To keep the task running until it is stopped manually set the trigger on the update of a non-existing object, e.g. 'newobject:ccdb:TPC/ThisDoesNotExist'",
-                                 "There will be a end of run trigger implemented so the above workaround can be abandoned later." ],
         "stopTrigger": [
-          "newobject:ccdb:TPC/ThisDoesNotExist"
+          "userorcontrol"
         ]
       }
     }

--- a/Modules/TPC/run/tpcQCRawDigitVisualizer.json
+++ b/Modules/TPC/run/tpcQCRawDigitVisualizer.json
@@ -70,10 +70,8 @@
         "updateTrigger": [
           "newobject:ccdb:qc/TPC/MO/RawDigits/RawDigitData"
         ],
-        "stopTrigger_comment": [ "To keep the task running until it is stopped manually set the trigger on the update of a non-existing object, e.g. 'newobject:ccdb:TPC/ThisDoesNotExist'",
-                                 "There will be a end of run trigger implemented so the above workaround can be abandoned later." ],
         "stopTrigger": [
-          "newobject:ccdb:TPC/ThisDoesNotExist"
+          "userorcontrol"
         ]
       }
     }

--- a/Modules/TPC/src/ClusterVisualizer.cxx
+++ b/Modules/TPC/src/ClusterVisualizer.cxx
@@ -171,11 +171,6 @@ void ClusterVisualizer::update(Trigger t, framework::ServiceRegistry&)
   o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
   calDetIter++;
 
-  calDet = clusters.getTimeBin();
-  vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
-  o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
-  calDetIter++;
-
   if (mIsClusters) {
     calDet = clusters.getQTot();
     vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
@@ -192,6 +187,11 @@ void ClusterVisualizer::update(Trigger t, framework::ServiceRegistry&)
     o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
     calDetIter++;
   }
+
+  calDet = clusters.getTimeBin();
+  vecPtr = toVector(mCalDetCanvasVec.at(calDetIter));
+  o2::tpc::painter::makeSummaryCanvases(calDet, int(mRanges[calDet.getName()].at(0)), mRanges[calDet.getName()].at(1), mRanges[calDet.getName()].at(2), false, &vecPtr);
+  calDetIter++;
 }
 
 void ClusterVisualizer::finalize(Trigger, framework::ServiceRegistry&)


### PR DESCRIPTION
This introduces a bug fix to the TPC Cluster task where plots were stored in the qcdb under mixed up names.