### PR TITLE
Adapt TOF postprocessing to use timestamps and activities

### DIFF
--- a/Modules/TOF/include/TOF/TrendingHits.h
+++ b/Modules/TOF/include/TOF/TrendingHits.h
@@ -56,7 +56,7 @@ class TrendingHits : public PostProcessingInterface
     Int_t runNumber = 0;
   };
 
-  void trendValues(uint64_t timestamp, repository::DatabaseInterface&);
+  void trendValues(const Trigger& t, repository::DatabaseInterface&);
   void generatePlots();
 
   TrendingConfigTOF mConfig;

--- a/Modules/TOF/src/PostProcessDiagnosticPerCrate.cxx
+++ b/Modules/TOF/src/PostProcessDiagnosticPerCrate.cxx
@@ -52,7 +52,7 @@ void PostProcessDiagnosticPerCrate::initialize(Trigger, framework::ServiceRegist
   mDatabase = &services.get<o2::quality_control::repository::DatabaseInterface>();
 }
 
-void PostProcessDiagnosticPerCrate::update(Trigger, framework::ServiceRegistry&)
+void PostProcessDiagnosticPerCrate::update(Trigger t, framework::ServiceRegistry&)
 {
   ILOG(Debug) << "UPDATING !" << ENDM;
   for (int slot = 0; slot < mNSlots; slot++) { // Loop over slots
@@ -63,7 +63,7 @@ void PostProcessDiagnosticPerCrate::update(Trigger, framework::ServiceRegistry&)
       moName = Form("TRMCounterSlot%i", slot);
     }
     ILOG(Debug) << "Processing slot " << slot << " from " << moName << ENDM;
-    auto mo = mDatabase->retrieveMO(mCCDBPath, moName);
+    auto mo = mDatabase->retrieveMO(mCCDBPath, moName, t.timestamp, t.activity);
     TH2F* moH = static_cast<TH2F*>(mo ? mo->getObject() : nullptr);
     if (moH) {
       for (int crate = 0; crate < moH->GetNbinsY(); crate++) { // Loop over crates
@@ -85,7 +85,7 @@ void PostProcessDiagnosticPerCrate::update(Trigger, framework::ServiceRegistry&)
   ILOG(Debug) << "DONE UPDATING !" << ENDM;
 }
 
-void PostProcessDiagnosticPerCrate::finalize(Trigger, framework::ServiceRegistry&)
+void PostProcessDiagnosticPerCrate::finalize(Trigger t, framework::ServiceRegistry&)
 {
   ILOG(Info) << "FINALIZING !" << ENDM;
 

--- a/Modules/TOF/src/TrendingHits.cxx
+++ b/Modules/TOF/src/TrendingHits.cxx
@@ -63,18 +63,18 @@ void TrendingHits::update(Trigger t, framework::ServiceRegistry& services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
-  trendValues(t.timestamp, qcdb);
+  trendValues(t, qcdb);
   generatePlots();
 }
 
-void TrendingHits::finalize(Trigger, framework::ServiceRegistry&)
+void TrendingHits::finalize(Trigger t, framework::ServiceRegistry&)
 {
   generatePlots();
 }
 
-void TrendingHits::trendValues(uint64_t timestamp, repository::DatabaseInterface& qcdb)
+void TrendingHits::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
-  mTime = timestamp / 1000; // ROOT expects seconds since epoch
+  mTime = t.timestamp / 1000; // ROOT expects seconds since epoch
   // todo get run number when it is available. consider putting it inside monitor object's metadata (this might be not
   //  enough if we trend across runs).
   mMetaData.runNumber = -1;
@@ -83,13 +83,13 @@ void TrendingHits::trendValues(uint64_t timestamp, repository::DatabaseInterface
 
     // todo: make it agnostic to MOs, QOs or other objects. Let the reductor cast to whatever it needs.
     if (dataSource.type == "repository") {
-      auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name, timestamp);
+      auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name, t.timestamp, t.activity);
       TObject* obj = mo ? mo->getObject() : nullptr;
       if (obj) {
         mReductors[dataSource.name]->update(obj);
       }
     } else if (dataSource.type == "repository-quality") {
-      auto qo = qcdb.retrieveQO(dataSource.path + "/" + dataSource.name, timestamp);
+      auto qo = qcdb.retrieveQO(dataSource.path + "/" + dataSource.name, t.timestamp, t.activity);
       if (qo) {
         mReductors[dataSource.name]->update(qo.get());
       }


### PR DESCRIPTION
This will allow you to use triggers which can iterate on all existing objects in QCDB which match certain criteria, e.g. all runs for apass2 of OCT data.
See the doc for more information:
https://github.com/AliceO2Group/QualityControl/blob/master/doc/PostProcessing.md#i-want-to-run-postprocessing-on-all-already-existing-objects-for-a-run