### PR TITLE
new plots for ITSTrackTask / ClusterSize vs Chip (QC modification)

### DIFF
--- a/Modules/ITS/include/ITS/ITSTrackTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackTask.h
@@ -23,6 +23,7 @@
 #include <DataFormatsITSMFT/TopologyDictionary.h>
 #include <ITSBase/GeometryTGeo.h>
 #include <TTree.h>
+#include <TLine.h>
 
 class TH1D;
 class TH2D;
@@ -56,6 +57,17 @@ class ITSTrackTask : public TaskInterface
   static constexpr int NLayer = 7;
   static constexpr int NLayerIB = 3;
 
+  static constexpr int NSubStave2[NLayer] = { 1, 1, 1, 2, 2, 2, 2 };
+  const int NSubStave[NLayer] = { 1, 1, 1, 2, 2, 2, 2 };
+  const int NStaves[NLayer] = { 12, 16, 20, 24, 30, 42, 48 };
+  const int nHicPerStave[NLayer] = { 1, 1, 1, 8, 8, 14, 14 };
+  const int nChipsPerHic[NLayer] = { 9, 9, 9, 14, 14, 14, 14 };
+  const int ChipBoundary[NLayer + 1] = { 0, 108, 252, 432, 3120, 6480, 14712, 24120 };
+  const int StaveBoundary[NLayer + 1] = { 0, 12, 28, 48, 72, 102, 144, 192 };
+  const int ReduceFraction = 1;
+  const float StartAngle[NLayer] = { 16.997 / 360 * (TMath::Pi() * 2.), 17.504 / 360 * (TMath::Pi() * 2.), 17.337 / 360 * (TMath::Pi() * 2.), 8.75 / 360 * (TMath::Pi() * 2.), 7 / 360 * (TMath::Pi() * 2.), 5.27 / 360 * (TMath::Pi() * 2.), 4.61 / 360 * (TMath::Pi() * 2.) };
+  const float MidPointRad[NLayer] = { 23.49, 31.586, 39.341, 197.598, 246.944, 345.348, 394.883 };
+
   std::vector<TObject*> mPublishedObjects;
   TH1D* hNClusters;
   TH1D* hTrackEta;
@@ -69,6 +81,10 @@ class ITSTrackTask : public TaskInterface
   TH1D* hNtracks;
   TH2D* hNClustersPerTrackEta;
   TH2D* hClusterVsBunchCrossing;
+  TH2D* hNClusterVsChip[NLayer];
+  TH2D* hNClusterVsChipITS;
+
+  std::string mDictPath;
 
   float mVertexXYsize;
   float mVertexZsize;

--- a/Modules/ITS/itsTrack.json
+++ b/Modules/ITS/itsTrack.json
@@ -57,7 +57,23 @@
         "dataSource" : [ {
           "type" : "Task",
           "name" : "ITSTrackTask",
-          "MOs" : ["NClusters","PhiDistribution","AngularDistribution","EtaDistribution","VertexCoordinates","VertexRvsZ","VertexZ","BunchCrossingIDvsClusterRatio"]
+          "MOs" : ["NClusters",
+                   "PhiDistribution",
+                   "AngularDistribution",
+                   "EtaDistribution",
+                   "VertexCoordinates",
+                   "VertexRvsZ",
+                   "VertexZ",
+                   "BunchCrossingIDvsClusterRatio",
+                   "NClusterVsChipInLayer0",
+                   "NClusterVsChipInLayer1",
+                   "NClusterVsChipInLayer2",
+                   "NClusterVsChipInLayer3",
+                   "NClusterVsChipInLayer4",
+                   "NClusterVsChipInLayer5",
+                   "NClusterVsChipInLayer6",
+                   "NClusterVsChipITS"
+                   ]
         } ]
       }
     }

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -23,6 +23,7 @@
 #include "ReconstructionDataFormats/PrimaryVertex.h"
 
 #include <Framework/DataSpecUtils.h>
+#include "ITStracking/Constants.h"
 
 using namespace o2::itsmft;
 using namespace o2::its;
@@ -49,6 +50,10 @@ ITSTrackTask::~ITSTrackTask()
   delete hNtracks;
   delete hNClustersPerTrackEta;
   delete hClusterVsBunchCrossing;
+  for (int l = 0; l < NLayer; l++) {
+    delete hNClusterVsChip[l];
+  }
+  delete hNClusterVsChipITS;
 }
 
 void ITSTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
@@ -62,9 +67,26 @@ void ITSTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
   mNtracksMAX = std::stof(mCustomParameters["NtracksMAX"]);
   mDoTTree = std::stoi(mCustomParameters["doTTree"]);
   nBCbins = std::stoi(mCustomParameters.find("nBCbins")->second);
+  mDictPath = mCustomParameters["clusterDictionaryPath"];
 
   createAllHistos();
   publishHistos();
+
+  std::ifstream file(mDictPath.c_str());
+
+  if (file.good()) {
+    mDict.readBinaryFile(mDictPath);
+    ILOG(Info, Support) << "Running with dictionary: " << mDictPath << " with size: " << mDict.getSize();
+
+  } else {
+    ILOG(Info, Support) << "Running without dictionary !";
+  }
+
+  // NClusterVsChip Full Detector distinguishable
+  for (int l = 0; l < NLayer + 1; l++) {
+    auto line = new TLine(ChipBoundary[l], 0, ChipBoundary[l], 10);
+    hNClusterVsChipITS->GetListOfFunctions()->Add(line);
+  }
 }
 
 void ITSTrackTask::startOfActivity(Activity& /*activity*/)
@@ -81,11 +103,13 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
   ILOG(Info, Support) << "START DOING QC General" << ENDM;
-  auto trackArr = ctx.inputs().get<gsl::span<o2::its::TrackITS>>("tracks");
+  auto trackArr = ctx.inputs().get<gsl::span<o2::its::TrackITSExt>>("tracks");
   auto trackRofArr = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("rofs");
   auto clusRofArr = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clustersrof");
   auto clusArr = ctx.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compclus");
   auto vertexArr = ctx.inputs().get<gsl::span<o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>>>("Vertices");
+  auto clusPatternArr = ctx.inputs().get<gsl::span<unsigned char>>("patterns");
+  auto pattIt = clusPatternArr.begin();
 
   for (const auto& vertex : vertexArr) {
 
@@ -120,6 +144,34 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
 
       hNClustersPerTrackEta->Fill(Eta, track.getNumberOfClusters());
       nClusterCntTrack += track.getNumberOfClusters();
+      for (int icluster = 0; icluster < TrackITSExt::MaxClusters; icluster++) {
+        const int index = track.getClusterIndex(icluster);
+        if (index == o2::its::constants::its::UnusedIndex)
+          continue;
+        auto& cluster = clusArr[index];
+
+        auto row = cluster.getRow();
+        auto col = cluster.getCol();
+        auto ChipID = cluster.getSensorID();
+        auto ClusterID = cluster.getPatternID(); // used for normal (frequent) cluster shapes
+        int npix = -1;
+        int isGrouped = -1;
+        if (ClusterID != o2::itsmft::CompCluster::InvalidPatternID && !mDict.isGroup(ClusterID)) { // Normal (frequent) cluster shapes
+          npix = mDict.getNpixels(ClusterID);
+          isGrouped = 0;
+        } else {
+          o2::itsmft::ClusterPattern patt(pattIt);
+          npix = patt.getNPixels();
+          isGrouped = 1;
+        }
+        int layer = 0;
+        while (ChipID > ChipBoundary[layer])
+          layer++;
+        layer--;
+        double clusterSizeWithCorrection = (double)npix * cos(TMath::ATan(out.getTgl()));
+        hNClusterVsChip[layer]->Fill(ChipID, clusterSizeWithCorrection);
+        hNClusterVsChipITS->Fill(ChipID, clusterSizeWithCorrection);
+      }
     }
 
     int nTotCls = clusRofArr[iROF].getNEntries();
@@ -173,6 +225,10 @@ void ITSTrackTask::reset()
   hNtracks->Reset();
   hNClustersPerTrackEta->Reset();
   hClusterVsBunchCrossing->Reset();
+  for (int l = 0; l < NLayer; l++) {
+    hNClusterVsChip[l]->Reset();
+  }
+  hNClusterVsChipITS->Reset();
 }
 
 void ITSTrackTask::createAllHistos()
@@ -256,6 +312,25 @@ void ITSTrackTask::createAllHistos()
   addObject(hClusterVsBunchCrossing);
   formatAxes(hClusterVsBunchCrossing, "Bunch Crossing ID", "Fraction of clusters in tracks", 1, 1.10);
   hClusterVsBunchCrossing->SetStats(0);
+
+  for (int l = 0; l < NLayer; l++) {
+    hNClusterVsChip[l] = new TH2D(Form("NClusterVsChipInLayer%d", l), Form("NClusterVsChipInLayer%d", l), (int)(ChipBoundary[l + 1] - ChipBoundary[l]), ChipBoundary[l], ChipBoundary[l + 1], 60, 0, 15);
+    hNClusterVsChip[l]->SetTitle(Form("Corrected cluster size for track clusters vs Chip in layer %d", l));
+    addObject(hNClusterVsChip[l]);
+    formatAxes(hNClusterVsChip[l], "chipID", "corrected cluster size for track clusters", 1, 1.10);
+    hNClusterVsChip[l]->SetStats(0);
+  }
+
+  hNClusterVsChipITS = new TH2D(Form("NClusterVsChipITS"), Form("NClusterVsChipITS"), (int)ChipBoundary[NLayer], 0, ChipBoundary[NLayer], 60, 0, 15);
+  hNClusterVsChipITS->SetTitle(Form("Corrected cluster size for track clusters vs Chip Full Detector"));
+  addObject(hNClusterVsChipITS);
+  formatAxes(hNClusterVsChipITS, "chipID", "corrected cluster size for track clusters", 1, 1.10);
+  hNClusterVsChipITS->SetStats(0);
+  // NClusterVsChip Full Detector distinguishable
+  for (int l = 0; l < NLayer + 1; l++) {
+    auto line = new TLine(ChipBoundary[l], 0, ChipBoundary[l], 15);
+    hNClusterVsChipITS->GetListOfFunctions()->Add(line);
+  }
 }
 
 void ITSTrackTask::addObject(TObject* aObject)


### PR DESCRIPTION
(TH2D) Corrected cluster size for track clusters vs Chip by Layer

(TH2D) Corrected cluster size for track clusters vs Chip Full Detector

QC modification is implemented.
There is one modification for O2/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
TrackITS ->TrackITSExt (L196)