### PR TITLE
CPV: add CCDB objects drawing in physics task

### DIFF
--- a/Modules/CPV/etc/read-raw-from-file/physics-taskOnly-no-sampling.json
+++ b/Modules/CPV/etc/read-raw-from-file/physics-taskOnly-no-sampling.json
@@ -1,0 +1,48 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "CPVPhysicsTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsTask",
+        "moduleName": "QcCPV",
+        "detectorName": "CPV",
+        "cycleDurationSeconds": "10000",
+        "maxNumberCycles": "100",
+        "": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:CPV/DIGITS/0;dtrigrec:CPV/DIGITTRIGREC/0;clusters:CPV/CLUSTERS/0;ctrigrec:CPV/CLUSTERTRIGRECS/0;calibdigits:CPV/CALIBDIGITS/0;rawerrors:CPV/RAWHWERRORS/0;peds:CPV/CPV_Pedestals;badmap:CPV/CPV_BadMap;gains:CPV/CPV_Gains"
+        },
+        "taskParameters": {
+          "": ""
+        },
+        "location": "remote",
+        "saveObjectsToFile": "MOs.root",
+        "": "For debugging, path to the file where to save. If empty or missing it won't save."
+      }
+    },
+    "dataSamplingPolicies": []
+  }
+}

--- a/Modules/CPV/include/CPV/PhysicsTask.h
+++ b/Modules/CPV/include/CPV/PhysicsTask.h
@@ -87,7 +87,7 @@ class PhysicsTask final : public TaskInterface
                   H1DNDigitsInClusterM4
   };
 
-  static constexpr short kNHist2D = 12;
+  static constexpr short kNHist2D = 24;
   enum Histos2D { H2DDigitMapM2,
                   H2DDigitMapM3,
                   H2DDigitMapM4,
@@ -99,13 +99,25 @@ class PhysicsTask final : public TaskInterface
                   H2DDigitFreqM4,
                   H2DClusterMapM2,
                   H2DClusterMapM3,
-                  H2DClusterMapM4
+                  H2DClusterMapM4,
+                  H2DPedestalValueM2,
+                  H2DPedestalValueM3,
+                  H2DPedestalValueM4,
+                  H2DPedestalSigmaM2,
+                  H2DPedestalSigmaM3,
+                  H2DPedestalSigmaM4,
+                  H2DBadChannelMapM2,
+                  H2DBadChannelMapM3,
+                  H2DBadChannelMapM4,
+                  H2DGainsM2,
+                  H2DGainsM3,
+                  H2DGainsM4
   };
 
   static constexpr short kNModules = 3;
   static constexpr short kNChannels = 23040;
-  int mNEventsTotal;
-
+  int mNEventsTotal = 0;
+  int mCcdbCheckIntervalInMinutes = 10;
   std::array<TH1F*, kNHist1D> mHist1D = { nullptr }; ///< Array of 1D histograms
   std::array<TH2F*, kNHist2D> mHist2D = { nullptr }; ///< Array of 2D histograms
 };


### PR DESCRIPTION
Hello! Drawing of CPV pedestals, gains and bad channel map is added to PhysicsTask.
Objects can be fetched directly from CCDB or from internal-ccdb-backend if corresponding input is specified.
