### PR TITLE
MCH: add bad digits time errors

### DIFF
--- a/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
@@ -95,7 +95,9 @@ std::string DecodingErrorsCheck::getAcceptedType() { return "TH1"; }
 
 static void updateTitle(TH1* hist, std::string suffix)
 {
-  if (!hist) return;
+  if (!hist) {
+    return;
+  }
   TString title = hist->GetTitle();
   title.Append(" ");
   title.Append(suffix.c_str());
@@ -104,11 +106,11 @@ static void updateTitle(TH1* hist, std::string suffix)
 
 static std::string getCurrentTime()
 {
-  time_t t ;
-  time( &t );
+  time_t t;
+  time(&t);
 
-  struct tm *tmp ;
-  tmp = localtime( &t );
+  struct tm* tmp;
+  tmp = localtime(&t);
 
   char timestr[500];
   strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);

--- a/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
@@ -93,8 +93,35 @@ Quality DecodingErrorsCheck::check(std::map<std::string, std::shared_ptr<Monitor
 
 std::string DecodingErrorsCheck::getAcceptedType() { return "TH1"; }
 
+static void updateTitle(TH1* hist, std::string suffix)
+{
+  if (!hist) return;
+  TString title = hist->GetTitle();
+  title.Append(" ");
+  title.Append(suffix.c_str());
+  hist->SetTitle(title);
+}
+
+static std::string getCurrentTime()
+{
+  time_t t ;
+  time( &t );
+
+  struct tm *tmp ;
+  tmp = localtime( &t );
+
+  char timestr[500];
+  strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);
+
+  std::string result = timestr;
+  return result;
+}
+
 void DecodingErrorsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
+  auto currentTime = getCurrentTime();
+  updateTitle(dynamic_cast<TH1*>(mo->getObject()), currentTime);
+
   if (mo->getName().find("DecodingErrorsPerFeeId") != std::string::npos ||
       mo->getName().find("DecodingErrorsPerChamber") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());

--- a/Modules/MUON/MCH/src/GlobalHistogram.cxx
+++ b/Modules/MUON/MCH/src/GlobalHistogram.cxx
@@ -53,63 +53,63 @@ int getDEindex(int deId)
   if (deId < (DEmin + 100)) {
     return (deId - DEmin);
   }
-  offset += 5;
+  offset += 4;
 
   // CH 2 - 4 DE
   DEmin = 200;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 5;
+  offset += 4;
 
   // CH 3 - 4 DE
   DEmin = 300;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 5;
+  offset += 4;
 
   // CH 4 - 4 DE
   DEmin = 400;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 5;
+  offset += 4;
 
   // CH 5 - 18 DE
   DEmin = 500;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 19;
+  offset += 18;
 
   // CH 6 - 18 DE
   DEmin = 600;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 19;
+  offset += 18;
 
   // CH 7 - 26 DE
   DEmin = 700;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 27;
+  offset += 26;
 
   // CH 8 - 26 DE
   DEmin = 800;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 27;
+  offset += 26;
 
   // CH 9 - 26 DE
   DEmin = 900;
   if (deId < (DEmin + 100)) {
     return (deId - DEmin + offset);
   }
-  offset += 27;
+  offset += 26;
 
   // CH 10 - 26 DE
   DEmin = 1000;

--- a/Modules/MUON/MCH/src/PedestalsCheck.cxx
+++ b/Modules/MUON/MCH/src/PedestalsCheck.cxx
@@ -177,8 +177,35 @@ Quality PedestalsCheck::check(std::map<std::string, std::shared_ptr<MonitorObjec
 
 std::string PedestalsCheck::getAcceptedType() { return "TH1"; }
 
+static void updateTitle(TH1* hist, std::string suffix)
+{
+  if (!hist) return;
+  TString title = hist->GetTitle();
+  title.Append(" ");
+  title.Append(suffix.c_str());
+  hist->SetTitle(title);
+}
+
+static std::string getCurrentTime()
+{
+  time_t t ;
+  time( &t );
+
+  struct tm *tmp ;
+  tmp = localtime( &t );
+
+  char timestr[500];
+  strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);
+
+  std::string result = timestr;
+  return result;
+}
+
 void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
+  auto currentTime = getCurrentTime();
+  updateTitle(dynamic_cast<TH1*>(mo->getObject()), currentTime);
+
   if (mo->getName().find("Pedestals_Elec") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
     h->SetOption("colz");

--- a/Modules/MUON/MCH/src/PedestalsCheck.cxx
+++ b/Modules/MUON/MCH/src/PedestalsCheck.cxx
@@ -179,7 +179,9 @@ std::string PedestalsCheck::getAcceptedType() { return "TH1"; }
 
 static void updateTitle(TH1* hist, std::string suffix)
 {
-  if (!hist) return;
+  if (!hist) {
+    return;
+  }
   TString title = hist->GetTitle();
   title.Append(" ");
   title.Append(suffix.c_str());
@@ -188,11 +190,11 @@ static void updateTitle(TH1* hist, std::string suffix)
 
 static std::string getCurrentTime()
 {
-  time_t t ;
-  time( &t );
+  time_t t;
+  time(&t);
 
-  struct tm *tmp ;
-  tmp = localtime( &t );
+  struct tm* tmp;
+  tmp = localtime(&t);
 
   char timestr[500];
   strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);

--- a/Modules/MUON/MCH/src/PhysicsCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsCheck.cxx
@@ -229,7 +229,9 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
   }
 
   if ((mo->getName().find("Occupancy_ST12") != std::string::npos) ||
-      (mo->getName().find("Occupancy_ST345") != std::string::npos)) {
+      (mo->getName().find("Occupancy_ST345") != std::string::npos) ||
+      (mo->getName().find("Occupancy_B_XY") != std::string::npos) ||
+      (mo->getName().find("Occupancy_NB_XY") != std::string::npos)) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
     h->SetDrawOption("colz");
     h->SetMinimum(mOccupancyPlotScaleMin);

--- a/Modules/MUON/MCH/src/PhysicsCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsCheck.cxx
@@ -164,7 +164,9 @@ std::string PhysicsCheck::getAcceptedType() { return "TH1"; }
 
 static void updateTitle(TH1* hist, std::string suffix)
 {
-  if (!hist) return;
+  if (!hist) {
+    return;
+  }
   TString title = hist->GetTitle();
   title.Append(" ");
   title.Append(suffix.c_str());
@@ -173,11 +175,11 @@ static void updateTitle(TH1* hist, std::string suffix)
 
 static std::string getCurrentTime()
 {
-  time_t t ;
-  time( &t );
+  time_t t;
+  time(&t);
 
-  struct tm *tmp ;
-  tmp = localtime( &t );
+  struct tm* tmp;
+  tmp = localtime(&t);
 
   char timestr[500];
   strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -81,7 +81,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   }
 
   // Histograms in electronics coordinates
-  mHistogramOccupancyElec = std::make_shared<MergeableTH2Ratio>("Occupancy_Elec", "Occupancy (KHz)", nElecXbins, 0, nElecXbins, 64, 0, 64);
+  mHistogramOccupancyElec = std::make_shared<MergeableTH2Ratio>("Occupancy_Elec", "Occupancy", nElecXbins, 0, nElecXbins, 64, 0, 64);
   mHistogramOccupancyElec->SetOption("colz");
   mAllHistograms.push_back(mHistogramOccupancyElec.get());
   if (!mSaveToRootFile) {
@@ -93,7 +93,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   mAllHistograms.push_back(mHistogramNHitsElec);
   mAllHistograms.push_back(mHistogramNorbitsElec);
 
-  mMeanOccupancyPerDE = std::make_shared<MergeableTH1OccupancyPerDE>("MeanOccupancy", "Mean Occupancy of each DE (KHz)");
+  mMeanOccupancyPerDE = std::make_shared<MergeableTH1OccupancyPerDE>("MeanOccupancy", "Mean Occupancy vs DE");
   mMeanOccupancyPerDE->SetOption("hist");
   mAllHistograms.push_back(mMeanOccupancyPerDE.get());
   if (!mSaveToRootFile) {
@@ -101,7 +101,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   }
 
   // Histograms in global detector coordinates
-  mHistogramOccupancyST12 = std::make_shared<MergeableTH2Ratio>("Occupancy_ST12", "ST12 Occupancy (KHz)", 10, 0, 10, 10, 0, 10);
+  mHistogramOccupancyST12 = std::make_shared<MergeableTH2Ratio>("Occupancy_ST12", "ST12 Occupancy", 10, 0, 10, 10, 0, 10);
   mAllHistograms.push_back(mHistogramOccupancyST12.get());
   if (!mSaveToRootFile) {
     getObjectsManager()->startPublishing(mHistogramOccupancyST12.get());
@@ -116,7 +116,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   mHistogramNorbitsST12->init();
   mAllHistograms.push_back(mHistogramNorbitsST12->getHist());
 
-  mHistogramOccupancyST345 = std::make_shared<MergeableTH2Ratio>("Occupancy_ST345", "ST345 Occupancy (KHz)", 10, 0, 10, 10, 0, 10);
+  mHistogramOccupancyST345 = std::make_shared<MergeableTH2Ratio>("Occupancy_ST345", "ST345 Occupancy", 10, 0, 10, 10, 0, 10);
   mAllHistograms.push_back(mHistogramOccupancyST345.get());
   if (!mSaveToRootFile) {
     getObjectsManager()->startPublishing(mHistogramOccupancyST345.get());
@@ -136,7 +136,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   // getObjectsManager()->startPublishing(mMeanOccupancyPerDECycle.get());
 
   mHistogramDigitsOrbitInTFDE = std::make_shared<TH2F>("DigitOrbitInTFDE", "Digit orbits vs DE", getDEindexMax(), 0, getDEindexMax(), 768, -384, 384);
-  mHistogramDigitsOrbitInTFDE->SetOption("colz");
+  mHistogramDigitsOrbitInTFDE->SetOption("col");
   mAllHistograms.push_back(mHistogramDigitsOrbitInTFDE.get());
   if (!mSaveToRootFile) {
     getObjectsManager()->startPublishing(mHistogramDigitsOrbitInTFDE.get());


### PR DESCRIPTION
The digit time errors are added to existing QC histograms.
This is the follow-up of AliceO2Group/AliceO2#8573.

In addition, this PR introduces some further visual improvements to several plots, without changing the actual contents of the plots or the way they are filled.