### PR TITLE
[QC-751] Do not use the ProcessingError flag

### DIFF
--- a/Framework/test/testQualitiesToTRFCollectionConverter.cxx
+++ b/Framework/test/testQualitiesToTRFCollectionConverter.cxx
@@ -240,10 +240,10 @@ BOOST_AUTO_TEST_CASE(test_KnownReasons)
     { Quality::Bad, "xyzCheck", "DET", {}, {}, {}, { { "Valid-From", "30" }, { "Valid-Until", "80" } } },
     { Quality::Bad, "xyzCheck", "DET", {}, {}, {}, { { "Valid-From", "50" }, { "Valid-Until", "100" } } }
   };
-  qos[1].addReason(FlagReasonFactory::ProcessingError(), "Bug in reco");
-  qos[2].addReason(FlagReasonFactory::ProcessingError(), "Bug in reco");
+  qos[1].addReason(FlagReasonFactory::BadTracking(), "Bug in reco");
+  qos[2].addReason(FlagReasonFactory::BadTracking(), "Bug in reco");
   qos[2].addReason(FlagReasonFactory::LimitedAcceptance(), "Sector C was off");
-  qos[3].addReason(FlagReasonFactory::ProcessingError(), "Bug in reco");
+  qos[3].addReason(FlagReasonFactory::BadTracking(), "Bug in reco");
 
   std::unique_ptr<TimeRangeFlagCollection> trfc{ new TimeRangeFlagCollection("test1", "DET", { 5, 100 }) };
   QualitiesToTRFCollectionConverter converter(std::move(trfc), "qc/DET/QO/xyzCheck");
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(test_KnownReasons)
   auto& trf1 = *trfc->begin();
   BOOST_CHECK_EQUAL(trf1.getStart(), 10);
   BOOST_CHECK_EQUAL(trf1.getEnd(), 100);
-  BOOST_CHECK_EQUAL(trf1.getFlag(), FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(trf1.getFlag(), FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(trf1.getComment(), "Bug in reco");
   BOOST_CHECK_EQUAL(trf1.getSource(), "qc/DET/QO/xyzCheck");
 
@@ -277,9 +277,9 @@ BOOST_AUTO_TEST_CASE(test_TheSameReasonsButSeparated)
     { Quality::Bad, "xyzCheck", "DET", {}, {}, {}, { { "Valid-From", "30" }, { "Valid-Until", "50" } } },
     { Quality::Bad, "xyzCheck", "DET", {}, {}, {}, { { "Valid-From", "80" }, { "Valid-Until", "100" } } }
   };
-  qos[0].addReason(FlagReasonFactory::ProcessingError(), "Bug in reco");
-  qos[2].addReason(FlagReasonFactory::ProcessingError(), "Bug in reco");
-  qos[3].addReason(FlagReasonFactory::ProcessingError(), "Bug in reco");
+  qos[0].addReason(FlagReasonFactory::BadTracking(), "Bug in reco");
+  qos[2].addReason(FlagReasonFactory::BadTracking(), "Bug in reco");
+  qos[3].addReason(FlagReasonFactory::BadTracking(), "Bug in reco");
 
   std::unique_ptr<TimeRangeFlagCollection> trfc{ new TimeRangeFlagCollection("test1", "DET", { 5, 100 }) };
   QualitiesToTRFCollectionConverter converter(std::move(trfc), "qc/DET/QO/xyzCheck");
@@ -295,21 +295,21 @@ BOOST_AUTO_TEST_CASE(test_TheSameReasonsButSeparated)
   auto& trf1 = *it;
   BOOST_CHECK_EQUAL(trf1.getStart(), 5);
   BOOST_CHECK_EQUAL(trf1.getEnd(), 10);
-  BOOST_CHECK_EQUAL(trf1.getFlag(), FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(trf1.getFlag(), FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(trf1.getComment(), "Bug in reco");
   BOOST_CHECK_EQUAL(trf1.getSource(), "qc/DET/QO/xyzCheck");
 
   auto& trf2 = *(++it);
   BOOST_CHECK_EQUAL(trf2.getStart(), 30);
   BOOST_CHECK_EQUAL(trf2.getEnd(), 50);
-  BOOST_CHECK_EQUAL(trf2.getFlag(), FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(trf2.getFlag(), FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(trf2.getComment(), "Bug in reco");
   BOOST_CHECK_EQUAL(trf2.getSource(), "qc/DET/QO/xyzCheck");
 
   auto& trf3 = *(++it);
   BOOST_CHECK_EQUAL(trf3.getStart(), 80);
   BOOST_CHECK_EQUAL(trf3.getEnd(), 100);
-  BOOST_CHECK_EQUAL(trf3.getFlag(), FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(trf3.getFlag(), FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(trf3.getComment(), "Bug in reco");
   BOOST_CHECK_EQUAL(trf3.getSource(), "qc/DET/QO/xyzCheck");
 }

--- a/Framework/test/testQuality.cxx
+++ b/Framework/test/testQuality.cxx
@@ -59,23 +59,23 @@ BOOST_AUTO_TEST_CASE(quality_test)
 BOOST_AUTO_TEST_CASE(quality_reasons)
 {
   Quality myQuality = Quality::Bad;
-  myQuality.addReason(FlagReasonFactory::ProcessingError(), "exception in x");
-  myQuality.addReason(FlagReasonFactory::ProcessingError(), "exception in y");
+  myQuality.addReason(FlagReasonFactory::BadTracking(), "exception in x");
+  myQuality.addReason(FlagReasonFactory::BadTracking(), "exception in y");
   myQuality.addReason(FlagReasonFactory::LimitedAcceptance(), "sector C off");
 
   auto myReasons = myQuality.getReasons();
-  BOOST_CHECK_EQUAL(myReasons[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(myReasons[0].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(myReasons[0].second, "exception in x");
-  BOOST_CHECK_EQUAL(myReasons[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(myReasons[1].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(myReasons[1].second, "exception in y");
   BOOST_CHECK_EQUAL(myReasons[2].first, FlagReasonFactory::LimitedAcceptance());
   BOOST_CHECK_EQUAL(myReasons[2].second, "sector C off");
 
   auto copyQuality = myQuality;
   auto copyReasons = copyQuality.getReasons();
-  BOOST_CHECK_EQUAL(copyReasons[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(copyReasons[0].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(copyReasons[0].second, "exception in x");
-  BOOST_CHECK_EQUAL(copyReasons[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(copyReasons[1].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(copyReasons[1].second, "exception in y");
   BOOST_CHECK_EQUAL(copyReasons[2].first, FlagReasonFactory::LimitedAcceptance());
   BOOST_CHECK_EQUAL(copyReasons[2].second, "sector C off");

--- a/Framework/test/testQualityObject.cxx
+++ b/Framework/test/testQualityObject.cxx
@@ -117,32 +117,32 @@ BOOST_AUTO_TEST_CASE(qopath)
 BOOST_AUTO_TEST_CASE(qo_reasons)
 {
   QualityObject qo1(Quality::Bad, "xyzCheck", "DET");
-  qo1.addReason(FlagReasonFactory::ProcessingError(), "exception in x");
-  qo1.addReason(FlagReasonFactory::ProcessingError(), "exception in y");
+  qo1.addReason(FlagReasonFactory::BadTracking(), "exception in x");
+  qo1.addReason(FlagReasonFactory::BadTracking(), "exception in y");
   qo1.addReason(FlagReasonFactory::LimitedAcceptance(), "sector C off");
 
   auto reasons1 = qo1.getReasons();
-  BOOST_CHECK_EQUAL(reasons1[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons1[0].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(reasons1[0].second, "exception in x");
-  BOOST_CHECK_EQUAL(reasons1[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons1[1].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(reasons1[1].second, "exception in y");
   BOOST_CHECK_EQUAL(reasons1[2].first, FlagReasonFactory::LimitedAcceptance());
   BOOST_CHECK_EQUAL(reasons1[2].second, "sector C off");
 
   auto qo2 = qo1;
   auto reasons2 = qo2.getReasons();
-  BOOST_CHECK_EQUAL(reasons2[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons2[0].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(reasons2[0].second, "exception in x");
-  BOOST_CHECK_EQUAL(reasons2[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons2[1].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(reasons2[1].second, "exception in y");
   BOOST_CHECK_EQUAL(reasons2[2].first, FlagReasonFactory::LimitedAcceptance());
   BOOST_CHECK_EQUAL(reasons2[2].second, "sector C off");
 
   auto quality = qo1.getQuality();
   auto reasons3 = quality.getReasons();
-  BOOST_CHECK_EQUAL(reasons3[0].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons3[0].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(reasons3[0].second, "exception in x");
-  BOOST_CHECK_EQUAL(reasons3[1].first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(reasons3[1].first, FlagReasonFactory::BadTracking());
   BOOST_CHECK_EQUAL(reasons3[1].second, "exception in y");
   BOOST_CHECK_EQUAL(reasons3[2].first, FlagReasonFactory::LimitedAcceptance());
   BOOST_CHECK_EQUAL(reasons3[2].second, "sector C off");

--- a/Modules/Common/test/testWorstOfAllAggregator.cxx
+++ b/Modules/Common/test/testWorstOfAllAggregator.cxx
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(test_WorstOfAllAggregator)
 
   // prepare data
   std::shared_ptr<QualityObject> qoNull = std::make_shared<QualityObject>(Quality::Null, "testCheckNull", "TST");
-  qoNull->addReason(FlagReasonFactory::ProcessingError(), "oh no");
+  qoNull->addReason(FlagReasonFactory::BadTracking(), "oh no");
   std::shared_ptr<QualityObject> qoGood = std::make_shared<QualityObject>(Quality::Good, "testCheckGood", "TST");
   std::shared_ptr<QualityObject> qoMedium = std::make_shared<QualityObject>(Quality::Medium, "testCheckMedium", "TST");
   qoMedium->addReason(FlagReasonFactory::LimitedAcceptance(), "booo");
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(test_WorstOfAllAggregator)
   BOOST_CHECK_EQUAL(result5["agg1"], Quality::Null);
   BOOST_REQUIRE_EQUAL(result5["agg1"].getReasons().size(), 2);
   BOOST_CHECK_EQUAL(result5["agg1"].getReasons().at(0).first, FlagReasonFactory::LimitedAcceptance());
-  BOOST_CHECK_EQUAL(result5["agg1"].getReasons().at(1).first, FlagReasonFactory::ProcessingError());
+  BOOST_CHECK_EQUAL(result5["agg1"].getReasons().at(1).first, FlagReasonFactory::BadTracking());
 }
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Skeleton/src/SkeletonCheck.cxx
+++ b/Modules/Skeleton/src/SkeletonCheck.cxx
@@ -53,7 +53,7 @@ Quality SkeletonCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
           result = Quality::Medium;
           result.addReason(FlagReasonFactory::Unknown(),
                            "It is medium because bin " + std::to_string(i) + " is not empty");
-          result.addReason(FlagReasonFactory::ProcessingError(),
+          result.addReason(FlagReasonFactory::BadTracking(),
                            "This is to demonstrate that we can assign more than one Reason to a Quality");
         }
       }

--- a/Modules/TRD/src/PulseHeightCheck.cxx
+++ b/Modules/TRD/src/PulseHeightCheck.cxx
@@ -60,7 +60,7 @@ Quality PulseHeightCheck::check(std::map<std::string, std::shared_ptr<MonitorObj
           result = Quality::Medium;
           result.addReason(FlagReasonFactory::Unknown(),
                            "Peak rather low " + std::to_string(i) + " is not empty");
-          result.addReason(FlagReasonFactory::ProcessingError(),
+          result.addReason(FlagReasonFactory::BadTracking(),
                            "This is to demonstrate that we can assign more than one Reason to a Quality");
         }
       }

--- a/Modules/TRD/src/TrackletsCheck.cxx
+++ b/Modules/TRD/src/TrackletsCheck.cxx
@@ -53,7 +53,7 @@ Quality TrackletsCheck::check(std::map<std::string, std::shared_ptr<MonitorObjec
           result = Quality::Medium;
           result.addReason(FlagReasonFactory::Unknown(),
                            "It is medium because bin " + std::to_string(i) + " is not empty");
-          result.addReason(FlagReasonFactory::ProcessingError(),
+          result.addReason(FlagReasonFactory::BadTracking(),
                            "This is to demonstrate that we can assign more than one Reason to a Quality");
         }
       }

--- a/Modules/ZDC/src/ZDCRawDataCheck.cxx
+++ b/Modules/ZDC/src/ZDCRawDataCheck.cxx
@@ -53,7 +53,7 @@ Quality ZDCRawDataCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
           result = Quality::Medium;
           result.addReason(FlagReasonFactory::Unknown(),
                            "It is medium because bin " + std::to_string(i) + " is not empty");
-          result.addReason(FlagReasonFactory::ProcessingError(),
+          result.addReason(FlagReasonFactory::BadTracking(),
                            "This is to demonstrate that we can assign more than one Reason to a Quality");
         }
       }


### PR DESCRIPTION
It indicates a cause, not effect on data, thus shall be removed.