### PR TITLE
Adapt TPC postprocessing to use timestamps and activities

### DIFF
--- a/Modules/TPC/include/TPC/TrendingTaskTPC.h
+++ b/Modules/TPC/include/TPC/TrendingTaskTPC.h
@@ -66,7 +66,7 @@ class TrendingTaskTPC : public PostProcessingInterface
   };
 
   /// \brief Methods specific to the trending itself.
-  void trendValues(uint64_t timestamp, o2::quality_control::repository::DatabaseInterface&);
+  void trendValues(const Trigger& t, o2::quality_control::repository::DatabaseInterface&);
   void generatePlots();
   void drawCanvas(TCanvas* thisCanvas, const std::string& var,
                   const std::string& name, const std::string& opt, const std::string& err);

--- a/Modules/TPC/src/CalDetPublisher.cxx
+++ b/Modules/TPC/src/CalDetPublisher.cxx
@@ -274,7 +274,7 @@ void CalDetPublisher::update(Trigger t, framework::ServiceRegistry&)
   }
 }
 
-void CalDetPublisher::finalize(Trigger, framework::ServiceRegistry&)
+void CalDetPublisher::finalize(Trigger t, framework::ServiceRegistry&)
 {
   for (const auto& calDetCanvasVec : mCalDetCanvasVec) {
     for (const auto& canvas : calDetCanvasVec) {

--- a/Modules/TPC/src/ClusterVisualizer.cxx
+++ b/Modules/TPC/src/ClusterVisualizer.cxx
@@ -194,7 +194,7 @@ void ClusterVisualizer::update(Trigger t, framework::ServiceRegistry&)
   calDetIter++;
 }
 
-void ClusterVisualizer::finalize(Trigger, framework::ServiceRegistry&)
+void ClusterVisualizer::finalize(Trigger t, framework::ServiceRegistry&)
 {
   for (const auto& calDetCanvasVec : mCalDetCanvasVec) {
     for (const auto& canvas : calDetCanvasVec) {

--- a/Modules/TPC/src/LaserTracks.cxx
+++ b/Modules/TPC/src/LaserTracks.cxx
@@ -54,7 +54,7 @@ void LaserTracks::update(Trigger t, framework::ServiceRegistry&)
   o2::tpc::painter::makeSummaryCanvases(calibData, &vecPtr);
 }
 
-void LaserTracks::finalize(Trigger, framework::ServiceRegistry&)
+void LaserTracks::finalize(Trigger t, framework::ServiceRegistry&)
 {
   for (const auto& canvas : mLaserTracksCanvasVec) {
     getObjectsManager()->stopPublishing(canvas.get());


### PR DESCRIPTION
This will allow you to use triggers which can iterate on all existing objects in QCDB which match certain criteria, e.g. all runs for apass2 of OCT data.
See the doc for more information:
https://github.com/AliceO2Group/QualityControl/blob/master/doc/PostProcessing.md#i-want-to-run-postprocessing-on-all-already-existing-objects-for-a-run