### PR TITLE
MFT: Major update of readout, digit and cluster task. 

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -54,12 +54,12 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   std::unique_ptr<TH1F> mClusterLayerIndexH1 = nullptr;
   std::unique_ptr<TH1F> mClusterDiskIndex = nullptr;
 
-  std::unique_ptr<TH1F> mClusterSensorIndex = nullptr;
+  std::unique_ptr<TH1F> mClusterOccupancy = nullptr;
   std::unique_ptr<TH1F> mClusterPatternIndex = nullptr;
 
   std::unique_ptr<TH2F> mClusterPatternSensorIndices = nullptr;
   std::vector<std::unique_ptr<TH1F>> mClusterPatternSensorMap;
-  std::vector<std::unique_ptr<TH2F>> mChipOccupancyMap;
+  std::vector<std::unique_ptr<TH2F>> mClusterChipOccupancyMap;
 
   // needed to construct the name and path of some histograms
   int mHalf[936] = { 0 };

--- a/Modules/MFT/include/MFT/QcMFTDigitTask.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitTask.h
@@ -81,11 +81,12 @@ class QcMFTDigitTask final : public TaskInterface
   float mX[936] = { 0 };
   float mY[936] = { 0 };
 
-  std::unique_ptr<TH1F> mChipOccupancy = nullptr;
-  std::unique_ptr<TH1F> mChipOccupancyStdDev = nullptr;
+  std::unique_ptr<TH1F> mDigitChipOccupancy = nullptr;
+  std::unique_ptr<TH1F> mDigitChipStdDev = nullptr;
+  std::unique_ptr<TH2F> mDigitOccupancySummary = nullptr;
 
-  std::vector<std::unique_ptr<TH2F>> mChipOccupancyMap;
-  std::vector<std::unique_ptr<TH2F>> mPixelOccupancyMap;
+  std::vector<std::unique_ptr<TH2F>> mDigitChipOccupancyMap;
+  std::vector<std::unique_ptr<TH2F>> mDigitPixelOccupancyMap;
 
   //  functions
   int getVectorIndexChipOccupancyMap(int chipIndex);

--- a/Modules/MFT/include/MFT/QcMFTReadoutTask.h
+++ b/Modules/MFT/include/MFT/QcMFTReadoutTask.h
@@ -72,12 +72,12 @@ class QcMFTReadoutTask /*final*/ : public TaskInterface // todo add back the "fi
   std::array<int, (104 * 25)> mChipIndex;
 
   // histos
-  std::unique_ptr<TH1F> mSummaryLaneStatus = nullptr;
-  std::unique_ptr<TH1F> mSummaryChipError = nullptr;
-  std::unique_ptr<TH1F> mSummaryChipFault = nullptr;
+  std::unique_ptr<TH1F> mRDHSummary = nullptr;
+  std::unique_ptr<TH1F> mDDWSummary = nullptr;
   std::unique_ptr<TH1F> mSummaryChipOk = nullptr;
   std::unique_ptr<TH1F> mSummaryChipWarning = nullptr;
-  // std::vector<std::unique_ptr<TH2F>> mIndividualLaneStatus;
+  std::unique_ptr<TH1F> mSummaryChipError = nullptr;
+  std::unique_ptr<TH1F> mSummaryChipFault = nullptr;
 
   // maps RU+lane to Chip
   void generateChipIndex();

--- a/Modules/MFT/qc-mft-async.json
+++ b/Modules/MFT/qc-mft-async.json
@@ -1,67 +1,67 @@
 {
-  "qc": {
-    "config": {
-      "database": {
-        "implementation": "CCDB",
-        "host": "ccdb-test.cern.ch:8080",
-        "username": "not_applicable",
-        "password": "not_applicable",
-        "name": "not_applicable"
+  "qc" : {
+    "config" : {
+      "database" : {
+        "implementation" : "CCDB",
+        "host" : "ccdb-test.cern.ch:8080",
+        "username" : "not_applicable",
+        "password" : "not_applicable",
+        "name" : "not_applicable"
       },
-      "Activity": {
-        "number": "42",
-        "type": "2"
+      "Activity" : {
+        "number" : "42",
+        "type" : "2"
       },
-      "monitoring": {
-        "url": "infologger:///debug?qc"
+      "monitoring" : {
+        "url" : "infologger:///debug?qc"
       },
-      "consul": {
-        "url": ""
+      "consul" : {
+        "url" : ""
       },
-      "conditionDB": {
-        "url": "ccdb-test.cern.ch:8080"
+      "conditionDB" : {
+        "url" : "ccdb-test.cern.ch:8080"
       }
     },
-    "tasks": {
-      "QcMFTAsync": {
-        "active": "true",
-        "className": "o2::quality_control_modules::mft::QcMFTAsyncTask",
-        "moduleName": "QcMFT",
-        "detectorName": "MFT",
-        "cycleDurationSeconds": "60",
-        "maxNumberCycles": "-1",
-        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
-        "dataSource": {
-          "type": "dataSamplingPolicy",
-          "name": "mft-async"
+    "tasks" : {
+      "QcMFTAsync" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::mft::QcMFTAsyncTask",
+        "moduleName" : "QcMFT",
+        "detectorName" : "MFT",
+        "cycleDurationSeconds" : "60",
+        "maxNumberCycles" : "-1",
+        "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource" : {
+          "type" : "dataSamplingPolicy",
+          "name" : "mft-async"
         },
-        "taskParameters": {
-          "ROFLengthInBC": "198",
-          "MaxTrackROFSize": "1000",
-          "MaxClusterROFSize": "5000",
-          "MaxDuration": "60000",
-          "TimeBinSize": "0.1",
-          "RefOrbit": "0"
+        "taskParameters" : {
+          "ROFLengthInBC" : "198",
+          "MaxTrackROFSize" : "1000",
+          "MaxClusterROFSize" : "5000",
+          "MaxDuration" : "60000",
+          "TimeBinSize" : "0.1",
+          "RefOrbit" : "0"
         },
-        "location": "remote"
+        "location" : "remote"
       }
     },
-    "checks": {}
+    "checks" : {}
   },
-  "dataSamplingPolicies": [
+  "dataSamplingPolicies" : [
     {
-      "id": "mft-async",
-      "active": "true",
-      "machines": [],
-      "query": "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clusters:MFT/COMPCLUSTERS/0;clustersrofs:MFT/CLUSTERSROF/0",
-      "samplingConditions": [
+      "id" : "mft-async",
+      "active" : "true",
+      "machines" : [],
+      "query" : "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clusters:MFT/COMPCLUSTERS/0;clustersrofs:MFT/CLUSTERSROF/0",
+      "samplingConditions" : [
         {
-          "condition": "random",
-          "fraction": "0.05",
-          "seed": "1234"
+          "condition" : "random",
+          "fraction" : "0.05",
+          "seed" : "1234"
         }
       ],
-      "blocking": "false"
+      "blocking" : "false"
     }
   ]
 }

--- a/Modules/MFT/qc-mft-async_direct.json
+++ b/Modules/MFT/qc-mft-async_direct.json
@@ -1,52 +1,52 @@
 {
-  "qc": {
-    "config": {
-      "database": {
-        "implementation": "Dummy",
-        "host": "not_applicable",
-        "username": "not_applicable",
-        "password": "not_applicable",
-        "name": "not_applicable"
+  "qc" : {
+    "config" : {
+      "database" : {
+        "implementation" : "Dummy",
+        "host" : "not_applicable",
+        "username" : "not_applicable",
+        "password" : "not_applicable",
+        "name" : "not_applicable"
       },
-      "Activity": {
-        "number": "42",
-        "type": "2"
+      "Activity" : {
+        "number" : "42",
+        "type" : "2"
       },
-      "monitoring": {
-        "url": "infologger:///debug?qc"
+      "monitoring" : {
+        "url" : "infologger:///debug?qc"
       },
-      "consul": {
-        "url": ""
+      "consul" : {
+        "url" : ""
       },
-      "conditionDB": {
-        "url": "qcdb.cern.ch:8083"
+      "conditionDB" : {
+        "url" : "ccdb-test.cern.ch:8080"
       }
     },
-    "tasks": {
-      "QcMFTAsync": {
-        "active": "true",
-        "className": "o2::quality_control_modules::mft::QcMFTAsyncTask",
-        "moduleName": "QcMFT",
-        "detectorName": "MFT",
-        "cycleDurationSeconds": "60",
-        "maxNumberCycles": "-1",
-        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
-        "dataSource": {
-          "type": "direct",
-          "query": "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clusters:MFT/COMPCLUSTERS/0;clustersrofs:MFT/CLUSTERSROF/0"
+    "tasks" : {
+      "QcMFTAsync" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::mft::QcMFTAsyncTask",
+        "moduleName" : "QcMFT",
+        "detectorName" : "MFT",
+        "cycleDurationSeconds" : "60",
+        "maxNumberCycles" : "-1",
+        "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource" : {
+          "type" : "direct",
+          "query" : "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clusters:MFT/COMPCLUSTERS/0;clustersrofs:MFT/CLUSTERSROF/0"
         },
-        "taskParameters": {
-          "ROFLengthInBC": "198",
-          "MaxTrackROFSize": "1000",
-          "MaxClusterROFSize": "5000",
-          "MaxDuration": "60000",
-          "TimeBinSize": "0.1",
-          "RefOrbit": "0"
+        "taskParameters" : {
+          "ROFLengthInBC" : "198",
+          "MaxTrackROFSize" : "1000",
+          "MaxClusterROFSize" : "5000",
+          "MaxDuration" : "60000",
+          "TimeBinSize" : "0.1",
+          "RefOrbit" : "0"
         },
-        "location": "remote"
+        "location" : "remote"
       }
     },
-    "checks": {}
+    "checks" : {}
   },
-  "dataSamplingPolicies": []
+  "dataSamplingPolicies" : []
 }

--- a/Modules/MFT/qc-mft-cluster.json
+++ b/Modules/MFT/qc-mft-cluster.json
@@ -3,7 +3,7 @@
     "config" : {
       "database" : {
         "implementation" : "CCDB",
-        "host" : "qcdb.cern.ch:8083",
+        "host" : "ccdb-test.cern.ch:8080",
         "username" : "not_applicable",
         "password" : "not_applicable",
         "name" : "not_applicable"
@@ -16,14 +16,14 @@
         "url" : "infologger:///debug?qc"
       },
       "consul" : {
-        "url" : "aliecs.cern.ch:8500"
+        "url" : ""
       },
       "conditionDB" : {
-        "url" : "qcdb.cern.ch:8083"
+        "url" : "ccdb-test.cern.ch:8080"
       }
     },
     "tasks" : {
-      "QcMFTClusterTask" : {
+      "MFTClusterTask" : {
         "active" : "true",
         "className" : "o2::quality_control_modules::mft::QcMFTClusterTask",
         "moduleName" : "QcMFT",
@@ -42,12 +42,12 @@
       }
     },
     "checks" : {
-      "QcMFTClusterCheck" : {
+      "MFTClusterCheck" : {
         "active" : "false",
         "dataSource" : [ {
           "type" : "Task",
-          "name" : "QcMFTClusterTask",
-          "MOs" : ["mMFTClusterSensorIndex"]
+          "name" : "MFTClusterTask",
+          "MOs" : ["mClusterOccupancy"]
         } ],
         "className" : "o2::quality_control_modules::mft::QcMFTClusterCheck",
         "moduleName" : "QcMFT",

--- a/Modules/MFT/qc-mft-digit.json
+++ b/Modules/MFT/qc-mft-digit.json
@@ -23,7 +23,7 @@
       }
     },
     "tasks" : {
-      "QcMFTDigitTask" : {
+      "MFTDigitTask" : {
         "active" : "true",
         "className" : "o2::quality_control_modules::mft::QcMFTDigitTask",
         "moduleName" : "QcMFT",
@@ -43,7 +43,7 @@
       }
     },
     "checks" : {
-      "QcMFTDigitCheck" : {
+      "MFTDigitCheck" : {
         "active" : "true",
         "className" : "o2::quality_control_modules::mft::QcMFTDigitCheck",
         "moduleName" : "QcMFT",
@@ -51,7 +51,8 @@
         "policy" : "OnEachSeparately",
         "dataSource" : [ {
           "type" : "Task",
-          "name" : "QcMFTDigitTask"
+          "name" : "MFTDigitTask",
+            "MOs"  : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
         } ]
       }
     }

--- a/Modules/MFT/qc-mft-readout.json
+++ b/Modules/MFT/qc-mft-readout.json
@@ -23,7 +23,7 @@
       }
     },
     "tasks" : {
-      "QcMFTReadout" : {
+      "MFTReadoutTask" : {
         "active" : "true",
         "className" : "o2::quality_control_modules::mft::QcMFTReadoutTask",
         "moduleName" : "QcMFT",
@@ -42,7 +42,7 @@
       }
     },
     "checks" : {
-      "QcMFTReadout" : {
+      "MFTReadoutCheck" : {
         "active" : "true",
         "className" : "o2::quality_control_modules::mft::QcMFTReadoutCheck",
         "moduleName" : "QcMFT",
@@ -50,8 +50,8 @@
         "policy" : "OnEachSeparately",
         "dataSource" : [ {
           "type" : "Task",
-          "name" : "QcMFTReadout",
-          "MOs"  : ["mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning"]
+          "name" : "MFTReadoutTask",
+            "MOs"  : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
         } ]
       }
     }

--- a/Modules/MFT/qc-mft-track.json
+++ b/Modules/MFT/qc-mft-track.json
@@ -3,7 +3,7 @@
     "config" : {
       "database" : {
         "implementation" : "CCDB",
-        "host" : "qcdb.cern.ch:8083",
+        "host" : "ccdb-test.cern.ch:8080",
         "username" : "not_applicable",
         "password" : "not_applicable",
         "name" : "not_applicable"
@@ -16,10 +16,10 @@
         "url" : "infologger:///debug?qc"
       },
       "consul" : {
-        "url" : "aliecs.cern.ch:8500"
+        "url" : ""
       },
       "conditionDB" : {
-        "url" : "qcdb.cern.ch:8083"
+        "url" : "ccdb-test.cern.ch:8080"
       }
     },
     "tasks" : {

--- a/Modules/MFT/src/QcMFTClusterCheck.cxx
+++ b/Modules/MFT/src/QcMFTClusterCheck.cxx
@@ -41,7 +41,7 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
   for (auto& [moName, mo] : *moMap) {
 
     (void)moName;
-    if (mo->getName() == "mMFTClusterSensorIndex") {
+    if (mo->getName() == "mClusterOccupancy") {
       auto* histogram = dynamic_cast<TH1F*>(mo->getObject());
 
       // test it
@@ -63,7 +63,7 @@ std::string QcMFTClusterCheck::getAcceptedType() { return "TH1"; }
 
 void QcMFTClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  if (mo->getName() == "mMFTClusterSensorIndex") {
+  if (mo->getName() == "mClusterOccupancy") {
     auto* histogram = dynamic_cast<TH1F*>(mo->getObject());
 
     if (checkResult == Quality::Good) {

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -53,15 +53,40 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
   }
 
   // define histograms
-  mClusterLayerIndexH0 = std::make_unique<TH1F>("mClusterLayerIndexH0", "Clusters per layer in H0;Layer(=Disk*2+Face);Entries", 10, -0.5, 9.5);
+  mClusterLayerIndexH0 = std::make_unique<TH1F>("mClusterLayerIndexH0", "Clusters per layer in H0;Layer;Entries", 10, -0.5, 9.5);
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(1, "d0-f0");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(2, "d0-f1");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(3, "d1-f0");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(4, "d1-f1");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(5, "d2-f0");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(6, "d2-f1");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(7, "d3-f0");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(8, "d3-f1");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(9, "d4-f0");
+  mClusterLayerIndexH0->GetXaxis()->SetBinLabel(10, "d4-f1");
+  mClusterLayerIndexH0->SetStats(0);
   getObjectsManager()->startPublishing(mClusterLayerIndexH0.get());
-  mClusterLayerIndexH1 = std::make_unique<TH1F>("mClusterLayerIndexH1", "Clusters per layer in H1;Layer(=Disk*2+Face);Entries", 10, -0.5, 9.5);
+
+  mClusterLayerIndexH1 = std::make_unique<TH1F>("mClusterLayerIndexH1", "Clusters per layer in H1;Layer;Entries", 10, -0.5, 9.5);
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(1, "d0-f0");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(2, "d0-f1");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(3, "d1-f0");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(4, "d1-f1");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(5, "d2-f0");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(6, "d2-f1");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(7, "d3-f0");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(8, "d3-f1");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(9, "d4-f0");
+  mClusterLayerIndexH1->GetXaxis()->SetBinLabel(10, "d4-f1");
+  mClusterLayerIndexH1->SetStats(0);
   getObjectsManager()->startPublishing(mClusterLayerIndexH1.get());
 
-  mClusterSensorIndex = std::make_unique<TH1F>("mMFTClusterSensorIndex", "Chip Cluster Occupancy;Chip ID;#Entries", 936, -0.5, 935.5);
-  getObjectsManager()->startPublishing(mClusterSensorIndex.get());
+  mClusterOccupancy = std::make_unique<TH1F>("mClusterOccupancy", "Chip Cluster Occupancy;Chip ID;#Entries", 936, -0.5, 935.5);
+  mClusterOccupancy->SetStats(0);
+  getObjectsManager()->startPublishing(mClusterOccupancy.get());
 
-  mClusterPatternIndex = std::make_unique<TH1F>("mMFTClusterPatternIndex", "Cluster Pattern ID;Pattern ID;#Entries", 300, -0.5, 299.5);
+  mClusterPatternIndex = std::make_unique<TH1F>("mClusterPatternIndex", "Cluster Pattern ID;Pattern ID;#Entries", 300, -0.5, 299.5);
+  mClusterPatternIndex->SetStats(0);
   getObjectsManager()->startPublishing(mClusterPatternIndex.get());
 
   mClusterPatternSensorIndices = std::make_unique<TH2F>("mClusterPatternSensorIndices",
@@ -91,8 +116,8 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
       for (int iFace = 0; iFace < 2; iFace++) {
         int idx = (iDisk * 2 + iFace) + (10 * iHalf);
         auto chipmap = std::make_unique<TH2F>(
-          Form("ChipOccupancyMaps/Half_%d/Disk_%d/Face_%d/mMFTChipOccupancyMap", iHalf, iDisk, iFace),
-          Form("h%d-d%d-f%d;x (cm);y (cm)", iHalf, iDisk, iFace),
+          Form("ChipOccupancyMaps/Half_%d/Disk_%d/Face_%d/mClusterChipOccupancyMap", iHalf, iDisk, iFace),
+          Form("Cluster Chip Map h%d-d%d-f%d;x (cm);y (cm)", iHalf, iDisk, iFace),
           MFTTable.mNumberOfBinsInOccupancyMaps[idx][0],
           MFTTable.mNumberOfBinsInOccupancyMaps[idx][1],
           MFTTable.mNumberOfBinsInOccupancyMaps[idx][2],
@@ -101,8 +126,8 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
           MFTTable.mNumberOfBinsInOccupancyMaps[idx][5]);
         chipmap->SetStats(0);
         chipmap->SetOption("colz");
-        mChipOccupancyMap.push_back(std::move(chipmap));
-        getObjectsManager()->startPublishing(mChipOccupancyMap[idx].get());
+        mClusterChipOccupancyMap.push_back(std::move(chipmap));
+        getObjectsManager()->startPublishing(mClusterChipOccupancyMap[idx].get());
       } // loop over faces
     }   // loop over disks
   }     // loop over halfs
@@ -111,7 +136,7 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
 void QcMFTClusterTask::startOfActivity(Activity& /*activity*/)
 {
   ILOG(Info, Support) << "startOfActivity" << ENDM;
-  mClusterSensorIndex->Reset();
+  mClusterOccupancy->Reset();
   mClusterPatternIndex->Reset();
   mClusterPatternSensorIndices->Reset();
   mClusterLayerIndexH0->Reset();
@@ -120,7 +145,7 @@ void QcMFTClusterTask::startOfActivity(Activity& /*activity*/)
     mClusterPatternSensorMap[i]->Reset();
   }
   for (int i = 0; i < 20; i++) {
-    mChipOccupancyMap[i]->Reset();
+    mClusterChipOccupancyMap[i]->Reset();
   }
 }
 
@@ -141,14 +166,14 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     int layerID = mDisk[sensorID] * 2 + mFace[sensorID];
     (mHalf[sensorID] == 0) ? mClusterLayerIndexH0->Fill(layerID)
                            : mClusterLayerIndexH1->Fill(layerID);
-    mClusterSensorIndex->Fill(sensorID);
+    mClusterOccupancy->Fill(sensorID);
     mClusterPatternIndex->Fill(oneCluster.getPatternID());
     mClusterPatternSensorIndices->Fill(sensorID,
                                        oneCluster.getPatternID());
     mClusterPatternSensorMap[oneCluster.getSensorID()]->Fill(oneCluster.getPatternID());
     // fill occupancy maps
     int idx = layerID + (10 * mHalf[sensorID]);
-    mChipOccupancyMap[idx]->Fill(mX[sensorID], mY[sensorID]);
+    mClusterChipOccupancyMap[idx]->Fill(mX[sensorID], mY[sensorID]);
   }
 }
 
@@ -167,7 +192,7 @@ void QcMFTClusterTask::reset()
   // clean all the monitor objects here
 
   ILOG(Info, Support) << "Resetting the histogram" << ENDM;
-  mClusterSensorIndex->Reset();
+  mClusterOccupancy->Reset();
   mClusterPatternIndex->Reset();
   mClusterPatternSensorIndices->Reset();
   mClusterLayerIndexH0->Reset();
@@ -176,7 +201,7 @@ void QcMFTClusterTask::reset()
     mClusterPatternSensorMap[i]->Reset();
   }
   for (int i = 0; i < 20; i++) {
-    mChipOccupancyMap[i]->Reset();
+    mClusterChipOccupancyMap[i]->Reset();
   }
 }
 
@@ -186,15 +211,15 @@ void QcMFTClusterTask::getNameOfMap(TString& folderName, TString& histogramName,
                     mHalf[iChipIndex], mDisk[iChipIndex], mFace[iChipIndex], mZone[iChipIndex],
                     mLadder[iChipIndex], mSensor[iChipIndex], mTransID[iChipIndex]);
 
-  histogramName = Form("h%d-d%d-f%d-z%d-l%d-s%d-tr%d;Pattern ID;#Entries",
+  histogramName = Form("Cluster Pattern h%d-d%d-f%d-z%d-l%d-s%d-tr%d;Pattern ID;#Entries",
                        mHalf[iChipIndex], mDisk[iChipIndex], mFace[iChipIndex], mZone[iChipIndex],
                        mLadder[iChipIndex], mSensor[iChipIndex], mTransID[iChipIndex]);
 }
 
 void QcMFTClusterTask::getChipMapData()
 {
-  const o2::itsmft::ChipMappingMFT map;
-  auto chipMapData = map.getChipMappingData();
+  const o2::itsmft::ChipMappingMFT mapMFT;
+  auto chipMapData = mapMFT.getChipMappingData();
   QcMFTUtilTables MFTTable;
 
   for (int i = 0; i < 936; i++) {

--- a/Modules/MFT/src/QcMFTReadoutCheck.cxx
+++ b/Modules/MFT/src/QcMFTReadoutCheck.cxx
@@ -27,6 +27,7 @@
 #include "MFT/QcMFTReadoutCheck.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
 
 using namespace std;
 
@@ -43,14 +44,41 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
 
     (void)moName;
 
+    if (mo->getName() == "mDDWSummary") {
+      // get the histogram
+      auto* hDDW = dynamic_cast<TH1F*>(mo->getObject());
+      // normalise it using the underflow bin as normalisation factor
+      float den = hDDW->GetBinContent(0);
+      for (int i = 1; i < 4; i++) {
+        float num = hDDW->GetBinContent(i);
+        float ratio = (den > 0) ? (num / den) : 0.0;
+        hDDW->SetBinContent(i, ratio);
+      }
+    }
+
+    if (mo->getName() == "mSummaryChipOk") {
+      auto* hOK = dynamic_cast<TH1F*>(mo->getObject());
+      float den = hOK->GetBinContent(0); // normalisation stored in the uderflow bin
+
+      for (int iBin = 0; iBin < hOK->GetNbinsX(); iBin++) {
+        float num = hOK->GetBinContent(iBin + 1);
+        float ratio = (den > 0) ? (num / den) : 0.0;
+        hOK->SetBinContent(iBin + 1, ratio);
+      }
+    }
+
     if (mo->getName() == "mSummaryChipFault") {
       resetVector(mVectorOfFaultBins);
       auto* hFault = dynamic_cast<TH1F*>(mo->getObject());
+      float den = hFault->GetBinContent(0); // normalisation stored in the uderflow bin
 
       for (int iBin = 0; iBin < hFault->GetNbinsX(); iBin++) {
         if (hFault->GetBinContent(iBin + 1) != 0) {
           mVectorOfFaultBins.push_back(iBin + 1);
         }
+        float num = hFault->GetBinContent(iBin + 1);
+        float ratio = (den > 0) ? (num / den) : 0.0;
+        hFault->SetBinContent(iBin + 1, ratio);
       }
       result = checkQualityStatus(hFault, mVectorOfFaultBins);
     }
@@ -58,11 +86,15 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
     if (mo->getName() == "mSummaryChipError") {
       resetVector(mVectorOfErrorBins);
       auto* hError = dynamic_cast<TH1F*>(mo->getObject());
+      float den = hError->GetBinContent(0); // normalisation stored in the uderflow bin
 
       for (int iBin = 0; iBin < hError->GetNbinsX(); iBin++) {
         if (hError->GetBinContent(iBin + 1) != 0) {
           mVectorOfErrorBins.push_back(iBin + 1);
         }
+        float num = hError->GetBinContent(iBin + 1);
+        float ratio = (den > 0) ? (num / den) : 0.0;
+        hError->SetBinContent(iBin + 1, ratio);
       }
       result = checkQualityStatus(hError, mVectorOfErrorBins);
     }
@@ -70,13 +102,28 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
     if (mo->getName() == "mSummaryChipWarning") {
       resetVector(mVectorOfWarningBins);
       auto* hWarning = dynamic_cast<TH1F*>(mo->getObject());
+      float den = hWarning->GetBinContent(0); // normalisation stored in the uderflow bin
 
       for (int iBin = 0; iBin < hWarning->GetNbinsX(); iBin++) {
         if (hWarning->GetBinContent(iBin + 1) != 0) {
           mVectorOfWarningBins.push_back(iBin + 1);
         }
+        float num = hWarning->GetBinContent(iBin + 1);
+        float ratio = (den > 0) ? (num / den) : 0.0;
+        hWarning->SetBinContent(iBin + 1, ratio);
       }
       result = checkQualityStatus(hWarning, mVectorOfWarningBins);
+    }
+
+    if (mo->getName() == "mRDHSummary") {
+      auto* hSLS = dynamic_cast<TH1F*>(mo->getObject());
+      float den = hSLS->GetBinContent(0); // normalisation stored in the uderflow bin
+
+      for (int iBin = 0; iBin < hSLS->GetNbinsX(); iBin++) {
+        float num = hSLS->GetBinContent(iBin + 1);
+        float ratio = (den > 0) ? (num / den) : 0.0;
+        hSLS->SetBinContent(iBin + 1, ratio);
+      }
     }
 
   } // end of loop over MO
@@ -125,12 +172,28 @@ Quality QcMFTReadoutCheck::checkQualityStatus(TH1F* histo, std::vector<int>& vec
 {
   Quality result = Quality::Good;
 
-  if (vector.size() > 20)
-    result = Quality::Bad;
-  if (vector.size() > 0 && vector.size() <= 20)
-    result = Quality::Medium;
-  if (vector.size() == 0)
-    result = Quality::Good;
+  if (strcmp(histo->GetName(), "mSummaryChipFault") == 0) {
+    if (vector.size() > 3)
+      result = Quality::Bad;
+    if (vector.size() > 0 && vector.size() <= 3)
+      result = Quality::Medium;
+    if (vector.size() == 0)
+      result = Quality::Good;
+  }
+  if (strcmp(histo->GetName(), "mSummaryChipError") == 0) {
+    if (vector.size() > 20)
+      result = Quality::Bad;
+    if (vector.size() > 9 && vector.size() <= 20)
+      result = Quality::Medium;
+    if (vector.size() <= 9)
+      result = Quality::Good;
+  }
+  if (strcmp(histo->GetName(), "mSummaryChipWarning") == 0) {
+    if (vector.size() > 0)
+      result = Quality::Bad;
+    if (vector.size() == 0)
+      result = Quality::Good;
+  }
 
   return result;
 }
@@ -140,27 +203,35 @@ void QcMFTReadoutCheck::writeMessages(TH1F* histo, std::vector<int>& vector, Qua
   if (checkResult == Quality::Good) {
     TLatex* tlGood;
     if (strcmp(histo->GetName(), "mSummaryChipFault") == 0)
-      tlGood = drawLatex(0.15, 0.85, kGreen + 2, "No lanes in Fault.");
+      tlGood = drawLatex(0.15, 0.85, kGreen + 2, "No chips in Fault.");
     if (strcmp(histo->GetName(), "mSummaryChipError") == 0)
-      tlGood = drawLatex(0.15, 0.85, kGreen + 2, "No lanes in Error.");
+      tlGood = drawLatex(0.15, 0.85, kGreen + 2, Form("%lu chips in Error as expected. Quality is good.", vector.size()));
     if (strcmp(histo->GetName(), "mSummaryChipWarning") == 0)
-      tlGood = drawLatex(0.15, 0.85, kGreen + 2, "No lanes in Warning.");
+      tlGood = drawLatex(0.15, 0.85, kGreen + 2, "No chips in Warning.");
     histo->GetListOfFunctions()->Add(tlGood);
     tlGood->Draw();
   } else if (checkResult == Quality::Medium) {
     histo->SetFillColor(kOrange + 7);
     histo->SetLineColor(kOrange + 7);
-    histo->SetMaximum(histo->GetMaximum() * (3. / 2.));
+    histo->SetMaximum(histo->GetMaximum() * (3.2 / 2.));
+
+    TLatex* tlMediumCount;
+    if (strcmp(histo->GetName(), "mSummaryChipFault") == 0)
+      tlMediumCount = drawLatex(0.15, 0.875, kOrange + 7, Form("%lu chips in Fault. Inform the MFT oncall (via Mattermost during night).", vector.size()));
+    if (strcmp(histo->GetName(), "mSummaryChipError") == 0)
+      tlMediumCount = drawLatex(0.15, 0.875, kOrange + 7, Form("%lu chips in Error. Inform the MFT oncall (via Mattermost during night).", vector.size()));
+    histo->GetListOfFunctions()->Add(tlMediumCount);
+    tlMediumCount->Draw();
 
     int midBinIteration = (vector.size() < 10) ? vector.size() : 10;
     for (int iBin = 0; iBin < midBinIteration; iBin++) {
-      TLatex* tlMedium = drawLatex(0.15, 0.875 - iBin * 0.025, kBlack, Form("%s", histo->GetXaxis()->GetBinLabel(vector[iBin])));
+      TLatex* tlMedium = drawLatex(0.15, 0.85 - iBin * 0.025, kBlack, Form("%s", histo->GetXaxis()->GetBinLabel(vector[iBin])));
       histo->GetListOfFunctions()->Add(tlMedium);
       tlMedium->Draw();
     }
     int maxBinIteration = (vector.size() < 20) ? vector.size() : 20;
     for (int iBin = midBinIteration; iBin < maxBinIteration; iBin++) {
-      TLatex* tlMedium = drawLatex(0.55, 0.875 - (iBin - midBinIteration) * 0.025, kBlack, Form("%s", histo->GetXaxis()->GetBinLabel(vector[iBin])));
+      TLatex* tlMedium = drawLatex(0.55, 0.85 - (iBin - midBinIteration) * 0.025, kBlack, Form("%s", histo->GetXaxis()->GetBinLabel(vector[iBin])));
       histo->GetListOfFunctions()->Add(tlMedium);
       tlMedium->Draw();
     }
@@ -170,11 +241,11 @@ void QcMFTReadoutCheck::writeMessages(TH1F* histo, std::vector<int>& vector, Qua
     histo->SetMaximum(histo->GetMaximum() * (6. / 5.));
     TLatex* tlBad;
     if (strcmp(histo->GetName(), "mSummaryChipFault") == 0)
-      tlBad = drawLatex(0.15, 0.85, kRed + 1, Form("%lu lanes in Fault.", vector.size()));
+      tlBad = drawLatex(0.15, 0.85, kRed + 1, Form("%lu chips in Fault. Inform the MFT oncall immediately!", vector.size()));
     if (strcmp(histo->GetName(), "mSummaryChipError") == 0)
-      tlBad = drawLatex(0.15, 0.85, kRed + 1, Form("%lu lanes in Error.", vector.size()));
+      tlBad = drawLatex(0.15, 0.85, kRed + 1, Form("%lu chips in Error. Inform the MFT oncall immediately!", vector.size()));
     if (strcmp(histo->GetName(), "mSummaryChipWarning") == 0)
-      tlBad = drawLatex(0.15, 0.85, kRed + 1, Form("%lu lanes in Warning.", vector.size()));
+      tlBad = drawLatex(0.15, 0.85, kRed + 1, Form("%lu chips in Warning. Inform the MFT oncall immediately!", vector.size()));
     histo->GetListOfFunctions()->Add(tlBad);
     tlBad->Draw();
   }


### PR DESCRIPTION
Updates in this PR:
- Readout Task checks updated
- Adding readout task normalization to DDW
- Adding digit task normalization to ROF
- Update of histogram names (pointer names, histogram names, histogram titles) to comply with our conventions.
- QC Task/Check name changes in json file to be shorter then 16 characters and comply with the central system limitations
- Pointing the json files to the test ccdb by default.
- Adding new DDW summary histogram to the readout task.
- Adding general occupancy plot to the digit task
- General update of axis labels.
- JSON formatting fix (to be consistent).
- Digit checker limit to 3 plots.

Sorry for the large PR, too many things piled up.