### PR TITLE
MCH: improve mean occupancy and digit time visualization

### DIFF
--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
@@ -97,6 +97,7 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   std::shared_ptr<MergeableTH2Ratio> mHistogramOccupancyST345; // Mergeable object, Occupancy histogram (global XY view)
 
   std::shared_ptr<TH2F> mHistogramDigitsOrbitInTF;
+  std::shared_ptr<TH2F> mHistogramDigitsOrbitInTFDE;
   std::shared_ptr<TH2F> mHistogramDigitsBcInOrbit;
   std::shared_ptr<TH2F> mHistogramAmplitudeVsSamples;
 

--- a/Modules/MUON/MCH/src/GlobalHistogram.cxx
+++ b/Modules/MUON/MCH/src/GlobalHistogram.cxx
@@ -76,19 +76,19 @@ int getDEindex(int deId)
   }
   offset += 5;
 
-  // CH 5 - 17 DE
+  // CH 5 - 18 DE
   DEmin = 500;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 18;
+  offset += 19;
 
-  // CH 6 - 17 DE
+  // CH 6 - 18 DE
   DEmin = 600;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 18;
+  offset += 19;
 
   // CH 7 - 26 DE
   DEmin = 700;

--- a/Modules/MUON/MCH/src/PhysicsCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsCheck.cxx
@@ -214,12 +214,14 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
   if (mo->getName().find("MeanOccupancy") != std::string::npos) {
     auto* h = dynamic_cast<TH1F*>(mo->getObject());
     // disable ticks on vertical axis
+    h->GetXaxis()->SetTickLength(0.0);
+    h->GetXaxis()->SetLabelSize(0.0);
     h->GetYaxis()->SetTickLength(0);
-    h->SetMaximum(h->GetMaximum() * 1.2);
+    h->SetMaximum(h->GetMaximum() * 2);
     // draw chamber delimiters
     for (int demin = 200; demin <= 1000; demin += 100) {
       float xpos = static_cast<float>(getDEindex(demin)) - 0.5;
-      TLine* delimiter = new TLine(xpos, 0, xpos, 1.1 * h->GetMaximum());
+      TLine* delimiter = new TLine(xpos, 0, xpos, h->GetMaximum());
       delimiter->SetLineColor(kBlack);
       delimiter->SetLineStyle(kDashed);
       h->GetListOfFunctions()->Add(delimiter);
@@ -227,21 +229,29 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
       if (demin < 600) {
         float x1 = static_cast<float>(getDEindex(demin - 100));
         float x2 = static_cast<float>(getDEindex(demin));
-        float x0 = (x1 + x2) / 2;
-        TText* msg = new TText(x0, 0.88 * h->GetMaximum(), TString::Format("CH%d", (demin - 1) / 100));
-        msg->SetTextAngle(90);
-        h->GetListOfFunctions()->Add(msg);
+        float x0 = 0.8 * (x1 + x2) / (2 * h->GetXaxis()->GetXmax()) + 0.105;
+        float y0 = 0.82;
+        TText* label = new TText();
+        label->SetNDC();
+        label->SetText(x0, y0, TString::Format("CH%d", (demin - 1) / 100));
+        label->SetTextSize(22);
+        label->SetTextAngle(90);
+        h->GetListOfFunctions()->Add(label);
       } else {
         float x1 = static_cast<float>(getDEindex(demin - 100));
         float x2 = static_cast<float>(getDEindex(demin));
-        float x0 = (x1 + x2) / 2;
-        TText* msg = new TText(x0, 0.95 * h->GetMaximum(), TString::Format("CH%d", (demin - 1) / 100));
-        msg->SetTextAlign(22);
-        h->GetListOfFunctions()->Add(msg);
+        float x0 = 0.8 * (x1 + x2) / (2 * h->GetXaxis()->GetXmax()) + 0.1;
+        float y0 = 0.87;
+        TText* label = new TText();
+        label->SetNDC();
+        label->SetText(x0, y0, TString::Format("CH%d", (demin - 1) / 100));
+        label->SetTextSize(25);
+        label->SetTextAlign(22);
+        h->GetListOfFunctions()->Add(label);
       }
     }
 
-    TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
+    TPaveText* msg = new TPaveText(0.1, 0.903, 0.9, 0.945, "NDC");
     h->GetListOfFunctions()->Add(msg);
     msg->SetName(Form("%s_msg", mo->GetName()));
     msg->SetBorderSize(0);

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -135,6 +135,13 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   // mMeanOccupancyPerDECycle = std::make_shared<MergeableTH1OccupancyPerDECycle>("MeanOccupancyPerCycle", "Mean Occupancy of each DE Per Cycle (MHz)", mHistogramNHitsElec, mHistogramNorbitsElec);
   // getObjectsManager()->startPublishing(mMeanOccupancyPerDECycle.get());
 
+  mHistogramDigitsOrbitInTFDE = std::make_shared<TH2F>("DigitOrbitInTFDE", "Digit orbits vs DE", getDEindexMax(), 0, getDEindexMax(), 768, -384, 384);
+  mHistogramDigitsOrbitInTFDE->SetOption("colz");
+  mAllHistograms.push_back(mHistogramDigitsOrbitInTFDE.get());
+  if (!mSaveToRootFile) {
+    getObjectsManager()->startPublishing(mHistogramDigitsOrbitInTFDE.get());
+  }
+
   mHistogramDigitsOrbitInTF = std::make_shared<TH2F>("Expert/DigitOrbitInTF", "Digit orbits vs DS Id", nElecXbins, 0, nElecXbins, 768, -384, 384);
   mHistogramDigitsOrbitInTF->SetOption("colz");
   mAllHistograms.push_back(mHistogramDigitsOrbitInTF.get());
@@ -309,11 +316,13 @@ void PhysicsTaskDigits::plotDigit(const o2::mch::Digit& digit)
   auto tfTime = digit.getTime();
   if (tfTime == o2::mch::raw::DataDecoder::tfTimeInvalid) {
     mHistogramDigitsOrbitInTF->Fill(xbin - 0.5, -256);
+    mHistogramDigitsOrbitInTFDE->Fill(getDEindex(deId), -256);
     mHistogramDigitsBcInOrbit->Fill(xbin - 0.5, 3559);
   } else {
     auto orbit = digit.getTime() / o2::constants::lhc::LHCMaxBunches;
     auto bc = digit.getTime() % o2::constants::lhc::LHCMaxBunches;
     mHistogramDigitsOrbitInTF->Fill(xbin - 0.5, orbit);
+    mHistogramDigitsOrbitInTFDE->Fill(getDEindex(deId), orbit);
     mHistogramDigitsBcInOrbit->Fill(xbin - 0.5, bc);
   }
 


### PR DESCRIPTION
- added plot with orbit distribution for each DE
- changed placement of the labels in the mean occupancy plot such that it is compatible with both linear and log vertical scales