### PR TITLE
 ITSFeeTask and Checks: SummaryPlots and RDH

### DIFF
--- a/Modules/ITS/include/ITS/ITSFeeCheck.h
+++ b/Modules/ITS/include/ITS/ITSFeeCheck.h
@@ -52,6 +52,10 @@ class ITSFeeCheck : public o2::quality_control::checker::CheckInterface
   static constexpr int NFlags = 3;
   const double minTextPosY[NLayer] = { 0.43, 0.41, 0.39, 0.23, 0.21, 0.16, 0.13 }; // Text y coordinates in TH2Poly
   std::string mLaneStatusFlag[NFlags] = { "WARNING", "ERROR", "FAULT" };
+  static constexpr int NSummary = 4;
+  std::string mSummaryPlots[NSummary] = { "Global", "IB", "ML", "OL" };
+  const int laneMaxSummaryPlots[NSummary] = { 3816, 1, 864, 2520 };
+  const int laneMax[NLayer] = { 108, 144, 180, 384, 480, 1176, 1344 };
 };
 
 } // namespace o2::quality_control_modules::its

--- a/Modules/ITS/include/ITS/ITSFeeTask.h
+++ b/Modules/ITS/include/ITS/ITSFeeTask.h
@@ -94,6 +94,14 @@ class ITSFeeTask final : public TaskInterface
   const int LayerBoundaryFEE[NLayer - 1] = { 35, 83, 143, 191, 251, 335 };
   const float StartAngle[7] = { 16.997 / 360 * (TMath::Pi() * 2.), 17.504 / 360 * (TMath::Pi() * 2.), 17.337 / 360 * (TMath::Pi() * 2.), 8.75 / 360 * (TMath::Pi() * 2.), 7 / 360 * (TMath::Pi() * 2.), 5.27 / 360 * (TMath::Pi() * 2.), 4.61 / 360 * (TMath::Pi() * 2.) }; // start angle of first stave in each layer
   const float MidPointRad[7] = { 23.49, 31.586, 39.341, 197.598, 246.944, 345.348, 394.883 };
+  const int laneMax[NLayer] = { 108, 144, 180, 384, 480, 1176, 1344 };
+  const int lanesPerFeeId[NLayer] = { 3, 3, 3, 8, 8, 14, 14 };
+  const int feePerLayer[NLayer] = { 36, 48, 60, 48, 60, 84, 96 };
+  const int StavePerLayer[NLayer] = { 12, 16, 20, 24, 30, 42, 48 };
+  const int feePerStave[NLayer] = { 3, 3, 3, 2, 2, 2, 2 };
+  const int feeBoundary[NLayer] = { 0, 35, 83, 143, 191, 251, 335 };
+  const int indexFeeLow[NLayer] = { 0, 3, 6, 3, 17, 0, 14 };
+  const int indexFeeUp[NLayer] = { 3, 6, 9, 11, 25, 14, 28 };
   int mTimeFrameId = 0;
   TString mTriggerType[NTrigger] = { "ORBIT", "HB", "HBr", "HC", "PHYSICS", "PP", "CAL", "SOT", "EOT", "SOC", "EOC", "TF", "INT" };
   std::string mLaneStatusFlag[NFlags] = { "WARNING", "ERROR", "FAULT" }; // b00 OK, b01 WARNING, b10 ERROR, b11 FAULT

--- a/Modules/ITS/include/ITS/ITSFeeTask.h
+++ b/Modules/ITS/include/ITS/ITSFeeTask.h
@@ -27,6 +27,7 @@
 #include <TH2Poly.h>
 #include "TMath.h"
 #include <TLine.h>
+#include <TText.h>
 
 class TH2I;
 class TH1I;
@@ -79,6 +80,7 @@ class ITSFeeTask final : public TaskInterface
   void createFeePlots();
   void getStavePoint(int layer, int stave, double* px, double* py); // prepare for fill TH2Poly, get all point for add TH2Poly bin
   void setPlotsFormat();
+  void drawLayerName(TH2I* laneStatus);
   void resetGeneralPlots();
   static constexpr int NLayer = 7;
   const int NStaves[NLayer] = { 12, 16, 20, 24, 30, 42, 48 };
@@ -97,6 +99,8 @@ class ITSFeeTask final : public TaskInterface
   std::string mLaneStatusFlag[NFlags] = { "WARNING", "ERROR", "FAULT" }; // b00 OK, b01 WARNING, b10 ERROR, b11 FAULT
 
   int mStatusFlagNumber[7][48][28][3] = { { { 0 } } }; //[iLayer][iStave][iLane][iLaneStatusFlag]
+  int mStatusSummaryLayerNumber[7][3] = { { 0 } };     //[iLayer][iflag]
+  int mStatusSummaryNumber[4][3] = { { 0 } };          //[summary][iflag] ---> Global, IB, ML, OL
 
   // parameters taken from the .json
   int mNPayloadSizeBins = 0;
@@ -105,9 +109,10 @@ class ITSFeeTask final : public TaskInterface
   TH2I* mTriggerVsFeeId;
   TH1I* mTrigger;
   TH2I* mLaneInfo;
-  TH2I* mFlag1Check;         // include transmission_timeout, packet_overflow, lane_starts_violation
-  TH2I* mIndexCheck;         // should be zero
-  TH2I* mIdCheck;            // should be 0x : e4
+  TH2I* mFlag1Check; // include transmission_timeout, packet_overflow, lane_starts_violation
+  TH2I* mIndexCheck; // should be zero
+  TH2I* mIdCheck;    // should be 0x : e4
+  TH2I* mRDHSummary;
   TH2I* mLaneStatus[NFlags]; // 4 flags for each lane. 3/8/14 lane for each link. 3/2/2 link for each RU. TODO: remove the OK flag in these 4 flag plots, OK flag plot just used to debug.
   TH2Poly* mLaneStatusOverview[NFlags] = { 0x0 };
   TH1I* mLaneStatusSummary[NLayer];

--- a/Modules/ITS/itsFee.json
+++ b/Modules/ITS/itsFee.json
@@ -36,7 +36,7 @@
                 },
                 "location": "local",
                 "taskParameters": {
-                    "NPayloadSizeBins": "4096",
+                    "NPayloadSizeBins": "4096"
                 }
             }
         },
@@ -57,7 +57,12 @@
                             "LaneStatus/laneStatusFlagWARNING",
                             "LaneStatus/laneStatusOverviewFlagFAULT",
                             "LaneStatus/laneStatusOverviewFlagERROR",
-                            "LaneStatus/laneStatusOverviewFlagWARNING"
+                            "LaneStatus/laneStatusOverviewFlagWARNING",
+                            "LaneStatusSummary/LaneStatusSummaryGlobal",
+                            "LaneStatusSummary/LaneStatusSummaryIB",
+                            "LaneStatusSummary/LaneStatusSummaryML",
+                            "LaneStatusSummary/LaneStatusSummaryOL",
+                            "RDHSummary"
                         ]
                     }
                 ]

--- a/Modules/ITS/src/ITSFeeTask.cxx
+++ b/Modules/ITS/src/ITSFeeTask.cxx
@@ -123,12 +123,33 @@ void ITSFeeTask::createFeePlots()
 
   mPayloadSize = new TH2F("PayloadSize", "Payload Size", NFees, 0, NFees, mNPayloadSizeBins, 0, 4.096e4);
   getObjectsManager()->startPublishing(mPayloadSize); // mPayloadSize
+
+  mRDHSummary = new TH2I("RDHSummary", "RDH Summary", NFees, 0, NFees, 7, 0, 7);
+  getObjectsManager()->startPublishing(mRDHSummary);
 }
 
 void ITSFeeTask::setAxisTitle(TH1* object, const char* xTitle, const char* yTitle)
 {
   object->GetXaxis()->SetTitle(xTitle);
   object->GetYaxis()->SetTitle(yTitle);
+}
+
+void ITSFeeTask::drawLayerName(TH2I* histo2D)
+{
+  TText* t[NLayer];
+  double minTextPosX[NLayer] = { 0.11, 0.185, 0.285, 0.385, 0.48, 0.615, 0.78 };
+  for (int ilayer = 0; ilayer < NLayer; ilayer++) {
+    t[ilayer] = new TText();
+    t[ilayer]->SetText(minTextPosX[ilayer], 0.9075, Form("Layer %d", ilayer));
+    t[ilayer]->SetTextColor(1);
+    t[ilayer]->SetTextSize(22);
+    t[ilayer]->SetNDC();
+    histo2D->GetListOfFunctions()->Add(t[ilayer]);
+  }
+  for (const int& lay : LayerBoundaryFEE) {
+    auto l = new TLine(lay, 0, lay, histo2D->GetNbinsY());
+    histo2D->GetListOfFunctions()->Add(l);
+  }
 }
 
 void ITSFeeTask::setPlotsFormat()
@@ -163,14 +184,25 @@ void ITSFeeTask::setPlotsFormat()
     setAxisTitle(mProcessingTime, "STF", "Time (us)");
   }
 
+  // Defining RDH summary histogram
+  if (mRDHSummary) {
+    setAxisTitle(mRDHSummary, "FEEId", "");
+    mRDHSummary->SetStats(0);
+    mRDHSummary->GetYaxis()->SetBinLabel(1, "Missing data");
+    mRDHSummary->GetYaxis()->SetBinLabel(2, "Warning");
+    mRDHSummary->GetYaxis()->SetBinLabel(3, "Error");
+    mRDHSummary->GetYaxis()->SetBinLabel(4, "Fault");
+    mRDHSummary->GetYaxis()->SetBinLabel(5, "ClockEvent");
+    mRDHSummary->GetYaxis()->SetBinLabel(6, "TimebaseEvent");
+    mRDHSummary->GetYaxis()->SetBinLabel(7, "TimebaseUnsyncEvent");
+    drawLayerName(mRDHSummary);
+  }
+
   for (int i = 0; i < NFlags; i++) {
     if (mLaneStatus[i]) {
       setAxisTitle(mLaneStatus[i], "FEEID", "Lane");
       mLaneStatus[i]->SetStats(0);
-      for (const int& lay : LayerBoundaryFEE) {
-        auto l = new TLine(lay, 0, lay, NLanesMax);
-        mLaneStatus[i]->GetListOfFunctions()->Add(l);
-      }
+      drawLayerName(mLaneStatus[i]);
     }
   }
 
@@ -179,6 +211,7 @@ void ITSFeeTask::setPlotsFormat()
     title += ";mm;mm";
     mLaneStatusOverview[i]->SetTitle(title);
     mLaneStatusOverview[i]->SetStats(0);
+    mLaneStatusOverview[i]->SetOption("lcolz");
     mLaneStatusOverview[i]->SetMinimum(0);
     mLaneStatusOverview[i]->SetMaximum(1);
     for (int ilayer = 0; ilayer < 7; ilayer++) {
@@ -194,7 +227,7 @@ void ITSFeeTask::setPlotsFormat()
 
   for (int i = 0; i < NLayer; i++) {
     if (mLaneStatusSummary[i]) {
-      setAxisTitle(mLaneStatusSummary[i], "", "#Entries");
+      setAxisTitle(mLaneStatusSummary[i], "", "#Lanes");
       for (int j = 0; j < NFlags; j++) {
         mLaneStatusSummary[i]->GetXaxis()->SetBinLabel(j + 1, mLaneStatusFlag[j].c_str());
       }
@@ -204,7 +237,7 @@ void ITSFeeTask::setPlotsFormat()
   }
 
   if (mLaneStatusSummaryIB) {
-    setAxisTitle(mLaneStatusSummaryIB, "", "#Entries");
+    setAxisTitle(mLaneStatusSummaryIB, "", "#Lanes");
     for (int i = 0; i < NFlags; i++) {
       mLaneStatusSummaryIB->GetXaxis()->SetBinLabel(i + 1, mLaneStatusFlag[i].c_str());
     }
@@ -213,7 +246,7 @@ void ITSFeeTask::setPlotsFormat()
   }
 
   if (mLaneStatusSummaryML) {
-    setAxisTitle(mLaneStatusSummaryML, "", "#Entries");
+    setAxisTitle(mLaneStatusSummaryML, "", "#Lanes");
     for (int i = 0; i < NFlags; i++) {
       mLaneStatusSummaryML->GetXaxis()->SetBinLabel(i + 1, mLaneStatusFlag[i].c_str());
     }
@@ -222,7 +255,7 @@ void ITSFeeTask::setPlotsFormat()
   }
 
   if (mLaneStatusSummaryOL) {
-    setAxisTitle(mLaneStatusSummaryOL, "", "#Entries");
+    setAxisTitle(mLaneStatusSummaryOL, "", "#Lanes");
     for (int i = 0; i < NFlags; i++) {
       mLaneStatusSummaryOL->GetXaxis()->SetBinLabel(i + 1, mLaneStatusFlag[i].c_str());
     }
@@ -231,7 +264,7 @@ void ITSFeeTask::setPlotsFormat()
   }
 
   if (mLaneStatusSummaryGlobal) {
-    setAxisTitle(mLaneStatusSummaryGlobal, "", "#Entries");
+    setAxisTitle(mLaneStatusSummaryGlobal, "", "#Lanes");
     for (int i = 0; i < NFlags; i++) {
       mLaneStatusSummaryGlobal->GetXaxis()->SetBinLabel(i + 1, mLaneStatusFlag[i].c_str());
     }
@@ -292,6 +325,28 @@ void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
     int headersize = (int)(rdh->headerSize);
 
     payloadTot[ifee] += memorysize - headersize;
+    bool clockEvt = false;
+
+    // RDHSummaryPlot
+    //  get detector field
+    uint64_t summaryLaneStatus = rdh->detectorField;
+    // fill statusVsFeeId if set
+    if (summaryLaneStatus & (1 << 0))
+      mRDHSummary->Fill(ifee, 0); // missing data
+    if (summaryLaneStatus & (1 << 1))
+      mRDHSummary->Fill(ifee, 1); // warning
+    if (summaryLaneStatus & (1 << 2))
+      mRDHSummary->Fill(ifee, 2); // error
+    if (summaryLaneStatus & (1 << 3))
+      mRDHSummary->Fill(ifee, 3); // fault
+    if (summaryLaneStatus & (1 << 27)) {
+      mRDHSummary->Fill(ifee, 4); // clock evt
+      clockEvt = true;
+    }
+    if (summaryLaneStatus & (1 << 26))
+      mRDHSummary->Fill(ifee, 5); // Timebase evt
+    if (summaryLaneStatus & (1 << 25))
+      mRDHSummary->Fill(ifee, 6); // Timebase Unsync evt
 
     if ((int)(rdh->stop) && it.size()) { // looking into the DDW0 from the closing packet
       auto const* ddw = reinterpret_cast<const GBTDiagnosticWord*>(it.data());
@@ -327,27 +382,11 @@ void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
         if (laneValue) {
           mStatusFlagNumber[ilayer][istave][i][laneValue - 1]++;
           mLaneStatus[laneValue - 1]->Fill(ifee, i);
-          mLaneStatusSummary[ilayer]->Fill(laneValue - 1);
-          mLaneStatusSummaryGlobal->Fill(laneValue - 1);
-          if (ilayer < 3) {
-            mLaneStatusSummaryIB->Fill(laneValue - 1);
-          } else if (ilayer < 5) {
-            mLaneStatusSummaryML->Fill(laneValue - 1);
-          } else {
-            mLaneStatusSummaryOL->Fill(laneValue - 1);
-          }
+        }
+        if (clockEvt) {
+          mLaneStatus[laneValue - 1]->Fill(ifee, i);
         }
       }
-    }
-
-    for (int iflag = 0; iflag < NFlags; iflag++) {
-      int flagCount = 0;
-      for (int ilane = 0; ilane < NLanesMax; ilane++) {
-        if (mStatusFlagNumber[ilayer][istave][ilane][iflag] > 0) {
-          flagCount++;
-        }
-      }
-      mLaneStatusOverview[iflag]->SetBinContent(istave + 1 + StaveBoundary[ilayer], (float)(flagCount) / (float)(NLanePerStaveLayer[ilayer]));
     }
 
     for (int i = 0; i < 13; i++) {
@@ -360,6 +399,36 @@ void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
     if ((int)(rdh->stop)) {
       nStops[ifee]++;
     }
+  }
+
+  // Filling histograms: loop over mStatusFlagNumber[ilayer][istave][ilane][iflag]
+  int counterSummary[4][3] = { { 0 } };
+  int layerSummary[7][3] = { { 0 } };
+  for (int iflag = 0; iflag < NFlags; iflag++) {
+    for (int ilayer = 0; ilayer < NLayer; ilayer++) {
+      for (int istave = 0; istave < NStaves[ilayer]; istave++) {
+        int flagCount = 0;
+        for (int ilane = 0; ilane < NLanesMax; ilane++) {
+          if (mStatusFlagNumber[ilayer][istave][ilane][iflag] > 0) {
+            flagCount++;
+            counterSummary[0][iflag]++;
+            if (ilayer < 3) {
+              counterSummary[1][iflag]++;
+            } else if (ilayer < 5) {
+              counterSummary[2][iflag]++;
+            } else {
+              counterSummary[3][iflag]++;
+            }
+          }
+        }
+        mLaneStatusOverview[iflag]->SetBinContent(istave + 1 + StaveBoundary[ilayer], (float)(flagCount) / (float)(NLanePerStaveLayer[ilayer]));
+      }
+      mLaneStatusSummary[ilayer]->SetBinContent(iflag + 1, layerSummary[ilayer][iflag]);
+    }
+    mLaneStatusSummaryGlobal->SetBinContent(iflag + 1, counterSummary[0][iflag]);
+    mLaneStatusSummaryIB->SetBinContent(iflag + 1, counterSummary[1][iflag]);
+    mLaneStatusSummaryML->SetBinContent(iflag + 1, counterSummary[2][iflag]);
+    mLaneStatusSummaryOL->SetBinContent(iflag + 1, counterSummary[3][iflag]);
   }
 
   for (int i = 0; i < NFees; i++) {

--- a/Modules/ITS/src/ITSFeeTask.cxx
+++ b/Modules/ITS/src/ITSFeeTask.cxx
@@ -377,14 +377,25 @@ void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
         }
       }
 
+      // std::cout << "Layer:"<< ilayer << "Stave:" << istave << std::endl;
       for (int i = 0; i < NLanesMax; i++) {
         int laneValue = laneInfo >> (2 * i) & 0x3;
         if (laneValue) {
           mStatusFlagNumber[ilayer][istave][i][laneValue - 1]++;
           mLaneStatus[laneValue - 1]->Fill(ifee, i);
         }
+      }
+
+      for (int iflag = 0; iflag < 3; iflag++) {
         if (clockEvt) {
-          mLaneStatus[laneValue - 1]->Fill(ifee, i);
+          int feeInStave = (ifee - feeBoundary[ilayer]) - (feePerStave[ilayer] * (istave));
+          int startingLane = (feeInStave - 1) * lanesPerFeeId[ilayer];
+          for (int indexLaneFee = indexFeeLow[ilayer]; indexLaneFee < indexFeeUp[ilayer]; indexLaneFee++) {
+            mLaneStatus[iflag]->Fill(ifee, indexLaneFee);
+          }
+          for (int indexLane = startingLane; indexLane < (startingLane + lanesPerFeeId[ilayer]); indexLane++) {
+            mStatusFlagNumber[ilayer][istave][indexLane][iflag]++;
+          }
         }
       }
     }


### PR DESCRIPTION
Pending activities:
– Correct lane status summary plots putting #lanes on y axis (now: #Errors)
    → Add then QC checks
– Add labels for layers in lane status plots (lanes vs feeid)
– Correction number of entries in SummaryPlots
    → QC checks added

RDH Summary Plot introduced
