### PR TITLE
MCH: update global histograms in digits task

### DIFF
--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
@@ -65,7 +65,6 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
  private:
   TH2F* mHistoNum{ nullptr };
   TH2F* mHistoDen{ nullptr };
-  TList* mlistOfFunctions{ nullptr };
   std::string mTreatMeAs = "TH2F";
   double mScalingFactor = 1.;
 

--- a/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
@@ -25,8 +25,6 @@ MergeableTH2Ratio::MergeableTH2Ratio(MergeableTH2Ratio const& copymerge)
          copymerge.getNum()->GetXaxis()->GetNbins(), copymerge.getNum()->GetXaxis()->GetXmin(), copymerge.getNum()->GetXaxis()->GetXmax(),
          copymerge.getNum()->GetYaxis()->GetNbins(), copymerge.getNum()->GetYaxis()->GetXmin(), copymerge.getNum()->GetYaxis()->GetXmax()),
     o2::mergers::MergeInterface(),
-    // mlistOfFunctions(copymerge.getNum()->GetListOfFunctions()),
-    mlistOfFunctions(nullptr),
     mScalingFactor(copymerge.getScalingFactor())
 {
   Bool_t bStatus = TH1::AddDirectoryStatus();
@@ -39,8 +37,6 @@ MergeableTH2Ratio::MergeableTH2Ratio(MergeableTH2Ratio const& copymerge)
 MergeableTH2Ratio::MergeableTH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, double scaling)
   : TH2F(name, title, nbinsx, xmin, xmax, nbinsy, ymin, ymax),
     o2::mergers::MergeInterface(),
-    // mlistOfFunctions(mHistoNum->GetListOfFunctions()),
-    mlistOfFunctions(nullptr),
     mScalingFactor(scaling)
 {
   Bool_t bStatus = TH1::AddDirectoryStatus();
@@ -54,8 +50,6 @@ MergeableTH2Ratio::MergeableTH2Ratio(const char* name, const char* title, int nb
 MergeableTH2Ratio::MergeableTH2Ratio(const char* name, const char* title, double scaling)
   : TH2F(name, title, 10, 0, 10, 10, 0, 10),
     o2::mergers::MergeInterface(),
-    // mlistOfFunctions(mHistoNum->GetListOfFunctions()),
-    mlistOfFunctions(nullptr),
     mScalingFactor(scaling)
 {
   Bool_t bStatus = TH1::AddDirectoryStatus();
@@ -91,26 +85,28 @@ void MergeableTH2Ratio::update()
   static constexpr double sOrbitLengthInMilliseconds = sOrbitLengthInMicroseconds / 1000;
   const char* name = this->GetName();
   const char* title = this->GetTitle();
+
   Reset();
-  // if(mlistOfFunctions->GetLast() > 0){
-  //     beautify();
-  // }
+  beautify();
+
   GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
   GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXmin(), mHistoNum->GetYaxis()->GetXmax());
   SetBinsLength();
+
   Divide(mHistoNum, mHistoDen);
   SetNameTitle(name, title);
+
   // convertion to KHz units
   if (mScalingFactor != 1.) {
     Scale(1. / sOrbitLengthInMilliseconds);
   }
-  SetOption("colz");
 }
 
 void MergeableTH2Ratio::beautify()
 {
-  // GetListOfFunctions()->RemoveAll();
-  // GetListOfFunctions()->AddAll(mlistOfFunctions);
+  SetOption("colz");
+  GetListOfFunctions()->RemoveAll();
+  GetListOfFunctions()->AddAll((TList*)(mHistoNum->GetListOfFunctions()->Clone()));
 }
 
 } // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/MCH/include/MCH/GlobalHistogram.h
+++ b/Modules/MUON/MCH/include/MCH/GlobalHistogram.h
@@ -72,10 +72,12 @@ class DetectorHistogram
   float mHistHeight{ 0 };
 };
 
-class GlobalHistogram : public TH2F
+class GlobalHistogram
 {
  public:
-  GlobalHistogram(std::string name, std::string title, int id = 0);
+  GlobalHistogram(std::string name, std::string title, int id);
+  GlobalHistogram(std::string name, std::string title, int id, TH2F* hist);
+  ~GlobalHistogram();
 
   void init();
 
@@ -88,6 +90,8 @@ class GlobalHistogram : public TH2F
   // replace the contents with the histograms of the individual detection elements
   void set(std::map<int, std::shared_ptr<DetectorHistogram>>& histB, std::map<int, std::shared_ptr<DetectorHistogram>>& histNB, bool doAverage = true, bool includeNullBins = false);
 
+  TH2F* getHist() { return mHist.first; }
+
  private:
   void initST345();
   void initST12();
@@ -97,7 +101,10 @@ class GlobalHistogram : public TH2F
   void getDeCenterST4(int de, float& xB0, float& yB0, float& xNB0, float& yNB0);
   void getDeCenterST5(int de, float& xB0, float& yB0, float& xNB0, float& yNB0);
 
+  TString mName;
+  TString mTitle;
   int mId;
+  std::pair<TH2F*, bool> mHist;
 };
 
 } // namespace muonchambers

--- a/Modules/MUON/MCH/include/MCH/PhysicsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsCheck.h
@@ -47,16 +47,19 @@ class PhysicsCheck : public o2::quality_control::checker::CheckInterface
  private:
   bool checkPadMapping(uint16_t feeId, uint8_t linkId, uint8_t eLinkId, o2::mch::raw::DualSampaChannelId channel);
 
-  int mPrintLevel;
   double mMinOccupancy;
   double mMaxOccupancy;
+  double mMinGoodFraction;
+  double mOccupancyPlotScaleMin;
+  double mOccupancyPlotScaleMax;
+  bool mVerbose;
 
   o2::mch::raw::Elec2DetMapper mElec2DetMapper;
   o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
   o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
   o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
 
-  ClassDefOverride(PhysicsCheck, 2);
+  ClassDefOverride(PhysicsCheck, 3);
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
@@ -86,9 +86,16 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   uint32_t mLastOrbitSeen[sMaxFeeId][sMaxLinkId];
 
   // 2D Histograms, using Elec view (where x and y uniquely identify each pad based on its Elec info (fee, link, de)
-  TH2F* mHistogramNHitsElec;                                  // Histogram of Number of hits (Elec view)
-  TH2F* mHistogramNorbitsElec;                                // Histogram of Number of orbits (Elec view)
-  std::shared_ptr<MergeableTH2Ratio> mHistogramOccupancyElec; // Mergeable object, Occupancy histogram (Elec view)
+  TH2F* mHistogramNHitsElec;                                   // Histogram of Number of hits (Elec view)
+  TH2F* mHistogramNorbitsElec;                                 // Histogram of Number of orbits (Elec view)
+  std::shared_ptr<MergeableTH2Ratio> mHistogramOccupancyElec;  // Mergeable object, Occupancy histogram (Elec view)
+  std::shared_ptr<GlobalHistogram> mHistogramNhitsST12;        // Histogram of Number of hits (global XY view)
+  std::shared_ptr<GlobalHistogram> mHistogramNorbitsST12;      // Histogram of Number of orbits (global XY view)
+  std::shared_ptr<MergeableTH2Ratio> mHistogramOccupancyST12;  // Mergeable object, Occupancy histogram (global XY view)
+  std::shared_ptr<GlobalHistogram> mHistogramNhitsST345;       // Histogram of Number of hits (global XY view)
+  std::shared_ptr<GlobalHistogram> mHistogramNorbitsST345;     // Histogram of Number of orbits (global XY view)
+  std::shared_ptr<MergeableTH2Ratio> mHistogramOccupancyST345; // Mergeable object, Occupancy histogram (global XY view)
+
 
   std::shared_ptr<TH2F> mHistogramDigitsOrbitInTF;
   std::shared_ptr<TH2F> mHistogramDigitsBcInOrbit;

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
@@ -96,7 +96,6 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   std::shared_ptr<GlobalHistogram> mHistogramNorbitsST345;     // Histogram of Number of orbits (global XY view)
   std::shared_ptr<MergeableTH2Ratio> mHistogramOccupancyST345; // Mergeable object, Occupancy histogram (global XY view)
 
-
   std::shared_ptr<TH2F> mHistogramDigitsOrbitInTF;
   std::shared_ptr<TH2F> mHistogramDigitsBcInOrbit;
   std::shared_ptr<TH2F> mHistogramAmplitudeVsSamples;

--- a/Modules/MUON/MCH/src/GlobalHistogram.cxx
+++ b/Modules/MUON/MCH/src/GlobalHistogram.cxx
@@ -363,8 +363,8 @@ void DetectorHistogram::init()
 
   mHist.first->SetNameTitle(mName, mTitle);
 
-  mHist.first->GetXaxis()->Set(getDetectorHistXbins(mDeId), -1.0 * getDetectorHistWidth(mDeId) / 2, getDetectorHistWidth(mDeId) / 2);
-  mHist.first->GetYaxis()->Set(getDetectorHistYbins(mDeId), -1.0 * getDetectorHistHeight(mDeId) / 2, getDetectorHistHeight(mDeId) / 2);
+  mHist.first->GetXaxis()->Set(getNbinsX(), getXmin(), getXmax());
+  mHist.first->GetYaxis()->Set(getNbinsY(), getYmin(), getYmax());
   mHist.first->SetBinsLength();
 }
 
@@ -518,16 +518,37 @@ static float getGlobalHistHeight(int id)
   return (getGlobalHistDeHeight(id) * getNHistPerChamberY(id) * 2);
 }
 
-GlobalHistogram::GlobalHistogram(std::string name, std::string title, int id)
-  : TH2F(name.c_str(), title.c_str(), getGlobalHistWidth(id) / GLOBAL_HIST_SCALE, 0, getGlobalHistWidth(id),
-         getGlobalHistHeight(id) / GLOBAL_HIST_SCALE, 0, getGlobalHistHeight(id)),
-    mId(id)
+GlobalHistogram::GlobalHistogram(std::string name, std::string title, int id) : mName(name), mTitle(title), mId(id)
 {
-  SetOption("colz");
+  auto hist = new TH2F(name.c_str(), title.c_str(), getGlobalHistWidth(id) / GLOBAL_HIST_SCALE, 0, getGlobalHistWidth(id),
+                       getGlobalHistHeight(id) / GLOBAL_HIST_SCALE, 0, getGlobalHistHeight(id));
+  mHist = std::make_pair(hist, true);
+  mHist.first->SetOption("colz");
+}
+
+GlobalHistogram::GlobalHistogram(std::string name, std::string title, int id, TH2F* hist) : mName(name), mTitle(title), mId(id)
+{
+  mHist = std::make_pair(hist, false);
+  mHist.first->SetOption("colz");
+}
+
+GlobalHistogram::~GlobalHistogram()
+{
+  if (mHist.first && mHist.second) {
+    delete mHist.first;
+  }
 }
 
 void GlobalHistogram::init()
 {
+  mHist.first->Reset();
+
+  mHist.first->SetNameTitle(mName, mTitle);
+
+  mHist.first->GetXaxis()->Set(getGlobalHistWidth(mId) / GLOBAL_HIST_SCALE, 0, getGlobalHistWidth(mId));
+  mHist.first->GetYaxis()->Set(getGlobalHistHeight(mId) / GLOBAL_HIST_SCALE, 0, getGlobalHistHeight(mId));
+  mHist.first->SetBinsLength();
+
   switch (mId) {
     case 0:
       initST12();
@@ -549,56 +570,62 @@ void GlobalHistogram::initST12()
 
   TLine* line;
 
-  float histWidth = GetXaxis()->GetXmax();
-  float histHeight = GetYaxis()->GetXmax();
+  float histWidth = getHist()->GetXaxis()->GetXmax();
+  float histHeight = getHist()->GetYaxis()->GetXmax();
   float stationWidth = histWidth / 2;
 
   line = new TLine(0, histHeight / 2, histWidth, histHeight / 2);
-  GetListOfFunctions()->Add(line);
+  getHist()->GetListOfFunctions()->Add(line);
 
   line = new TLine(stationWidth, 0, stationWidth, histHeight);
-  GetListOfFunctions()->Add(line);
+  getHist()->GetListOfFunctions()->Add(line);
 
   for (auto& de : allDE) {
     if (de >= 500) {
       continue;
     }
     const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(de);
-    const o2::mch::mapping::CathodeSegmentation& csegment = segment.bending();
-    o2::mch::contour::Contour<double> envelop = o2::mch::mapping::getEnvelop(csegment);
-    std::vector<o2::mch::contour::Vertex<double>> vertices = envelop.getVertices();
 
-    float xB0, yB0, xNB0, yNB0;
-    getDeCenter(de, xB0, yB0, xNB0, yNB0);
+    std::vector<o2::mch::contour::Vertex<double>> vertices[2];
+    const o2::mch::mapping::CathodeSegmentation& csegmentB = segment.bending();
+    o2::mch::contour::Contour<double> envelopB = o2::mch::mapping::getEnvelop(csegmentB);
+    vertices[0] = envelopB.getVertices();
+
+    const o2::mch::mapping::CathodeSegmentation& csegmentNB = segment.nonBending();
+    o2::mch::contour::Contour<double> envelopNB = o2::mch::mapping::getEnvelop(csegmentNB);
+    vertices[1] = envelopNB.getVertices();
+
+    float x0[2], y0[2], xNB0, yNB0;
+    getDeCenter(de, x0[0], y0[0], x0[1], y0[1]);
     bool flipX = getDetectorFlipX(de);
     bool flipY = getDetectorFlipY(de);
 
     float shiftX = getDetectorShiftX(de);
     float shiftY = getDetectorShiftY(de);
 
-    for (unsigned int vi = 0; vi < vertices.size(); vi++) {
-      o2::mch::contour::Vertex<double> v1 = vertices[vi];
-      o2::mch::contour::Vertex<double> v2 = (vi < (vertices.size() - 1)) ? vertices[vi + 1] : vertices[0];
+    for (unsigned int ci = 0; ci < 2; ci++) {
+      for (unsigned int vi = 0; vi < vertices[ci].size(); vi++) {
+        o2::mch::contour::Vertex<double> v1 = vertices[ci][vi];
+        o2::mch::contour::Vertex<double> v2 = (vi < (vertices[ci].size() - 1)) ? vertices[ci][vi + 1] : vertices[ci][0];
 
-      v1.x += shiftX;
-      v1.y += shiftY;
-      v2.x += shiftX;
-      v2.y += shiftY;
+        v1.x += shiftX;
+        v1.y += shiftY;
+        v2.x += shiftX;
+        v2.y += shiftY;
 
-      if (flipX) {
-        v1.x *= -1;
-        v2.x *= -1;
+        if (flipX) {
+          v1.x *= -1;
+          v2.x *= -1;
+        }
+
+        if (flipY) {
+          v1.y *= -1;
+          v2.y *= -1;
+        }
+
+        line = new TLine(v1.x + x0[ci], v1.y + y0[ci], v2.x + x0[ci], v2.y + y0[ci]);
+        getHist()->GetListOfFunctions()->Add(line);
       }
-
-      if (flipY) {
-        v1.y *= -1;
-        v2.y *= -1;
-      }
-
-      line = new TLine(v1.x + xB0, v1.y + yB0, v2.x + xB0, v2.y + yB0);
-      GetListOfFunctions()->Add(line);
-      line = new TLine(v1.x + xNB0, v1.y + yNB0, v2.x + xNB0, v2.y + yNB0);
-      GetListOfFunctions()->Add(line);
     }
   }
 }
@@ -614,18 +641,18 @@ void GlobalHistogram::initST345()
 
   TLine* line;
 
-  float histWidth = GetXaxis()->GetXmax();
-  float histHeight = GetYaxis()->GetXmax();
+  float histWidth = getHist()->GetXaxis()->GetXmax();
+  float histHeight = getHist()->GetYaxis()->GetXmax();
   float stationWidth = histWidth / 3;
 
   line = new TLine(0, histHeight / 2, histWidth, histHeight / 2);
-  GetListOfFunctions()->Add(line);
+  getHist()->GetListOfFunctions()->Add(line);
 
   line = new TLine(stationWidth, 0, stationWidth, histHeight);
-  GetListOfFunctions()->Add(line);
+  getHist()->GetListOfFunctions()->Add(line);
 
   line = new TLine(stationWidth * 2, 0, stationWidth * 2, histHeight);
-  GetListOfFunctions()->Add(line);
+  getHist()->GetListOfFunctions()->Add(line);
 
   for (auto& de : allDE) {
     if (de < 500) {
@@ -652,14 +679,14 @@ void GlobalHistogram::initST345()
 
       if (isR) {
         line = new TLine(-v1.x + xB0, v1.y + yB0, -v2.x + xB0, v2.y + yB0);
-        GetListOfFunctions()->Add(line);
+        getHist()->GetListOfFunctions()->Add(line);
         line = new TLine(-v1.x + xNB0, v1.y + yNB0, -v2.x + xNB0, v2.y + yNB0);
-        GetListOfFunctions()->Add(line);
+        getHist()->GetListOfFunctions()->Add(line);
       } else {
         line = new TLine(v1.x + xB0, v1.y + yB0, v2.x + xB0, v2.y + yB0);
-        GetListOfFunctions()->Add(line);
+        getHist()->GetListOfFunctions()->Add(line);
         line = new TLine(v1.x + xNB0, v1.y + yNB0, v2.x + xNB0, v2.y + yNB0);
-        GetListOfFunctions()->Add(line);
+        getHist()->GetListOfFunctions()->Add(line);
       }
     }
   }
@@ -1030,8 +1057,8 @@ void GlobalHistogram::set(std::map<int, std::shared_ptr<DetectorHistogram>>& his
       yMax[1] = flipY ? yNB0 - shiftY : (yNB0 + bboxNB.height() + shiftY);
     }
 
-    float binWidthX = GetXaxis()->GetBinWidth(1);
-    float binWidthY = GetYaxis()->GetBinWidth(1);
+    float binWidthX = getHist()->GetXaxis()->GetBinWidth(1);
+    float binWidthY = getHist()->GetYaxis()->GetBinWidth(1);
 
     // loop on bending and non-bending planes
     for (int i = 0; i < 2; i++) {
@@ -1041,15 +1068,15 @@ void GlobalHistogram::set(std::map<int, std::shared_ptr<DetectorHistogram>>& his
       }
 
       // loop on destination bins
-      int binXmin = GetXaxis()->FindBin(xMin[i] + binWidthX / 2);
-      int binXmax = GetXaxis()->FindBin(xMax[i] - binWidthX / 2);
-      int binYmin = GetYaxis()->FindBin(yMin[i] + binWidthY / 2);
-      int binYmax = GetYaxis()->FindBin(yMax[i] - binWidthY / 2);
+      int binXmin = getHist()->GetXaxis()->FindBin(xMin[i] + binWidthX / 2);
+      int binXmax = getHist()->GetXaxis()->FindBin(xMax[i] - binWidthX / 2);
+      int binYmin = getHist()->GetYaxis()->FindBin(yMin[i] + binWidthY / 2);
+      int binYmax = getHist()->GetYaxis()->FindBin(yMax[i] - binWidthY / 2);
 
       for (int by = binYmin; by <= binYmax; by++) {
         // vertical boundaries of current bin, in DE coordinates
-        float minY = GetYaxis()->GetBinLowEdge(by) - y0[i];
-        float maxY = GetYaxis()->GetBinUpEdge(by) - y0[i];
+        float minY = getHist()->GetYaxis()->GetBinLowEdge(by) - y0[i];
+        float maxY = getHist()->GetYaxis()->GetBinUpEdge(by) - y0[i];
 
         // find Y bin range in source histogram
         int srcBinYmin = hist[i]->GetYaxis()->FindBin(minY);
@@ -1063,8 +1090,8 @@ void GlobalHistogram::set(std::map<int, std::shared_ptr<DetectorHistogram>>& his
 
         for (int bx = binXmin; bx <= binXmax; bx++) {
           // horizontal boundaries of current bin, in DE coordinates
-          float minX = GetXaxis()->GetBinLowEdge(bx) - x0[i];
-          float maxX = GetXaxis()->GetBinUpEdge(bx) - x0[i];
+          float minX = getHist()->GetXaxis()->GetBinLowEdge(bx) - x0[i];
+          float maxX = getHist()->GetXaxis()->GetBinUpEdge(bx) - x0[i];
 
           // find X bin range in source histogram
           int srcBinXmin = hist[i]->GetXaxis()->FindBin(minX);
@@ -1093,7 +1120,7 @@ void GlobalHistogram::set(std::map<int, std::shared_ptr<DetectorHistogram>>& his
           if (doAverage && (nBins > 0)) {
             tot /= nBins;
           }
-          SetBinContent(bx, by, tot);
+          getHist()->SetBinContent(bx, by, tot);
         }
       }
     }

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -90,18 +90,16 @@ void PedestalsTask::initialize(o2::framework::InitContext& /*ctx*/)
   for (int i = 0; i < 2; i++) {
     mHistogramPedestalsMCH[i] = std::make_shared<GlobalHistogram>(fmt::format("Pedestals_{}", stname[i]), "Pedestals", i);
     mHistogramPedestalsMCH[i]->init();
-    mHistogramPedestalsMCH[i]->SetOption("colz");
-    mAllHistograms.push_back(mHistogramPedestalsMCH[i].get());
+    mAllHistograms.push_back(mHistogramPedestalsMCH[i]->getHist());
     if (!mSaveToRootFile) {
-      getObjectsManager()->startPublishing(mHistogramPedestalsMCH[i].get());
+      getObjectsManager()->startPublishing(mHistogramPedestalsMCH[i]->getHist());
     }
 
     mHistogramNoiseMCH[i] = std::make_shared<GlobalHistogram>(fmt::format("Noise_{}", stname[i]), "Noise", i);
     mHistogramNoiseMCH[i]->init();
-    mHistogramNoiseMCH[i]->SetOption("colz");
-    mAllHistograms.push_back(mHistogramNoiseMCH[i].get());
+    mAllHistograms.push_back(mHistogramNoiseMCH[i]->getHist());
     if (!mSaveToRootFile) {
-      getObjectsManager()->startPublishing(mHistogramNoiseMCH[i].get());
+      getObjectsManager()->startPublishing(mHistogramNoiseMCH[i]->getHist());
     }
   }
 

--- a/Modules/MUON/MCH/src/PhysicsCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsCheck.cxx
@@ -36,12 +36,8 @@ using namespace std;
 namespace o2::quality_control_modules::muonchambers
 {
 
-PhysicsCheck::PhysicsCheck()
+PhysicsCheck::PhysicsCheck() : mMinOccupancy(0.001), mMaxOccupancy(1.0), mMinGoodFraction(0.9), mOccupancyPlotScaleMin(0), mOccupancyPlotScaleMax(1), mVerbose(false)
 {
-  mPrintLevel = 0;
-  mMinOccupancy = 0.001;
-  mMaxOccupancy = 1.00;
-
   mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
   mDet2ElecMapper = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
   mFeeLink2SolarMapper = o2::mch::raw::createFeeLink2SolarMapper<o2::mch::raw::ElectronicMapperGenerated>();
@@ -57,6 +53,20 @@ void PhysicsCheck::configure()
   }
   if (auto param = mCustomParameters.find("MaxOccupancy"); param != mCustomParameters.end()) {
     mMaxOccupancy = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("MinGoodFraction"); param != mCustomParameters.end()) {
+    mMinGoodFraction = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("OccupancyPlotScaleMin"); param != mCustomParameters.end()) {
+    mOccupancyPlotScaleMin = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("OccupancyPlotScaleMax"); param != mCustomParameters.end()) {
+    mOccupancyPlotScaleMax = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("Verbose"); param != mCustomParameters.end()) {
+    if (param->second == "true" || param->second == "True" || param->second == "TRUE") {
+      mVerbose = true;
+    }
   }
 }
 
@@ -114,7 +124,7 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
       } else {
         int nbinsx = h->GetXaxis()->GetNbins();
         int nbinsy = h->GetYaxis()->GetNbins();
-        int nbad = 0;
+        int ngood = 0;
         int npads = 0;
         for (int i = 1; i <= nbinsx; i++) {
           int index = i - 1;
@@ -132,18 +142,15 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
 
             Float_t occupancy = h->GetBinContent(i, j);
             if (occupancy >= mMinOccupancy && occupancy <= mMaxOccupancy) {
-              continue;
-            }
-
-            nbad += 1;
-
-            if (mPrintLevel >= 1) {
-              std::cout << "Channel with unusual occupancy read from OccupancyElec histogrm: fee_id = " << fee_id << ", link_id = " << link_id << ", ds_addr = " << ds_addr << " , chan_addr = " << chan_addr << " with an occupancy of " << occupancy << std::endl;
+              ngood += 1;
             }
           }
         }
-        std::cout << fmt::format("Npads {}  Nbad {}   Frac {}", npads, nbad, nbad / npads) << std::endl;
-        if (nbad < 0.1 * npads)
+        if (mVerbose) {
+          LOGP(debug, "Npads {}  Ngood {}   Frac {}", npads, ngood, float(ngood) / float(npads));
+        }
+
+        if (ngood >= mMinGoodFraction * npads)
           result = Quality::Good;
         else
           result = Quality::Bad;
@@ -157,17 +164,15 @@ std::string PhysicsCheck::getAcceptedType() { return "TH1"; }
 
 void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  // std::cout<<"===================================="<<std::endl;
-  // std::cout<<"PhysicsCheck::beautify() called"<<std::endl;
-  // std::cout<<"===================================="<<std::endl;
   if (mo->getName().find("Occupancy_Elec") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
     h->SetDrawOption("colz");
-    h->SetMinimum(0);
-    h->SetMaximum(10);
+    h->SetMinimum(mOccupancyPlotScaleMin);
+    h->SetMaximum(mOccupancyPlotScaleMax);
     TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
     h->GetListOfFunctions()->Add(msg);
     msg->SetName(Form("%s_msg", mo->GetName()));
+    msg->SetBorderSize(0);
 
     if (checkResult == Quality::Good) {
       msg->Clear();
@@ -194,6 +199,18 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
     h->SetLineColor(kBlack);
   }
 
+  if ((mo->getName().find("Occupancy_ST12") != std::string::npos) ||
+      (mo->getName().find("Occupancy_ST345") != std::string::npos)) {
+    auto* h = dynamic_cast<TH2F*>(mo->getObject());
+    h->SetDrawOption("colz");
+    h->SetMinimum(mOccupancyPlotScaleMin);
+    h->SetMaximum(mOccupancyPlotScaleMax);
+    h->GetXaxis()->SetTickLength(0.0);
+    h->GetXaxis()->SetLabelSize(0.0);
+    h->GetYaxis()->SetTickLength(0.0);
+    h->GetYaxis()->SetLabelSize(0.0);
+  }
+
   if (mo->getName().find("MeanOccupancy") != std::string::npos) {
     auto* h = dynamic_cast<TH1F*>(mo->getObject());
     // disable ticks on vertical axis
@@ -202,7 +219,6 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
     // draw chamber delimiters
     for (int demin = 200; demin <= 1000; demin += 100) {
       float xpos = static_cast<float>(getDEindex(demin)) - 0.5;
-      std::cout << "DEmin " << demin << "  ID " << getDEindex(demin) << std::endl;
       TLine* delimiter = new TLine(xpos, 0, xpos, 1.1 * h->GetMaximum());
       delimiter->SetLineColor(kBlack);
       delimiter->SetLineStyle(kDashed);


### PR DESCRIPTION
This PR re-introduces the filling of occupancy plots in global detector coordinates, and introduces improvements in both the plots cosmetics and the quality checks, namely:

- the global plots show the detector outlines and are plotted with `colz` option by default
- the axis labels for the global plots are hidden
- the z-axis scale of the 2-D occupancy plots is configurable in the JSON file
- the acceptable occupancy limits as well as the minimum fraction of good channels needed to flag the data quality as Good are also configurable in the JSON file.

The new configuration variables, with their default values, are the following:
```
        "checkParameters": {
          "MinOccupancy": "0.001",
          "MaxOccupancy": "1.0",
          "MinGoodFraction": "0.9",
          "OccupancyPlotScaleMin": "0.0",
          "OccupancyPlotScaleMax": "1.0",
          "Verbose" : "false"
        }
 ```

Here is an example of the global occupancy plots:
<img width="1203" alt="Global plots ST12" src="https://user-images.githubusercontent.com/6229237/160357752-ca0d560c-2c2a-43e5-9ad8-9cf34f942026.png">
<img width="1203" alt="Global plots ST345" src="https://user-images.githubusercontent.com/6229237/160358157-8a6c9ec9-1a5c-4170-8d12-d2fd90566e89.png">

