### PR TITLE
A switch to decide if default Activity metadata should be created

### DIFF
--- a/Framework/include/QualityControl/DatabaseHelpers.h
+++ b/Framework/include/QualityControl/DatabaseHelpers.h
@@ -25,7 +25,7 @@
 namespace o2::quality_control::repository::database_helpers
 {
 
-std::map<std::string, std::string> asDatabaseMetadata(const core::Activity&);
+std::map<std::string, std::string> asDatabaseMetadata(const core::Activity&, bool putDefault = true);
 core::Activity asActivity(const std::map<std::string, std::string>& metadata, const std::string& provenance = "qc");
 core::Activity asActivity(const boost::property_tree::ptree&, const std::string& provenance = "qc");
 

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -299,7 +299,7 @@ std::shared_ptr<o2::quality_control::core::MonitorObject> CcdbDatabase::retrieve
 {
   string path = objectPath + "/" + objectName;
   map<string, string> headers;
-  map<string, string> metadata = database_helpers::asDatabaseMetadata(activity);
+  map<string, string> metadata = database_helpers::asDatabaseMetadata(activity, false);
   TObject* obj = retrieveTObject(path, metadata, timestamp, &headers);
 
   // no object found
@@ -339,7 +339,7 @@ std::shared_ptr<o2::quality_control::core::MonitorObject> CcdbDatabase::retrieve
 std::shared_ptr<o2::quality_control::core::QualityObject> CcdbDatabase::retrieveQO(std::string qoPath, long timestamp, const core::Activity& activity)
 {
   map<string, string> headers;
-  map<string, string> metadata = database_helpers::asDatabaseMetadata(activity);
+  map<string, string> metadata = database_helpers::asDatabaseMetadata(activity, false);
   TObject* obj = retrieveTObject(qoPath, metadata, timestamp, &headers);
   std::shared_ptr<QualityObject> qo(dynamic_cast<QualityObject*>(obj));
   if (qo == nullptr) {

--- a/Framework/src/DatabaseHelpers.cxx
+++ b/Framework/src/DatabaseHelpers.cxx
@@ -20,21 +20,21 @@
 namespace o2::quality_control::repository::database_helpers
 {
 
-std::map<std::string, std::string> asDatabaseMetadata(const core::Activity& activity)
+std::map<std::string, std::string> asDatabaseMetadata(const core::Activity& activity, bool putDefault)
 {
   std::map<std::string, std::string> metadata;
-  if (activity.mType != 0) {
+  if (putDefault || activity.mType != 0) {
     // TODO should we really treat 0 as none?
     //  we could consider making Activity use std::optional to be clear about this
     metadata["RunType"] = std::to_string(activity.mType);
   }
-  if (activity.mId != 0) {
+  if (putDefault || activity.mId != 0) {
     metadata["RunNumber"] = std::to_string(activity.mId);
   }
-  if (!activity.mPassName.empty()) {
+  if (putDefault || !activity.mPassName.empty()) {
     metadata["PassName"] = activity.mPassName;
   }
-  if (!activity.mPeriodName.empty()) {
+  if (putDefault || !activity.mPeriodName.empty()) {
     metadata["PeriodName"] = activity.mPeriodName;
   }
   return metadata;

--- a/Framework/src/Triggers.cxx
+++ b/Framework/src/Triggers.cxx
@@ -153,7 +153,7 @@ TriggerFcn NewObject(std::string databaseUrl, std::string objectPath, const Acti
   // We rely on changing MD5 - if the object has changed, it should have a different check sum.
   // If someone reuploaded an old object, it should not have an influence.
   std::string lastMD5;
-  auto metadata = repository::database_helpers::asDatabaseMetadata(activity);
+  auto metadata = repository::database_helpers::asDatabaseMetadata(activity, false);
   if (auto headers = db->retrieveHeaders(objectPath, metadata); headers.count(md5key)) {
     lastMD5 = headers[md5key];
   } else {


### PR DESCRIPTION
It is needed when we want to store an object, but it should not be used when
trying to retrieve objects with some metadata filter.