### PR TITLE
[QC-751] Use UnknownQuality instead of MissingQualityObject

### DIFF
--- a/Framework/src/QualitiesToTRFCollectionConverter.cxx
+++ b/Framework/src/QualitiesToTRFCollectionConverter.cxx
@@ -73,7 +73,7 @@ void QualitiesToTRFCollectionConverter::operator()(const QualityObject& newQO)
 
   // Is the beginning of time range covered by the first QO provided?
   if (mCurrentStartTime < mConverted->getStart() && validFrom > mConverted->getStart()) {
-    mConverted->insert({ mConverted->getStart(), validFrom - 1, FlagReasonFactory::MissingQualityObject(), noQualityObjectsComment, newQO.getPath() });
+    mConverted->insert({ mConverted->getStart(), validFrom - 1, FlagReasonFactory::UnknownQuality(), noQualityObjectsComment, newQO.getPath() });
   }
 
   mCurrentStartTime = std::max(validFrom, mConverted->getStart());
@@ -113,7 +113,7 @@ std::unique_ptr<TimeRangeFlagCollection> QualitiesToTRFCollectionConverter::getR
     mCurrentEndTime = std::max(mCurrentEndTime, trf.getEnd());
   }
   if (mCurrentEndTime < mConverted->getEnd()) {
-    mConverted->insert({ mCurrentEndTime, mConverted->getEnd(), FlagReasonFactory::MissingQualityObject(), noQualityObjectsComment, mQOPath });
+    mConverted->insert({ mCurrentEndTime, mConverted->getEnd(), FlagReasonFactory::UnknownQuality(), noQualityObjectsComment, mQOPath });
   }
 
   auto result = std::make_unique<TimeRangeFlagCollection>(

--- a/Framework/test/testQualitiesToTRFCollectionConverter.cxx
+++ b/Framework/test/testQualitiesToTRFCollectionConverter.cxx
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(test_NoQOs)
   auto& trf = *trfc->begin();
   BOOST_CHECK_EQUAL(trf.getStart(), 5);
   BOOST_CHECK_EQUAL(trf.getEnd(), 100);
-  BOOST_CHECK_EQUAL(trf.getFlag(), FlagReasonFactory::MissingQualityObject());
+  BOOST_CHECK_EQUAL(trf.getFlag(), FlagReasonFactory::UnknownQuality());
   BOOST_CHECK_EQUAL(trf.getSource(), "qc/DET/QO/xyzCheck");
 }
 
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(test_NoBeginning)
   auto& trf1 = *trfc->begin();
   BOOST_CHECK_EQUAL(trf1.getStart(), 5);
   BOOST_CHECK_EQUAL(trf1.getEnd(), 9);
-  BOOST_CHECK_EQUAL(trf1.getFlag(), FlagReasonFactory::MissingQualityObject());
+  BOOST_CHECK_EQUAL(trf1.getFlag(), FlagReasonFactory::UnknownQuality());
   BOOST_CHECK_EQUAL(trf1.getSource(), "qc/DET/QO/xyzCheck");
 
   auto& trf2 = *(++trfc->begin());
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(test_NoEnd)
   auto& trf = *trfc->begin();
   BOOST_CHECK_EQUAL(trf.getStart(), 80);
   BOOST_CHECK_EQUAL(trf.getEnd(), 100);
-  BOOST_CHECK_EQUAL(trf.getFlag(), FlagReasonFactory::MissingQualityObject());
+  BOOST_CHECK_EQUAL(trf.getFlag(), FlagReasonFactory::UnknownQuality());
   BOOST_CHECK_EQUAL(trf.getSource(), "qc/DET/QO/xyzCheck");
 }
 

--- a/Modules/Common/src/WorstOfAllAggregator.cxx
+++ b/Modules/Common/src/WorstOfAllAggregator.cxx
@@ -32,7 +32,7 @@ std::map<std::string, Quality> WorstOfAllAggregator::aggregate(QualityObjectsMap
 {
   if (qoMap.empty()) {
     Quality null = Quality::Null;
-    null.addReason(FlagReasonFactory::MissingQualityObject(),
+    null.addReason(FlagReasonFactory::UnknownQuality(),
                    "QO map given to the aggregator '" + mName + "' is empty.");
     return { { mName, null } };
   }

--- a/Modules/Common/test/testWorstOfAllAggregator.cxx
+++ b/Modules/Common/test/testWorstOfAllAggregator.cxx
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(test_WorstOfAllAggregator)
   BOOST_REQUIRE_EQUAL(result1.size(), 1);
   BOOST_CHECK_EQUAL(result1["agg1"], Quality::Null); // because empty vector passed
   BOOST_REQUIRE_EQUAL(result1["agg1"].getReasons().size(), 1);
-  BOOST_CHECK_EQUAL(result1["agg1"].getReasons().at(0).first, FlagReasonFactory::MissingQualityObject());
+  BOOST_CHECK_EQUAL(result1["agg1"].getReasons().at(0).first, FlagReasonFactory::UnknownQuality());
 
   input[qoGood->getName()] = qoGood;
   std::map<std::string, Quality> result2 = agg1.aggregate(input);


### PR DESCRIPTION
The latter flag will be deleted, as it does not indicate the knowledge of data quality, but a cause.