### PR TITLE
[EMCAL-524, EMCAL-525, EMCAL-758, EMCAL-759] Move cell-level QC to Cel…

### DIFF
--- a/Modules/EMCAL/CMakeLists.txt
+++ b/Modules/EMCAL/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(O2QcEMCAL)
 
-target_sources(O2QcEMCAL PRIVATE src/RawTask.cxx src/RawCheck.cxx src/DigitsQcTask.cxx src/DigitCheck.cxx src/DigitOccupancyReductor.cxx src/ClusterTask.cxx)
+target_sources(O2QcEMCAL PRIVATE src/RawTask.cxx src/RawCheck.cxx src/CellTask.cxx src/CellCheck.cxx src/DigitsQcTask.cxx src/DigitCheck.cxx src/DigitOccupancyReductor.cxx src/ClusterTask.cxx)
 
 target_include_directories(
   O2QcEMCAL
@@ -17,6 +17,8 @@ add_root_dictionary(O2QcEMCAL
   include/EMCAL/DigitCheck.h
   include/EMCAL/RawTask.h
   include/EMCAL/RawCheck.h
+  include/EMCAL/CellTask.h
+  include/EMCAL/CellCheck.h
   include/EMCAL/DigitOccupancyReductor.h
   include/EMCAL/ClusterTask.h
   LINKDEF include/EMCAL/LinkDef.h

--- a/Modules/EMCAL/etc/cells.json
+++ b/Modules/EMCAL/etc/cells.json
@@ -1,0 +1,143 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "emcccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "CellTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::CellTask",
+        "moduleName": "QcEMCAL",
+        "detectorName": "EMC",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "emcal-cells:EMC/CELLS/0;emcal-triggerecords:EMC/CELLSSTRGR/0"
+        },
+        "taskParameters": {
+          "nothing": "rien"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "checkAmplHighG": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::CellCheck",
+        "moduleName": "QcEMCAL",
+        "policy": "OnAny",
+        "detectorName": "EMC",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "CellTask",
+            "MOs": [
+              "cellAmplitudeHG"
+            ]
+          }
+        ]
+      },
+      "checkAmplLowG": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::CellCheck",
+        "moduleName": "QcEMCAL",
+        "policy": "OnAny",
+        "detectorName": "EMC",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "CellTask",
+            "MOs": [
+              "cellAmplitudeLG"
+            ]
+          }
+        ]
+      },
+      "checkDigitTimeHighG": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::CellCheck",
+        "moduleName": "QcEMCAL",
+        "policy": "OnAny",
+        "detectorName": "EMC",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "CellTask",
+            "MOs": [
+              "cellTimeHG"
+            ]
+          }
+        ]
+      },
+      "checkDigitTimeLowG": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::CellCheck",
+        "moduleName": "QcEMCAL",
+        "policy": "OnAny",
+        "detectorName": "EMC",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "CellTask",
+            "MOs": [
+              "cellTimeLG"
+            ]
+          }
+        ]
+      },
+      "checkAmplEMCAL": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::CellCheck",
+        "moduleName": "QcEMCAL",
+        "policy": "OnAny",
+        "detectorName": "EMC",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "CellTask",
+            "MOs": [
+              "cellAmplitudeEMCAL"
+            ]
+          }
+        ]
+      },
+      "checkAmplDCAL": {
+        "active": "true",
+        "className": "o2::quality_control_modules::emcal::CellCheck",
+        "moduleName": "QcEMCAL",
+        "policy": "OnAny",
+        "detectorName": "EMC",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "CellTask",
+            "MOs": [
+              "cellAmplitudeDCAL"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": []
+}

--- a/Modules/EMCAL/include/EMCAL/CellCheck.h
+++ b/Modules/EMCAL/include/EMCAL/CellCheck.h
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CellCheck.h
+/// \author Cristina Terrevoli
+///
+
+#ifndef QC_MODULE_EMCAL_EMCALCELLCHECK_HH
+#define QC_MODULE_EMCAL_EMCALCELLCHECK_HH
+
+#include "QualityControl/CheckInterface.h"
+
+namespace o2::quality_control_modules::emcal
+{
+
+/// \brief  Check whether a plot is empty or not.
+///
+/// \author Barthelemy von Haller
+class CellCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  CellCheck() = default;
+  /// Destructor
+  ~CellCheck() override = default;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+  ClassDefOverride(CellCheck, 1);
+};
+
+} // namespace o2::quality_control_modules::emcal
+
+#endif // QC_MODULE_EMCAL_EMCALCELLCHECK_HH

--- a/Modules/EMCAL/include/EMCAL/CellTask.h
+++ b/Modules/EMCAL/include/EMCAL/CellTask.h
@@ -1,0 +1,164 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CellTask.h
+/// \author Markus Fasel, Cristina Terrevoli
+///
+
+#ifndef QC_MODULE_EMCAL_CELLTASK_H
+#define QC_MODULE_EMCAL_CELLTASK_H
+
+#include "QualityControl/TaskInterface.h"
+#include <array>
+#include <unordered_map>
+#include <string_view>
+#include <gsl/span>
+#include <CCDB/TObjectWrapper.h>
+#include <TProfile2D.h>
+#include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/RangeReference.h"
+#include "Headers/DataHeader.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
+
+class TH1;
+class TH2;
+
+using namespace o2::quality_control::core;
+
+namespace o2
+{
+namespace emcal
+{
+class Geometry;
+class BadChannelMap;
+class TimeCalibrationParams;
+class Cell;
+} // namespace emcal
+
+namespace quality_control_modules
+{
+namespace emcal
+{
+
+/// \brief QC Task for EMCAL cells
+/// \author Markus Fasel
+///
+/// The main monitoring component for EMCAL cell (energy and time measurement in tower).
+/// Monitoring observables:
+/// - Amplitude for different towers
+/// - Time for different towers
+class CellTask final : public TaskInterface
+{
+ public:
+  struct CellHistograms {
+    o2::emcal::Geometry* mGeometry;
+    double mCellThreshold = 0; //
+    // std::array<TH2*, 2> mCellAmplitude;      ///< Cell amplitude
+    TH2* mCellAmplitude = nullptr; ///< Cell amplitude
+                                   //    std::array<TH2*, 2> mCellTime;           ///< Cell time
+    TH2* mCellTime = nullptr;      ///< Cell time
+    // std::array<TH2*, 2> mCellAmplitudeCalib; ///< Cell amplitude calibrated
+    TH2* mCellAmplitudeCalib = nullptr; ///< Cell amplitude calibrated
+                                        //  std::array<TH2*, 2> mCellTimeCalib;      ///< Cell time calibrated
+    TH2* mCellTimeCalib = nullptr;      ///< Cell time calibrated
+
+    TH2* mCellAmpSupermodule = nullptr;
+    TH2* mCellAmpSupermoduleCalib = nullptr;
+    TH2* mCellTimeSupermodule = nullptr;
+    TH2* mCellTimeSupermoduleCalib = nullptr;
+
+    TH2* mCellOccupancy = nullptr;                             ///< Cell occupancy EMCAL and DCAL
+    TH2* mCellOccupancyThr = nullptr;                          ///< Cell occupancy EMCAL and DCAL with Energy trheshold
+    TH2* mCellOccupancyThrBelow = nullptr;                     ///< Cell occupancy EMCAL and DCAL with Energy trheshold
+    TH2* mIntegratedOccupancy = nullptr;                       ///< Cell integrated occupancy
+    TH1* mCellAmplitude_tot = nullptr;                         ///< Cell amplitude in EMCAL,DCAL
+    TH1* mCellAmplitudeEMCAL = nullptr;                        ///< Cell amplitude in EMCAL
+    std::unordered_map<int, std::array<TH1*, 20>> mCellTimeBC; ///< Cell amplitude in EMCAL if bc==0
+    TH1* mCellAmplitudeDCAL = nullptr;                         ///< Cell amplitude in DCAL
+    TH1* mCellTimeSupermodule_tot = nullptr;                   ///< Cell time in EMCAL,DCAL per SuperModule
+    TH1* mCellTimeSupermoduleEMCAL = nullptr;                  ///< Cell time in EMCAL per SuperModule
+    TH1* mCellTimeSupermoduleDCAL = nullptr;                   ///< Cell time in DCAL per SuperModule
+    TH1* mnumberEvents = nullptr;                              ///< Number of Events for normalization
+
+    void initForTrigger(const std::string trigger, bool hasAmpVsCellID, bool hasTimeVsCellID, bool hasHistosCalib2D);
+    void startPublishing(o2::quality_control::core::ObjectsManager& manager);
+    void reset();
+    void clean();
+
+    void fillHistograms(const o2::emcal::Cell& cell, bool isGood, double timeoffset, int bcphase);
+    void countEvent();
+  };
+
+  TH1* mEvCounterTF = nullptr;      ///< Number of Events per timeframe
+  TH1* mEvCounterTFPHYS = nullptr;  ///< Number of Events per timeframe per PHYS
+  TH1* mEvCounterTFCALIB = nullptr; ///< Number of Events per timeframe per CALIB
+  TH1* mTFPerCyclesTOT = nullptr;   ///< Number of Time Frame per cycles TOT
+  TH1* mTFPerCycles = nullptr;      ///< Number of Time Frame per cycles per MonitorData
+  TH1* mCellsMaxSM = nullptr;       ///< Supermodule with the largest amount of cells
+
+  /// \brief Constructor
+  CellTask() = default;
+  /// Destructor
+  ~CellTask() override;
+
+  // Definition of the methods for the template method pattern
+  void initialize(o2::framework::InitContext& ctx) override;
+  void startOfActivity(Activity& activity) override;
+  void startOfCycle() override;
+  void monitorData(o2::framework::ProcessingContext& ctx) override;
+  void endOfCycle() override;
+  void endOfActivity(Activity& activity) override;
+  void reset() override;
+
+  bool hasConfigValue(const std::string_view key);
+  std::string getConfigValue(const std::string_view key);
+  std::string getConfigValueLower(const std::string_view key);
+
+ private:
+  struct SubEvent {
+    header::DataHeader::SubSpecificationType mSpecification;
+    dataformats::RangeReference<int, int> mCellRange;
+  };
+
+  struct CombinedEvent {
+    InteractionRecord mInteractionRecord;
+    uint32_t mTriggerType;
+    std::vector<SubEvent> mSubevents;
+
+    int getNumberOfObjects() const
+    {
+      int nObjects = 0;
+      for (auto ev : mSubevents) {
+        nObjects += ev.mCellRange.getEntries();
+      }
+      return nObjects;
+    }
+
+    int getNumberOfSubevents()
+    {
+      return mSubevents.size();
+    };
+  };
+  std::vector<CombinedEvent> buildCombinedEvents(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const;
+  Bool_t mIgnoreTriggerTypes = false;                        ///< Do not differenciate between trigger types, treat all triggers as phys. triggers
+  std::map<std::string, CellHistograms> mHistogramContainer; ///< Container with histograms per trigger class
+  o2::emcal::Geometry* mGeometry = nullptr;                  ///< EMCAL geometry
+  o2::emcal::BadChannelMap* mBadChannelMap;                  ///< EMCAL channel map
+  o2::emcal::TimeCalibrationParams* mTimeCalib;              ///< EMCAL time calib
+  int mTimeFramesPerCycles = 0;                              ///< TF per cycles
+};
+
+} // namespace emcal
+} // namespace quality_control_modules
+} // namespace o2
+
+#endif // QC_MODULE_EMCAL_CELLTASK_H

--- a/Modules/EMCAL/include/EMCAL/LinkDef.h
+++ b/Modules/EMCAL/include/EMCAL/LinkDef.h
@@ -7,6 +7,10 @@
 
 #pragma link C++ class o2::quality_control_modules::emcal::DigitCheck + ;
 
+#pragma link C++ class o2::quality_control_modules::emcal::CellTask + ;
+
+#pragma link C++ class o2::quality_control_modules::emcal::CellCheck + ;
+
 #pragma link C++ class o2::quality_control_modules::emcal::RawTask + ;
 
 #pragma link C++ class o2::quality_control_modules::emcal::RawCheck + ;

--- a/Modules/EMCAL/src/CellCheck.cxx
+++ b/Modules/EMCAL/src/CellCheck.cxx
@@ -1,0 +1,199 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CellCheck.cxx
+/// \author Cristina Terrevoli
+///
+
+#include "EMCAL/CellCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include <fairlogger/Logger.h>
+// ROOT
+#include <TH1.h>
+#include <TH2.h>
+#include <TPaveText.h>
+#include <TLatex.h>
+#include <TList.h>
+#include <TRobustEstimator.h>
+#include <ROOT/TSeq.hxx>
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+namespace o2::quality_control_modules::emcal
+{
+
+void CellCheck::configure() {}
+
+Quality CellCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  auto mo = moMap->begin()->second;
+  Quality result = Quality::Good;
+  // cellAmplidute_PHYS
+  // cellTime_PHYS
+  std::vector<std::string> amplitudeHist = { "cellAmplitudeEMCAL", "cellAmplitudeDCAL", "cellAmplitude_PHYS" };
+  if (std::find(amplitudeHist.begin(), amplitudeHist.end(), mo->getName()) != amplitudeHist.end()) {
+    auto* h = dynamic_cast<TH1*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+  }
+  if (mo->getName() == "SMMaxNumDigits") {
+    double errormargin = 2.;
+    auto hist = dynamic_cast<TH1*>(mo->getObject());
+    std::vector<double> smcounts;
+    for (auto ib : ROOT::TSeqI(0, hist->GetXaxis()->GetNbins())) {
+      auto countSM = hist->GetBinContent(ib + 1);
+      if (countSM > 0)
+        smcounts.emplace_back(countSM);
+    }
+    if (!smcounts.size()) {
+      result = Quality::Medium;
+    } else {
+      TRobustEstimator meanfinder;
+      double mean, sigma;
+      meanfinder.EvaluateUni(smcounts.size(), smcounts.data(), mean, sigma);
+      for (auto ib : ROOT::TSeqI(0, hist->GetXaxis()->GetNbins())) {
+        if (hist->GetBinContent(ib + 1) > mean + errormargin * sigma) {
+          result = Quality::Bad;
+          break;
+        }
+      }
+    }
+  }
+
+  /* if (mo->getName() == "cellTimeHG") {
+    auto* h = dynamic_cast<TH2*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+    else {
+      Float_t timeMean = h->GetMean();
+      Float_t timeThrs = 60.;
+      if (timeMean < timeThrs - 20. || timeMean > timeThrs + 20.) {
+        result = Quality::Bad;
+      }
+    }
+  }
+
+  if (mo->getName() == "cellTimeLG") {
+    auto* h = dynamic_cast<TH2*>(mo->getObject());
+    if (h->GetEntries() == 0)
+      result = Quality::Bad;
+    else {
+      Float_t timeMean = h->GetMean();
+      Float_t timeThrs = 60;
+      if (timeMean < timeThrs - 20 || timeMean > timeThrs + 20) {
+        result = Quality::Bad;
+      }
+    }
+  }
+  */
+  return result;
+}
+
+std::string CellCheck::getAcceptedType() { return "TH1"; }
+
+void CellCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (mo->getName().find("Time") != std::string::npos) {
+    auto* h = dynamic_cast<TH2*>(mo->getObject());
+    TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
+    h->GetListOfFunctions()->Add(msg);
+    msg->SetName(Form("%s_msg", mo->GetName()));
+
+    if (checkResult == Quality::Good) {
+      //
+      msg->Clear();
+      msg->AddText("Mean inside limits: OK!!!");
+      msg->SetFillColor(kGreen);
+      //
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      LOG(info) << "Quality::Bad, setting to red";
+      msg->Clear();
+      msg->AddText("Mean outside limits or no entries");
+      msg->AddText("If NOT a technical run,");
+      msg->AddText("call EMCAL on-call.");
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      LOG(info) << "Quality::medium, setting to orange";
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+  if (mo->getName().find("Amplitude") != std::string::npos) {
+    auto* h = dynamic_cast<TH1*>(mo->getObject());
+    TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
+    h->GetListOfFunctions()->Add(msg);
+    msg->SetName(Form("%s_msg", mo->GetName()));
+
+    if (checkResult == Quality::Good) {
+      //
+      msg->Clear();
+      msg->AddText("Mean inside limits: OK!!!");
+      msg->SetFillColor(kGreen);
+      //
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      LOG(info) << "Quality::Bad, setting to red";
+      msg->Clear();
+      msg->AddText("Mean outside limits or no entries");
+      msg->AddText("If NOT a technical run,");
+      msg->AddText("call EMCAL on-call.");
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      LOG(info) << "Quality::medium, setting to orange";
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+  if (mo->getName() == "SMMaxNumDigits") {
+    auto* h = dynamic_cast<TH1*>(mo->getObject());
+    if (checkResult == Quality::Good) {
+      TLatex* msg = new TLatex(0.2, 0.8, "#color[418]{Data OK}");
+      msg->SetNDC();
+      msg->SetTextSize(16);
+      msg->SetTextFont(43);
+      h->SetFillColor(kGreen);
+      h->GetListOfFunctions()->Add(msg);
+      msg->Draw();
+    } else if (checkResult == Quality::Bad) {
+      LOG(info) << "Quality::Bad, setting to red";
+      TLatex* msg = new TLatex(0.2, 0.8, "#color[2]{Noisy supermodule detected}");
+      // Large payload in several DDLs
+      msg->SetNDC();
+      msg->SetTextSize(16);
+      msg->SetTextFont(43);
+      msg->SetTextColor(kRed);
+      h->GetListOfFunctions()->Add(msg);
+      msg->Draw();
+      msg = new TLatex(0.2, 0.7, "#color[2]{If NOT techn.run: call EMCAL oncall}");
+      msg->SetNDC();
+      msg->SetTextSize(16);
+      msg->SetTextFont(43);
+      msg->SetTextColor(kRed);
+      h->GetListOfFunctions()->Add(msg);
+      msg->Draw();
+    } else if (checkResult == Quality::Medium) {
+      LOG(info) << "Quality::medium, setting to orange";
+      TLatex* msg = new TLatex(0.2, 0.8, "#color[42]{empty:if in run, call EMCAL-oncall}");
+      msg->SetNDC();
+      msg->SetTextSize(16);
+      msg->SetTextFont(43);
+      h->GetListOfFunctions()->Add(msg);
+      msg->Draw();
+    }
+    h->SetLineColor(kBlack);
+  }
+}
+} // namespace o2::quality_control_modules::emcal

--- a/Modules/EMCAL/src/CellTask.cxx
+++ b/Modules/EMCAL/src/CellTask.cxx
@@ -1,0 +1,694 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CellTask.cxx
+/// \author Markus Fasel, Cristina Terrevoli
+///
+
+#include <boost/algorithm/string.hpp>
+#include <algorithm>
+#include <iostream>
+
+#include <TCanvas.h>
+#include <TH2.h>
+#include <TProfile2D.h>
+
+#include <DataFormatsEMCAL/TriggerRecord.h>
+#include "QualityControl/QcInfoLogger.h"
+#include "EMCAL/CellTask.h"
+#include "DataFormatsEMCAL/Cell.h"
+#include "EMCALBase/Geometry.h"
+#include "EMCALCalib/BadChannelMap.h"
+#include "EMCALCalib/TimeCalibrationParams.h"
+#include <Framework/ConcreteDataMatcher.h>
+#include <Framework/DataRefUtils.h>
+#include <Framework/DataSpecUtils.h>
+#include <Framework/InputRecord.h>
+#include <Framework/InputRecordWalker.h>
+#include <CommonConstants/Triggers.h>
+
+namespace o2
+{
+namespace quality_control_modules
+{
+namespace emcal
+{
+
+CellTask::~CellTask()
+{
+  for (auto en : mHistogramContainer) {
+    en.second.clean();
+  }
+  if (mEvCounterTF)
+    delete mEvCounterTF;
+  if (mEvCounterTFPHYS)
+    delete mEvCounterTFPHYS;
+  if (mEvCounterTFCALIB)
+    delete mEvCounterTFCALIB;
+  if (mTFPerCycles)
+    delete mTFPerCycles;
+  if (mTFPerCyclesTOT)
+    delete mTFPerCyclesTOT;
+  if (mCellsMaxSM)
+    delete mCellsMaxSM;
+}
+
+void CellTask::initialize(o2::framework::InitContext& /*ctx*/)
+{
+  QcInfoLogger::setDetector("EMC");
+  ILOG(Info, Support) << "initialize CellTask" << ENDM;
+  // define histograms
+
+  auto get_bool = [](const std::string_view input) -> bool {
+    return input == "true";
+  };
+
+  auto get_double = [](const std::string_view input) -> double {
+    double result = 0.;
+    if (input.length()) {
+      try {
+        result = std::stof(input.data());
+      } catch (...) {
+      }
+    }
+    return result;
+  };
+
+  auto hasAmpVsCell = get_bool(getConfigValueLower("hasAmpVsCell")),
+       hasTimeVsCell = get_bool(getConfigValueLower("hasTimeVsCell")),
+       hasCalib2D = get_bool(getConfigValueLower("hasHistValibVsCell"));
+
+  mIgnoreTriggerTypes = get_bool(getConfigValue("ignoreTriggers"));
+  // add a second threshold
+  double thresholdCAL = hasConfigValue("threshold") ? get_double(getConfigValue("threshold")) : 0.5;
+  double thresholdPHYS = hasConfigValue("threshold") ? get_double(getConfigValue("threshold")) : 0.2;
+
+  if (hasAmpVsCell) {
+    ILOG(Debug, Support) << "Enabling histograms : Amplitude vs. cellID" << ENDM;
+  }
+  if (hasTimeVsCell) {
+    ILOG(Debug, Support) << "Enabling histograms : Time vs. cellID" << ENDM;
+  }
+  if (hasCalib2D) {
+    ILOG(Debug, Support) << "Enabling calibrated histograms" << ENDM;
+  }
+
+  // initialize geometry
+  if (!mGeometry)
+    mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
+
+  std::array<std::string, 2> triggers = { { "CAL", "PHYS" } };
+  for (const auto& trg : triggers) {
+    CellHistograms histos;
+    histos.mCellThreshold = (trg == "CAL") ? thresholdCAL : thresholdPHYS;
+    histos.mGeometry = mGeometry;
+    histos.initForTrigger(trg.data(), hasAmpVsCell, hasTimeVsCell, hasCalib2D);
+    histos.startPublishing(*getObjectsManager());
+    mHistogramContainer[trg] = histos;
+  } // trigger type
+  // new histos`
+  mTFPerCyclesTOT = new TH1D("NumberOfTFperCycles_TOT", "NumberOfTFperCycles_TOT", 100, -0.5, 99.5); //
+  mTFPerCyclesTOT->GetXaxis()->SetTitle("NumberOfTFperCyclesTOT");
+  mTFPerCyclesTOT->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mTFPerCyclesTOT);
+
+  mTFPerCycles = new TH1D("NumberOfTFperCycles_1", "NumberOfTFperCycles_1", 1, -0.5, 1.5);
+  mTFPerCycles->GetXaxis()->SetTitle("NumberOfTFperCycles");
+  mTFPerCycles->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mTFPerCycles);
+
+  mEvCounterTF = new TH1D("NEventsPerTF", "NEventsPerTF", 401, -0.5, 400.5);
+  mEvCounterTF->GetXaxis()->SetTitle("NEventsPerTimeFrame");
+  mEvCounterTF->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mEvCounterTF);
+
+  mEvCounterTFPHYS = new TH1D("NEventsPerTFPHYS", "NEventsPerTFPHYS", 401, -0.5, 400.5);
+  mEvCounterTFPHYS->GetXaxis()->SetTitle("NEventsPerTimeFrame_PHYS");
+  mEvCounterTFPHYS->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mEvCounterTFPHYS);
+
+  mEvCounterTFCALIB = new TH1D("NEventsPerTFCALIB", "NEventsPerTFCALIB", 6, -0.5, 5.5);
+  mEvCounterTFCALIB->GetXaxis()->SetTitle("NEventsPerTimeFrame_CALIB");
+  mEvCounterTFCALIB->GetYaxis()->SetTitle("Counts");
+  getObjectsManager()->startPublishing(mEvCounterTFCALIB);
+
+  mCellsMaxSM = new TH1D("SMMaxNumCells", "Supermodule with largest amount of cells", 20, -0.5, 19.5);
+  mCellsMaxSM->GetXaxis()->SetTitle("Supermodule");
+  mCellsMaxSM->GetYaxis()->SetTitle("counts");
+  getObjectsManager()->startPublishing(mCellsMaxSM);
+}
+
+void CellTask::startOfActivity(Activity& /*activity*/)
+{
+  ILOG(Info, Support) << "startOfActivity" << ENDM;
+  reset();
+}
+
+void CellTask::startOfCycle()
+{
+  mTimeFramesPerCycles = 0;
+  ILOG(Debug, Support) << "startOfCycle" << ENDM;
+  std::map<std::string, std::string> metadata;
+  mBadChannelMap = retrieveConditionAny<o2::emcal::BadChannelMap>("EMC/Calib/BadChannels", metadata);
+  // it was EMC/BadChannelMap
+  if (!mBadChannelMap)
+    ILOG(Info, Support) << "No Bad Channel Map object " << ENDM;
+
+  mTimeCalib = retrieveConditionAny<o2::emcal::TimeCalibrationParams>("EMC/Calib/Time", metadata);
+  //"EMC/TimeCalibrationParams
+  if (!mTimeCalib)
+    ILOG(Info, Support) << " No Time Calib object " << ENDM;
+}
+
+void CellTask::monitorData(o2::framework::ProcessingContext& ctx)
+{
+  mTFPerCycles->Fill(1); // number of timeframe process per cycle
+  mTimeFramesPerCycles++;
+  // check if we have payoad
+  using MaskType_t = o2::emcal::BadChannelMap::MaskType_t;
+
+  // Handling of inputs from multiple subevents (multiple FLPs)
+  // Build maps of trigger records and cells according to the subspecification
+  // and combine trigger records from different maps into a single map of range
+  // references and subspecifications
+  std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::Cell>> cellSubEvents;
+  std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>> triggerRecordSubevents;
+
+  auto posCells = ctx.inputs().getPos("emcal-cells"),
+       posTriggerRecords = ctx.inputs().getPos("emcal-triggerecords");
+  auto numSlotsCells = ctx.inputs().getNofParts(posCells),
+       numSlotsTriggerRecords = ctx.inputs().getNofParts(posTriggerRecords);
+  for (decltype(numSlotsCells) islot = 0; islot < numSlotsCells; islot++) {
+    auto celldata = ctx.inputs().getByPos(posCells, islot);
+    auto subspecification = framework::DataRefUtils::getHeader<header::DataHeader*>(celldata)->subSpecification;
+    // Discard message if it is a deadbeaf message (empty timeframe)
+    if (subspecification == 0xDEADBEEF) {
+      continue;
+    }
+    cellSubEvents[subspecification] = ctx.inputs().get<gsl::span<o2::emcal::Cell>>(celldata);
+  }
+  for (decltype(numSlotsTriggerRecords) islot = 0; islot < numSlotsTriggerRecords; islot++) {
+    auto trgrecorddata = ctx.inputs().getByPos(posTriggerRecords, islot);
+    auto subspecification = framework::DataRefUtils::getHeader<header::DataHeader*>(trgrecorddata)->subSpecification;
+    // Discard message if it is a deadbeaf message (empty timeframe)
+    if (subspecification == 0xDEADBEEF) {
+      continue;
+    }
+    triggerRecordSubevents[subspecification] = ctx.inputs().get<gsl::span<o2::emcal::TriggerRecord>>(trgrecorddata);
+  }
+
+  auto combinedEvents = buildCombinedEvents(triggerRecordSubevents);
+
+  //  ILOG(Info, Support) <<"Received " << cellcontainer.size() << " cells " << ENDM;
+  int eventcounter = 0;
+  int eventcounterCALIB = 0;
+  int eventcounterPHYS = 0;
+  std::array<int, 20> numCellsSM;
+  std::fill(numCellsSM.begin(), numCellsSM.end(), 0);
+  for (auto trg : combinedEvents) {
+    if (!trg.getNumberOfObjects()) {
+      continue;
+    }
+    ILOG(Debug, Support) << "Next event " << eventcounter << " has " << trg.getNumberOfObjects() << " cells from " << trg.getNumberOfSubevents() << " subevent(s)" << ENDM;
+
+    // trigger type
+    auto triggertype = trg.mTriggerType;
+    bool isPhysTrigger = mIgnoreTriggerTypes || (triggertype & o2::trigger::PhT),
+         isCalibTrigger = (!mIgnoreTriggerTypes) && (triggertype & o2::trigger::Cal);
+    std::string trgClass;
+    if (isPhysTrigger) {
+      trgClass = "PHYS";
+      eventcounterPHYS++;
+    } else if (isCalibTrigger) {
+      trgClass = "CAL";
+      eventcounterCALIB++;
+    } else {
+      ILOG(Error, Support) << " Unmonitored trigger class requested " << ENDM;
+      continue;
+    }
+
+    auto bcphase = trg.mInteractionRecord.bc % 4; // to be fixed:4 histos for EMCAL, 4 histos for DCAL
+    auto histos = mHistogramContainer[trgClass];
+    std::fill(numCellsSM.begin(), numCellsSM.end(), 0);
+
+    // iterate over subevents
+    for (auto& subev : trg.mSubevents) {
+      auto cellsSubspec = cellSubEvents.find(subev.mSpecification);
+      if (cellsSubspec == cellSubEvents.end()) {
+        ILOG(Error, Support) << "No cell data found for subspecification " << subev.mSpecification << ENDM;
+      } else {
+        ILOG(Debug, Support) << subev.mCellRange.getEntries() << " cells in subevent from equipment " << subev.mSpecification << ENDM;
+        gsl::span<const o2::emcal::Cell> eventcells(cellsSubspec->second.data() + subev.mCellRange.getFirstEntry(), subev.mCellRange.getEntries());
+        int ncell = 0, ncellGlobal = subev.mCellRange.getFirstEntry();
+        for (auto cell : eventcells) {
+          // int index = cell.getHighGain() ? 0 : (cell.getLowGain() ? 1 : -1);
+          // if (index < 0)
+          //   continue;
+          auto timeoffset = mTimeCalib ? mTimeCalib->getTimeCalibParam(cell.getTower(), cell.getLowGain()) : 0.;
+          bool goodcell = true;
+          if (mBadChannelMap) {
+            goodcell = mBadChannelMap->getChannelStatus(cell.getTower()) != MaskType_t::GOOD_CELL;
+          }
+          histos.fillHistograms(cell, goodcell, timeoffset, bcphase);
+          if (isPhysTrigger) {
+            auto [sm, mod, iphi, ieta] = mGeometry->GetCellIndex(cell.getTower());
+            numCellsSM[sm]++;
+          }
+          ncell++;
+          ncellGlobal++;
+        }
+      }
+    }
+    histos.countEvent();
+
+    if (isPhysTrigger) {
+      auto maxSM = std::max_element(numCellsSM.begin(), numCellsSM.end());
+      auto indexMaxSM = maxSM - numCellsSM.begin();
+      mCellsMaxSM->Fill(indexMaxSM);
+    }
+
+    eventcounter++;
+  }
+  mEvCounterTF->Fill(eventcounter);
+  mEvCounterTFPHYS->Fill(eventcounterPHYS);
+  mEvCounterTFCALIB->Fill(eventcounterCALIB);
+  // event counter per TimeFrame  (range 0-100) for the moment (parameter)
+}
+
+void CellTask::endOfCycle()
+{
+  mTFPerCyclesTOT->Fill(mTimeFramesPerCycles); // do not reset this histo
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
+}
+
+void CellTask::endOfActivity(Activity& /*activity*/)
+{
+  ILOG(Debug, Support) << "endOfActivity" << ENDM;
+}
+
+void CellTask::reset()
+{
+  // clean all the monitor objects here
+
+  ILOG(Debug, Support) << "Resetting the histogram" << ENDM;
+  for (auto cont : mHistogramContainer) {
+    cont.second.reset();
+  }
+  if (mEvCounterTF)
+    mEvCounterTF->Reset();
+  if (mEvCounterTFPHYS)
+    mEvCounterTFPHYS->Reset();
+  if (mEvCounterTFCALIB)
+    mEvCounterTFCALIB->Reset();
+  if (mTFPerCycles)
+    mTFPerCycles->Reset();
+  if (mCellsMaxSM)
+    mCellsMaxSM->Reset();
+}
+
+std::vector<CellTask::CombinedEvent> CellTask::buildCombinedEvents(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const
+{
+  std::vector<CellTask::CombinedEvent> events;
+
+  // Search interaction records from all subevents
+  std::set<o2::InteractionRecord> allInteractions;
+  for (auto& [subspecification, trgrec] : triggerrecords) {
+    for (auto rec : trgrec) {
+      auto eventIR = rec.getBCData();
+      if (allInteractions.find(eventIR) == allInteractions.end())
+        allInteractions.insert(eventIR);
+    }
+  }
+
+  // iterate over all subevents for all bunch crossings
+  for (auto collision : allInteractions) {
+    CombinedEvent nextevent;
+    nextevent.mInteractionRecord = collision;
+    bool first = true,
+         hasSubevent = false;
+    for (auto [subspecification, records] : triggerrecords) {
+      auto found = std::find_if(records.begin(), records.end(), [&collision](const o2::emcal::TriggerRecord& rec) { return rec.getBCData() == collision; });
+      if (found != records.end()) {
+        hasSubevent = true;
+        if (first) {
+          nextevent.mTriggerType = found->getTriggerBits();
+          first = false;
+        }
+        nextevent.mSubevents.push_back({ subspecification, o2::dataformats::RangeReference(found->getFirstEntry(), found->getNumberOfObjects()) });
+      }
+    }
+    if (hasSubevent)
+      events.emplace_back(nextevent);
+  }
+  return events;
+}
+
+bool CellTask::hasConfigValue(const std::string_view key)
+{
+  if (auto param = mCustomParameters.find(key.data()); param != mCustomParameters.end()) {
+    return true;
+  }
+  return false;
+}
+
+std::string CellTask::getConfigValue(const std::string_view key)
+{
+  std::string result;
+  if (auto param = mCustomParameters.find(key.data()); param != mCustomParameters.end()) {
+    result = param->second;
+  }
+  return result;
+}
+
+std::string CellTask::getConfigValueLower(const std::string_view key)
+{
+  auto input = getConfigValue(key);
+  std::string result;
+  if (input.length()) {
+    result = boost::algorithm::to_lower_copy(input);
+  }
+  return result;
+}
+
+void CellTask::CellHistograms::initForTrigger(const std::string trigger, bool hasAmpVsCellID, bool hasTimeVsCellID, bool hasHistosCalib2D)
+{
+  auto histBuilder1D = [trigger](const std::string name, const std::string title, int nbinsx, double xmin, double xmax) -> TH1* {
+    std::string histname = name + "_" + trigger,
+                histtitle = title + " " + trigger;
+    return new TH1D(histname.data(), histtitle.data(), nbinsx, xmin, xmax);
+  };
+  auto histBuilder2D = [trigger](const std::string_view name, const std::string_view title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, bool profile) -> TH2* {
+    std::string histname = std::string(name.data()) + "_" + trigger,
+                histtitle = std::string(title.data()) + " " + trigger;
+    if (profile)
+      return new TProfile2D(histname.data(), histtitle.data(), nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+    return new TH2D(histname.data(), histtitle.data(), nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+  };
+
+  std::map<std::string, double> maxAmps = { { "PHYS", 50. }, { "CAL", 10. } };
+  double maxAmp = maxAmps[trigger];
+
+  bool isPhysTrigger = trigger == "PHYS";
+  if (isPhysTrigger) {
+    if (hasAmpVsCellID) {
+      mCellAmplitude = histBuilder2D("cellAmplitudeHG", "Cell Amplitude (High gain)", 80, 0, 16, 17664, -0.5, 17663.5, false);
+      mCellAmplitude->SetStats(0);
+      // mCellAmplitude[1] = histBuilder2D("cellAmplitudeLG", "Cell Amplitude (Low gain)", 100, 0, 100, 17664, -0.5, 17663.5, false);
+      if (hasHistosCalib2D) {
+        mCellAmplitudeCalib = histBuilder2D("cellAmplitudeHGCalib", "Cell Amplitude (High gain)", 80, 0, 16, 17664, -0.5, 17663.5, false);
+        mCellAmplitudeCalib->SetStats(0);
+        // mCellAmplitudeCalib[1] = histBuilder2D("cellAmplitudeLGCalib", "Cell Amplitude (Low gain)", 100, 0, 100, 17664, -0.5, 17663.5, false);
+      }
+    }
+    if (hasTimeVsCellID) {
+      mCellTime = histBuilder2D("cellTimeHG", "Cell Time (High gain)", 400, -200, 200, 17664, -0.5, 17663.5, false);
+      mCellTime->SetStats(0);
+      // mCellTime[1] = histBuilder2D("cellTimeLG", "Cell Time (Low gain)", 400, -200, 200, 17664, -0.5, 17663.5, false);
+      if (hasHistosCalib2D) {
+        mCellTimeCalib = histBuilder2D("cellTimeHGCalib", "Cell Time Calib (High gain)", 400, -200, 200, 17664, -0.5, 17663.5, false);
+        mCellTimeCalib->SetStats(0);
+        // mCellTimeCalib[1] = histBuilder2D("cellTimeLGCalib", "Cell Time Calib (Low gain)", 400, -200, 200, 17664, -0.5, 17663.5, false);
+      }
+    }
+
+    mCellAmpSupermodule = histBuilder2D("cellAmplitudeSupermodule", "Cell amplitude vs. supermodule ID ", 4 * static_cast<int>(maxAmp), 0., maxAmp, 20, -0.5, 19.5, false);
+    mCellAmpSupermodule->SetStats(0);
+    mCellTimeSupermodule = histBuilder2D("cellTimeSupermodule", "Cell Time vs. supermodule ID ", 600, -400, 800, 20, -0.5, 19.5, false);
+    mCellTimeSupermodule->SetStats(0);
+    if (hasHistosCalib2D) {
+      mCellAmpSupermoduleCalib = histBuilder2D("cellAmplitudeSupermoduleCalib", "Cell amplitude (Calib) vs. supermodule ID ", 4 * static_cast<int>(maxAmp), 0., maxAmp, 20, -0.5, 19.5, false);
+      mCellAmpSupermoduleCalib->SetStats(0);
+      mCellTimeSupermoduleCalib = histBuilder2D("cellTimeSupermoduleCalib", "Cell Time (Calib) vs. supermodule ID (High gain)", 600, -400, 800, 20, -0.5, 19.5, false);
+      mCellTimeSupermoduleCalib->SetStats(0);
+    }
+  }
+
+  mCellOccupancy = histBuilder2D("cellOccupancyEMC", "Cell Occupancy EMCAL", 96, -0.5, 95.5, 208, -0.5, 207.5, false);
+  mCellOccupancy->SetStats(0);
+  mCellOccupancyThr = histBuilder2D("cellOccupancyEMCwThr", Form("Cell Occupancy EMCAL,DCAL with E>%.1f GeV/c", mCellThreshold), 96, -0.5, 95.5, 208, -0.5, 207.5, false);
+  mCellOccupancyThr->SetStats(0);
+  mCellOccupancyThrBelow = histBuilder2D("cellOccupancyEMCwThrBelow", Form("Cell Occupancy EMCAL,DCAL with E<%.1f GeV/c", mCellThreshold), 96, -0.5, 95.5, 208, -0.5, 207.5, false);
+  mCellOccupancyThrBelow->SetStats(0);
+
+  mIntegratedOccupancy = histBuilder2D("cellOccupancyInt", "Cell Occupancy Integrated", 96, -0.5, 95.5, 208, -0.5, 207.5, true);
+  mIntegratedOccupancy->GetXaxis()->SetTitle("col");
+  mIntegratedOccupancy->GetYaxis()->SetTitle("row");
+  mIntegratedOccupancy->SetStats(0);
+  // 1D histograms for showing the integrated spectrum
+
+  mCellTimeSupermodule_tot = histBuilder1D("cellTime", "Cell Time EMCAL,DCAL", 600, -400, 800);
+  mCellTimeSupermoduleEMCAL = histBuilder1D("cellTimeEMCAL", "Cell Time EMCAL", 600, -400, 800);
+  mCellTimeSupermoduleDCAL = histBuilder1D("cellTimeDCAL", "Cell Time DCAL", 600, -400, 800);
+  mCellAmplitude_tot = histBuilder1D("cellAmplitude", "Cell amplitude in EMCAL,DCAL", 4 * static_cast<int>(maxAmp), 0., maxAmp);
+  mCellAmplitudeEMCAL = histBuilder1D("cellAmplitudeEMCAL", "Cell amplitude in EMCAL", 4 * static_cast<int>(maxAmp), 0., maxAmp);
+  mCellAmplitudeDCAL = histBuilder1D("cellAmplitudeDCAL", "Cell amplitude in DCAL", 4 * static_cast<int>(maxAmp), 0., maxAmp);
+  mnumberEvents = histBuilder1D("NumberOfEvents", "Number Of Events", 1, 0.5, 1.5);
+  if (isPhysTrigger) {
+    // Phys. trigger: monitor all bunch crossings
+    for (auto bcID = 0; bcID < 4; bcID++) {
+      std::array<TH1*, 20> cellTimeBCSM;
+      for (auto smID = 0; smID < 20; smID++) {
+        cellTimeBCSM[smID] = histBuilder1D(Form("cellTimeBC%dSM%d", bcID, smID), Form("Cell Time BC%d SM%d", bcID, smID), 600, -400, 800);
+      }
+      mCellTimeBC[bcID] = cellTimeBCSM;
+    }
+  } else {
+    // Calib trigger: Only bc0;
+    std::array<TH1*, 20> cellTimeBCSM;
+    for (auto smID = 0; smID < 20; smID++) {
+      cellTimeBCSM[smID] = histBuilder1D(Form("cellTimeBC0SM%d", smID), Form("Cell Time BC0 SM%d", smID), 600, -400, 800);
+    }
+    mCellTimeBC[0] = cellTimeBCSM;
+  }
+}
+
+void CellTask::CellHistograms::fillHistograms(const o2::emcal::Cell& cell, bool goodCell, double timecalib, int bcphase)
+{
+  auto fillOptional1D = [](TH1* hist, double x, double weight = 1.) {
+    if (hist)
+      hist->Fill(x, weight);
+  };
+  auto fillOptional2D = [](TH2* hist, double x, double y, double weight = 1.) {
+    if (hist)
+      hist->Fill(x, y, weight);
+  };
+
+  fillOptional2D(mCellAmplitude, cell.getEnergy(), cell.getTower());
+  // fillOptional2D(mCellAmplitude[index], cell.getEnergy(), cell.getTower());
+
+  if (goodCell) {
+    fillOptional2D(mCellAmplitudeCalib, cell.getEnergy(), cell.getTower());
+    fillOptional2D(mCellTimeCalib, cell.getTimeStamp() - timecalib, cell.getTower());
+    // fillOptional2D(mCellAmplitudeCalib[index], cell.getEnergy(), cell.getTower());
+    // fillOptional2D(mCellTimeCalib[index], cell.getTimeStamp() - timeoffset, cell.getTower());
+  }
+  fillOptional2D(mCellTime, cell.getTimeStamp(), cell.getTower());
+  // fillOptional2D(mCellTime[index], cell.getTimeStamp(), cell.getTower());
+
+  try {
+    auto [row, col] = mGeometry->GlobalRowColFromIndex(cell.getTower());
+    if (cell.getEnergy() > 0) {
+      fillOptional2D(mCellOccupancy, col, row);
+    }
+    if (cell.getEnergy() > mCellThreshold) {
+      fillOptional2D(mCellOccupancyThr, col, row);
+    } else {
+      fillOptional2D(mCellOccupancyThrBelow, col, row);
+    }
+
+    fillOptional2D(mIntegratedOccupancy, col, row, cell.getEnergy());
+
+  } catch (o2::emcal::InvalidCellIDException& e) {
+    ILOG(Error, Support) << "Invalid cell ID: " << e.getCellID() << ENDM;
+  };
+
+  try {
+    auto cellindices = mGeometry->GetCellIndex(cell.getTower());
+    auto supermoduleID = std::get<0>(cellindices);
+    fillOptional2D(mCellAmpSupermodule, cell.getEnergy(), supermoduleID);
+    if (cell.getEnergy() > 0.3)
+      fillOptional2D(mCellTimeSupermodule, cell.getTimeStamp(), supermoduleID);
+    if (goodCell) {
+      fillOptional2D(mCellAmpSupermoduleCalib, cell.getEnergy(), supermoduleID);
+      if (cell.getEnergy() > 0.3)
+        fillOptional2D(mCellTimeSupermoduleCalib, cell.getTimeStamp() - timecalib, supermoduleID);
+    }
+    fillOptional1D(mCellAmplitude_tot, cell.getEnergy()); // EMCAL+DCAL, shifter
+    if (cell.getEnergy() > 0.15)
+      fillOptional1D(mCellTimeSupermodule_tot, cell.getTimeStamp()); // EMCAL+DCAL shifter
+    if (supermoduleID < 12) {
+
+      if (cell.getEnergy() > 0.15)
+        fillOptional1D(mCellTimeSupermoduleEMCAL, cell.getTimeStamp());
+      fillOptional1D(mCellAmplitudeEMCAL, cell.getEnergy()); // EMCAL
+    } else {
+      fillOptional1D(mCellAmplitudeDCAL, cell.getEnergy());
+      if (cell.getEnergy() > 0.15)
+        fillOptional1D(mCellTimeSupermoduleDCAL, cell.getTimeStamp());
+    }
+    // bc phase histograms
+    if (cell.getEnergy() > 0.15) {
+      auto bchistos = mCellTimeBC.find(bcphase);
+      if (bchistos != mCellTimeBC.end()) {
+        auto histcontainer = bchistos->second;
+        histcontainer[supermoduleID]->Fill(cell.getTimeStamp());
+      }
+    }
+  } catch (o2::emcal::InvalidCellIDException& e) {
+    ILOG(Info, Support) << "Invalid cell ID: " << e.getCellID() << ENDM;
+  }
+}
+
+void CellTask::CellHistograms::countEvent()
+{
+  mnumberEvents->Fill(1);
+}
+
+void CellTask::CellHistograms::startPublishing(o2::quality_control::core::ObjectsManager& manager)
+{
+  auto publishOptional = [&manager](TH1* hist) {
+    if (hist)
+      manager.startPublishing(hist);
+  };
+
+  publishOptional(mCellTime);
+  publishOptional(mCellTimeCalib);
+  publishOptional(mCellAmplitude);
+  publishOptional(mCellAmplitudeCalib);
+  publishOptional(mCellAmpSupermodule);
+  publishOptional(mCellAmpSupermoduleCalib);
+  publishOptional(mCellTimeSupermodule);
+  publishOptional(mCellTimeSupermodule_tot);
+  publishOptional(mCellTimeSupermoduleEMCAL);
+  publishOptional(mCellTimeSupermoduleDCAL);
+  publishOptional(mCellTimeSupermoduleCalib);
+  publishOptional(mCellAmplitude_tot);
+  publishOptional(mCellAmplitudeEMCAL);
+  publishOptional(mCellAmplitudeDCAL);
+  publishOptional(mCellOccupancy);
+  publishOptional(mCellOccupancyThr);
+  publishOptional(mCellOccupancyThrBelow);
+  publishOptional(mIntegratedOccupancy);
+  publishOptional(mnumberEvents);
+  for (auto& [bcID, histos] : mCellTimeBC) {
+    for (auto hist : histos)
+      publishOptional(hist);
+  }
+  //  publishOptional(mEvCounterTF);
+  //  publishOptional(mEvCounterTFPHYS);
+  //  publishOptional(mEvCounterTFCALIB);
+  //  publishOptional(mTFPerCycles);
+}
+
+void CellTask::CellHistograms::reset()
+{
+
+  //  for (auto h : mCellAmplitude) {
+  //    h->Reset();
+  //  }
+  //  for (auto h : mCellTime) {
+  //    h->Reset();
+  //  }
+  //  for (auto h : mCellAmplitudeCalib) {
+  //    h->Reset();
+  //  }
+  //  for (auto h : mCellTimeCalib) {
+  //    h->Reset();
+  //  }
+
+  auto resetOptional = [](TH1* hist) {
+    if (hist)
+      hist->Reset();
+  };
+
+  resetOptional(mCellTime);
+  resetOptional(mCellTimeCalib);
+  resetOptional(mCellAmplitude);
+  resetOptional(mCellAmplitudeCalib);
+  resetOptional(mCellAmpSupermodule);
+  resetOptional(mCellAmpSupermoduleCalib);
+  resetOptional(mCellTimeSupermodule);
+  resetOptional(mCellTimeSupermodule_tot);
+  resetOptional(mCellTimeSupermoduleEMCAL);
+  resetOptional(mCellTimeSupermoduleDCAL);
+  resetOptional(mCellTimeSupermoduleCalib);
+  resetOptional(mCellAmplitude_tot);
+  resetOptional(mCellAmplitudeEMCAL);
+  resetOptional(mCellAmplitudeDCAL);
+  resetOptional(mCellOccupancy);
+  resetOptional(mCellOccupancyThr);
+  resetOptional(mCellOccupancyThrBelow);
+  resetOptional(mIntegratedOccupancy);
+  resetOptional(mnumberEvents);
+  for (auto& [bcID, histos] : mCellTimeBC) {
+    for (auto hist : histos)
+      resetOptional(hist);
+  }
+  //  resetOptional(mEvCounterTF);
+  //  resetOptional(mEvCounterTFPHYS);
+  //  resetOptional(mEvCounterTFCALIB);
+  //  resetOptional(mTFPerCycles);
+}
+
+void CellTask::CellHistograms::clean()
+{
+  // for (auto h : mCellAmplitude) {
+  //   delete h;
+  // }
+  //  for (auto h : mCellTime) {
+  //   delete h;
+  //  }
+  // for (auto h : mCellAmplitudeCalib) {
+  //   delete h;
+  // }
+  // for (auto h : mCellTimeCalib) {
+  //   delete h;
+  //  }
+
+  auto cleanOptional = [](TObject* hist) {
+    if (hist)
+      delete hist;
+  };
+
+  cleanOptional(mCellTime);
+  cleanOptional(mCellTimeCalib);
+  cleanOptional(mCellAmplitude);
+  cleanOptional(mCellAmplitudeCalib);
+  cleanOptional(mCellAmpSupermodule);
+  cleanOptional(mCellAmpSupermoduleCalib);
+  cleanOptional(mCellTimeSupermodule);
+  cleanOptional(mCellTimeSupermodule_tot);
+  cleanOptional(mCellTimeSupermoduleEMCAL);
+  cleanOptional(mCellTimeSupermoduleDCAL);
+  cleanOptional(mCellTimeSupermoduleCalib);
+  cleanOptional(mCellAmplitude_tot);
+  cleanOptional(mCellAmplitudeEMCAL);
+  cleanOptional(mCellAmplitudeDCAL);
+  cleanOptional(mCellOccupancy);
+  cleanOptional(mCellOccupancyThr);
+  cleanOptional(mCellOccupancyThrBelow);
+  cleanOptional(mIntegratedOccupancy);
+  cleanOptional(mnumberEvents);
+  for (auto& [bcID, histos] : mCellTimeBC) {
+    for (auto hist : histos)
+      cleanOptional(hist);
+  }
+  //  cleanOptional(mEvCounterTF);
+  //  cleanOptional(mEvCounterTFPHYS);
+  //  cleanOptional(mEvCounterTFCALIB);
+  //  cleanOptional(mTFPerCycles);
+  //
+}
+
+} // namespace emcal
+} // namespace quality_control_modules
+} // namespace o2


### PR DESCRIPTION
…lTask

Move current cell level QC implemented in DigitsQcTask
to CellTask (1-1 copy). The DigitsQcTask (after renaming
to DigitsTask) will be needed in the simulation to
monitor MC simulated digits.