### PR TITLE
MCH: adapt calls to avoid deprecated O2 MCH functions

### DIFF
--- a/Modules/MUON/MCH/include/MCH/PedestalsTask.h
+++ b/Modules/MUON/MCH/include/MCH/PedestalsTask.h
@@ -21,7 +21,7 @@
 #include "MCHRawElecMap/Mapper.h"
 #include "MCH/GlobalHistogram.h"
 #include "Framework/DataRef.h"
-#include "MCHCalibration/MCHChannelCalibrator.h"
+#include "MCHCalibration/PedestalData.h"
 
 class TH1F;
 class TH2F;
@@ -56,7 +56,7 @@ class PedestalsTask final : public TaskInterface
   o2::mch::raw::Elec2DetMapper mElec2DetMapper;
 
   /// helper class that performs the actual computation of the pedestals from the input digits
-  o2::mch::calibration::PedestalProcessor mPedestalProcessor;
+  o2::mch::calibration::PedestalData mPedestalData;
 
   TH2F* mHistogramPedestals;
   TH2F* mHistogramNoise;


### PR DESCRIPTION
@aferrero2707 this is step 2 of a 3 steps process (to avoid having to sync an O2 PR with a QC one) to finalise the renaming/reorganisation of some code related to pedestal calibration. 

Step 1 was in https://github.com/AliceO2Group/AliceO2/pull/8215. 

Step 3 is already prepared in https://github.com/aphecetche/AliceO2/tree/mch-remove-deprecated-pedestals-api ready for a PR once this one is merged.