### PR TITLE
Adapt FT0 postprocessing to use timestamps and activities

### DIFF
--- a/Modules/FT0/src/BasicPPTask.cxx
+++ b/Modules/FT0/src/BasicPPTask.cxx
@@ -114,15 +114,15 @@ void BasicPPTask::initialize(Trigger, framework::ServiceRegistry& services)
   getObjectsManager()->startPublishing(mTime);
 }
 
-void BasicPPTask::update(Trigger, framework::ServiceRegistry&)
+void BasicPPTask::update(Trigger t, framework::ServiceRegistry&)
 {
-  auto mo = mDatabase->retrieveMO(mPathDigitQcTask, "Triggers");
+  auto mo = mDatabase->retrieveMO(mPathDigitQcTask, "Triggers", t.timestamp, t.activity);
   auto hTriggers = mo ? (TH1F*)mo->getObject() : nullptr;
   if (!hTriggers) {
     ILOG(Error) << "MO \"Triggers\" NOT retrieved!!!" << ENDM;
   }
 
-  auto mo2 = mDatabase->retrieveMO(mPathDigitQcTask, mCycleDurationMoName);
+  auto mo2 = mDatabase->retrieveMO(mPathDigitQcTask, mCycleDurationMoName, t.timestamp, t.activity);
   auto hCycleDuration = mo2 ? (TH1D*)mo2->getObject() : nullptr;
   if (!hCycleDuration) {
     ILOG(Error) << "MO \"" << mCycleDurationMoName << "\" NOT retrieved!!!" << ENDM;
@@ -171,13 +171,13 @@ void BasicPPTask::update(Trigger, framework::ServiceRegistry&)
     leg->SetFillStyle(1);
   }
 
-  auto mo3 = mDatabase->retrieveMO(mPathDigitQcTask, "AmpPerChannel");
+  auto mo3 = mDatabase->retrieveMO(mPathDigitQcTask, "AmpPerChannel", t.timestamp, t.activity);
   auto hAmpPerChannel = mo3 ? (TH2D*)mo3->getObject() : nullptr;
   if (!hAmpPerChannel) {
     ILOG(Error) << "MO \"AmpPerChannel\" NOT retrieved!!!"
                 << ENDM;
   }
-  auto mo4 = mDatabase->retrieveMO(mPathDigitQcTask, "TimePerChannel");
+  auto mo4 = mDatabase->retrieveMO(mPathDigitQcTask, "TimePerChannel", t.timestamp, t.activity);
   auto hTimePerChannel = mo4 ? (TH2D*)mo4->getObject() : nullptr;
   if (!hTimePerChannel) {
     ILOG(Error) << "MO \"TimePerChannel\" NOT retrieved!!!"
@@ -203,7 +203,7 @@ void BasicPPTask::update(Trigger, framework::ServiceRegistry&)
   }
 }
 
-void BasicPPTask::finalize(Trigger, framework::ServiceRegistry&)
+void BasicPPTask::finalize(Trigger t, framework::ServiceRegistry&)
 {
 }
 

--- a/Modules/FT0/src/OutOfBunchCollTask.cxx
+++ b/Modules/FT0/src/OutOfBunchCollTask.cxx
@@ -87,7 +87,7 @@ void OutOfBunchCollTask::initialize(Trigger, framework::ServiceRegistry& service
   getObjectsManager()->startPublishing(mHistBcPattern.get());
 }
 
-void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
+void OutOfBunchCollTask::update(Trigger t, framework::ServiceRegistry&)
 {
   std::map<std::string, std::string> metadata;
   std::map<std::string, std::string> headers;
@@ -106,7 +106,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
 
   for (auto& entry : mMapOutOfBunchColl) {
     auto moName = Form("BcOrbitMap_Trg%s", mMapDigitTrgNames.at(entry.first).c_str());
-    auto mo = mDatabase->retrieveMO(mPathDigitQcTask, moName);
+    auto mo = mDatabase->retrieveMO(mPathDigitQcTask, moName, t.timestamp, t.activity);
     auto hBcOrbitMapTrg = mo ? (TH2F*)mo->getObject() : nullptr;
     if (!hBcOrbitMapTrg) {
       ILOG(Error, Support) << "MO \"" << moName << "\" NOT retrieved!!!"
@@ -127,7 +127,7 @@ void OutOfBunchCollTask::update(Trigger, framework::ServiceRegistry&)
   }
 }
 
-void OutOfBunchCollTask::finalize(Trigger, framework::ServiceRegistry&)
+void OutOfBunchCollTask::finalize(Trigger t, framework::ServiceRegistry&)
 {
 }
 

--- a/Modules/FT0/src/TreeReaderPostProcessing.cxx
+++ b/Modules/FT0/src/TreeReaderPostProcessing.cxx
@@ -37,10 +37,10 @@ void TreeReaderPostProcessing::initialize(Trigger, framework::ServiceRegistry& s
   mDatabase = &services.get<o2::quality_control::repository::DatabaseInterface>();
 }
 
-void TreeReaderPostProcessing::update(Trigger, framework::ServiceRegistry&)
+void TreeReaderPostProcessing::update(Trigger t, framework::ServiceRegistry&)
 {
   mChargeHistogram->Reset();
-  auto mo = mDatabase->retrieveMO("qc/FT0/MO/BasicDigitQcTask", "EventTree");
+  auto mo = mDatabase->retrieveMO("qc/FT0/MO/BasicDigitQcTask", "EventTree", t.timestamp, t.activity);
   TTree* moTree = static_cast<TTree*>(mo ? mo->getObject() : nullptr);
 
   if (moTree) {
@@ -56,7 +56,7 @@ void TreeReaderPostProcessing::update(Trigger, framework::ServiceRegistry&)
   }
 }
 
-void TreeReaderPostProcessing::finalize(Trigger, framework::ServiceRegistry&)
+void TreeReaderPostProcessing::finalize(Trigger t, framework::ServiceRegistry&)
 {
   getObjectsManager()->stopPublishing(mChargeHistogram.get());
 }


### PR DESCRIPTION
This will allow you to use triggers which can iterate on all existing objects in QCDB which match certain criteria, e.g. all runs for apass2 of OCT data.
See the doc for more information:
https://github.com/AliceO2Group/QualityControl/blob/master/doc/PostProcessing.md#i-want-to-run-postprocessing-on-all-already-existing-objects-for-a-run

@afurs @Kavaldrin @sbysiak 