### PR TITLE
[QC-743] Trending on a range of timestamps

### DIFF
--- a/Framework/include/QualityControl/Activity.h
+++ b/Framework/include/QualityControl/Activity.h
@@ -19,6 +19,8 @@
 
 #include <map>
 #include <string>
+#include <iosfwd>
+#include "QualityControl/ValidityInterval.h"
 
 #include "Rtypes.h"
 
@@ -36,11 +38,14 @@ class Activity
            int type,
            const std::string& periodName = "",
            const std::string& passName = "",
-           const std::string& provenance = "qc") : mId(id),
-                                                   mType(type),
-                                                   mPeriodName(periodName),
-                                                   mPassName(passName),
-                                                   mProvenance(provenance) {}
+           const std::string& provenance = "qc",
+           ValidityInterval validity = gFullValidityInterval)
+    : mId(id),
+      mType(type),
+      mPeriodName(periodName),
+      mPassName(passName),
+      mProvenance(provenance),
+      mValidity(validity) {}
 
   /// Copy constructor
   Activity(const Activity& other) = default;
@@ -50,11 +55,16 @@ class Activity
   Activity& operator=(const Activity& other) = default;
   /// Move assignment operator
   Activity& operator=(Activity&& other) noexcept = default;
-  /// Comparator
+  /// Comparator. All fields should be exactly the same
   bool operator==(const Activity& other) const;
+
+  /// prints Activity
+  friend std::ostream& operator<<(std::ostream& out, const Activity& activity);
 
   /// Checks if the other activity matches this, taking into account that default values match any.
   bool matches(const Activity& other) const;
+  /// Checks if the other object describes the same Activity (but e.g. in different time)
+  bool same(const Activity& other) const;
 
   virtual ~Activity() = default;
 
@@ -63,8 +73,9 @@ class Activity
   std::string mPeriodName{};
   std::string mPassName{};
   std::string mProvenance{ "qc" };
+  ValidityInterval mValidity{ gFullValidityInterval };
 
-  ClassDef(Activity, 1);
+  ClassDef(Activity, 2);
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/CommonSpec.h
+++ b/Framework/include/QualityControl/CommonSpec.h
@@ -32,6 +32,8 @@ struct CommonSpec {
   std::string activityPeriodName;
   std::string activityPassName;
   std::string activityProvenance = "qc";
+  uint64_t activityStart = 0;
+  uint64_t activityEnd = -1;
   std::string monitoringUrl = "infologger:///debug?qc";
   std::string consulUrl;
   std::string conditionDBUrl = "http://ccdb-test.cern.ch:8080";

--- a/Framework/include/QualityControl/LinkDef.h
+++ b/Framework/include/QualityControl/LinkDef.h
@@ -13,5 +13,6 @@
 #pragma link C++ class o2::quality_control::postprocessing::PostProcessingInterface + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTask + ;
 #pragma link C++ class o2::quality_control::core::MonitorObjectCollection + ;
+#pragma link C++ class o2::quality_control::core::ValidityInterval + ;
 
 #endif

--- a/Framework/include/QualityControl/PostProcessingConfig.h
+++ b/Framework/include/QualityControl/PostProcessingConfig.h
@@ -30,7 +30,7 @@ namespace o2::quality_control::postprocessing
 /// \brief  Post-processing configuration structure
 struct PostProcessingConfig {
   PostProcessingConfig() = default;
-  PostProcessingConfig(std::string name, const boost::property_tree::ptree& config);
+  PostProcessingConfig(const std::string& name, const boost::property_tree::ptree& config);
   ~PostProcessingConfig() = default;
   std::string taskName;
   std::string moduleName;

--- a/Framework/include/QualityControl/ValidityInterval.h
+++ b/Framework/include/QualityControl/ValidityInterval.h
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    ValidityInterval.h
+/// \author  Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_VALIDITYINTERVAL_H
+#define QUALITYCONTROL_VALIDITYINTERVAL_H
+
+#include <MathUtils/detail/Bracket.h>
+
+namespace o2::quality_control::core
+{
+
+using validity_time_t = uint64_t; // ms since epoch
+using ValidityInterval = o2::math_utils::detail::Bracket<validity_time_t>;
+const static ValidityInterval gInvalidValidityInterval{
+  std::numeric_limits<validity_time_t>::max(), std::numeric_limits<validity_time_t>::min()
+};
+const static ValidityInterval gFullValidityInterval{
+  std::numeric_limits<validity_time_t>::min(), std::numeric_limits<validity_time_t>::max()
+};
+
+} // namespace o2::quality_control::core
+
+#endif //QUALITYCONTROL_VALIDITYINTERVAL_H

--- a/Framework/src/Activity.cxx
+++ b/Framework/src/Activity.cxx
@@ -15,23 +15,45 @@
 ///
 
 #include "QualityControl/Activity.h"
+#include <iostream>
 
 namespace o2::quality_control::core
 {
+
+std::ostream& operator<<(std::ostream& out, const Activity& activity)
+{
+  out << "id: " << activity.mId
+      << ", type: " << activity.mType
+      << ", period: '" << activity.mPeriodName
+      << "', pass: '" << activity.mPassName
+      << "', provenance: '" << activity.mProvenance
+      << ", start: " << activity.mValidity.getMin()
+      << ", end: " << activity.mValidity.getMax();
+  return out;
+}
 
 bool Activity::matches(const Activity& other) const
 {
   // Note that 'this' can be 'any', but 'other' cannot.
   // E.g. if we require that run number is concrete, it cannot match 'other' which has 'any' run number.
+  // Also, since we do not indicate the correct validity of objects, we require that the other Activity validity start
+  // is included in this validity. If checked for any overlaps, we would match with all past Activities, which is not
+  // what we want e.g. in Post-processing triggers. Once we indicate the correct validity, we can change this behaviour.
   return (mId == 0 || mId == other.mId) &&
          (mType == 0 || mType == other.mType) &&
          (mPeriodName.empty() || mPeriodName == other.mPeriodName) &&
          (mPassName.empty() || mPassName == other.mPassName) &&
-         (mProvenance == other.mProvenance); // provenance has to match!
+         (mProvenance == other.mProvenance) && // provenance has to match!
+         !mValidity.isOutside(other.mValidity.getMin());
+}
+
+bool Activity::same(const Activity& other) const
+{
+  return mId == other.mId && mType == other.mType && mPeriodName == other.mPeriodName && mPassName == other.mPassName && mProvenance == other.mProvenance;
 }
 
 bool Activity::operator==(const Activity& other) const
 {
-  return mId == other.mId && mType == other.mType && mPeriodName == other.mPeriodName && mPassName == other.mPassName && mProvenance == other.mProvenance;
+  return mId == other.mId && mType == other.mType && mPeriodName == other.mPeriodName && mPassName == other.mPassName && mProvenance == other.mProvenance && mValidity == other.mValidity;
 }
 } // namespace o2::quality_control::core

--- a/Framework/src/DatabaseHelpers.cxx
+++ b/Framework/src/DatabaseHelpers.cxx
@@ -55,6 +55,12 @@ core::Activity asActivity(const std::map<std::string, std::string>& metadata, co
   if (auto periodName = metadata.find("PeriodName"); periodName != metadata.end()) {
     activity.mPeriodName = periodName->second;
   }
+  if (auto validFrom = metadata.find("Valid-From"); validFrom != metadata.end()) {
+    activity.mValidity.setMin(std::stoull(validFrom->second));
+  }
+  if (auto validUntil = metadata.find("Valid-Until"); validUntil != metadata.end()) {
+    activity.mValidity.setMax(std::stoull(validUntil->second));
+  }
   activity.mProvenance = provenance;
   return activity;
 }
@@ -73,6 +79,12 @@ core::Activity asActivity(const boost::property_tree::ptree& tree, const std::st
   }
   if (auto periodName = tree.get_optional<std::string>("PeriodName"); periodName.has_value()) {
     activity.mPeriodName = periodName.value();
+  }
+  if (auto validFrom = tree.get_optional<core::validity_time_t>("Valid-From"); validFrom.has_value()) {
+    activity.mValidity.setMin(validFrom.value());
+  }
+  if (auto validUntil = tree.get_optional<core::validity_time_t>("Valid-Until"); validUntil.has_value()) {
+    activity.mValidity.setMax(validUntil.value());
   }
   activity.mProvenance = provenance;
   return activity;

--- a/Framework/src/InfrastructureSpecReader.cxx
+++ b/Framework/src/InfrastructureSpecReader.cxx
@@ -63,6 +63,8 @@ CommonSpec InfrastructureSpecReader::readSpecEntry<CommonSpec>(std::string, cons
   spec.activityPassName = commonTree.get<std::string>("Activity.passName", spec.activityPassName);
   spec.activityPeriodName = commonTree.get<std::string>("Activity.periodName", spec.activityPeriodName);
   spec.activityProvenance = commonTree.get<std::string>("Activity.provenance", spec.activityProvenance);
+  spec.activityStart = commonTree.get<uint64_t>("Activity.start", spec.activityStart);
+  spec.activityEnd = commonTree.get<uint64_t>("Activity.end", spec.activityEnd);
   spec.monitoringUrl = commonTree.get<std::string>("monitoring.url", spec.monitoringUrl);
   spec.consulUrl = commonTree.get<std::string>("consul.url", spec.consulUrl);
   spec.conditionDBUrl = commonTree.get<std::string>("conditionDB.url", spec.conditionDBUrl);

--- a/Framework/src/PostProcessingConfig.cxx
+++ b/Framework/src/PostProcessingConfig.cxx
@@ -20,7 +20,7 @@
 namespace o2::quality_control::postprocessing
 {
 
-PostProcessingConfig::PostProcessingConfig(std::string name, const boost::property_tree::ptree& config) //
+PostProcessingConfig::PostProcessingConfig(const std::string& name, const boost::property_tree::ptree& config) //
   : taskName(name),
     moduleName(config.get<std::string>("qc.postprocessing." + name + ".moduleName")),
     className(config.get<std::string>("qc.postprocessing." + name + ".className")),
@@ -32,7 +32,9 @@ PostProcessingConfig::PostProcessingConfig(std::string name, const boost::proper
              config.get<int>("qc.config.Activity.type", 0),
              config.get<std::string>("qc.config.Activity.periodName", ""),
              config.get<std::string>("qc.config.Activity.passName", ""),
-             config.get<std::string>("qc.config.Activity.provenance", "qc"))
+             config.get<std::string>("qc.config.Activity.provenance", "qc"),
+             { config.get<uint64_t>("qc.config.Activity.start", 0),
+               config.get<uint64_t>("qc.config.Activity.end", -1) })
 {
   for (const auto& initTrigger : config.get_child("qc.postprocessing." + name + ".initTrigger")) {
     initTriggers.push_back(initTrigger.second.get_value<std::string>());

--- a/Framework/src/Triggers.cxx
+++ b/Framework/src/Triggers.cxx
@@ -196,7 +196,7 @@ TriggerFcn ForEachObject(std::string databaseUrl, std::string databaseType, std:
   auto filteredObjects = std::make_shared<std::vector<boost::property_tree::ptree>>();
   const auto& filter = activity;
 
-  ILOG(Debug, Devel) << "Filter activity: " << activity.mId << ", " << activity.mType << ", " << activity.mPassName << ", " << activity.mPeriodName << ", " << activity.mProvenance << ENDM;
+  ILOG(Debug, Devel) << "Filter activity: " << activity << ENDM;
 
   // As for today, we receive objects in the order of the newest to the oldest.
   // We prefer the other order here.
@@ -204,7 +204,7 @@ TriggerFcn ForEachObject(std::string databaseUrl, std::string databaseType, std:
     auto objectActivity = repository::database_helpers::asActivity(rit->second);
     if (filter.matches(objectActivity)) {
       filteredObjects->emplace_back(rit->second);
-      ILOG(Debug, Devel) << "Matched an object with activity: " << objectActivity.mId << ", " << objectActivity.mType << ", " << objectActivity.mPassName << ", " << objectActivity.mPeriodName << ", " << objectActivity.mProvenance << ENDM;
+      ILOG(Debug, Devel) << "Matched an object with activity: " << activity << ENDM;
     }
   }
   ILOG(Info, Support) << filteredObjects->size() << " objects matched the specified activity" << ENDM;
@@ -244,7 +244,7 @@ TriggerFcn ForEachLatest(std::string databaseUrl, std::string databaseType, std:
   auto filteredObjects = std::make_shared<std::vector<std::pair<Activity, boost::property_tree::ptree>>>();
   const auto& filter = activity;
 
-  ILOG(Debug, Devel) << "Filter activity: " << activity.mId << ", " << activity.mType << ", " << activity.mPassName << ", " << activity.mPeriodName << ", " << activity.mProvenance << ENDM;
+  ILOG(Debug, Devel) << "Filter activity: " << activity << ENDM;
 
   // As for today, we receive objects in the order of the newest to the oldest.
   // We prefer the other order here.
@@ -252,14 +252,14 @@ TriggerFcn ForEachLatest(std::string databaseUrl, std::string databaseType, std:
     auto objectActivity = repository::database_helpers::asActivity(rit->second);
     if (filter.matches(objectActivity)) {
       auto latestObject = std::find_if(filteredObjects->begin(), filteredObjects->end(), [&](const std::pair<Activity, boost::property_tree::ptree>& entry) {
-        return entry.first == objectActivity;
+        return entry.first.same(objectActivity);
       });
       if (latestObject != filteredObjects->end() && latestObject->second.get<int64_t>(timestampKey) < rit->second.get<int64_t>(timestampKey)) {
         *latestObject = { objectActivity, rit->second };
-        ILOG(Debug, Devel) << "Updated the object with activity: " << objectActivity.mId << ", " << objectActivity.mType << ", " << objectActivity.mPassName << ", " << objectActivity.mPeriodName << ", " << objectActivity.mProvenance << ENDM;
+        ILOG(Debug, Devel) << "Updated the object with activity: " << objectActivity << ENDM;
       } else {
         filteredObjects->emplace_back(objectActivity, rit->second);
-        ILOG(Debug, Devel) << "Matched an object with activity: " << objectActivity.mId << ", " << objectActivity.mType << ", " << objectActivity.mPassName << ", " << objectActivity.mPeriodName << ", " << objectActivity.mProvenance << ENDM;
+        ILOG(Debug, Devel) << "Matched an object with activity: " << objectActivity << ENDM;
       }
     }
   }

--- a/Framework/test/testTriggers.cxx
+++ b/Framework/test/testTriggers.cxx
@@ -155,9 +155,9 @@ BOOST_AUTO_TEST_CASE(test_trigger_for_each_object)
   mo->setActivity({ 100, 2, "FCC42x", "tpass1", "qc" });
   repository->storeMO(mo, currentTimestamp);
   mo->setActivity({ 101, 2, "FCC42x", "tpass1", "qc" });
-  repository->storeMO(mo, currentTimestamp);
+  repository->storeMO(mo, currentTimestamp + 1000);
   mo->setActivity({ 100, 2, "FCC42x", "tpass2", "qc" });
-  repository->storeMO(mo, currentTimestamp);
+  repository->storeMO(mo, currentTimestamp + 2000);
 
   {
     const Activity activityAllRunsPass1{ 0, 2, "FCC42x", "tpass1", "qc" };
@@ -187,6 +187,13 @@ BOOST_AUTO_TEST_CASE(test_trigger_for_each_object)
     BOOST_CHECK_EQUAL(forEachObjectTrigger(), TriggerType::No);
   }
 
+  {
+    const Activity activityTimeRestriction{ 0, 0, "", "", "qc", { static_cast<validity_time_t>(currentTimestamp), static_cast<validity_time_t>(currentTimestamp + 5) } };
+    auto forEachObjectTrigger = triggers::ForEachObject(CCDB_ENDPOINT, "qcdb", objectPath, activityTimeRestriction);
+
+    BOOST_CHECK_EQUAL(forEachObjectTrigger(), TriggerType::ForEachObject);
+    BOOST_CHECK_EQUAL(forEachObjectTrigger(), TriggerType::No);
+  }
   // Clean up remaining objects
   directDBAPI->truncate(fullObjectPath);
 }

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -801,7 +801,9 @@ should not be present in real configuration files.
         "type": "2",                      "": "Arbitrary activity type.",
         "periodName": "",                 "": "Period name - e.g. LHC22c, LHC22c1b_test",
         "passName": "",                   "": "Pass type - e.g. spass, cpass1",
-        "provenance": "qc",               "": "Provenance - qc or qc_mc depending whether it is normal data or monte carlo data"
+        "provenance": "qc",               "": "Provenance - qc or qc_mc depending whether it is normal data or monte carlo data",
+        "start" : "0",                    "": "Activity start time in ms since epoch. One can use it as a filter in post-processing",
+        "end" : "1234",                   "": "Activity end time in ms since epoch. One can use it as a filter in post-processing"
       },
       "monitoring": {                     "": "Configuration of the Monitoring library.",
         "url": "infologger:///debug?qc",  "": ["URI to the Monitoring backend. Refer to the link below for more info:",

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -50,7 +50,7 @@ Interfaces to databases and other services are accesible via `ServiceRegistry`, 
 Triggers are complemented with:
 - timestamps which correspond the time when trigger started to be valid, in form of ms since epoch, just like in CCDB and QCDB,
 - `last` flag, being `true` if it is the last time trigger will fire,
-- `Activity` object, which contains metadata such as run type and number, pass name, periond name, data provenance.
+- `Activity` object, which contains metadata such as run type and number, pass name, period name, data provenance.
 
 For example, the periodic trigger will provide evenly spaced timestamps, even if the trigger is checked more rarely.
 The New Object trigger provide the timestamp of the updated object. The timestamps and Activites should be used to
@@ -352,7 +352,7 @@ Use either Periodic or NewObject as the update trigger:
         "updateTrigger": [ "5 seconds" ],
 ```
 ```json
-        "updateTrigger": [ "newobject:qcdb:qc/TST/MO/QcTask/example" ],
+        "updateTrigger": [ "newobject:qcdb:TST/MO/QcTask/example" ],
 ```
 
 Be sure to match the run number and other Activity metadata to isolate the QC run you need.
@@ -371,7 +371,7 @@ Leaving values empty will match anything available (which might be also what you
 
 Use ForEachObject as the update trigger:
 ```json
-        "updateTrigger": [ "foreachobject:qcdb:qc/TST/MO/QcTask/example" ],
+        "updateTrigger": [ "foreachobject:qcdb:TST/MO/QcTask/example" ],
 ```
 Since objects are usually published in collections at the same time, you can use a path for one object to be triggered 
  for a collection of them (all objects produced by a QC Task).
@@ -391,7 +391,7 @@ Use the Activity which matches the run, and (optionally) period and pass name:
 
 Use ForEachObject as the update trigger:
 ```json
-        "updateTrigger": [ "foreachobject:qcdb:qc/TST/MO/QcTask/example" ],
+        "updateTrigger": [ "foreachobject:qcdb:TST/MO/QcTask/example" ],
 ```
 Use the Activity which leaves the run number empty, but indicate the pass and period names.
 ```json
@@ -404,11 +404,31 @@ Use the Activity which leaves the run number empty, but indicate the pass and pe
       },
 ```
 
+### I want to run postprocessing for all objects in all the runs of a given reconstruction pass and period which are valid in given time interval
+
+Use ForEachObject as the update trigger:
+```json
+        "updateTrigger": [ "foreachobject:qcdb:TST/MO/QcTask/example" ],
+```
+Use the Activity which leaves the run number empty, but indicate the pass and period names.
+Add `start` and `end` values in ms since epoch to restrict the validity start of objects.
+```json
+      "Activity": {
+        "number": "",
+        "type": "",
+        "passName": "apass2",
+        "periodName" : "OCT",
+        "provenance" : "qc",
+        "start" : "1649417693630",
+        "end" : "1649417800000"
+      },
+```
+
 ### I want to run postprocessing for the latest object for each available run in a given pass and period
 
 Use ForEachObject as the update trigger:
 ```json
-        "updateTrigger": [ "foreachlatest:qcdb:qc/TST/MO/QcTask/example" ],
+        "updateTrigger": [ "foreachlatest:qcdb:TST/MO/QcTask/example" ],
 ```
 This way you will avoid iterating on potential duplicates and intermediate objects, and get only the final versions instead.
 


### PR DESCRIPTION
This allows to restrain the timestamp range in postprocessing to certain start and end values.
Also, once GUI is ready, we can use the same fields to store time validity of Monitor Objects and translate it to "Valid-From" and "Valid-Until" values in QCDB.