### PR TITLE
Get payload size from DataRefUtils instead of DataHeader

### DIFF
--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -30,6 +30,7 @@
 #include <Framework/DataSpecUtils.h>
 #include <Framework/InputRecordWalker.h>
 #include <Framework/InputSpan.h>
+#include <Framework/DataRefUtils.h>
 
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/TaskFactory.h"
@@ -427,12 +428,13 @@ void TaskRunner::updateMonitoringStats(ProcessingContext& pCtx)
 {
   mNumberMessagesReceivedInCycle++;
   for (const auto& input : InputRecordWalker(pCtx.inputs())) {
-    const auto* inputHeader = header::get<header::DataHeader*>(input.header);
+    const auto* inputHeader = DataRefUtils::getHeader<header::DataHeader*>(input);
+    auto payloadSize = DataRefUtils::getPayloadSize(input);
     if (inputHeader == nullptr) {
       ILOG(Warning, Devel) << "No DataHeader found in message, ignoring this one for the statistics." << ENDM;
       continue;
     }
-    mDataReceivedInCycle += inputHeader->headerSize + inputHeader->payloadSize;
+    mDataReceivedInCycle += inputHeader->headerSize + payloadSize;
   }
 }
 

--- a/Modules/Benchmark/src/TH1FTask.cxx
+++ b/Modules/Benchmark/src/TH1FTask.cxx
@@ -20,6 +20,8 @@
 #include <Headers/DataHeader.h>
 #include "QualityControl/QcInfoLogger.h"
 #include <Framework/InputRecord.h>
+#include <Framework/InputRecordWalker.h>
+#include <Framework/DataRefUtils.h>
 
 namespace o2::quality_control_modules::benchmark
 {
@@ -70,10 +72,13 @@ void TH1FTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
   // the minimum that we can do, which includes accessing data and creating non-empty histograms
   size_t dummySum = 0;
-  for (auto&& input : ctx.inputs()) {
+  for (auto&& input : o2::framework::InputRecordWalker(ctx.inputs())) {
     if (input.header != nullptr && input.payload != nullptr) {
-      const auto* header = header::get<header::DataHeader*>(input.header);
-      dummySum += header->payloadSize + input.payload[0];
+      // TODO: better use InputRecord::get<std::byte> to get a span of the raw input data
+      // and use its size and first byte
+      const auto* header = o2::framework::DataRefUtils::getHeader<header::DataHeader*>(input);
+      auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(input);
+      dummySum += payloadSize + input.payload[0];
     }
   }
 

--- a/Modules/CPV/src/PedestalTask.cxx
+++ b/Modules/CPV/src/PedestalTask.cxx
@@ -22,6 +22,8 @@
 #include "QualityControl/QcInfoLogger.h"
 #include "CPV/PedestalTask.h"
 #include <Framework/InputRecord.h>
+#include <Framework/InputRecordWalker.h>
+#include <Framework/DataRefUtils.h>
 #include "DataFormatsCPV/TriggerRecord.h"
 #include "DataFormatsCPV/Digit.h"
 
@@ -112,15 +114,15 @@ void PedestalTask::monitorData(o2::framework::ProcessingContext& ctx)
   int nValidInputs = ctx.inputs().countValidInputs();
   mHist1D[H1DNValidInputs]->Fill(nValidInputs);
 
-  for (auto&& input : ctx.inputs()) {
+  for (auto&& input : o2::framework::InputRecordWalker(ctx.inputs())) {
     // get message header
     if (input.header != nullptr && input.payload != nullptr) {
-      const auto* header = header::get<header::DataHeader*>(input.header);
+      auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(input);
       // get payload of a specific input, which is a char array.
       // const char* payload = input.payload;
 
       // for the sake of an example, let's fill the histogram with payload sizes
-      mHist1D[H1DInputPayloadSize]->Fill(header->payloadSize);
+      mHist1D[H1DInputPayloadSize]->Fill(payloadSize);
     }
   }
 
@@ -148,31 +150,6 @@ void PedestalTask::monitorData(o2::framework::ProcessingContext& ctx)
       }
     }
   }
-  // get the payload of a specific input, which is a char array. "random" is the binding specified in the config file.
-  //   auto payload = ctx.inputs().get("random").payload;
-
-  // get payload of a specific input, which is a structure array:
-  //  const auto* header = header::get<header::DataHeader*>(ctx.inputs().get("random").header);
-  //  struct s {int a; double b;};
-  //  auto array = ctx.inputs().get<s*>("random");
-  //  for (int j = 0; j < header->payloadSize / sizeof(s); ++j) {
-  //    int i = array.get()[j].a;
-  //  }
-
-  // get payload of a specific input, which is a root object
-  //   auto h = ctx.inputs().get<TH1F*>("histos");
-  //   Double_t stats[4];
-  //   h->GetStats(stats);
-  //   auto s = ctx.inputs().get<TObjString*>("string");
-  //   LOG(info) << "String is " << s->GetString().Data();
-
-  // 3. Access CCDB. If it is enough to retrieve it once, do it in initialize().
-  // Remember to delete the object when the pointer goes out of scope or it is no longer needed.
-  //   TObject* condition = TaskInterface::retrieveCondition("QcTask/example"); // put a valid condition path here
-  //   if (condition) {
-  //     LOG(info) << "Retrieved " << condition->ClassName();
-  //     delete condition;
-  //   }
 }
 
 void PedestalTask::endOfCycle()

--- a/Modules/CPV/src/PhysicsTask.cxx
+++ b/Modules/CPV/src/PhysicsTask.cxx
@@ -21,6 +21,7 @@
 #include "CPV/PhysicsTask.h"
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
+#include <Framework/DataRefUtils.h>
 #include "DataFormatsCPV/Digit.h"
 #include "DataFormatsCPV/Cluster.h"
 #include "DataFormatsCPV/TriggerRecord.h"
@@ -89,10 +90,11 @@ void PhysicsTask::monitorData(o2::framework::ProcessingContext& ctx)
   mHist1D[H1DNValidInputs]->Fill(nValidInputs);
 
   bool hasClusters = false, hasDigits = false;
-  for (auto&& input : ctx.inputs()) {
+  for (auto&& input : o2::framework::InputRecordWalker(ctx.inputs())) {
     // get message header
     if (input.header != nullptr && input.payload != nullptr) {
-      const auto* header = header::get<header::DataHeader*>(input.header);
+      const auto* header = o2::framework::DataRefUtils::getHeader<header::DataHeader*>(input);
+      auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(input);
       //LOG(info) << "monitorData() : obtained input " << header->dataOrigin.str << "/" << header->dataDescription.str;
       if ((strcmp(header->dataOrigin.str, "CPV") == 0) && (strcmp(header->dataDescription.str, "DIGITS") == 0)) {
         //LOG(info) << "monitorData() : I found digits in inputs";
@@ -107,7 +109,7 @@ void PhysicsTask::monitorData(o2::framework::ProcessingContext& ctx)
       // const char* payload = input.payload;
 
       // for the sake of an example, let's fill the histogram with payload sizes
-      mHist1D[H1DInputPayloadSize]->Fill(header->payloadSize);
+      mHist1D[H1DInputPayloadSize]->Fill(payloadSize);
     }
   }
 

--- a/Modules/Daq/include/Daq/DaqTask.h
+++ b/Modules/Daq/include/Daq/DaqTask.h
@@ -51,7 +51,7 @@ class DaqTask final : public o2::quality_control::core::TaskInterface
   void reset() override;
 
  private:
-  void printInputPayload(const header::DataHeader* header, const char* payload);
+  void printInputPayload(const header::DataHeader* header, const char* payload, size_t payloadSize);
   void monitorInputRecord(o2::framework::InputRecord& inputRecord);
   void monitorRDHs(o2::framework::InputRecord& inputRecord);
 

--- a/Modules/Example/src/EveryObject.cxx
+++ b/Modules/Example/src/EveryObject.cxx
@@ -21,6 +21,7 @@
 #include "Example/EveryObject.h"
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
+#include <Framework/DataRefUtils.h>
 
 #include <TH1F.h>
 #include <TH2F.h>
@@ -98,10 +99,11 @@ void EveryObject::startOfCycle()
 void EveryObject::monitorData(o2::framework::ProcessingContext& ctx)
 {
   for (auto&& input : framework::InputRecordWalker(ctx.inputs())) {
-    const auto* header = header::get<header::DataHeader*>(input.header);
-    auto value1 = (Float_t)(header->payloadSize % (size_t)rangeLimiter);
-    auto value2 = (Float_t)((header->tfCounter + header->payloadSize) % (size_t)rangeLimiter);
-    auto value3 = (Float_t)((header->tfCounter * header->payloadSize) % (size_t)rangeLimiter);
+    const auto* header = framework::DataRefUtils::getHeader<header::DataHeader*>(input);
+    const auto payloadSize = framework::DataRefUtils::getPayloadSize(input);
+    auto value1 = (Float_t)(payloadSize % (size_t)rangeLimiter);
+    auto value2 = (Float_t)((header->tfCounter + payloadSize) % (size_t)rangeLimiter);
+    auto value3 = (Float_t)((header->tfCounter * payloadSize) % (size_t)rangeLimiter);
 
     if (mTH1F) {
       mTH1F->Fill(value1);

--- a/Modules/Example/src/ExampleTask.cxx
+++ b/Modules/Example/src/ExampleTask.cxx
@@ -16,6 +16,8 @@
 
 #include "Example/ExampleTask.h"
 #include <Framework/InputRecord.h>
+#include <Framework/InputRecordWalker.h>
+#include <Framework/DataRefUtils.h>
 #include "QualityControl/QcInfoLogger.h"
 #include <TH1.h>
 #include "Example/CustomTH2F.h"
@@ -80,11 +82,11 @@ void ExampleTask::startOfCycle()
 
 void ExampleTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  for (auto& input : ctx.inputs()) {
+  for (const auto& input : o2::framework::InputRecordWalker(ctx.inputs())) {
     if (input.header != nullptr) {
-      const auto* header = o2::header::get<header::DataHeader*>(input.header); // header of first valid input
-      mHistos[0]->Fill(header->payloadSize);
-      mCustomTH2F->Fill(header->payloadSize % 100, header->payloadSize % 100);
+      const auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(input);
+      mHistos[0]->Fill(payloadSize);
+      mCustomTH2F->Fill(payloadSize % 100, payloadSize % 100);
       for (auto& mHisto : mHistos) {
         if (mHisto) {
           mHisto->FillRandom("gaus", 1);

--- a/Modules/HMPID/src/HmpidTask.cxx
+++ b/Modules/HMPID/src/HmpidTask.cxx
@@ -20,6 +20,7 @@
 #include <TMath.h>
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
+#include <Framework/DataRefUtils.h>
 
 #include "QualityControl/QcInfoLogger.h"
 //#include "HMPID/HmpidDecodeRawMem.h"
@@ -134,13 +135,13 @@ void HmpidTask::monitorData(o2::framework::ProcessingContext& ctx)
   for (auto&& input : o2::framework::InputRecordWalker(ctx.inputs())) {
     // get message header
     if (input.header != nullptr && input.payload != nullptr) {
-      const auto* header = header::get<header::DataHeader*>(input.header);
+      auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(input);
       int32_t* ptrToPayload = (int32_t*)(input.payload);
 
-      if (header->payloadSize < 80) {
+      if (payloadSize < 80) {
         continue;
       }
-      mDecoder->setUpStream(ptrToPayload, (long int)header->payloadSize);
+      mDecoder->setUpStream(ptrToPayload, (long int)payloadSize);
       if (!mDecoder->decodeBufferFast()) {
         ILOG(Error, Devel) << "Error decoding the Superpage !" << ENDM;
       }

--- a/Modules/MUON/MCH/src/DecodingErrorsTask.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsTask.cxx
@@ -21,6 +21,7 @@
 #include "DetectorsRaw/RDHUtils.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "Framework/WorkflowSpec.h"
+#include "Framework/DataRefUtils.h"
 
 #include "MCHRawElecMap/Mapper.h"
 #include "MCHMappingInterface/Segmentation.h"
@@ -147,12 +148,12 @@ void DecodingErrorsTask::decodeReadout(const o2::framework::DataRef& input)
     return;
   }
 
-  const auto* header = o2::header::get<header::DataHeader*>(input.header);
+  const auto* header = o2::framework::DataRefUtils::getHeader<header::DataHeader*>(input);
   if (!header) {
     return;
   }
 
-  size_t payloadSize = header->payloadSize;
+  size_t payloadSize = o2::framework::DataRefUtils::getPayloadSize(input);
   if (payloadSize == 0) {
     return;
   }

--- a/Modules/Skeleton/src/SkeletonTask.cxx
+++ b/Modules/Skeleton/src/SkeletonTask.cxx
@@ -21,6 +21,7 @@
 #include "Skeleton/SkeletonTask.h"
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
+#include <Framework/DataRefUtils.h>
 
 namespace o2::quality_control_modules::skeleton
 {
@@ -84,12 +85,13 @@ void SkeletonTask::monitorData(o2::framework::ProcessingContext& ctx)
   // 1. In a loop
   for (auto&& input : framework::InputRecordWalker(ctx.inputs())) {
     // get message header
-    const auto* header = header::get<header::DataHeader*>(input.header);
+    const auto* header = o2::framework::DataRefUtils::getHeader<header::DataHeader*>(input);
+    auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(input);
     // get payload of a specific input, which is a char array.
     // const char* payload = input.payload;
 
     // for the sake of an example, let's fill the histogram with payload sizes
-    mHistogram->Fill(header->payloadSize);
+    mHistogram->Fill(payloadSize);
   }
 
   // 2. Using get("<binding>")
@@ -98,10 +100,15 @@ void SkeletonTask::monitorData(o2::framework::ProcessingContext& ctx)
   //   auto payload = ctx.inputs().get("random").payload;
 
   // get payload of a specific input, which is a structure array:
-  //  const auto* header = header::get<header::DataHeader*>(ctx.inputs().get("random").header);
+  //   auto input = ctx.inputs().get("random");
+  //   auto payload = input.payload;
+
+  // get payload of a specific input, which is a structure array:
+  //  const auto* header = DataRefUtils::getHeader<header::DataHeader*>(input);
+  //  auto payloadSize = DataRefUtils::getPayloadSize(input);
   //  struct s {int a; double b;};
-  //  auto array = ctx.inputs().get<s*>("random");
-  //  for (int j = 0; j < header->payloadSize / sizeof(s); ++j) {
+  //  auto array = ctx.inputs().get<s*>(input);
+  //  for (int j = 0; j < payloadSize / sizeof(s); ++j) {
   //    int i = array.get()[j].a;
   //  }
 

--- a/Modules/TOF/src/TaskRaw.cxx
+++ b/Modules/TOF/src/TaskRaw.cxx
@@ -30,6 +30,7 @@
 #include "Headers/RAWDataHeader.h"
 #include "DetectorsRaw/HBFUtils.h"
 #include <Framework/InputRecord.h>
+#include <Framework/InputRecordWalker.h>
 #include "DetectorsRaw/RDHUtils.h"
 
 using namespace o2::framework;
@@ -481,16 +482,15 @@ void TaskRaw::monitorData(o2::framework::ProcessingContext& ctx)
   // Reset counter before decode() call
   mDecoderRaw.mCounterRDHOpen.Reset();
   //
-  for (auto iit = ctx.inputs().begin(), iend = ctx.inputs().end(); iit != iend; ++iit) {
-    if (!iit.isValid()) {
-      continue;
-    }
+  {
     /** loop over input parts **/
-    for (auto const& input : iit) {
+    for (auto const& input : o2::framework::InputRecordWalker(ctx.inputs())) {
       /** input **/
       const auto* headerIn = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(input);
       const auto payloadIn = input.payload;
-      const auto payloadInSize = headerIn->payloadSize;
+      const auto payloadInSize = o2::framework::DataRefUtils::getPayloadSize(input);
+      // TODO: better use InputRecord::get<byte type>(input) to extract a span and pass
+      // either the span or its data pointer and size
       mDecoderRaw.setDecoderBuffer(payloadIn);
       mDecoderRaw.setDecoderBufferSize(payloadInSize);
       //


### PR DESCRIPTION
The extended data model allows to have have multiple payloads per header
which requires to extract the actual data size from the message size.
`DataRefUtils::getPayloadSize` handles this transparently.