### PR TITLE
MCH: remove stat boxes and improve detector contour drawing

### DIFF
--- a/Modules/MUON/MCH/include/MCH/PedestalsTask.h
+++ b/Modules/MUON/MCH/include/MCH/PedestalsTask.h
@@ -52,13 +52,24 @@ class PedestalsTask final : public TaskInterface
   void reset() override;
 
  private:
+  template <typename T>
+  void publishObject(T* histo, std::string drawOption, bool statBox)
+  {
+    histo->SetOption(drawOption.c_str());
+    if (!statBox) {
+      histo->SetStats(0);
+    }
+    mAllHistograms.push_back(histo);
+    getObjectsManager()->startPublishing(histo);
+    getObjectsManager()->setDefaultDrawOptions(histo, drawOption);
+  }
+
   void monitorDataDigits(o2::framework::ProcessingContext& ctx);
   void monitorDataPedestals(o2::framework::ProcessingContext& ctx);
 
   void PlotPedestal(uint16_t solarID, uint8_t dsID, uint8_t channel, double mean, double rms);
   void PlotPedestalDE(uint16_t solarID, uint8_t dsID, uint8_t channel, double mean, double rms);
   void fill_noise_distributions();
-  void writeHistos();
 
   static constexpr int sMaxFeeId = 64;
   static constexpr int sMaxLinkId = 12;
@@ -85,7 +96,6 @@ class PedestalsTask final : public TaskInterface
   std::shared_ptr<GlobalHistogram> mHistogramNoiseMCH[2];
 
   int mPrintLevel;
-  bool mSaveToRootFile{ false };
 
   std::vector<TH1*> mAllHistograms;
 };

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
@@ -69,14 +69,26 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   void addDefaultOrbitsInTF();
   void plotDigit(const o2::mch::Digit& digit);
   void updateOrbits();
-  void writeHistos();
+
+  template <typename T>
+  void publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox, bool isExpert)
+  {
+    histo->SetOption(drawOption.c_str());
+    if (!statBox) {
+      histo->SetStats(0);
+    }
+    mAllHistograms.push_back(histo.get());
+    if (mDiagnostic || (isExpert == false)) {
+      getObjectsManager()->startPublishing(histo.get());
+      getObjectsManager()->setDefaultDrawOptions(histo.get(), drawOption);
+    }
+  }
 
   static constexpr int sMaxFeeId = 64;
   static constexpr int sMaxLinkId = 12;
   static constexpr int sMaxDsId = 40;
 
   bool mDiagnostic{ false };
-  bool mSaveToRootFile{ false };
 
   o2::mch::raw::Elec2DetMapper mElec2DetMapper;
   o2::mch::raw::Det2ElecMapper mDet2ElecMapper;

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskPreclusters.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskPreclusters.h
@@ -68,15 +68,16 @@ class PhysicsTaskPreclusters /*final*/ : public o2::quality_control::core::TaskI
 
  private:
   template <typename T>
-  void publishObject(std::shared_ptr<T> histo, const char* drawOption, bool statBox, bool isExpert)
+  void publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox, bool isExpert)
   {
-    histo->SetOption(drawOption);
+    histo->SetOption(drawOption.c_str());
     if (!statBox) {
       histo->SetStats(0);
     }
     mAllHistograms.push_back(histo.get());
     if (mDiagnostic || (isExpert == false)) {
       getObjectsManager()->startPublishing(histo.get());
+      getObjectsManager()->setDefaultDrawOptions(histo.get(), drawOption);
     }
   }
 

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskRofs.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskRofs.h
@@ -57,14 +57,15 @@ class PhysicsTaskRofs /*final*/ : public TaskInterface
 
  private:
   template <typename T>
-  void publishObject(std::shared_ptr<T> histo, const char* drawOption, bool statBox)
+  void publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox)
   {
-    histo->SetOption(drawOption);
+    histo->SetOption(drawOption.c_str());
     if (!statBox) {
       histo->SetStats(0);
     }
     mAllHistograms.push_back(histo.get());
     getObjectsManager()->startPublishing(histo.get());
+    getObjectsManager()->setDefaultDrawOptions(histo.get(), drawOption);
   }
 
   void plotROF(const o2::mch::ROFRecord& rof, gsl::span<const o2::mch::Digit> digits);

--- a/Modules/MUON/MCH/src/GlobalHistogram.cxx
+++ b/Modules/MUON/MCH/src/GlobalHistogram.cxx
@@ -197,7 +197,7 @@ static int getDetectorHistHeight(int deId)
   if (deId >= 500) {
     return (50);
   } else if (deId >= 300) {
-    return 120;
+    return 130;
   } else {
     return 100;
   }

--- a/Modules/MUON/MCH/src/PedestalsCheck.cxx
+++ b/Modules/MUON/MCH/src/PedestalsCheck.cxx
@@ -210,9 +210,10 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
 
   if (mo->getName().find("Pedestals_Elec") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
-    h->SetOption("colz");
+
     h->SetMinimum(mPedestalsPlotScaleMin);
     h->SetMaximum(mPedestalsPlotScaleMax);
+
     TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
     h->GetListOfFunctions()->Add(msg);
     msg->SetName(Form("%s_msg", mo->GetName()));
@@ -241,9 +242,7 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
 
   if (mo->getName().find("Noise_Elec") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
-    if (!h)
-      return;
-    h->SetOption("colz");
+
     h->SetMinimum(mNoisePlotScaleMin);
     h->SetMaximum(mNoisePlotScaleMax);
 
@@ -277,7 +276,6 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
   if ((mo->getName().find("Pedestals_ST12") != std::string::npos) ||
       (mo->getName().find("Pedestals_ST345") != std::string::npos)) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
-    h->SetDrawOption("colz");
     h->SetMinimum(mPedestalsPlotScaleMin);
     h->SetMaximum(mPedestalsPlotScaleMax);
     h->GetXaxis()->SetTickLength(0.0);
@@ -289,7 +287,6 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
   if ((mo->getName().find("Noise_ST12") != std::string::npos) ||
       (mo->getName().find("Noise_ST345") != std::string::npos)) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
-    h->SetDrawOption("colz");
     h->SetMinimum(mNoisePlotScaleMin);
     h->SetMaximum(mNoisePlotScaleMax);
     h->GetXaxis()->SetTickLength(0.0);
@@ -298,18 +295,24 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
     h->GetYaxis()->SetLabelSize(0.0);
   }
 
-  if (mo->getName().find("Pedestals_DE") != std::string::npos) {
+  if (mo->getName().find("Pedestals_XY") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
-    h->SetDrawOption("colz");
     h->SetMinimum(mPedestalsPlotScaleMin);
     h->SetMaximum(mPedestalsPlotScaleMax);
+    h->GetXaxis()->SetTickLength(0.0);
+    h->GetXaxis()->SetLabelSize(0.0);
+    h->GetYaxis()->SetTickLength(0.0);
+    h->GetYaxis()->SetLabelSize(0.0);
   }
 
-  if (mo->getName().find("Noise_DE") != std::string::npos) {
+  if (mo->getName().find("Noise_XY") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
-    h->SetDrawOption("colz");
     h->SetMinimum(mNoisePlotScaleMin);
     h->SetMaximum(mNoisePlotScaleMax);
+    h->GetXaxis()->SetTickLength(0.0);
+    h->GetXaxis()->SetLabelSize(0.0);
+    h->GetYaxis()->SetTickLength(0.0);
+    h->GetYaxis()->SetLabelSize(0.0);
   }
 }
 

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -38,8 +38,6 @@
 using namespace std;
 using namespace o2::framework;
 
-//#define QC_MCH_SAVE_TEMP_ROOTFILE 1
-
 #define MCH_FFEID_MAX (31 * 2 + 1)
 
 namespace o2
@@ -60,56 +58,32 @@ void PedestalsTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Info, Support) << "initialize PedestalsTask" << AliceO2::InfoLogger::InfoLogger::endm;
 
-  mSaveToRootFile = false;
-  if (auto param = mCustomParameters.find("SaveToRootFile"); param != mCustomParameters.end()) {
-    if (param->second == "true" || param->second == "True" || param->second == "TRUE") {
-      mSaveToRootFile = true;
-    }
-  }
-
   mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
   mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
 
   const uint32_t nElecXbins = PedestalsTask::sMaxFeeId * PedestalsTask::sMaxLinkId * PedestalsTask::sMaxDsId;
 
   mHistogramPedestals = std::make_shared<TH2F>("Pedestals_Elec", "Pedestals", nElecXbins, 0, nElecXbins, 64, 0, 64);
-  mHistogramPedestals->SetOption("colz");
-  mAllHistograms.push_back(mHistogramPedestals.get());
-  if (!mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mHistogramPedestals.get());
-  }
+  publishObject(mHistogramPedestals.get(), "colz", false);
 
   mHistogramNoise = std::make_shared<TH2F>("Noise_Elec", "Noise", nElecXbins, 0, nElecXbins, 64, 0, 64);
-  mHistogramNoise->SetOption("colz");
-  mAllHistograms.push_back(mHistogramNoise.get());
-  if (!mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mHistogramNoise.get());
-  }
+  publishObject(mHistogramNoise.get(), "colz", false);
 
   std::string stname[2]{ "ST12", "ST345" };
   for (int i = 0; i < 2; i++) {
     mHistogramPedestalsMCH[i] = std::make_shared<GlobalHistogram>(fmt::format("Pedestals_{}", stname[i]), "Pedestals", i);
     mHistogramPedestalsMCH[i]->init();
-    mAllHistograms.push_back(mHistogramPedestalsMCH[i]->getHist());
-    if (!mSaveToRootFile) {
-      getObjectsManager()->startPublishing(mHistogramPedestalsMCH[i]->getHist());
-    }
+    publishObject(mHistogramPedestalsMCH[i]->getHist(), "colz", false);
 
     mHistogramNoiseMCH[i] = std::make_shared<GlobalHistogram>(fmt::format("Noise_{}", stname[i]), "Noise", i);
     mHistogramNoiseMCH[i]->init();
-    mAllHistograms.push_back(mHistogramNoiseMCH[i]->getHist());
-    if (!mSaveToRootFile) {
-      getObjectsManager()->startPublishing(mHistogramNoiseMCH[i]->getHist());
-    }
+    publishObject(mHistogramNoiseMCH[i]->getHist(), "colz", false);
   }
 
   for (int si = 0; si < 5; si++) {
     mHistogramNoiseDistribution[si] = std::make_shared<TH1F>(TString::Format("ST%d/Noise_Distr_ST%d", si + 1, si + 1),
                                                              TString::Format("Noise distribution (ST%d)", si + 1), 1000, 0, 10);
-    mAllHistograms.push_back(mHistogramNoiseDistribution[si].get());
-    if (!mSaveToRootFile) {
-      getObjectsManager()->startPublishing(mHistogramNoiseDistribution[si].get());
-    }
+    publishObject(mHistogramNoiseDistribution[si].get(), "hist", false);
   }
 
   for (auto de : o2::mch::raw::deIdsForAllMCH) {
@@ -129,55 +103,35 @@ void PedestalsTask::initialize(o2::framework::InitContext& /*ctx*/)
       auto hNoiseDE = std::make_shared<TH1F>(TString::Format("%sNoise_Distr_DE%03d_b_%d", getHistoPath(de).c_str(), de, pi),
                                              TString::Format("Noise distribution (DE%03d B, %d)", de, pi), 1000, 0, 10);
       mHistogramNoiseDistributionDE[pi][0].insert(make_pair(de, hNoiseDE));
-      hNoiseDE->SetOption("hist");
-      mAllHistograms.push_back(hNoiseDE.get());
-      if (!mSaveToRootFile) {
-        getObjectsManager()->startPublishing(hNoiseDE.get());
-      }
+      publishObject(hNoiseDE.get(), "hist", false);
 
       hNoiseDE = std::make_shared<TH1F>(TString::Format("%sNoise_Distr_DE%03d_nb_%d", getHistoPath(de).c_str(), de, pi),
                                         TString::Format("Noise distribution (DE%03d NB, %d)", de, pi), 1000, 0, 10);
       mHistogramNoiseDistributionDE[pi][1].insert(make_pair(de, hNoiseDE));
-      hNoiseDE->SetOption("hist");
-      mAllHistograms.push_back(hNoiseDE.get());
-      if (!mSaveToRootFile) {
-        getObjectsManager()->startPublishing(hNoiseDE.get());
-      }
+      publishObject(hNoiseDE.get(), "hist", false);
     }
 
     {
-      auto hPedXY = std::make_shared<DetectorHistogram>(TString::Format("%sPedestals_DE%03d_B", getHistoPath(de).c_str(), de),
+      auto hPedXY = std::make_shared<DetectorHistogram>(TString::Format("%sPedestals_XY_B_%03d", getHistoPath(de).c_str(), de),
                                                         TString::Format("Pedestals (DE%03d B)", de), de, 0);
       mHistogramPedestalsXY[0].insert(make_pair(de, hPedXY));
-      mAllHistograms.push_back(hPedXY->getHist());
-      if (!mSaveToRootFile) {
-        getObjectsManager()->startPublishing(hPedXY->getHist());
-      }
+      publishObject(hPedXY->getHist(), "colz", false);
 
-      auto hNoiseXY = std::make_shared<DetectorHistogram>(TString::Format("%sNoise_DE%03d_B", getHistoPath(de).c_str(), de),
+      auto hNoiseXY = std::make_shared<DetectorHistogram>(TString::Format("%sNoise_XY_B_%03d", getHistoPath(de).c_str(), de),
                                                           TString::Format("Noise (DE%03d B)", de), de, 0);
       mHistogramNoiseXY[0].insert(make_pair(de, hNoiseXY));
-      mAllHistograms.push_back(hNoiseXY->getHist());
-      if (!mSaveToRootFile) {
-        getObjectsManager()->startPublishing(hNoiseXY->getHist());
-      }
+      publishObject(hNoiseXY->getHist(), "colz", false);
     }
     {
-      auto hPedXY = std::make_shared<DetectorHistogram>(TString::Format("%sPedestals_DE%03d_NB", getHistoPath(de).c_str(), de),
+      auto hPedXY = std::make_shared<DetectorHistogram>(TString::Format("%sPedestals_XY_NB_%03d", getHistoPath(de).c_str(), de),
                                                         TString::Format("Pedestals (DE%03d NB)", de), de, 1);
       mHistogramPedestalsXY[1].insert(make_pair(de, hPedXY));
-      mAllHistograms.push_back(hPedXY->getHist());
-      if (!mSaveToRootFile) {
-        getObjectsManager()->startPublishing(hPedXY->getHist());
-      }
+      publishObject(hPedXY->getHist(), "colz", false);
 
-      auto hNoiseXY = std::make_shared<DetectorHistogram>(TString::Format("%sNoise_DE%03d_NB", getHistoPath(de).c_str(), de),
+      auto hNoiseXY = std::make_shared<DetectorHistogram>(TString::Format("%sNoise_XY_NB_%03d", getHistoPath(de).c_str(), de),
                                                           TString::Format("Noise (DE%03d NB)", de), de, 1);
       mHistogramNoiseXY[1].insert(make_pair(de, hNoiseXY));
-      mAllHistograms.push_back(hNoiseXY->getHist());
-      if (!mSaveToRootFile) {
-        getObjectsManager()->startPublishing(hNoiseXY->getHist());
-      }
+      publishObject(hNoiseXY->getHist(), "colz", false);
     }
   }
 
@@ -381,19 +335,6 @@ void PedestalsTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
 }
 
-void PedestalsTask::writeHistos()
-{
-  if (!mSaveToRootFile) {
-    return;
-  }
-
-  TFile f("mch-qc-pedestals.root", "RECREATE");
-  for (auto h : mAllHistograms) {
-    h->Write();
-  }
-  f.Close();
-}
-
 void PedestalsTask::endOfCycle()
 {
   ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
@@ -405,8 +346,6 @@ void PedestalsTask::endOfCycle()
 
   mHistogramPedestalsMCH[1]->set(mHistogramPedestalsXY[0], mHistogramPedestalsXY[1], true);
   mHistogramNoiseMCH[1]->set(mHistogramNoiseXY[0], mHistogramNoiseXY[1], true);
-
-  writeHistos();
 }
 
 void PedestalsTask::endOfActivity(Activity& /*activity*/)
@@ -415,8 +354,6 @@ void PedestalsTask::endOfActivity(Activity& /*activity*/)
   ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 
   fill_noise_distributions();
-
-  writeHistos();
 }
 
 void PedestalsTask::reset()

--- a/Modules/MUON/MCH/src/PhysicsCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsCheck.cxx
@@ -233,7 +233,6 @@ void PhysicsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResu
       (mo->getName().find("Occupancy_B_XY") != std::string::npos) ||
       (mo->getName().find("Occupancy_NB_XY") != std::string::npos)) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
-    h->SetDrawOption("colz");
     h->SetMinimum(mOccupancyPlotScaleMin);
     h->SetMaximum(mOccupancyPlotScaleMax);
     h->GetXaxis()->SetTickLength(0.0);

--- a/Modules/MUON/MCH/src/PhysicsPreclustersCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsPreclustersCheck.cxx
@@ -135,7 +135,10 @@ void PhysicsPreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Qualit
     h->GetYaxis()->SetTitle("efficiency");
 
     h->SetMinimum(0);
-    h->SetMaximum(2);
+    if ((mo->getName().find("MeanPseudoeffPerDE_B") != std::string::npos) ||
+        (mo->getName().find("MeanPseudoeffPerDE_NB") != std::string::npos)) {
+      h->SetMaximum(2);
+    }
 
     TText* xtitle = new TText();
     xtitle->SetNDC();
@@ -170,12 +173,6 @@ void PhysicsPreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Qualit
     h->GetListOfFunctions()->Add(msg);
     msg->SetName(Form("%s_msg", mo->GetName()));
 
-    TLine* lmin = new TLine(0, mMinPseudoeff, getDEindexMax(), mMinPseudoeff);
-    TLine* lmax = new TLine(0, mMaxPseudoeff, getDEindexMax(), mMaxPseudoeff);
-
-    h->GetListOfFunctions()->Add(lmin);
-    h->GetListOfFunctions()->Add(lmax);
-
     if (checkResult == Quality::Good) {
       msg->Clear();
       msg->AddText("Pseudo-efficiency consistently within limits: OK!!!");
@@ -192,6 +189,19 @@ void PhysicsPreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Qualit
       msg->SetFillColor(kYellow);
     }
     h->SetLineColor(kBlack);
+  }
+
+  if ((mo->getName().find("Pseudoeff_ST12") != std::string::npos) ||
+      (mo->getName().find("Pseudoeff_ST345") != std::string::npos) ||
+      (mo->getName().find("Pseudoeff_B_XY") != std::string::npos) ||
+      (mo->getName().find("Pseudoeff_NB_XY") != std::string::npos)) {
+    auto* h = dynamic_cast<TH2F*>(mo->getObject());
+    h->SetMinimum(0);
+    h->SetMaximum(1);
+    h->GetXaxis()->SetTickLength(0.0);
+    h->GetXaxis()->SetLabelSize(0.0);
+    h->GetYaxis()->SetTickLength(0.0);
+    h->GetYaxis()->SetLabelSize(0.0);
   }
 }
 

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -61,13 +61,6 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
     }
   }
 
-  mSaveToRootFile = false;
-  if (auto param = mCustomParameters.find("SaveToRootFile"); param != mCustomParameters.end()) {
-    if (param->second == "true" || param->second == "True" || param->second == "TRUE") {
-      mSaveToRootFile = true;
-    }
-  }
-
   mElec2DetMapper = createElec2DetMapper<ElectronicMapperGenerated>();
   mDet2ElecMapper = createDet2ElecMapper<ElectronicMapperGenerated>();
   mFeeLink2SolarMapper = createFeeLink2SolarMapper<ElectronicMapperGenerated>();
@@ -83,11 +76,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
 
   // Histograms in electronics coordinates
   mHistogramOccupancyElec = std::make_shared<MergeableTH2Ratio>("Occupancy_Elec", "Occupancy", nElecXbins, 0, nElecXbins, 64, 0, 64);
-  mHistogramOccupancyElec->SetOption("colz");
-  mAllHistograms.push_back(mHistogramOccupancyElec.get());
-  if (!mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mHistogramOccupancyElec.get());
-  }
+  publishObject(mHistogramOccupancyElec, "colz", false, false);
 
   mHistogramNHitsElec = mHistogramOccupancyElec->getNum();
   mHistogramNorbitsElec = mHistogramOccupancyElec->getDen();
@@ -95,18 +84,11 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   mAllHistograms.push_back(mHistogramNorbitsElec);
 
   mMeanOccupancyPerDE = std::make_shared<MergeableTH1OccupancyPerDE>("MeanOccupancy", "Mean Occupancy vs DE");
-  mMeanOccupancyPerDE->SetOption("hist");
-  mAllHistograms.push_back(mMeanOccupancyPerDE.get());
-  if (!mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mMeanOccupancyPerDE.get());
-  }
+  publishObject(mMeanOccupancyPerDE, "hist", false, false);
 
   // Histograms in global detector coordinates
   mHistogramOccupancyST12 = std::make_shared<MergeableTH2Ratio>("Occupancy_ST12", "ST12 Occupancy", 10, 0, 10, 10, 0, 10);
-  mAllHistograms.push_back(mHistogramOccupancyST12.get());
-  if (!mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mHistogramOccupancyST12.get());
-  }
+  publishObject(mHistogramOccupancyST12, "colz", false, false);
 
   mHistogramNhitsST12 = std::make_shared<GlobalHistogram>("Nhits_ST12", "Number of hits (ST12)",
                                                           0, mHistogramOccupancyST12->getNum());
@@ -118,10 +100,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   mAllHistograms.push_back(mHistogramNorbitsST12->getHist());
 
   mHistogramOccupancyST345 = std::make_shared<MergeableTH2Ratio>("Occupancy_ST345", "ST345 Occupancy", 10, 0, 10, 10, 0, 10);
-  mAllHistograms.push_back(mHistogramOccupancyST345.get());
-  if (!mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mHistogramOccupancyST345.get());
-  }
+  publishObject(mHistogramOccupancyST345, "colz", false, false);
 
   mHistogramNhitsST345 = std::make_shared<GlobalHistogram>("Nhits_ST345", "Number of hits (ST345)",
                                                            1, mHistogramOccupancyST345->getNum());
@@ -137,47 +116,28 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   // getObjectsManager()->startPublishing(mMeanOccupancyPerDECycle.get());
 
   mHistogramDigitsOrbitInTFDE = std::make_shared<TH2F>("DigitOrbitInTFDE", "Digit orbits vs DE", getDEindexMax(), 0, getDEindexMax(), 768, -384, 384);
-  mHistogramDigitsOrbitInTFDE->SetOption("col");
-  mAllHistograms.push_back(mHistogramDigitsOrbitInTFDE.get());
-  if (!mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mHistogramDigitsOrbitInTFDE.get());
-  }
+  publishObject(mHistogramDigitsOrbitInTFDE, "colz", false, false);
 
   mHistogramDigitsOrbitInTF = std::make_shared<TH2F>("Expert/DigitOrbitInTF", "Digit orbits vs DS Id", nElecXbins, 0, nElecXbins, 768, -384, 384);
-  mHistogramDigitsOrbitInTF->SetOption("colz");
-  mAllHistograms.push_back(mHistogramDigitsOrbitInTF.get());
-  if (mDiagnostic && !mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mHistogramDigitsOrbitInTF.get());
-  }
+  publishObject(mHistogramDigitsOrbitInTF, "colz", false, false);
 
   mHistogramDigitsBcInOrbit = std::make_shared<TH2F>("Expert/DigitsBcInOrbit", "Digit BC vs DS Id", nElecXbins, 0, nElecXbins, 3600, 0, 3600);
-  mHistogramDigitsBcInOrbit->SetOption("colz");
-  mAllHistograms.push_back(mHistogramDigitsBcInOrbit.get());
-  if (mDiagnostic && !mSaveToRootFile) {
-    getObjectsManager()->startPublishing(mHistogramDigitsBcInOrbit.get());
-  }
+  publishObject(mHistogramDigitsBcInOrbit, "colz", false, true);
 
   mHistogramAmplitudeVsSamples = std::make_shared<TH2F>("Expert/AmplitudeVsSamples", "Digit amplitude vs nsamples", 1000, 0, 1000, 1000, 0, 10000);
-  mHistogramAmplitudeVsSamples->SetOption("colz");
-  mAllHistograms.push_back(mHistogramAmplitudeVsSamples.get());
+  publishObject(mHistogramAmplitudeVsSamples, "colz", false, true);
 
   // Histograms in detector coordinates
   for (auto de : o2::mch::raw::deIdsForAllMCH) {
     auto h = std::make_shared<TH1F>(TString::Format("Expert/%sADCamplitude_DE%03d", getHistoPath(de).c_str(), de),
                                     TString::Format("ADC amplitude (DE%03d)", de), 5000, 0, 5000);
     mHistogramADCamplitudeDE.insert(make_pair(de, h));
-    mAllHistograms.push_back(h.get());
-    if (mDiagnostic && !mSaveToRootFile) {
-      getObjectsManager()->startPublishing(h.get());
-    }
+    publishObject(h, "hist", false, true);
 
     auto hm = std::make_shared<MergeableTH2Ratio>(TString::Format("Expert/%sOccupancy_B_XY_%03d", getHistoPath(de).c_str(), de),
                                                   TString::Format("Occupancy XY (DE%03d B) (KHz)", de));
     mHistogramOccupancyDE[0].insert(make_pair(de, hm));
-    mAllHistograms.push_back(hm.get());
-    if (mDiagnostic && !mSaveToRootFile) {
-      getObjectsManager()->startPublishing(hm.get());
-    }
+    publishObject(hm, "colz", false, true);
 
     auto h2n0 = std::make_shared<DetectorHistogram>(TString::Format("Expert/%sNhits_DE%03d_B", getHistoPath(de).c_str(), de),
                                                     TString::Format("Number of hits (DE%03d B)", de), de, int(0), hm->getNum());
@@ -192,10 +152,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
     hm = std::make_shared<MergeableTH2Ratio>(TString::Format("Expert/%sOccupancy_NB_XY_%03d", getHistoPath(de).c_str(), de),
                                              TString::Format("Occupancy XY (DE%03d NB) (KHz)", de));
     mHistogramOccupancyDE[1].insert(make_pair(de, hm));
-    mAllHistograms.push_back(hm.get());
-    if (mDiagnostic && !mSaveToRootFile) {
-      getObjectsManager()->startPublishing(hm.get());
-    }
+    publishObject(hm, "colz", false, true);
 
     auto h2n1 = std::make_shared<DetectorHistogram>(TString::Format("Expert/%sNhits_DE%03d_NB", getHistoPath(de).c_str(), de),
                                                     TString::Format("Number of hits (DE%03d NB)", de), de, int(1), hm->getNum());
@@ -409,15 +366,6 @@ void PhysicsTaskDigits::updateOrbits()
   }
 }
 
-void PhysicsTaskDigits::writeHistos()
-{
-  TFile f("mch-qc-digits.root", "RECREATE");
-  for (auto h : mAllHistograms) {
-    h->Write();
-  }
-  f.Close();
-}
-
 void PhysicsTaskDigits::endOfCycle()
 {
   ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
@@ -445,19 +393,11 @@ void PhysicsTaskDigits::endOfCycle()
 
   mHistogramOccupancyST12->update();
   mHistogramOccupancyST345->update();
-
-  if (mSaveToRootFile) {
-    writeHistos();
-  }
 }
 
 void PhysicsTaskDigits::endOfActivity(Activity& /*activity*/)
 {
   ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
-
-  if (mSaveToRootFile) {
-    writeHistos();
-  }
 }
 
 void PhysicsTaskDigits::reset()


### PR DESCRIPTION
This PR introduces a call to `object->SetStats(0)` for all the histograms for which we want the stats box to be hidden.

It also moves the drawing of the detector contours into separate functions, which are now called in the `beautify()` method of the checkers. This way the contours do not need to be stored in the histograms upon creation, and there is no more need to copy copy around the histograms' list of functions when merging.

This solves the memory leak issue that was introduced in the `beautify()` method of the `MergeableTH2Ratio` class. The method is now removed since it is no longer needed.