### PR TITLE
MCH: add checker class for DecodingErrors plots

### DIFF
--- a/Modules/MUON/MCH/CMakeLists.txt
+++ b/Modules/MUON/MCH/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SRCS
   src/PhysicsTaskPreclusters.cxx
   src/DecodingErrorsTask.cxx
   src/PedestalsCheck.cxx
+  src/DecodingErrorsCheck.cxx
   src/PhysicsCheck.cxx
   src/PhysicsOccupancyCheck.cxx
   src/PhysicsPreclustersCheck.cxx
@@ -22,6 +23,7 @@ set(HEADERS
   include/MCH/PhysicsTaskPreclusters.h
   include/MCH/DecodingErrorsTask.h
   include/MCH/PedestalsCheck.h
+  include/MCH/DecodingErrorsCheck.h
   include/MCH/PhysicsCheck.h
   include/MCH/PhysicsOccupancyCheck.h
   include/MCH/PhysicsPreclustersCheck.h
@@ -78,6 +80,7 @@ add_root_dictionary(${MODULE_NAME}
                             include/MCH/PhysicsOccupancyCheck.h
                             include/MCH/PhysicsPreclustersCheck.h
                             include/MCH/DecodingErrorsTask.h
+                            include/MCH/DecodingErrorsCheck.h
                             include/MCH/PedestalsCheck.h
                             include/MCH/TH1MCHReductor.h
                             include/MCH/sampa_header.h

--- a/Modules/MUON/MCH/include/MCH/DecodingErrorsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingErrorsCheck.h
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   DecodingErrorsCheck.h
+/// \author Andrea Ferrero, Sebastien Perrin
+///
+
+#ifndef QC_MODULE_MCH_DECODINGERRORSCHECK_H
+#define QC_MODULE_MCH_DECODINGERRORSCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "MCHRawCommon/DataFormats.h"
+#include "MCHRawElecMap/Mapper.h"
+#include <string>
+
+namespace o2::quality_control_modules::muonchambers
+{
+
+/// \brief  Check if the occupancy on each pad is between the two specified values
+///
+/// \author Andrea Ferrero, Sebastien Perrin
+class DecodingErrorsCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  DecodingErrorsCheck();
+  /// Destructor
+  ~DecodingErrorsCheck() override;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+ private:
+  int mPrintLevel;
+  double mMaxErrorRate;
+
+  ClassDefOverride(DecodingErrorsCheck, 1);
+};
+
+} // namespace o2::quality_control_modules::muonchambers
+
+#endif // QC_MODULE_MCH_DECODINGERRORSCHECK_H

--- a/Modules/MUON/MCH/include/MCH/GlobalHistogram.h
+++ b/Modules/MUON/MCH/include/MCH/GlobalHistogram.h
@@ -31,6 +31,9 @@ namespace muonchambers
 
 std::string getHistoPath(int deId);
 
+int getDEindex(int de);
+int getDEindexMax();
+
 class DetectorHistogram
 {
  public:

--- a/Modules/MUON/MCH/include/MCH/LinkDef.h
+++ b/Modules/MUON/MCH/include/MCH/LinkDef.h
@@ -8,6 +8,7 @@
 #pragma link C++ class o2::quality_control_modules::muonchambers::PhysicsTaskPreclusters + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::DecodingErrorsTask + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PedestalsCheck + ;
+#pragma link C++ class o2::quality_control_modules::muonchambers::DecodingErrorsCheck + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PhysicsCheck + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PhysicsOccupancyCheck + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PhysicsPreclustersCheck + ;

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
@@ -74,6 +74,7 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   static constexpr int sMaxDsId = 40;
 
   bool mDiagnostic{ false };
+  bool mSaveToRootFile{ false };
 
   o2::mch::raw::Elec2DetMapper mElec2DetMapper;
   o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
@@ -91,8 +92,10 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   std::shared_ptr<TH2F> mDigitsOrbitInTF;
   std::shared_ptr<TH2F> mDigitsBcInOrbit;
   std::shared_ptr<TH2F> mAmplitudeVsSamples;
+  std::shared_ptr<TH2F> mAmplitudeElec;
 
   std::map<int, std::shared_ptr<TH1F>> mHistogramADCamplitudeDE;              // Histogram of ADC distribution per DE
+  std::map<int, std::shared_ptr<TH1F>> mHistogramADCamplitudeDEFiltered;      // Histogram of ADC distribution per DE
   std::map<int, std::shared_ptr<DetectorHistogram>> mHistogramNhitsDE[2];     // Histogram of Number of hits (XY view)
   std::map<int, std::shared_ptr<DetectorHistogram>> mHistogramNorbitsDE[2];   // Histogram of Number of orbits (XY view)
   std::map<int, std::shared_ptr<MergeableTH2Ratio>> mHistogramOccupancyDE[2]; // Mergeable object, Occupancy histogram (XY view)

--- a/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
@@ -1,0 +1,133 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   DecodingErrorsCheck.cxx
+/// \author Andrea Ferrero, Sebastien Perrin
+///
+
+#include "MCHMappingInterface/Segmentation.h"
+#include "MCHMappingSegContour/CathodeSegmentationContours.h"
+#include "MCH/DecodingErrorsCheck.h"
+#include "MCH/GlobalHistogram.h"
+
+// ROOT
+#include <fairlogger/Logger.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TList.h>
+#include <TMath.h>
+#include <TPaveText.h>
+#include <TLine.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+using namespace std;
+
+namespace o2::quality_control_modules::muonchambers
+{
+
+DecodingErrorsCheck::DecodingErrorsCheck()
+{
+  mPrintLevel = 0;
+  mMaxErrorRate = 100.00;
+}
+
+DecodingErrorsCheck::~DecodingErrorsCheck() {}
+
+void DecodingErrorsCheck::configure()
+{
+  bool mDiagnostic = false;
+  if (auto param = mCustomParameters.find("MaxErrorRate"); param != mCustomParameters.end()) {
+    mMaxErrorRate = std::stof(param->second);
+  }
+}
+
+Quality DecodingErrorsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Null;
+
+  for (auto& [moName, mo] : *moMap) {
+
+    (void)moName;
+    if (mo->getName().find("DecodingErrorsPerFeeId") != std::string::npos) {
+      auto* h = dynamic_cast<TH2F*>(mo->getObject());
+      if (!h) {
+        return result;
+      }
+
+      int nbad = 0;
+      if (h->GetEntries() == 0) {
+        result = Quality::Medium;
+      } else {
+        int nbinsx = h->GetXaxis()->GetNbins();
+        int nbinsy = h->GetYaxis()->GetNbins();
+        for (int i = 1; i <= nbinsx; i++) {
+          for (int j = 1; j <= nbinsy; j++) {
+            Float_t errorRate = h->GetBinContent(i, j);
+            if (errorRate < mMaxErrorRate) {
+              continue;
+            }
+
+            nbad += 1;
+          }
+        }
+        if (nbad == 0)
+          result = Quality::Good;
+        else
+          result = Quality::Bad;
+      }
+    }
+  }
+  return result;
+}
+
+std::string DecodingErrorsCheck::getAcceptedType() { return "TH1"; }
+
+void DecodingErrorsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (mo->getName().find("DecodingErrorsPerFeeId") != std::string::npos ||
+      mo->getName().find("DecodingErrorsPerChamber") != std::string::npos) {
+    auto* h = dynamic_cast<TH2F*>(mo->getObject());
+    h->SetDrawOption("colz");
+    TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
+    h->GetListOfFunctions()->Add(msg);
+    msg->SetName(Form("%s_msg", mo->GetName()));
+    msg->SetBorderSize(0);
+
+    if (checkResult == Quality::Good) {
+      msg->Clear();
+      msg->AddText("All errors within limits: OK!!!");
+      msg->SetFillColor(kGreen);
+
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      LOG(info) << "Quality::Bad, setting to red";
+      //
+      msg->Clear();
+      msg->AddText("Too many errors, call MCH on-call.");
+      msg->SetFillColor(kRed);
+
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      LOG(info) << "Quality::medium, setting to orange";
+
+      msg->Clear();
+      msg->AddText("No entries. If MCH in the run, check MCH TWiki");
+      msg->SetFillColor(kYellow);
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+}
+
+} // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/src/GlobalHistogram.cxx
+++ b/Modules/MUON/MCH/src/GlobalHistogram.cxx
@@ -55,6 +55,85 @@ std::string getHistoPath(int deId)
   return fmt::format("ST{}/DE{}/", (deId - 100) / 200 + 1, deId);
 }
 
+int getDEindex(int deId)
+{
+  // CH 1 - 4 DE
+  int DEmin = 100;
+  int offset = 0;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin);
+  }
+  offset += 5;
+
+  // CH 2 - 4 DE
+  DEmin = 200;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 5;
+
+  // CH 3 - 4 DE
+  DEmin = 300;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 5;
+
+  // CH 4 - 4 DE
+  DEmin = 400;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 5;
+
+  // CH 5 - 17 DE
+  DEmin = 500;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 20;
+
+  // CH 6 - 17 DE
+  DEmin = 600;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 20;
+
+  // CH 7 - 23 DE
+  DEmin = 700;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 25;
+
+  // CH 8 - 23 DE
+  DEmin = 800;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 25;
+
+  // CH 9 - 23 DE
+  DEmin = 900;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 25;
+
+  // CH 10 - 23 DE
+  DEmin = 1000;
+  if (deId < (DEmin + 100)) {
+    return (deId - DEmin + offset);
+  }
+  offset += 25;
+}
+
+int getDEindexMax()
+{
+  return getDEindex(1025);
+}
+
 static int getLR(int de)
 {
   int lr = -1;
@@ -108,7 +187,7 @@ static int getBT(int de)
 static int getDetectorHistWidth(int deId)
 {
   if (deId >= 500) {
-    return (40 * 5);
+    return (40 * 6 + 20);
   } else {
     return (300);
   }
@@ -138,10 +217,24 @@ static int getDetectorHistYbins(int deId)
 static bool getDetectorFlipX(int deId)
 {
   int lr = getLR(deId);
+  bool flip = false;
   if (lr == 1) {
-    return true;
+    flip = true;
   }
-  return false;
+
+  if (deId >= 700) {
+    int mod = (deId % 100);
+    if (mod == 0 || mod == 2 || mod == 3 || mod == 4 || mod == 9 || mod == 10 || mod == 11 || mod == 13 || mod == 15 || mod == 16 || mod == 17 || mod == 21 || mod == 22 || mod == 23 || mod == 24) {
+      flip = !flip;
+    }
+  } else if (deId >= 500) {
+    int mod = (deId % 100);
+    if (mod == 2 || mod == 7 || mod == 11 || mod == 16) {
+      flip = !flip;
+    }
+  }
+
+  return flip;
 }
 
 static bool getDetectorFlipY(int deId)
@@ -305,7 +398,7 @@ void GlobalHistogram::init()
   for (auto& de : allDE) {
     if (de < 500)
       continue;
-    //std::cout<<"DE: "<<de<<std::endl;
+    // std::cout<<"DE: "<<de<<std::endl;
     const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(de);
     if ((&segment) == nullptr) {
       continue;
@@ -408,15 +501,15 @@ void GlobalHistogram::getDeCenterST3(int de, float& xB0, float& yB0, float& xNB0
   yId += yOffset;
 
   xB0 = xNB0 = DE_WIDTH * xId + DE_WIDTH / 2;
-  //xNB0 = DE_WIDTH * xId + DE_WIDTH * 2 + DE_WIDTH / 2;
+  // xNB0 = DE_WIDTH * xId + DE_WIDTH * 2 + DE_WIDTH / 2;
 
   yB0 = yNB0 = DE_HEIGHT * yId + DE_HEIGHT / 2;
   yB0 += NYHIST_PER_CHAMBER * DE_HEIGHT;
 
   int chamber = de / 100;
   if ((chamber % 2) == 0) {
-    //yB0  += NYHIST_PER_CHAMBER * DE_HEIGHT;
-    //yNB0 += NYHIST_PER_CHAMBER * DE_HEIGHT;
+    // yB0  += NYHIST_PER_CHAMBER * DE_HEIGHT;
+    // yNB0 += NYHIST_PER_CHAMBER * DE_HEIGHT;
     xB0 += NXHIST_PER_CHAMBER * DE_WIDTH;
     xNB0 += NXHIST_PER_CHAMBER * DE_WIDTH;
   }
@@ -429,7 +522,7 @@ void GlobalHistogram::getDeCenterST3(int de, float& xB0, float& yB0, float& xNB0
   o2::mch::contour::Contour<double> envelop = o2::mch::mapping::getEnvelop(csegment);
   std::vector<o2::mch::contour::Vertex<double>> vertices = envelop.getVertices();
   o2::mch::contour::BBox<double> bbox = o2::mch::mapping::getBBox(csegment);
-  //std::cout<<"DE "<<de<<"  BBOX "<<bbox<<std::endl;
+  // std::cout<<"DE "<<de<<"  BBOX "<<bbox<<std::endl;
 
   double xmax = bbox.xmax();
   if (xId == 0) {
@@ -519,18 +612,18 @@ void GlobalHistogram::getDeCenterST4(int de, float& xB0, float& yB0, float& xNB0
 
   xB0 = xNB0 = DE_WIDTH * xId + DE_WIDTH / 2 + NXHIST_PER_STATION * DE_WIDTH;
 
-  //xB0  = DE_WIDTH * xId + DE_WIDTH / 2 + NXHIST_PER_STATION * DE_WIDTH;
-  //xNB0 = DE_WIDTH * xId + DE_WIDTH * 2 + DE_WIDTH / 2 + NXHIST_PER_STATION * DE_WIDTH;
-  //xB0  = DE_WIDTH * (2 * xId)     + DE_WIDTH / 2 + NXHIST_PER_CHAMBER * DE_WIDTH;
-  //xNB0 = DE_WIDTH * (2 * xId + 1) + DE_WIDTH / 2 + NXHIST_PER_CHAMBER * DE_WIDTH;
+  // xB0  = DE_WIDTH * xId + DE_WIDTH / 2 + NXHIST_PER_STATION * DE_WIDTH;
+  // xNB0 = DE_WIDTH * xId + DE_WIDTH * 2 + DE_WIDTH / 2 + NXHIST_PER_STATION * DE_WIDTH;
+  // xB0  = DE_WIDTH * (2 * xId)     + DE_WIDTH / 2 + NXHIST_PER_CHAMBER * DE_WIDTH;
+  // xNB0 = DE_WIDTH * (2 * xId + 1) + DE_WIDTH / 2 + NXHIST_PER_CHAMBER * DE_WIDTH;
 
   yB0 = yNB0 = DE_HEIGHT * yId + DE_HEIGHT / 2;
   yB0 += NYHIST_PER_CHAMBER * DE_HEIGHT;
 
   int chamber = de / 100;
   if ((chamber % 2) == 0) {
-    //yB0  += NYHIST_PER_CHAMBER * DE_HEIGHT;
-    //yNB0 += NYHIST_PER_CHAMBER * DE_HEIGHT;
+    // yB0  += NYHIST_PER_CHAMBER * DE_HEIGHT;
+    // yNB0 += NYHIST_PER_CHAMBER * DE_HEIGHT;
     xB0 += NXHIST_PER_CHAMBER * DE_WIDTH;
     xNB0 += NXHIST_PER_CHAMBER * DE_WIDTH;
   }
@@ -543,7 +636,7 @@ void GlobalHistogram::getDeCenterST4(int de, float& xB0, float& yB0, float& xNB0
   o2::mch::contour::Contour<double> envelop = o2::mch::mapping::getEnvelop(csegment);
   std::vector<o2::mch::contour::Vertex<double>> vertices = envelop.getVertices();
   o2::mch::contour::BBox<double> bbox = o2::mch::mapping::getBBox(csegment);
-  //std::cout<<"DE "<<de<<"  BBOX "<<bbox<<std::endl;
+  // std::cout<<"DE "<<de<<"  BBOX "<<bbox<<std::endl;
 
   double xmax = bbox.xmax();
   if (xId == 0) {
@@ -587,7 +680,7 @@ void GlobalHistogram::set(std::map<int, DetectorHistogram*>& histB, std::map<int
 {
   for (auto& ih : histB) {
     int de = ih.first;
-    //if (de != 819) continue;
+    // if (de != 819) continue;
     if (de < 500)
       continue;
     if (de >= 1100)


### PR DESCRIPTION
The checker marks the data quality as " bad" if any of the FEE IDs has an error rate per time-frame above a configurable threshold.

The threshold can be set via the "MaxErrorRate" checker configuration parameter in the QC JSON configuration file.
