### PR TITLE
MCH: add checker class for DecodingErrors plots

### DIFF
--- a/Modules/MUON/MCH/CMakeLists.txt
+++ b/Modules/MUON/MCH/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SRCS
   src/PhysicsTaskPreclusters.cxx
   src/DecodingErrorsTask.cxx
   src/PedestalsCheck.cxx
+  src/DecodingErrorsCheck.cxx
   src/PhysicsCheck.cxx
   src/PhysicsOccupancyCheck.cxx
   src/PhysicsPreclustersCheck.cxx
@@ -22,6 +23,7 @@ set(HEADERS
   include/MCH/PhysicsTaskPreclusters.h
   include/MCH/DecodingErrorsTask.h
   include/MCH/PedestalsCheck.h
+  include/MCH/DecodingErrorsCheck.h
   include/MCH/PhysicsCheck.h
   include/MCH/PhysicsOccupancyCheck.h
   include/MCH/PhysicsPreclustersCheck.h
@@ -78,6 +80,7 @@ add_root_dictionary(${MODULE_NAME}
                             include/MCH/PhysicsOccupancyCheck.h
                             include/MCH/PhysicsPreclustersCheck.h
                             include/MCH/DecodingErrorsTask.h
+                            include/MCH/DecodingErrorsCheck.h
                             include/MCH/PedestalsCheck.h
                             include/MCH/TH1MCHReductor.h
                             include/MCH/sampa_header.h

--- a/Modules/MUON/MCH/include/MCH/DecodingErrorsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingErrorsCheck.h
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   DecodingErrorsCheck.h
+/// \author Andrea Ferrero, Sebastien Perrin
+///
+
+#ifndef QC_MODULE_MCH_DECODINGERRORSCHECK_H
+#define QC_MODULE_MCH_DECODINGERRORSCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "MCHRawCommon/DataFormats.h"
+#include "MCHRawElecMap/Mapper.h"
+#include <string>
+
+namespace o2::quality_control_modules::muonchambers
+{
+
+/// \brief  Check if the occupancy on each pad is between the two specified values
+///
+/// \author Andrea Ferrero, Sebastien Perrin
+class DecodingErrorsCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  DecodingErrorsCheck();
+  /// Destructor
+  ~DecodingErrorsCheck() override;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+ private:
+  int mPrintLevel;
+  double mMaxErrorRate;
+
+  ClassDefOverride(DecodingErrorsCheck, 1);
+};
+
+} // namespace o2::quality_control_modules::muonchambers
+
+#endif // QC_MODULE_MCH_DECODINGERRORSCHECK_H

--- a/Modules/MUON/MCH/include/MCH/LinkDef.h
+++ b/Modules/MUON/MCH/include/MCH/LinkDef.h
@@ -8,6 +8,7 @@
 #pragma link C++ class o2::quality_control_modules::muonchambers::PhysicsTaskPreclusters + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::DecodingErrorsTask + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PedestalsCheck + ;
+#pragma link C++ class o2::quality_control_modules::muonchambers::DecodingErrorsCheck + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PhysicsCheck + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PhysicsOccupancyCheck + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PhysicsPreclustersCheck + ;

--- a/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
@@ -1,0 +1,133 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   DecodingErrorsCheck.cxx
+/// \author Andrea Ferrero, Sebastien Perrin
+///
+
+#include "MCHMappingInterface/Segmentation.h"
+#include "MCHMappingSegContour/CathodeSegmentationContours.h"
+#include "MCH/DecodingErrorsCheck.h"
+#include "MCH/GlobalHistogram.h"
+
+// ROOT
+#include <fairlogger/Logger.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TList.h>
+#include <TMath.h>
+#include <TPaveText.h>
+#include <TLine.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+using namespace std;
+
+namespace o2::quality_control_modules::muonchambers
+{
+
+DecodingErrorsCheck::DecodingErrorsCheck()
+{
+  mPrintLevel = 0;
+  mMaxErrorRate = 100.00;
+}
+
+DecodingErrorsCheck::~DecodingErrorsCheck() {}
+
+void DecodingErrorsCheck::configure()
+{
+  bool mDiagnostic = false;
+  if (auto param = mCustomParameters.find("MaxErrorRate"); param != mCustomParameters.end()) {
+    mMaxErrorRate = std::stof(param->second);
+  }
+}
+
+Quality DecodingErrorsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Null;
+
+  for (auto& [moName, mo] : *moMap) {
+
+    (void)moName;
+    if (mo->getName().find("DecodingErrorsPerFeeId") != std::string::npos) {
+      auto* h = dynamic_cast<TH2F*>(mo->getObject());
+      if (!h) {
+        return result;
+      }
+
+      int nbad = 0;
+      if (h->GetEntries() == 0) {
+        result = Quality::Medium;
+      } else {
+        int nbinsx = h->GetXaxis()->GetNbins();
+        int nbinsy = h->GetYaxis()->GetNbins();
+        for (int i = 1; i <= nbinsx; i++) {
+          for (int j = 1; j <= nbinsy; j++) {
+            Float_t errorRate = h->GetBinContent(i, j);
+            if (errorRate < mMaxErrorRate) {
+              continue;
+            }
+
+            nbad += 1;
+          }
+        }
+        if (nbad == 0)
+          result = Quality::Good;
+        else
+          result = Quality::Bad;
+      }
+    }
+  }
+  return result;
+}
+
+std::string DecodingErrorsCheck::getAcceptedType() { return "TH1"; }
+
+void DecodingErrorsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (mo->getName().find("DecodingErrorsPerFeeId") != std::string::npos ||
+      mo->getName().find("DecodingErrorsPerChamber") != std::string::npos) {
+    auto* h = dynamic_cast<TH2F*>(mo->getObject());
+    h->SetDrawOption("colz");
+    TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
+    h->GetListOfFunctions()->Add(msg);
+    msg->SetName(Form("%s_msg", mo->GetName()));
+    msg->SetBorderSize(0);
+
+    if (checkResult == Quality::Good) {
+      msg->Clear();
+      msg->AddText("All errors within limits: OK!!!");
+      msg->SetFillColor(kGreen);
+
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      LOG(info) << "Quality::Bad, setting to red";
+      //
+      msg->Clear();
+      msg->AddText("Too many errors, call MCH on-call.");
+      msg->SetFillColor(kRed);
+
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      LOG(info) << "Quality::medium, setting to orange";
+
+      msg->Clear();
+      msg->AddText("No entries. If MCH in the run, check MCH TWiki");
+      msg->SetFillColor(kYellow);
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+}
+
+} // namespace o2::quality_control_modules::muonchambers


### PR DESCRIPTION
The checker marks the data quality as " bad" if any of the FEE IDs has an error rate per time-frame above a configurable threshold.
The threshold can be set via the "MaxErrorRate" checker configuration parameter in the QC JSON configuration file.