### PR TITLE
MCH: handle missing ORBITS DPL message

### DIFF
--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
@@ -66,6 +66,7 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
 
  private:
   void storeOrbit(const uint64_t& orb);
+  void addDefaultOrbitsInTF();
   void plotDigit(const o2::mch::Digit& digit);
   void updateOrbits();
   void writeHistos();

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -34,6 +34,7 @@
 #include "QualityControl/QcInfoLogger.h"
 #include <Framework/InputRecord.h>
 #include <CommonConstants/LHCConstants.h>
+#include <DetectorsRaw/HBFUtils.h>
 
 using namespace std;
 using namespace o2::mch::raw;
@@ -186,18 +187,30 @@ void PhysicsTaskDigits::startOfCycle()
 
 void PhysicsTaskDigits::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  // get the input preclusters and associated digits with the orbit information
+  bool hasOrbits = false;
+  for (auto&& input : ctx.inputs()) {
+    if (input.spec->binding == "orbits") {
+      hasOrbits = true;
+    }
+  }
+
+  if (hasOrbits) {
+    auto orbits = ctx.inputs().get<gsl::span<uint64_t>>("orbits");
+    if (orbits.empty()) {
+      static AliceO2::InfoLogger::InfoLogger::AutoMuteToken msgLimit(LogWarningSupport, 1, 600); // send it once every 10 minutes
+      string msg = "WARNING: empty orbits vector";
+      ILOG_INST.log(msgLimit, "%s", msg.c_str());
+      return;
+    }
+
+    for (auto& orb : orbits) {
+      storeOrbit(orb);
+    }
+  } else {
+    addDefaultOrbitsInTF();
+  }
+
   auto digits = ctx.inputs().get<gsl::span<o2::mch::Digit>>("digits");
-  auto orbits = ctx.inputs().get<gsl::span<uint64_t>>("orbits");
-  if (orbits.empty()) {
-    ILOG(Info, Support) << "WARNING: empty orbits vector" << AliceO2::InfoLogger::InfoLogger::endm;
-    return;
-  }
-
-  for (auto& orb : orbits) {
-    storeOrbit(orb);
-  }
-
   for (auto& d : digits) {
     plotDigit(d);
   }
@@ -219,6 +232,15 @@ void PhysicsTaskDigits::storeOrbit(const uint64_t& orb)
         mNOrbits[fee][li] += 1;
       }
       mLastOrbitSeen[fee][li] = orbit;
+    }
+  }
+}
+
+void PhysicsTaskDigits::addDefaultOrbitsInTF()
+{
+  for (int fee = 0; fee < PhysicsTaskDigits::sMaxFeeId; fee++) {
+    for (int li = 0; li < PhysicsTaskDigits::sMaxLinkId; li++) {
+      mNOrbits[fee][li] += o2::raw::HBFUtils::Instance().getNOrbitsPerTF();
     }
   }
 }


### PR DESCRIPTION
The commit adds a check for the availability of the DPL message with the list of orbits from each CRU link.
If the message is missing, the orbits counters are increased by the default number of orbits in the time-frame as given by `HBFUtils::getNOrbitsPerTF()`.