### PR TITLE
MCH: fixed memory leak in MergeableTH2Ratio class

### DIFF
--- a/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
@@ -106,7 +106,12 @@ void MergeableTH2Ratio::beautify()
 {
   SetOption("colz");
   GetListOfFunctions()->RemoveAll();
-  GetListOfFunctions()->AddAll((TList*)(mHistoNum->GetListOfFunctions()->Clone()));
+
+  TList* functions = (TList*)mHistoNum->GetListOfFunctions()->Clone();
+  if (functions) {
+    GetListOfFunctions()->AddAll(functions);
+    delete functions;
+  }
 }
 
 } // namespace o2::quality_control_modules::muon


### PR DESCRIPTION
The list of functions of the numerator histogram was cloned in the `MergeableTH2Ratio::beautify()` method, and the clone was never deleted.