### PR TITLE
Doc: Mailing lists should have less priority when looking for help

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ For a general overview of our (O2) software, organization and processes, please 
 
 ### Where to get help
 
-* CERN Mailing lists: alice-o2-wp7 and alice-o2-qc-contact
 * Discourse: https://alice-talk.web.cern.ch/
 * JIRA: https://alice.its.cern.ch
 * O2 development newcomers' guide: https://aliceo2group.github.io/quickstart
 * Doxygen: https://aliceo2group.github.io/QualityControl/
+* CERN Mailing lists: alice-o2-wp7 and alice-o2-qc-contact


### PR DESCRIPTION
@Barthelemy I would put discourse on top, because anyone can find old issues there and those who do not want to see support questions can unwatch. On the other hand, our QC contacts should not unsubscribe from the QC contact mailing list. Do you agree?