### PR TITLE
MCH: improve digits task plots

### DIFF
--- a/Modules/MUON/MCH/include/MCH/GlobalHistogram.h
+++ b/Modules/MUON/MCH/include/MCH/GlobalHistogram.h
@@ -31,6 +31,9 @@ namespace muonchambers
 
 std::string getHistoPath(int deId);
 
+int getDEindex(int de);
+int getDEindexMax();
+
 class DetectorHistogram
 {
  public:
@@ -59,8 +62,11 @@ class DetectorHistogram
 
   bool mFlipX{ false };
   bool mFlipY{ false };
+  float mShiftX{ 0 };
+  float mShiftY{ 0 };
 
   void init();
+  void addContour();
 };
 
 class GlobalHistogram : public TH2F

--- a/Modules/MUON/MCH/include/MCH/MergeableTH1OccupancyPerDE.h
+++ b/Modules/MUON/MCH/include/MCH/MergeableTH1OccupancyPerDE.h
@@ -37,6 +37,7 @@
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHMappingInterface/CathodeSegmentation.h"
 #include "MCHMappingSegContour/CathodeSegmentationContours.h"
+#include "MCH/GlobalHistogram.h"
 
 using namespace std;
 namespace o2::quality_control_modules::muonchambers
@@ -48,7 +49,7 @@ class MergeableTH1OccupancyPerDE : public TH1F, public o2::mergers::MergeInterfa
   MergeableTH1OccupancyPerDE() = default;
 
   MergeableTH1OccupancyPerDE(MergeableTH1OccupancyPerDE const& copymerge)
-    : TH1F("DefaultName", "DefaultTitle", 1100, -0.5, 1099.5), o2::mergers::MergeInterface()
+    : TH1F("DefaultName", "DefaultTitle", getDEindexMax(), 0, getDEindexMax()), o2::mergers::MergeInterface()
   {
     Bool_t bStatus = TH1::AddDirectoryStatus();
     TH1::AddDirectory(kFALSE);
@@ -58,12 +59,12 @@ class MergeableTH1OccupancyPerDE : public TH1F, public o2::mergers::MergeInterfa
   }
 
   MergeableTH1OccupancyPerDE(const char* name, const char* title)
-    : TH1F(name, title, 1100, -0.5, 1099.5), o2::mergers::MergeInterface()
+    : TH1F(name, title, getDEindexMax(), 0, getDEindexMax()), o2::mergers::MergeInterface()
   {
     Bool_t bStatus = TH1::AddDirectoryStatus();
     TH1::AddDirectory(kFALSE);
-    mHistoNum = new TH1F("num", "num", 1100, -0.5, 1099.5);
-    mHistoDen = new TH1F("den", "den", 1100, -0.5, 1099.5);
+    mHistoNum = new TH1F("num", "num", getDEindexMax(), 0, getDEindexMax());
+    mHistoDen = new TH1F("den", "den", getDEindexMax(), 0, getDEindexMax());
     TH1::AddDirectory(bStatus);
     update();
   }
@@ -136,7 +137,6 @@ class MergeableTH1OccupancyPerDE : public TH1F, public o2::mergers::MergeInterfa
       for (int biny = 1; biny < horbits->GetYaxis()->GetNbins() + 1; biny++) {
 
         int mNOrbits = horbits->GetBinContent(binx, biny);
-        //std::cout << fmt::format("  norbits {}", mNOrbits) << std::endl;
         if (mNOrbits <= 0) {
           // no orbits detected for this channel, skip it
           continue;
@@ -163,8 +163,9 @@ class MergeableTH1OccupancyPerDE : public TH1F, public o2::mergers::MergeInterfa
     }
 
     for (auto i : o2::mch::raw::deIdsForAllMCH) {
-      mHistoNum->SetBinContent(i + 1, nHitsDE[i]);
-      mHistoDen->SetBinContent(i + 1, nOrbitsDE[i]);
+      auto id = getDEindex(i);
+      mHistoNum->SetBinContent(id + 1, nHitsDE[i]);
+      mHistoDen->SetBinContent(id + 1, nOrbitsDE[i]);
     }
 
     update();
@@ -180,4 +181,4 @@ class MergeableTH1OccupancyPerDE : public TH1F, public o2::mergers::MergeInterfa
 
 } // namespace o2::quality_control_modules::muonchambers
 
-#endif //O2_MERGEABLETH1OCCUPANCYPERDE_H
+#endif // O2_MERGEABLETH1OCCUPANCYPERDE_H

--- a/Modules/MUON/MCH/include/MCH/PhysicsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsCheck.h
@@ -20,6 +20,8 @@
 #include "QualityControl/CheckInterface.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
+#include "MCHRawCommon/DataFormats.h"
+#include "MCHRawElecMap/Mapper.h"
 #include <string>
 
 namespace o2::quality_control_modules::muonchambers
@@ -43,9 +45,17 @@ class PhysicsCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
+  bool checkPadMapping(uint16_t feeId, uint8_t linkId, uint8_t eLinkId, o2::mch::raw::DualSampaChannelId channel);
+
   int mPrintLevel;
-  double minOccupancy;
-  double maxOccupancy;
+  double mMinOccupancy;
+  double mMaxOccupancy;
+
+  o2::mch::raw::Elec2DetMapper mElec2DetMapper;
+  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
+  o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
+  o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
+
   ClassDefOverride(PhysicsCheck, 2);
 };
 

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
@@ -75,6 +75,7 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   static constexpr int sMaxDsId = 40;
 
   bool mDiagnostic{ false };
+  bool mSaveToRootFile{ false };
 
   o2::mch::raw::Elec2DetMapper mElec2DetMapper;
   o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
@@ -89,9 +90,9 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   TH2F* mHistogramNorbitsElec;                                // Histogram of Number of orbits (Elec view)
   std::shared_ptr<MergeableTH2Ratio> mHistogramOccupancyElec; // Mergeable object, Occupancy histogram (Elec view)
 
-  std::shared_ptr<TH2F> mDigitsOrbitInTF;
-  std::shared_ptr<TH2F> mDigitsBcInOrbit;
-  std::shared_ptr<TH2F> mAmplitudeVsSamples;
+  std::shared_ptr<TH2F> mHistogramDigitsOrbitInTF;
+  std::shared_ptr<TH2F> mHistogramDigitsBcInOrbit;
+  std::shared_ptr<TH2F> mHistogramAmplitudeVsSamples;
 
   std::map<int, std::shared_ptr<TH1F>> mHistogramADCamplitudeDE;              // Histogram of ADC distribution per DE
   std::map<int, std::shared_ptr<DetectorHistogram>> mHistogramNhitsDE[2];     // Histogram of Number of hits (XY view)

--- a/Modules/MUON/MCH/src/PhysicsCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsCheck.cxx
@@ -17,6 +17,7 @@
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHMappingSegContour/CathodeSegmentationContours.h"
 #include "MCH/PhysicsCheck.h"
+#include "MCH/GlobalHistogram.h"
 
 // ROOT
 #include <fairlogger/Logger.h>
@@ -25,6 +26,7 @@
 #include <TList.h>
 #include <TMath.h>
 #include <TPaveText.h>
+#include <TLine.h>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -37,25 +39,66 @@ namespace o2::quality_control_modules::muonchambers
 PhysicsCheck::PhysicsCheck()
 {
   mPrintLevel = 0;
-  minOccupancy = 0.05;
-  maxOccupancy = 1.00;
+  mMinOccupancy = 0.001;
+  mMaxOccupancy = 1.00;
+
+  mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mDet2ElecMapper = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mFeeLink2SolarMapper = o2::mch::raw::createFeeLink2SolarMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
 }
 
 PhysicsCheck::~PhysicsCheck() {}
 
 void PhysicsCheck::configure()
 {
-  //   if (AliRecoParam::ConvertIndex(specie) == AliRecoParam::kCosmic) {
-  //     minTOFrawTime = 150.; //ns
-  //     maxTOFrawTime = 250.; //ns
-  //   }
+  if (auto param = mCustomParameters.find("MinOccupancy"); param != mCustomParameters.end()) {
+    mMinOccupancy = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("MaxOccupancy"); param != mCustomParameters.end()) {
+    mMaxOccupancy = std::stof(param->second);
+  }
+}
+
+bool PhysicsCheck::checkPadMapping(uint16_t feeId, uint8_t linkId, uint8_t eLinkId, o2::mch::raw::DualSampaChannelId channel)
+{
+  uint16_t solarId = -1;
+  int deId = -1;
+  int dsIddet = -1;
+  int padId = -1;
+
+  o2::mch::raw::FeeLinkId feeLinkId{ feeId, linkId };
+
+  if (auto opt = mFeeLink2SolarMapper(feeLinkId); opt.has_value()) {
+    solarId = opt.value();
+  }
+  if (solarId < 0 || solarId > 1023) {
+    return false;
+  }
+
+  o2::mch::raw::DsElecId dsElecId{ solarId, static_cast<uint8_t>(eLinkId / 5), static_cast<uint8_t>(eLinkId % 5) };
+
+  if (auto opt = mElec2DetMapper(dsElecId); opt.has_value()) {
+    o2::mch::raw::DsDetId dsDetId = opt.value();
+    dsIddet = dsDetId.dsId();
+    deId = dsDetId.deId();
+  }
+
+  if (deId < 0 || dsIddet < 0) {
+    return false;
+  }
+
+  const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(deId);
+  padId = segment.findPadByFEE(dsIddet, int(channel));
+
+  if (padId < 0) {
+    return false;
+  }
+  return true;
 }
 
 Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
-  std::cout << "=================================" << std::endl;
-  std::cout << "PhysicsCheck::check() called" << std::endl;
-  std::cout << "=================================" << std::endl;
   Quality result = Quality::Null;
 
   for (auto& [moName, mo] : *moMap) {
@@ -72,23 +115,35 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
         int nbinsx = h->GetXaxis()->GetNbins();
         int nbinsy = h->GetYaxis()->GetNbins();
         int nbad = 0;
+        int npads = 0;
         for (int i = 1; i <= nbinsx; i++) {
-          for (int j = 1; j <= nbinsy; j++) {
-            Float_t occ = h->GetBinContent(i, j);
-            if (occ < minOccupancy || occ >= maxOccupancy) {
-              //nbad += 1;
-              int ds_addr = (i % 40) - 1;
-              int link_id = ((i - 1 - ds_addr) / 40) % 12;
-              int fee_id = (i - 1 - ds_addr - 40 * link_id) / (12 * 40);
-              int chan_addr = j - 1;
+          int index = i - 1;
+          int ds_addr = (index % 40);
+          int link_id = (index / 40) % 12;
+          int fee_id = index / (12 * 40);
 
-              if (mPrintLevel >= 1) {
-                std::cout << "Channel with unusual occupancy read from OccupancyElec histogrm: fee_id = " << fee_id << ", link_id = " << link_id << ", ds_addr = " << ds_addr << " , chan_addr = " << chan_addr << " with an occupancy of " << occ << std::endl;
-              }
+          for (int j = 1; j <= nbinsy; j++) {
+            int chan_addr = j - 1;
+
+            if (!checkPadMapping(fee_id, link_id, ds_addr, chan_addr)) {
+              continue;
+            }
+            npads += 1;
+
+            Float_t occupancy = h->GetBinContent(i, j);
+            if (occupancy >= mMinOccupancy && occupancy <= mMaxOccupancy) {
+              continue;
+            }
+
+            nbad += 1;
+
+            if (mPrintLevel >= 1) {
+              std::cout << "Channel with unusual occupancy read from OccupancyElec histogrm: fee_id = " << fee_id << ", link_id = " << link_id << ", ds_addr = " << ds_addr << " , chan_addr = " << chan_addr << " with an occupancy of " << occupancy << std::endl;
             }
           }
         }
-        if (nbad < 1)
+        std::cout << fmt::format("Npads {}  Nbad {}   Frac {}", npads, nbad, nbad / npads) << std::endl;
+        if (nbad < 0.1 * npads)
           result = Quality::Good;
         else
           result = Quality::Bad;
@@ -102,9 +157,9 @@ std::string PhysicsCheck::getAcceptedType() { return "TH1"; }
 
 void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  //std::cout<<"===================================="<<std::endl;
-  //std::cout<<"PhysicsCheck::beautify() called"<<std::endl;
-  //std::cout<<"===================================="<<std::endl;
+  // std::cout<<"===================================="<<std::endl;
+  // std::cout<<"PhysicsCheck::beautify() called"<<std::endl;
+  // std::cout<<"===================================="<<std::endl;
   if (mo->getName().find("Occupancy_Elec") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
     h->SetDrawOption("colz");
@@ -118,7 +173,7 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
       msg->Clear();
       msg->AddText("All occupancies within limits: OK!!!");
       msg->SetFillColor(kGreen);
-      //
+
       h->SetFillColor(kGreen);
     } else if (checkResult == Quality::Bad) {
       LOG(info) << "Quality::Bad, setting to red";
@@ -126,11 +181,72 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
       msg->Clear();
       msg->AddText("Call MCH on-call.");
       msg->SetFillColor(kRed);
-      //
+
       h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
       LOG(info) << "Quality::medium, setting to orange";
+
+      msg->Clear();
+      msg->AddText("No entries. If MCH in the run, check MCH TWiki");
+      msg->SetFillColor(kYellow);
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+
+  if (mo->getName().find("MeanOccupancy") != std::string::npos) {
+    auto* h = dynamic_cast<TH1F*>(mo->getObject());
+    // disable ticks on vertical axis
+    h->GetYaxis()->SetTickLength(0);
+    h->SetMaximum(h->GetMaximum() * 1.2);
+    // draw chamber delimiters
+    for (int demin = 200; demin <= 1000; demin += 100) {
+      float xpos = static_cast<float>(getDEindex(demin)) - 0.5;
+      std::cout << "DEmin " << demin << "  ID " << getDEindex(demin) << std::endl;
+      TLine* delimiter = new TLine(xpos, 0, xpos, 1.1 * h->GetMaximum());
+      delimiter->SetLineColor(kBlack);
+      delimiter->SetLineStyle(kDashed);
+      h->GetListOfFunctions()->Add(delimiter);
+
+      if (demin < 600) {
+        float x1 = static_cast<float>(getDEindex(demin - 100));
+        float x2 = static_cast<float>(getDEindex(demin));
+        float x0 = (x1 + x2) / 2;
+        TText* msg = new TText(x0, 0.88 * h->GetMaximum(), TString::Format("CH%d", (demin - 1) / 100));
+        msg->SetTextAngle(90);
+        h->GetListOfFunctions()->Add(msg);
+      } else {
+        float x1 = static_cast<float>(getDEindex(demin - 100));
+        float x2 = static_cast<float>(getDEindex(demin));
+        float x0 = (x1 + x2) / 2;
+        TText* msg = new TText(x0, 0.95 * h->GetMaximum(), TString::Format("CH%d", (demin - 1) / 100));
+        msg->SetTextAlign(22);
+        h->GetListOfFunctions()->Add(msg);
+      }
+    }
+
+    TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
+    h->GetListOfFunctions()->Add(msg);
+    msg->SetName(Form("%s_msg", mo->GetName()));
+    msg->SetBorderSize(0);
+
+    if (checkResult == Quality::Good) {
+      msg->Clear();
+      msg->AddText("All occupancies within limits: OK!!!");
+      msg->SetFillColor(kGreen);
+
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      LOG(info) << "Quality::Bad, setting to red";
       //
+      msg->Clear();
+      msg->AddText("Call MCH on-call.");
+      msg->SetFillColor(kRed);
+
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      LOG(info) << "Quality::medium, setting to orange";
+
       msg->Clear();
       msg->AddText("No entries. If MCH in the run, check MCH TWiki");
       msg->SetFillColor(kYellow);

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -38,8 +38,6 @@
 using namespace std;
 using namespace o2::mch::raw;
 
-//#define QC_MCH_SAVE_TEMP_ROOTFILE 1
-
 namespace o2
 {
 namespace quality_control_modules
@@ -62,30 +60,19 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
     }
   }
 
+  mSaveToRootFile = false;
+  if (auto param = mCustomParameters.find("SaveToRootFile"); param != mCustomParameters.end()) {
+    if (param->second == "true" || param->second == "True" || param->second == "TRUE") {
+      mSaveToRootFile = true;
+    }
+  }
+
   mElec2DetMapper = createElec2DetMapper<ElectronicMapperGenerated>();
   mDet2ElecMapper = createDet2ElecMapper<ElectronicMapperGenerated>();
   mFeeLink2SolarMapper = createFeeLink2SolarMapper<ElectronicMapperGenerated>();
   mSolar2FeeLinkMapper = createSolar2FeeLinkMapper<ElectronicMapperGenerated>();
 
   const uint32_t nElecXbins = PhysicsTaskDigits::sMaxFeeId * PhysicsTaskDigits::sMaxLinkId * PhysicsTaskDigits::sMaxDsId;
-
-  mDigitsOrbitInTF = std::make_shared<TH2F>("Expert/DigitOrbitInTF", "Digit orbits vs DS Id", nElecXbins, 0, nElecXbins, 768, -384, 384);
-  mDigitsOrbitInTF->SetOption("colz");
-  if (mDiagnostic) {
-    getObjectsManager()->startPublishing(mDigitsOrbitInTF.get());
-  }
-  mAllHistograms.push_back(mDigitsOrbitInTF.get());
-
-  mDigitsBcInOrbit = std::make_shared<TH2F>("Expert/DigitsBcInOrbit", "Digit BC vs DS Id", nElecXbins, 0, nElecXbins, 3600, 0, 3600);
-  mDigitsBcInOrbit->SetOption("colz");
-  if (mDiagnostic) {
-    getObjectsManager()->startPublishing(mDigitsBcInOrbit.get());
-  }
-  mAllHistograms.push_back(mDigitsBcInOrbit.get());
-
-  mAmplitudeVsSamples = std::make_shared<TH2F>("Expert/AmplitudeVsSamples", "Digit amplitude vs nsamples", 1000, 0, 1000, 1000, 0, 10000);
-  mAmplitudeVsSamples->SetOption("colz");
-  mAllHistograms.push_back(mAmplitudeVsSamples.get());
 
   for (int fee = 0; fee < PhysicsTaskDigits::sMaxFeeId; fee++) {
     for (int link = 0; link < PhysicsTaskDigits::sMaxLinkId; link++) {
@@ -95,9 +82,11 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
 
   // Histograms in electronics coordinates
   mHistogramOccupancyElec = std::make_shared<MergeableTH2Ratio>("Occupancy_Elec", "Occupancy (KHz)", nElecXbins, 0, nElecXbins, 64, 0, 64);
-  getObjectsManager()->startPublishing(mHistogramOccupancyElec.get());
   mHistogramOccupancyElec->SetOption("colz");
   mAllHistograms.push_back(mHistogramOccupancyElec.get());
+  if (!mSaveToRootFile) {
+    getObjectsManager()->startPublishing(mHistogramOccupancyElec.get());
+  }
 
   mHistogramNHitsElec = mHistogramOccupancyElec->getNum();
   mHistogramNorbitsElec = mHistogramOccupancyElec->getDen();
@@ -105,30 +94,55 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   mAllHistograms.push_back(mHistogramNorbitsElec);
 
   mMeanOccupancyPerDE = std::make_shared<MergeableTH1OccupancyPerDE>("MeanOccupancy", "Mean Occupancy of each DE (KHz)");
-  getObjectsManager()->startPublishing(mMeanOccupancyPerDE.get());
+  mMeanOccupancyPerDE->SetOption("hist");
   mAllHistograms.push_back(mMeanOccupancyPerDE.get());
+  if (!mSaveToRootFile) {
+    getObjectsManager()->startPublishing(mMeanOccupancyPerDE.get());
+  }
 
   // The code for the calculation of the on-cycle values is currently broken and therefore commented
-  //mMeanOccupancyPerDECycle = std::make_shared<MergeableTH1OccupancyPerDECycle>("MeanOccupancyPerCycle", "Mean Occupancy of each DE Per Cycle (MHz)", mHistogramNHitsElec, mHistogramNorbitsElec);
-  //getObjectsManager()->startPublishing(mMeanOccupancyPerDECycle.get());
+  // mMeanOccupancyPerDECycle = std::make_shared<MergeableTH1OccupancyPerDECycle>("MeanOccupancyPerCycle", "Mean Occupancy of each DE Per Cycle (MHz)", mHistogramNHitsElec, mHistogramNorbitsElec);
+  // getObjectsManager()->startPublishing(mMeanOccupancyPerDECycle.get());
+
+  if (!mDiagnostic) {
+    return;
+  }
+
+  mHistogramDigitsOrbitInTF = std::make_shared<TH2F>("Expert/DigitOrbitInTF", "Digit orbits vs DS Id", nElecXbins, 0, nElecXbins, 768, -384, 384);
+  mHistogramDigitsOrbitInTF->SetOption("colz");
+  mAllHistograms.push_back(mHistogramDigitsOrbitInTF.get());
+  if (!mSaveToRootFile) {
+    getObjectsManager()->startPublishing(mHistogramDigitsOrbitInTF.get());
+  }
+
+  mHistogramDigitsBcInOrbit = std::make_shared<TH2F>("Expert/DigitsBcInOrbit", "Digit BC vs DS Id", nElecXbins, 0, nElecXbins, 3600, 0, 3600);
+  mHistogramDigitsBcInOrbit->SetOption("colz");
+  mAllHistograms.push_back(mHistogramDigitsBcInOrbit.get());
+  if (!mSaveToRootFile) {
+    getObjectsManager()->startPublishing(mHistogramDigitsBcInOrbit.get());
+  }
+
+  mHistogramAmplitudeVsSamples = std::make_shared<TH2F>("Expert/AmplitudeVsSamples", "Digit amplitude vs nsamples", 1000, 0, 1000, 1000, 0, 10000);
+  mHistogramAmplitudeVsSamples->SetOption("colz");
+  mAllHistograms.push_back(mHistogramAmplitudeVsSamples.get());
 
   // Histograms in detector coordinates
   for (auto de : o2::mch::raw::deIdsForAllMCH) {
     auto h = std::make_shared<TH1F>(TString::Format("Expert/%sADCamplitude_DE%03d", getHistoPath(de).c_str(), de),
                                     TString::Format("ADC amplitude (DE%03d)", de), 5000, 0, 5000);
     mHistogramADCamplitudeDE.insert(make_pair(de, h));
-    if (mDiagnostic) {
+    mAllHistograms.push_back(h.get());
+    if (!mSaveToRootFile) {
       getObjectsManager()->startPublishing(h.get());
     }
-    mAllHistograms.push_back(h.get());
 
     auto hm = std::make_shared<MergeableTH2Ratio>(TString::Format("Expert/%sOccupancy_B_XY_%03d", getHistoPath(de).c_str(), de),
                                                   TString::Format("Occupancy XY (DE%03d B) (KHz)", de));
     mHistogramOccupancyDE[0].insert(make_pair(de, hm));
-    if (mDiagnostic) {
+    mAllHistograms.push_back(hm.get());
+    if (!mSaveToRootFile) {
       getObjectsManager()->startPublishing(hm.get());
     }
-    mAllHistograms.push_back(hm.get());
 
     auto h2n0 = std::make_shared<DetectorHistogram>(TString::Format("Expert/%sNhits_DE%03d_B", getHistoPath(de).c_str(), de),
                                                     TString::Format("Number of hits (DE%03d B)", de), de, hm->getNum());
@@ -143,10 +157,10 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
     hm = std::make_shared<MergeableTH2Ratio>(TString::Format("Expert/%sOccupancy_NB_XY_%03d", getHistoPath(de).c_str(), de),
                                              TString::Format("Occupancy XY (DE%03d NB) (KHz)", de));
     mHistogramOccupancyDE[1].insert(make_pair(de, hm));
-    if (mDiagnostic) {
+    mAllHistograms.push_back(hm.get());
+    if (!mSaveToRootFile) {
       getObjectsManager()->startPublishing(hm.get());
     }
-    mAllHistograms.push_back(hm.get());
 
     auto h2n1 = std::make_shared<DetectorHistogram>(TString::Format("Expert/%sNhits_DE%03d_NB", getHistoPath(de).c_str(), de),
                                                     TString::Format("Number of hits (DE%03d NB)", de), de, hm->getNum());
@@ -219,11 +233,6 @@ void PhysicsTaskDigits::plotDigit(const o2::mch::Digit& digit)
     return;
   }
 
-  auto h = mHistogramADCamplitudeDE.find(deId);
-  if ((h != mHistogramADCamplitudeDE.end()) && (h->second != NULL)) {
-    h->second->Fill(ADC);
-  }
-
   // Fill NHits Elec Histogram and ADC distribution
   const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(deId);
 
@@ -234,13 +243,6 @@ void PhysicsTaskDigits::plotDigit(const o2::mch::Digit& digit)
   int cathode = segment.isBendingPad(padId) ? 0 : 1;
   int dsId = segment.padDualSampaId(padId);
   int channel = segment.padDualSampaChannel(padId);
-
-  // Fill X Y 2D hits histogram with fired pads distribution
-  auto hNhits = mHistogramNhitsDE[cathode].find(deId);
-  if ((hNhits != mHistogramNhitsDE[cathode].end()) && (hNhits->second != NULL)) {
-    //std::cout << "DE " << deId << "  cathod " << cathode << "    filling " << hOccupancy->second->getNum() << " with " << hNhits->second << std::endl;
-    hNhits->second->Fill(padX, padY, padSizeX, padSizeY);
-  }
 
   // Using the mapping to go from Digit info (de, pad) to Elec info (fee, link) and fill Elec Histogram,
   // where one bin is one physical pad
@@ -265,21 +267,34 @@ void PhysicsTaskDigits::plotDigit(const o2::mch::Digit& digit)
 
   mHistogramNHitsElec->Fill(xbin - 0.5, ybin - 0.5);
 
-  float ToT = digit.getNofSamples() - 11; // time-over-threshold
+  if (!mDiagnostic) {
+    return;
+  }
 
-  mAmplitudeVsSamples->Fill(ToT, ADC);
+  auto h = mHistogramADCamplitudeDE.find(deId);
+  if ((h != mHistogramADCamplitudeDE.end()) && (h->second != NULL)) {
+    h->second->Fill(ADC);
+  }
+
+  // Fill X Y 2D hits histogram with fired pads distribution
+  auto hNhits = mHistogramNhitsDE[cathode].find(deId);
+  if ((hNhits != mHistogramNhitsDE[cathode].end()) && (hNhits->second != NULL)) {
+    hNhits->second->Fill(padX, padY, padSizeX, padSizeY);
+  }
 
   // orbit relative to start of TF (or so it is expected)
   auto tfTime = digit.getTime();
   if (tfTime == o2::mch::raw::DataDecoder::tfTimeInvalid) {
-    mDigitsOrbitInTF->Fill(xbin - 0.5, -256);
-    mDigitsBcInOrbit->Fill(xbin - 0.5, 3559);
+    mHistogramDigitsOrbitInTF->Fill(xbin - 0.5, -256);
+    mHistogramDigitsBcInOrbit->Fill(xbin - 0.5, 3559);
   } else {
     auto orbit = digit.getTime() / o2::constants::lhc::LHCMaxBunches;
     auto bc = digit.getTime() % o2::constants::lhc::LHCMaxBunches;
-    mDigitsOrbitInTF->Fill(xbin - 0.5, orbit);
-    mDigitsBcInOrbit->Fill(xbin - 0.5, bc);
+    mHistogramDigitsOrbitInTF->Fill(xbin - 0.5, orbit);
+    mHistogramDigitsBcInOrbit->Fill(xbin - 0.5, bc);
   }
+
+  mHistogramAmplitudeVsSamples->Fill(digit.getNofSamples(), ADC);
 }
 
 void PhysicsTaskDigits::updateOrbits()
@@ -324,15 +339,17 @@ void PhysicsTaskDigits::updateOrbits()
           int ybin = channel + 1;
           mHistogramNorbitsElec->SetBinContent(xbin, ybin, mNOrbits[feeId][linkId]);
 
-          double padX = segment.padPositionX(padId);
-          double padY = segment.padPositionY(padId);
-          float padSizeX = segment.padSizeX(padId);
-          float padSizeY = segment.padSizeY(padId);
-          int cathode = segment.isBendingPad(padId) ? 0 : 1;
+          if (mDiagnostic) {
+            double padX = segment.padPositionX(padId);
+            double padY = segment.padPositionY(padId);
+            float padSizeX = segment.padSizeX(padId);
+            float padSizeY = segment.padSizeY(padId);
+            int cathode = segment.isBendingPad(padId) ? 0 : 1;
 
-          auto hNorbits = mHistogramNorbitsDE[cathode].find(deId);
-          if ((hNorbits != mHistogramNorbitsDE[cathode].end()) && (hNorbits->second != NULL)) {
-            hNorbits->second->Set(padX, padY, padSizeX, padSizeY, mNOrbits[feeId][linkId]);
+            auto hNorbits = mHistogramNorbitsDE[cathode].find(deId);
+            if ((hNorbits != mHistogramNorbitsDE[cathode].end()) && (hNorbits->second != NULL)) {
+              hNorbits->second->Set(padX, padY, padSizeX, padSizeY, mNOrbits[feeId][linkId]);
+            }
           }
         }
       }
@@ -342,13 +359,11 @@ void PhysicsTaskDigits::updateOrbits()
 
 void PhysicsTaskDigits::writeHistos()
 {
-#ifdef QC_MCH_SAVE_TEMP_ROOTFILE
   TFile f("mch-qc-digits.root", "RECREATE");
   for (auto h : mAllHistograms) {
     h->Write();
   }
   f.Close();
-#endif
 }
 
 void PhysicsTaskDigits::endOfCycle()
@@ -359,25 +374,31 @@ void PhysicsTaskDigits::endOfCycle()
 
   // update mergeable ratios
   mHistogramOccupancyElec->update();
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
-    for (int i = 0; i < 2; i++) {
-      auto h = mHistogramOccupancyDE[i].find(de);
-      if ((h != mHistogramOccupancyDE[i].end()) && (h->second != NULL)) {
-        h->second->update();
+  mMeanOccupancyPerDE->update(mHistogramOccupancyElec->getNum(), mHistogramOccupancyElec->getDen());
+
+  if (mDiagnostic) {
+    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+      for (int i = 0; i < 2; i++) {
+        auto h = mHistogramOccupancyDE[i].find(de);
+        if ((h != mHistogramOccupancyDE[i].end()) && (h->second != NULL)) {
+          h->second->update();
+        }
       }
     }
   }
 
-  mMeanOccupancyPerDE->update(mHistogramOccupancyElec->getNum(), mHistogramOccupancyElec->getDen());
-
-  writeHistos();
+  if (mSaveToRootFile) {
+    writeHistos();
+  }
 }
 
 void PhysicsTaskDigits::endOfActivity(Activity& /*activity*/)
 {
   ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 
-  writeHistos();
+  if (mSaveToRootFile) {
+    writeHistos();
+  }
 }
 
 void PhysicsTaskDigits::reset()


### PR DESCRIPTION
This PR introduces several improvements to the MCH digits task:
- improved visualization of plots in detector coordinates
- added option for saving the plots to a local ROOT file
- improved separation between standard and experts plots
- added configurable min and max occupancy levels in checker
- improved plotting of per-DE occupancies
