### PR TITLE
[QC-788] Speed up the repo-cleaner by skipping useless updates

### DIFF
--- a/Framework/script/RepoCleaner/o2-qc-repo-cleaner
+++ b/Framework/script/RepoCleaner/o2-qc-repo-cleaner
@@ -39,7 +39,7 @@ from datetime import datetime
 
 from Ccdb import Ccdb
 from pidfile import PIDFile, AlreadyRunningError
-
+# from viztracer import log_sparse
 
 class Rule:
     """A class to hold information about a "rule" defined in the config file."""
@@ -289,7 +289,7 @@ def read_config(args):
     ccdb_url = config['ccdb_url']
     return ccdb_url, rules
 
-
+# @log_sparse
 def process_object(object_path, rules, ccdb, args):
     logger = create_parallel_logger()
     logger.setLevel(int(args.log_level))

--- a/Framework/script/RepoCleaner/o2-qc-repo-cleaner
+++ b/Framework/script/RepoCleaner/o2-qc-repo-cleaner
@@ -309,8 +309,11 @@ def process_object(object_path, rules, ccdb, args):
     except ModuleNotFoundError as err:
         logger.error(f"could not load module {rule.policy}")
         return
-    stats = module.process(ccdb, object_path, int(rule.delay),  # rule.migration == "True",
-                           rule.extra_params)
+    try:
+        stats = module.process(ccdb, object_path, int(rule.delay),  rule.extra_params)
+    except Exception as e:
+        logger.error(f"processing error:  {e}")
+
     logger.info(f"{rule.policy} applied on {object_path}: {stats}")
 
 
@@ -327,7 +330,7 @@ def run(args, ccdb_url, rules):
     logging.info("Loop through the objects and apply first matching rule.")
 
     logging.info(f"workers: {args.workers}")
-    pool = mp.Pool(int(args.workers))
+    pool = mp.Pool(processes=int(args.workers))
     [pool.apply_async(process_object, args=(object_path, rules, ccdb, args)) for object_path in paths]
     pool.close()
     pool.join()

--- a/Framework/script/RepoCleaner/rules/1_per_hour.py
+++ b/Framework/script/RepoCleaner/rules/1_per_hour.py
@@ -38,7 +38,8 @@ def process(ccdb: Ccdb, object_path: str, delay: int, #migration: bool,
         if last_preserved == None or last_preserved.validFromAsDt < v.validFromAsDt - timedelta(hours=1):
             # first extend validity of the previous preserved (should we take into account the run ?)
             if last_preserved != None:
-                ccdb.updateValidity(last_preserved, last_preserved.validFrom, str(int(v.validFrom) - 1))
+                if last_preserved.validTo != int(v.validFrom) - 1:  # only update it if it is needed
+                    ccdb.updateValidity(last_preserved, last_preserved.validFrom, str(int(v.validFrom) - 1))
                 update_list.append(last_preserved)
             last_preserved = v
         else:
@@ -61,7 +62,7 @@ def process(ccdb: Ccdb, object_path: str, delay: int, #migration: bool,
     for v in update_list:
         logger.debug(f"   {v}")
 
-    return {"deleted" : len(deletion_list), "preserved": len(preservation_list), "updated" : len(update_list)}
+    return {"deleted": len(deletion_list), "preserved": len(preservation_list), "updated" : len(update_list)}
 
 
 def main():

--- a/Framework/script/RepoCleaner/rules/production.py
+++ b/Framework/script/RepoCleaner/rules/production.py
@@ -156,7 +156,8 @@ def first_trimming(ccdb, delay_first_trimming, period_btw_versions_first, run_ve
                     last_preserved.validFromAsDt < v.validFromAsDt - timedelta(minutes=period_btw_versions_first):
                 if last_preserved is not None:
                     # first extend validity of the previous preserved and set flag
-                    ccdb.updateValidity(last_preserved, last_preserved.validFrom, str(int(v.validFrom) - 1), metadata)
+                    if last_preserved.validTo != int(v.validFrom) - 1:  # only update it if it is needed
+                        ccdb.updateValidity(last_preserved, last_preserved.validFrom, str(int(v.validFrom) - 1), metadata)
                     update_list.append(last_preserved)
                     logger.debug(f"      Extension of {last_preserved}")
                 last_preserved = v


### PR DESCRIPTION
We were updating the validity range of every objects every time. Not needed. Speedup on ccdb-test: 4x