### PR TITLE
Adapt ITS postprocessing to use timestamps and activities

### DIFF
--- a/Modules/ITS/include/ITS/TrendingTaskITSCluster.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSCluster.h
@@ -77,7 +77,7 @@ class TrendingTaskITSCluster : public PostProcessingInterface
     Int_t runNumber = 0;
   };
 
-  void trendValues(repository::DatabaseInterface& qcdb);
+  void trendValues(const Trigger& t, repository::DatabaseInterface& qcdb);
   void storePlots(repository::DatabaseInterface& qcdb);
   void storeTrend(repository::DatabaseInterface& qcdb);
 

--- a/Modules/ITS/include/ITS/TrendingTaskITSFhr.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSFhr.h
@@ -77,7 +77,7 @@ class TrendingTaskITSFhr : public PostProcessingInterface
     Int_t runNumber = 0;
   };
 
-  void trendValues(repository::DatabaseInterface& qcdb);
+  void trendValues(const Trigger& t, repository::DatabaseInterface& qcdb);
   void storePlots(repository::DatabaseInterface& qcdb);
   void storeTrend(repository::DatabaseInterface& qcdb);
 

--- a/Modules/ITS/include/ITS/TrendingTaskITSThr.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSThr.h
@@ -76,7 +76,7 @@ class TrendingTaskITSThr : public PostProcessingInterface
     Int_t runNumber = 0;
   };
 
-  void trendValues(repository::DatabaseInterface& qcdb);
+  void trendValues(const Trigger& t, repository::DatabaseInterface& qcdb);
   void storePlots(repository::DatabaseInterface& qcdb);
   void storeTrend(repository::DatabaseInterface& qcdb);
 

--- a/Modules/ITS/include/ITS/TrendingTaskITSTracks.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSTracks.h
@@ -76,7 +76,7 @@ class TrendingTaskITSTracks : public PostProcessingInterface
     Int_t runNumber = 0;
   };
 
-  void trendValues(repository::DatabaseInterface& qcdb);
+  void trendValues(const Trigger& t, repository::DatabaseInterface& qcdb);
   void storePlots(repository::DatabaseInterface& qcdb);
   void storeTrend(repository::DatabaseInterface& qcdb);
 

--- a/Modules/ITS/src/TrendingTaskITSCluster.cxx
+++ b/Modules/ITS/src/TrendingTaskITSCluster.cxx
@@ -59,17 +59,17 @@ void TrendingTaskITSCluster::initialize(Trigger, framework::ServiceRegistry&)
 }
 
 // todo: see if OptimizeBaskets() indeed helps after some time
-void TrendingTaskITSCluster::update(Trigger, framework::ServiceRegistry& services)
+void TrendingTaskITSCluster::update(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
-  trendValues(qcdb);
+  trendValues(t, qcdb);
 
   storePlots(qcdb);
   storeTrend(qcdb);
 }
 
-void TrendingTaskITSCluster::finalize(Trigger, framework::ServiceRegistry& services)
+void TrendingTaskITSCluster::finalize(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
@@ -87,7 +87,7 @@ void TrendingTaskITSCluster::storeTrend(repository::DatabaseInterface& qcdb)
   qcdb.storeMO(mo);
 }
 
-void TrendingTaskITSCluster::trendValues(repository::DatabaseInterface& qcdb)
+void TrendingTaskITSCluster::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
   // We use current date and time. This for planned processing (not history). We
   // still might need to use the objects
@@ -105,7 +105,7 @@ void TrendingTaskITSCluster::trendValues(repository::DatabaseInterface& qcdb)
     // cast to whatever it needs.
     if (dataSource.type == "repository") {
       // auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name);
-      auto mo = qcdb.retrieveMO(dataSource.path, "");
+      auto mo = qcdb.retrieveMO(dataSource.path, "", t.timestamp, t.activity);
       if (!count) {
         std::map<std::string, std::string> entryMetadata = mo->getMetadataMap(); // full list of metadata as a map
         mMetaData.runNumber = std::stoi(entryMetadata["RunNumber"]);             // get and set run number

--- a/Modules/ITS/src/TrendingTaskITSFhr.cxx
+++ b/Modules/ITS/src/TrendingTaskITSFhr.cxx
@@ -60,17 +60,17 @@ void TrendingTaskITSFhr::initialize(Trigger, framework::ServiceRegistry&)
 }
 
 // todo: see if OptimizeBaskets() indeed helps after some time
-void TrendingTaskITSFhr::update(Trigger, framework::ServiceRegistry& services)
+void TrendingTaskITSFhr::update(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
-  trendValues(qcdb);
+  trendValues(t, qcdb);
 
   storePlots(qcdb);
   storeTrend(qcdb);
 }
 
-void TrendingTaskITSFhr::finalize(Trigger, framework::ServiceRegistry& services)
+void TrendingTaskITSFhr::finalize(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
@@ -88,7 +88,7 @@ void TrendingTaskITSFhr::storeTrend(repository::DatabaseInterface& qcdb)
   qcdb.storeMO(mo);
 }
 
-void TrendingTaskITSFhr::trendValues(repository::DatabaseInterface& qcdb)
+void TrendingTaskITSFhr::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
   // We use current date and time. This for planned processing (not history). We
   // still might need to use the objects
@@ -106,7 +106,7 @@ void TrendingTaskITSFhr::trendValues(repository::DatabaseInterface& qcdb)
     // cast to whatever it needs.
     if (dataSource.type == "repository") {
       // auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name);
-      auto mo = qcdb.retrieveMO(dataSource.path, "");
+      auto mo = qcdb.retrieveMO(dataSource.path, "", t.timestamp, t.activity);
       if (!count) {
         std::map<std::string, std::string> entryMetadata = mo->getMetadataMap(); // full list of metadata as a map
         mMetaData.runNumber = std::stoi(entryMetadata["RunNumber"]);             // get and set run number

--- a/Modules/ITS/src/TrendingTaskITSThr.cxx
+++ b/Modules/ITS/src/TrendingTaskITSThr.cxx
@@ -55,17 +55,17 @@ void TrendingTaskITSThr::initialize(Trigger, framework::ServiceRegistry&)
 }
 
 // todo: see if OptimizeBaskets() indeed helps after some time
-void TrendingTaskITSThr::update(Trigger, framework::ServiceRegistry& services)
+void TrendingTaskITSThr::update(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
-  trendValues(qcdb);
+  trendValues(t, qcdb);
 
   storePlots(qcdb);
   storeTrend(qcdb);
 }
 
-void TrendingTaskITSThr::finalize(Trigger, framework::ServiceRegistry& services)
+void TrendingTaskITSThr::finalize(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
@@ -84,7 +84,7 @@ void TrendingTaskITSThr::storeTrend(repository::DatabaseInterface& qcdb)
   qcdb.storeMO(mo);
 }
 
-void TrendingTaskITSThr::trendValues(repository::DatabaseInterface& qcdb)
+void TrendingTaskITSThr::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
   // We use current date and time. This for planned processing (not history). We
   // still might need to use the objects
@@ -103,7 +103,7 @@ void TrendingTaskITSThr::trendValues(repository::DatabaseInterface& qcdb)
     // cast to whatever it needs.
     if (dataSource.type == "repository") {
       // auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name);
-      auto mo = qcdb.retrieveMO(dataSource.path, "");
+      auto mo = qcdb.retrieveMO(dataSource.path, "", t.timestamp, t.activity);
       if (!count) {
         std::map<std::string, std::string> entryMetadata = mo->getMetadataMap(); //full list of metadata as a map
         mMetaData.runNumber = std::stoi(entryMetadata["RunNumber"]);             //get and set run number

--- a/Modules/ITS/src/TrendingTaskITSTracks.cxx
+++ b/Modules/ITS/src/TrendingTaskITSTracks.cxx
@@ -55,21 +55,21 @@ void TrendingTaskITSTracks::initialize(Trigger, framework::ServiceRegistry&)
 }
 
 // todo: see if OptimizeBaskets() indeed helps after some time
-void TrendingTaskITSTracks::update(Trigger, framework::ServiceRegistry& services)
+void TrendingTaskITSTracks::update(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
-  trendValues(qcdb);
+  trendValues(t, qcdb);
 
   storePlots(qcdb);
   storeTrend(qcdb);
 }
 
-void TrendingTaskITSTracks::finalize(Trigger, framework::ServiceRegistry& services)
+void TrendingTaskITSTracks::finalize(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
-  trendValues(qcdb);
+  trendValues(t, qcdb);
 
   storePlots(qcdb);
   storeTrend(qcdb);
@@ -86,7 +86,7 @@ void TrendingTaskITSTracks::storeTrend(repository::DatabaseInterface& qcdb)
   qcdb.storeMO(mo);
 }
 
-void TrendingTaskITSTracks::trendValues(repository::DatabaseInterface& qcdb)
+void TrendingTaskITSTracks::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
   // We use current date and time. This for planned processing (not history). We
   // still might need to use the objects
@@ -105,7 +105,7 @@ void TrendingTaskITSTracks::trendValues(repository::DatabaseInterface& qcdb)
     // cast to whatever it needs.
     if (dataSource.type == "repository") {
       // auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name);
-      auto mo = qcdb.retrieveMO(dataSource.path, "");
+      auto mo = qcdb.retrieveMO(dataSource.path, "", t.timestamp, t.activity);
       if (!count) {
         std::map<std::string, std::string> entryMetadata = mo->getMetadataMap(); //full list of metadata as a map
         mMetaData.runNumber = std::stoi(entryMetadata["RunNumber"]);             //get and set run number


### PR DESCRIPTION
This will allow you to use triggers which can iterate on all existing objects in QCDB which match certain criteria, e.g. all runs for apass2 of OCT data.
See the doc for more information:
https://github.com/AliceO2Group/QualityControl/blob/master/doc/PostProcessing.md#i-want-to-run-postprocessing-on-all-already-existing-objects-for-a-run