### PR TITLE
Updated ITSTrackSimulation to run with O2DPG

### DIFF
--- a/Modules/ITS/include/ITS/ITSTrackSimTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackSimTask.h
@@ -105,9 +105,10 @@ class ITSTrackSimTask : public TaskInterface
   TH1F* hTrackImpactTransvFake;
   TH1F* hTrackImpactTransvValid;
 
-  std::string mRunNumber;
-  std::string mRunNumberPath;
-  std::string mMCKinePath;
+  TH1D* hPrimaryReco_pt;
+  TH1D* hPrimaryGen_pt;
+
+  std::string mRunNumber = "000000";
   std::string mO2GrpPath;
 
   o2::its::GeometryTGeo* mGeom;

--- a/Modules/ITS/include/ITS/ITSTrackSimTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackSimTask.h
@@ -108,8 +108,11 @@ class ITSTrackSimTask : public TaskInterface
   TH1D* hPrimaryReco_pt;
   TH1D* hPrimaryGen_pt;
 
-  std::string mRunNumber = "000000";
+  TH2D* hAngularDistribution;
+
+  int mRunNumber = 0;
   std::string mO2GrpPath;
+  std::string mCollisionsContextPath;
 
   o2::its::GeometryTGeo* mGeom;
 

--- a/Modules/ITS/itsTrackSim.json
+++ b/Modules/ITS/itsTrackSim.json
@@ -36,7 +36,10 @@
           "name" : "tracksim"
         },
         "location" : "remote",
-        "taskParameters" : { }
+        "taskParameters" : {
+                     "O2GrpPath" : "./o2sim_grp.root",
+                     "collisionsContextPath": "./collisioncontext.root" 
+          }
 
       }
     }

--- a/Modules/ITS/itsTrackSim.json
+++ b/Modules/ITS/itsTrackSim.json
@@ -36,11 +36,7 @@
           "name" : "tracksim"
         },
         "location" : "remote",
-        "taskParameters" : {
-          "runNumberPath" : "/home/its/QC/workdir/infiles/RunNumber.dat",
-          "MCKinePath" : "./o2sim_Kine.root",
-          "O2GrpPath" : "./o2sim_grp.root" 
-        }
+        "taskParameters" : { }
 
       }
     }


### PR DESCRIPTION
1) MCKinematics via MCKinematicsReader (previously was done using the .root file provided by o2-MC simulation workflow)
2) Improved aggregation of the averaged plots
3) Removed not used parameters from the .json file
4) Fixed titles of the histograms
5) Added binominal errors for ratio of the histograms
6) Added TH1 for pT distribution of primary generated/reconstructed particles 