### PR TITLE
TPC: Fix Cluster Task bug in large MC data sets

### DIFF
--- a/Modules/TPC/include/TPC/Utility.h
+++ b/Modules/TPC/include/TPC/Utility.h
@@ -20,6 +20,7 @@
 #include "QualityControl/ObjectsManager.h"
 
 #include "DataFormatsTPC/ClusterNative.h"
+#include "DataFormatsTPC/WorkflowHelper.h"
 #include "Framework/ProcessingContext.h"
 
 #include <TCanvas.h>
@@ -52,10 +53,10 @@ void fillCanvases(const o2::tpc::CalDet<float>& calDet, std::vector<std::unique_
 /// \param canvases Contains the canvases that will be cleared
 void clearCanvases(std::vector<std::unique_ptr<TCanvas>>& canvases);
 
-/// \brief Converts CLUSTERNATIVE from InputRecord to ClusterNativeAccess
+/// \brief Converts CLUSTERNATIVE from InputRecord to getWorkflowTPCInput_ret
 /// Convenience funtion to make native clusters accessible when receiving them from the DPL
 /// \param input InputReconrd from the ProcessingContext
-/// \return ClusterNativeAccess object for easy cluster access
-o2::tpc::ClusterNativeAccess clusterHandler(o2::framework::InputRecord& input);
+/// \return getWorkflowTPCInput_ret object for easy cluster access
+std::unique_ptr<o2::tpc::internal::getWorkflowTPCInput_ret> clusterHandler(o2::framework::InputRecord& inputs, int verbosity = 0, unsigned long tpcSectorMask = 0xFFFFFFFFF);
 } //namespace o2::quality_control_modules::tpc
 #endif //QUALITYCONTROL_TPCUTILITY_H

--- a/Modules/TPC/src/Clusters.cxx
+++ b/Modules/TPC/src/Clusters.cxx
@@ -99,16 +99,16 @@ void Clusters::startOfCycle()
 
 void Clusters::processClusterNative(InputRecord& inputs)
 {
-  ClusterNativeAccess clusterIndex = clusterHandler(inputs);
-  if (!clusterIndex.nClustersTotal) {
+  const auto& inputsTPCclusters = clusterHandler(inputs);
+  if (!inputsTPCclusters->clusterIndex.nClustersTotal) {
     return;
   }
 
-  for (int isector = 0; isector < constants::MAXSECTOR; ++isector) {
-    for (int irow = 0; irow < constants::MAXGLOBALPADROW; ++irow) {
-      const int nClusters = clusterIndex.nClusters[isector][irow];
+  for (int isector = 0; isector < o2::tpc::constants::MAXSECTOR; ++isector) {
+    for (int irow = 0; irow < o2::tpc::constants::MAXGLOBALPADROW; ++irow) {
+      const int nClusters = inputsTPCclusters->clusterIndex.nClusters[isector][irow];
       for (int icl = 0; icl < nClusters; ++icl) {
-        const auto& cl = *(clusterIndex.clusters[isector][irow] + icl);
+        const auto& cl = *(inputsTPCclusters->clusterIndex.clusters[isector][irow] + icl);
         mQCClusters.getClusters().processCluster(cl, Sector(isector), irow);
       }
     }


### PR DESCRIPTION
This fixes an issue where the cluster task failed with a segmentation violation when running on MC data where a TF exceeded a certain size.