### PR TITLE
MCH: improve preclusters task

### DIFF
--- a/Modules/MUON/Common/CMakeLists.txt
+++ b/Modules/MUON/Common/CMakeLists.txt
@@ -3,10 +3,12 @@ set(MODULE_NAME "O2QcMUONCommon")
 # ---- Files ----
 
 set(SRCS
+  src/MergeableTH1Ratio.cxx
   src/MergeableTH2Ratio.cxx
 )
 
 set(HEADERS
+  include/MUONCommon/MergeableTH1Ratio.h
   include/MUONCommon/MergeableTH2Ratio.h
 )
 
@@ -39,7 +41,8 @@ install(
 # ---- ROOT dictionary ----
 
 add_root_dictionary(${MODULE_NAME}
-                    HEADERS include/MUONCommon/MergeableTH2Ratio.h
+                    HEADERS include/MUONCommon/MergeableTH1Ratio.h
+                            include/MUONCommon/MergeableTH2Ratio.h
                     LINKDEF include/MUONCommon/LinkDef.h)
 
 # ---- Tests ----

--- a/Modules/MUON/Common/include/MUONCommon/LinkDef.h
+++ b/Modules/MUON/Common/include/MUONCommon/LinkDef.h
@@ -3,6 +3,7 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::quality_control_modules::muon::MergeableTH1Ratio + ;
 #pragma link C++ class o2::quality_control_modules::muon::MergeableTH2Ratio + ;
 
 #endif

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
@@ -1,0 +1,74 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MergeableTH1Ratio.h
+/// \brief An example of a custom TH2Quotient inheriting MergeInterface
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch, Sebastien Perrin, Andrea Ferrero
+
+#ifndef O2_MERGEABLETH1RATIO_H
+#define O2_MERGEABLETH1RATIO_H
+
+#include <sstream>
+#include <iostream>
+#include <TObject.h>
+#include <TH2.h>
+#include <TList.h>
+#include "Mergers/MergeInterface.h"
+
+using namespace std;
+namespace o2::quality_control_modules::muon
+{
+
+class MergeableTH1Ratio : public TH1F, public o2::mergers::MergeInterface
+{
+ public:
+  MergeableTH1Ratio() = default;
+
+  MergeableTH1Ratio(MergeableTH1Ratio const& copymerge);
+
+  MergeableTH1Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, double scaling = 1.);
+
+  MergeableTH1Ratio(const char* name, const char* title, double scaling = 1.);
+
+  ~MergeableTH1Ratio();
+
+  void merge(MergeInterface* const other) override;
+
+  TH1D* getNum() const
+  {
+    return mHistoNum;
+  }
+
+  TH1D* getDen() const
+  {
+    return mHistoDen;
+  }
+
+  double getScalingFactor() const
+  {
+    return mScalingFactor;
+  }
+
+  void update();
+
+ private:
+  TH1D* mHistoNum{ nullptr };
+  TH1D* mHistoDen{ nullptr };
+  std::string mTreatMeAs = "TH1F";
+  double mScalingFactor = 1.;
+
+  ClassDefOverride(MergeableTH1Ratio, 1);
+};
+
+} // namespace o2::quality_control_modules::muon
+
+#endif // O2_MERGEABLETH2RATIO_H

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
@@ -35,9 +35,9 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
 
   MergeableTH2Ratio(MergeableTH2Ratio const& copymerge);
 
-  MergeableTH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, double scaling = 1.);
+  MergeableTH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, double scaling = 1., bool showZeroBins = false);
 
-  MergeableTH2Ratio(const char* name, const char* title, double scaling = 1.);
+  MergeableTH2Ratio(const char* name, const char* title, double scaling = 1., bool showZeroBins = false);
 
   ~MergeableTH2Ratio();
 
@@ -58,6 +58,11 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
     return mScalingFactor;
   }
 
+  bool getShowZeroBins() const
+  {
+    return mShowZeroBins;
+  }
+
   void update();
 
   void beautify();
@@ -65,8 +70,9 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
  private:
   TH2F* mHistoNum{ nullptr };
   TH2F* mHistoDen{ nullptr };
-  std::string mTreatMeAs = "TH2F";
-  double mScalingFactor = 1.;
+  std::string mTreatMeAs{ "TH2F" };
+  double mScalingFactor{ 1. };
+  bool mShowZeroBins{ false };
 
   ClassDefOverride(MergeableTH2Ratio, 1);
 };

--- a/Modules/MUON/Common/src/MergeableTH1Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH1Ratio.cxx
@@ -1,0 +1,118 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MergeableTH1Ratio.cxx
+/// \brief An example of a custom TH2Quotient inheriting MergeInterface
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch, Sebastien Perrin, Andrea Ferrero
+
+#include "MUONCommon/MergeableTH1Ratio.h"
+
+using namespace std;
+namespace o2::quality_control_modules::muon
+{
+
+MergeableTH1Ratio::MergeableTH1Ratio(MergeableTH1Ratio const& copymerge)
+  : TH1F(copymerge.GetName(), copymerge.GetTitle(),
+         copymerge.getNum()->GetXaxis()->GetNbins(), copymerge.getNum()->GetXaxis()->GetXmin(), copymerge.getNum()->GetXaxis()->GetXmax()),
+    o2::mergers::MergeInterface(),
+    mScalingFactor(copymerge.getScalingFactor())
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = (TH1D*)copymerge.getNum()->Clone();
+  mHistoDen = (TH1D*)copymerge.getDen()->Clone();
+  TH1::AddDirectory(bStatus);
+
+  mHistoNum->Sumw2();
+  mHistoDen->Sumw2();
+}
+
+MergeableTH1Ratio::MergeableTH1Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, double scaling)
+  : TH1F(name, title, nbinsx, xmin, xmax),
+    o2::mergers::MergeInterface(),
+    mScalingFactor(scaling)
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = new TH1D("num", "num", nbinsx, xmin, xmax);
+  mHistoDen = new TH1D("den", "den", nbinsx, xmin, xmax);
+  TH1::AddDirectory(bStatus);
+
+  mHistoNum->Sumw2();
+  mHistoDen->Sumw2();
+
+  update();
+}
+
+MergeableTH1Ratio::MergeableTH1Ratio(const char* name, const char* title, double scaling)
+  : TH1F(name, title, 10, 0, 10),
+    o2::mergers::MergeInterface(),
+    mScalingFactor(scaling)
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = new TH1D("num", "num", 10, 0, 10);
+  mHistoDen = new TH1D("den", "den", 10, 0, 10);
+  TH1::AddDirectory(bStatus);
+
+  mHistoNum->Sumw2();
+  mHistoDen->Sumw2();
+
+  update();
+}
+
+MergeableTH1Ratio::~MergeableTH1Ratio()
+{
+  if (mHistoNum) {
+    delete mHistoNum;
+  }
+
+  if (mHistoDen) {
+    delete mHistoDen;
+  }
+}
+
+void MergeableTH1Ratio::merge(MergeInterface* const other)
+{
+  mHistoNum->Add(dynamic_cast<const MergeableTH1Ratio* const>(other)->getNum());
+  mHistoDen->Add(dynamic_cast<const MergeableTH1Ratio* const>(other)->getDen());
+  update();
+}
+
+void MergeableTH1Ratio::update()
+{
+  const char* name = this->GetName();
+  const char* title = this->GetTitle();
+
+  Reset();
+  GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
+  SetBinsLength();
+
+  // Compute the ratio with a temporary TH1D, then copy the bin contents and errors
+  TH1D* hRatio = (TH1D*)mHistoNum->Clone();
+  hRatio->Divide(mHistoDen);
+
+  for (int i = 1; i <= GetXaxis()->GetNbins(); i++) {
+    SetBinContent(i, hRatio->GetBinContent(i));
+    SetBinError(i, hRatio->GetBinError(i));
+  }
+  SetNameTitle(name, title);
+
+  delete hRatio;
+
+  // scale plot if needed
+  if (mScalingFactor != 1.) {
+    Scale(mScalingFactor);
+  }
+}
+
+} // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/MCH/include/MCH/PhysicsPreclustersCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsPreclustersCheck.h
@@ -42,12 +42,9 @@ class PhysicsPreclustersCheck : public o2::quality_control::checker::CheckInterf
   std::string getAcceptedType() override;
 
  private:
-  int mPrintLevel;
-  double minPseudoeff;
-  double maxPseudoeff;
-  double minMPV;
-  double maxMPV;
-  ClassDefOverride(PhysicsPreclustersCheck, 2);
+  double mMinPseudoeff;
+  double mMaxPseudoeff;
+  ClassDefOverride(PhysicsPreclustersCheck, 3);
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskPreclusters.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskPreclusters.h
@@ -23,6 +23,7 @@
 
 #include <TH2.h>
 #include "QualityControl/TaskInterface.h"
+#include "MUONCommon/MergeableTH1Ratio.h"
 #include "MUONCommon/MergeableTH2Ratio.h"
 #include "MCH/MergeableTH1PseudoEfficiencyPerDE.h"
 //#include "MCH/MergeableTH1PseudoEfficiencyPerDECycle.h"
@@ -33,6 +34,7 @@
 #else
 #include "MCHBase/Digit.h"
 #endif
+#include "MCHDigitFiltering/DigitFilter.h"
 #include "MCHBase/PreCluster.h"
 
 using namespace o2::quality_control_modules::muon;
@@ -65,30 +67,61 @@ class PhysicsTaskPreclusters /*final*/ : public o2::quality_control::core::TaskI
   void reset() override;
 
  private:
+  template <typename T>
+  void publishObject(std::shared_ptr<T> histo, const char* drawOption, bool statBox, bool isExpert)
+  {
+    histo->SetOption(drawOption);
+    if (!statBox) {
+      histo->SetStats(0);
+    }
+    mAllHistograms.push_back(histo.get());
+    if (mDiagnostic || (isExpert == false)) {
+      getObjectsManager()->startPublishing(histo.get());
+    }
+  }
+
   bool plotPrecluster(const o2::mch::PreCluster& preCluster, gsl::span<const o2::mch::Digit> digits);
   void printPrecluster(gsl::span<const o2::mch::Digit> preClusterDigits);
   void printPreclusters(gsl::span<const o2::mch::PreCluster> preClusters, gsl::span<const o2::mch::Digit> digits);
 
   void computePseudoEfficiency();
-  void writeHistos();
+  bool getFecChannel(int deId, int padId, int& fecId, int& channel);
+
+  static constexpr int sMaxFeeId = 64;
+  static constexpr int sMaxLinkId = 12;
+  static constexpr int sMaxDsId = 40;
+
+  bool mDiagnostic{ false };
+
+  o2::mch::raw::Elec2DetMapper mElec2DetMapper;
+  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
+  o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
+  o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
+
+  o2::mch::DigitFilter mIsSignalDigit;
 
   // TH1 of Mean Pseudo-efficiency on DEs
-  //Since beginning of run
-  std::shared_ptr<MergeableTH1PseudoEfficiencyPerDE> mMeanPseudoeffPerDE[2]; //Pseudoefficiency of B and NB
+  // Since beginning of run
+  // std::shared_ptr<MergeableTH1PseudoEfficiencyPerDE> mMeanPseudoeffPerDE[2]; // Pseudoefficiency of B and NB
+  std::shared_ptr<MergeableTH2Ratio> mHistogramPseudoeffElec; // Mergeable object, Occupancy histogram (Elec view)
 
-  //On last cycle only
-  // WARNING: the code for the efficiency on cycle is currently broken and therefore disabled
-  //MergeableTH1PseudoEfficiencyPerDECycle* mMeanPseudoeffPerDE_DoesGoodNBHaveSomethingB_Cycle;
-  //MergeableTH1PseudoEfficiencyPerDECycle* mMeanPseudoeffPerDE_DoesGoodBHaveSomethingNB_Cycle;
-  //MergeableTH1MPVPerDECycle* mMPVCycle; //MPV of the Landau best fitted to the cluster charge distribution on each DE each cycle
+  std::shared_ptr<GlobalHistogram> mHistogramNumST12;          // Histogram of Number of hits (global XY view)
+  std::shared_ptr<GlobalHistogram> mHistogramDenST12;          // Histogram of Number of orbits (global XY view)
+  std::shared_ptr<MergeableTH2Ratio> mHistogramPseudoeffST12;  // Mergeable object, Occupancy histogram (global XY view)
+  std::shared_ptr<GlobalHistogram> mHistogramNumST345;         // Histogram of Number of hits (global XY view)
+  std::shared_ptr<GlobalHistogram> mHistogramDenST345;         // Histogram of Number of orbits (global XY view)
+  std::shared_ptr<MergeableTH2Ratio> mHistogramPseudoeffST345; // Mergeable object, Occupancy histogram (global XY view)
 
-  std::shared_ptr<TH2F> mDigitChargeVsSize[4];
-  std::shared_ptr<TH2F> mDigitClsizeVsCharge[2];
-  std::shared_ptr<TH2F> mDigitChargeNBVsChargeB;
+  std::shared_ptr<MergeableTH1Ratio> mHistogramMeanPseudoeffPerDE[2]; // Pseudoefficiency of B and NB
 
-  std::map<int, std::shared_ptr<TH2F>> mHistogramClchgDE;
+  std::shared_ptr<MergeableTH1Ratio> mHistogramPreclustersPerDE;       // number of pre-clusters per DE and per TF
+  std::shared_ptr<MergeableTH1Ratio> mHistogramPreclustersSignalPerDE; // number of pre-clusters with signal per DE and per TF
+
+  std::map<int, std::shared_ptr<TH1F>> mHistogramClchgDE;
   std::map<int, std::shared_ptr<TH1F>> mHistogramClchgDEOnCycle;
-  std::map<int, std::shared_ptr<TH2F>> mHistogramClsizeDE;
+  std::map<int, std::shared_ptr<TH1F>> mHistogramClsizeDE;
+  std::map<int, std::shared_ptr<TH1F>> mHistogramClsizeDE_B;
+  std::map<int, std::shared_ptr<TH1F>> mHistogramClsizeDE_NB;
 
   std::map<int, std::shared_ptr<DetectorHistogram>> mHistogramPreclustersXY[4];
   std::map<int, std::shared_ptr<MergeableTH2Ratio>> mHistogramPseudoeffXY[2];

--- a/Modules/MUON/MCH/src/PhysicsPreclustersCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsPreclustersCheck.cxx
@@ -16,6 +16,7 @@
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHMappingSegContour/CathodeSegmentationContours.h"
 #include "MCH/PhysicsPreclustersCheck.h"
+#include "MCH/GlobalHistogram.h"
 
 // ROOT
 #include <fairlogger/Logger.h>
@@ -34,41 +35,33 @@ using namespace std;
 namespace o2::quality_control_modules::muonchambers
 {
 
-PhysicsPreclustersCheck::PhysicsPreclustersCheck()
+PhysicsPreclustersCheck::PhysicsPreclustersCheck() : mMinPseudoeff(0.5), mMaxPseudoeff(1.0)
 {
-  mPrintLevel = 1;
-  minPseudoeff = 0.5;
-  maxPseudoeff = 1.0;
-  minMPV = 300;
-  maxMPV = 700;
 }
 
 PhysicsPreclustersCheck::~PhysicsPreclustersCheck() {}
 
 void PhysicsPreclustersCheck::configure()
 {
-  //   if (AliRecoParam::ConvertIndex(specie) == AliRecoParam::kCosmic) {
-  //     minTOFrawTime = 150.; //ns
-  //     maxTOFrawTime = 250.; //ns
-  //   }
+  if (auto param = mCustomParameters.find("MinPseudoefficiency"); param != mCustomParameters.end()) {
+    mMinPseudoeff = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("MaxPseudoefficiency"); param != mCustomParameters.end()) {
+    mMaxPseudoeff = std::stof(param->second);
+  }
 }
 
 Quality PhysicsPreclustersCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
-  //  std::cout << "=================================" << std::endl;
-  //  std::cout << "PhysicsOccupancyCheck::check() called" << std::endl;
-  //  std::cout << "=================================" << std::endl;
   Quality result = Quality::Null;
 
   for (auto& [moName, mo] : *moMap) {
 
     (void)moName;
-    //   std::cout << mo->getName() <<endl;
-    if (mo->getName().find("QcMuonChambers_MeanPseudoeff_Mergeable_DoesGoodBHaveSomethingNB") != std::string::npos) {
+    if ((mo->getName().find("MeanPseudoeffPerDE_B") != std::string::npos) ||
+        (mo->getName().find("MeanPseudoeffPerDE_NB") != std::string::npos)) {
       auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      std::cout << mo->ClassName() << endl;
       if (!h) {
-        std::cout << "Pas trouvé l'objet" << std::endl;
         return result;
       }
 
@@ -78,140 +71,8 @@ Quality PhysicsPreclustersCheck::check(std::map<std::string, std::shared_ptr<Mon
         int nbinsx = h->GetXaxis()->GetNbins();
         int nbad = 0;
         for (int i = 1; i <= nbinsx; i++) {
-          Float_t occ = h->GetBinContent(i);
-          if (occ < minPseudoeff || occ > maxPseudoeff) {
-            nbad += 1;
-          }
-        }
-        if (nbad < 1) {
-          result = Quality::Good;
-          std::cout << "GOOD" << endl;
-        } else {
-          result = Quality::Bad;
-          std::cout << "BAD" << endl;
-        }
-      }
-    }
-  }
-  for (auto& [moName, mo] : *moMap) {
-    if (mo->getName().find("QcMuonChambers_MeanPseudoeff_Mergeable_DoesGoodNBHaveSomethingB") != std::string::npos) {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      std::cout << mo->ClassName() << endl;
-      if (!h) {
-        std::cout << "Pas trouvé l'objet" << std::endl;
-        return result;
-      }
-
-      if (h->GetEntries() == 0) {
-        result = Quality::Medium;
-      } else {
-        int nbinsx = h->GetXaxis()->GetNbins();
-        int nbad = 0;
-        for (int i = 1; i <= nbinsx; i++) {
-          Float_t occ = h->GetBinContent(i);
-          if (occ < minPseudoeff || occ > maxPseudoeff) {
-            nbad += 1;
-          }
-        }
-        if (nbad < 1) {
-          result = Quality::Good;
-          std::cout << "GOOD" << endl;
-        } else {
-          result = Quality::Bad;
-          std::cout << "BAD" << endl;
-        }
-      }
-    }
-  }
-
-  for (auto& [moName, mo] : *moMap) {
-
-    (void)moName;
-    //  std::cout << mo->getName() <<endl;
-    if (mo->getName().find("mMeanPseudoeffPerDE_DoesGoodBHaveSomethingNB_OnCycle") != std::string::npos) {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      std::cout << mo->ClassName() << endl;
-      if (!h) {
-        std::cout << "Pas trouvé l'objet" << std::endl;
-        return result;
-      }
-
-      if (h->GetEntries() == 0) {
-        result = Quality::Medium;
-      } else {
-        int nbinsx = h->GetXaxis()->GetNbins();
-        int nbad = 0;
-        for (int i = 1; i <= nbinsx; i++) {
-          Float_t occ = h->GetBinContent(i);
-          if (occ < minPseudoeff || occ > maxPseudoeff) {
-            nbad += 1;
-          }
-        }
-        if (nbad < 1) {
-          result = Quality::Good;
-          std::cout << "GOOD" << endl;
-        } else {
-          result = Quality::Bad;
-          std::cout << "BAD" << endl;
-        }
-      }
-    }
-  }
-
-  for (auto& [moName, mo] : *moMap) {
-
-    (void)moName;
-    //  std::cout << mo->getName() <<endl;
-    if (mo->getName().find("mMeanPseudoeffPerDE_DoesGoodNBHaveSomethingB_OnCycle") != std::string::npos) {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      std::cout << mo->ClassName() << endl;
-      if (!h) {
-        std::cout << "Pas trouvé l'objet" << std::endl;
-        return result;
-      }
-
-      if (h->GetEntries() == 0) {
-        result = Quality::Medium;
-      } else {
-        int nbinsx = h->GetXaxis()->GetNbins();
-        int nbad = 0;
-        for (int i = 1; i <= nbinsx; i++) {
-          Float_t occ = h->GetBinContent(i);
-          if (occ < minPseudoeff || occ > maxPseudoeff) {
-            nbad += 1;
-          }
-        }
-        if (nbad < 1) {
-          result = Quality::Good;
-          std::cout << "GOOD" << endl;
-        } else {
-          result = Quality::Bad;
-          std::cout << "BAD" << endl;
-        }
-      }
-    }
-  }
-
-  for (auto& [moName, mo] : *moMap) {
-
-    (void)moName;
-    //     std::cout << mo->getName() <<endl;
-    if (mo->getName().find("QcMuonChambers_MPV_Mergeable_OnCycle") != std::string::npos) {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      std::cout << mo->ClassName() << endl;
-      if (!h) {
-        std::cout << "Pas trouvé l'objet" << std::endl;
-        return result;
-      }
-
-      if (h->GetEntries() == 0) {
-        result = Quality::Medium;
-      } else {
-        int nbinsx = h->GetXaxis()->GetNbins();
-        int nbad = 0;
-        for (int i = 1; i <= nbinsx; i++) {
-          Float_t occ = h->GetBinContent(i);
-          if (occ < minMPV || occ > maxMPV) {
+          Float_t eff = h->GetBinContent(i);
+          if (eff < mMinPseudoeff || eff > mMaxPseudoeff) {
             nbad += 1;
           }
         }
@@ -231,264 +92,106 @@ Quality PhysicsPreclustersCheck::check(std::map<std::string, std::shared_ptr<Mon
 
 std::string PhysicsPreclustersCheck::getAcceptedType() { return "TH1"; }
 
+static void updateTitle(TH1* hist, std::string suffix)
+{
+  if (!hist) {
+    return;
+  }
+  TString title = hist->GetTitle();
+  title.Append(" ");
+  title.Append(suffix.c_str());
+  hist->SetTitle(title);
+}
+
+static std::string getCurrentTime()
+{
+  time_t t;
+  time(&t);
+
+  struct tm* tmp;
+  tmp = localtime(&t);
+
+  char timestr[500];
+  strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);
+
+  std::string result = timestr;
+  return result;
+}
+
 void PhysicsPreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  //  std::cout<<"===================================="<<std::endl;
-  //  std::cout<<"PhysicsOccupancyCheck::beautify() called"<<std::endl;
-  //  std::cout<<"===================================="<<std::endl;
-  if (mo->getName().find("QcMuonChambers_MeanPseudoeff_Mergeable_DoesGoodBHaveSomethingNB") != std::string::npos) {
+  auto currentTime = getCurrentTime();
+  updateTitle(dynamic_cast<TH1*>(mo->getObject()), currentTime);
+
+  if ((mo->getName().find("MeanPseudoeffPerDE_B") != std::string::npos) ||
+      (mo->getName().find("MeanPseudoeffPerDE_NB") != std::string::npos) ||
+      (mo->getName().find("PreclustersPerDE") != std::string::npos) ||
+      (mo->getName().find("PreclustersSignalPerDE") != std::string::npos)) {
     auto* h = dynamic_cast<TH1F*>(mo->getObject());
+    // disable ticks on axis
+    h->GetXaxis()->SetTickLength(0.0);
+    h->GetXaxis()->SetLabelSize(0.0);
+    h->GetYaxis()->SetTickLength(0);
+    h->GetYaxis()->SetTitle("efficiency");
+
+    h->SetMinimum(0);
+    h->SetMaximum(2);
+
+    TText* xtitle = new TText();
+    xtitle->SetNDC();
+    xtitle->SetText(0.87, 0.03, "chamber #");
+    xtitle->SetTextSize(15);
+    h->GetListOfFunctions()->Add(xtitle);
+
+    // draw chamber delimiters
+    for (int demin = 200; demin <= 1000; demin += 100) {
+      float xpos = static_cast<float>(getDEindex(demin));
+      TLine* delimiter = new TLine(xpos, 0, xpos, 2);
+      delimiter->SetLineColor(kBlack);
+      delimiter->SetLineStyle(kDashed);
+      h->GetListOfFunctions()->Add(delimiter);
+    }
+
+    // draw x-axis labels
+    for (int ch = 1; ch <= 10; ch += 1) {
+      float x1 = static_cast<float>(getDEindex(ch * 100));
+      float x2 = (ch < 10) ? static_cast<float>(getDEindex(ch * 100 + 100)) : h->GetXaxis()->GetXmax();
+      float x0 = 0.8 * (x1 + x2) / (2 * h->GetXaxis()->GetXmax()) + 0.1;
+      float y0 = 0.05;
+      TText* label = new TText();
+      label->SetNDC();
+      label->SetText(x0, y0, TString::Format("%d", ch));
+      label->SetTextSize(15);
+      label->SetTextAlign(22);
+      h->GetListOfFunctions()->Add(label);
+    }
+
     TPaveText* msg = new TPaveText(0.3, 0.9, 0.7, 0.95, "NDC");
     h->GetListOfFunctions()->Add(msg);
     msg->SetName(Form("%s_msg", mo->GetName()));
 
-    TLine* lmin = new TLine(0, minPseudoeff, 1100, minPseudoeff);
-    TLine* lmax = new TLine(0, maxPseudoeff, 1100, maxPseudoeff);
+    TLine* lmin = new TLine(0, mMinPseudoeff, getDEindexMax(), mMinPseudoeff);
+    TLine* lmax = new TLine(0, mMaxPseudoeff, getDEindexMax(), mMaxPseudoeff);
 
     h->GetListOfFunctions()->Add(lmin);
     h->GetListOfFunctions()->Add(lmax);
 
-    //      lmin->Draw();
-    //      lmax->Draw();
     if (checkResult == Quality::Good) {
       msg->Clear();
       msg->AddText("Pseudo-efficiency consistently within limits: OK!!!");
       msg->SetFillColor(kGreen);
-      //
-      //   h->SetFillColor(kGreen);
     } else if (checkResult == Quality::Bad) {
       LOG(info) << "Quality::Bad, setting to red";
-      //
       msg->Clear();
       msg->AddText("Call MCH on-call.");
       msg->SetFillColor(kRed);
-      //
-      //  h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
       LOG(info) << "Quality::medium, setting to orange";
-      //
       msg->Clear();
       msg->AddText("No entries. If MCH in the run, check MCH TWiki");
       msg->SetFillColor(kYellow);
-      //   h->SetFillColor(kOrange);
     }
     h->SetLineColor(kBlack);
-
-    for (Int_t i = 1; i <= h->GetNbinsX(); i += 1) {
-      TBox* b = new TBox(h->GetBinLowEdge(i),
-                         h->GetMinimum(),
-                         h->GetBinWidth(i) + h->GetBinLowEdge(i),
-                         h->GetBinContent(i));
-      b->SetFillColor(kGreen);
-      if (h->GetBinContent(i) < minPseudoeff || h->GetBinContent(i) > maxPseudoeff) {
-        b->SetFillColor(kRed);
-      }
-      h->GetListOfFunctions()->Add(b);
-    }
-  }
-
-  if (mo->getName().find("QcMuonChambers_MeanPseudoeff_Mergeable_DoesGoodNBHaveSomethingB") != std::string::npos) {
-    auto* h = dynamic_cast<TH1F*>(mo->getObject());
-    TPaveText* msg = new TPaveText(0.3, 0.9, 0.7, 0.95, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-
-    TLine* lmin = new TLine(0, minPseudoeff, 1100, minPseudoeff);
-    TLine* lmax = new TLine(0, maxPseudoeff, 1100, maxPseudoeff);
-
-    h->GetListOfFunctions()->Add(lmin);
-    h->GetListOfFunctions()->Add(lmax);
-
-    //      lmin->Draw();
-    //      lmax->Draw();
-    if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("Pseudo-efficiency consistently within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-      //
-      //   h->SetFillColor(kGreen);
-    } else if (checkResult == Quality::Bad) {
-      LOG(info) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Call MCH on-call.");
-      msg->SetFillColor(kRed);
-      //
-      //  h->SetFillColor(kRed);
-    } else if (checkResult == Quality::Medium) {
-      LOG(info) << "Quality::medium, setting to orange";
-      //
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, check MCH TWiki");
-      msg->SetFillColor(kYellow);
-      //   h->SetFillColor(kOrange);
-    }
-    h->SetLineColor(kBlack);
-
-    for (Int_t i = 1; i <= h->GetNbinsX(); i += 1) {
-      TBox* b = new TBox(h->GetBinLowEdge(i),
-                         h->GetMinimum(),
-                         h->GetBinWidth(i) + h->GetBinLowEdge(i),
-                         h->GetBinContent(i));
-      b->SetFillColor(kGreen);
-      if (h->GetBinContent(i) < minPseudoeff || h->GetBinContent(i) > maxPseudoeff) {
-        b->SetFillColor(kRed);
-      }
-      h->GetListOfFunctions()->Add(b);
-    }
-  }
-
-  if (mo->getName().find("mMeanPseudoeffPerDE_DoesGoodBHaveSomethingNB_OnCycle") != std::string::npos) {
-    auto* h = dynamic_cast<TH1F*>(mo->getObject());
-    TPaveText* msg = new TPaveText(0.3, 0.9, 0.7, 0.95, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-
-    TLine* lmin = new TLine(0, minPseudoeff, 1100, minPseudoeff);
-    TLine* lmax = new TLine(0, maxPseudoeff, 1100, maxPseudoeff);
-
-    h->GetListOfFunctions()->Add(lmin);
-    h->GetListOfFunctions()->Add(lmax);
-
-    //      lmin->Draw();
-    //      lmax->Draw();
-    if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("Pseudo-efficiency consistently within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-      //
-      //   h->SetFillColor(kGreen);
-    } else if (checkResult == Quality::Bad) {
-      LOG(info) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Call MCH on-call.");
-      msg->SetFillColor(kRed);
-      //
-      //  h->SetFillColor(kRed);
-    } else if (checkResult == Quality::Medium) {
-      LOG(info) << "Quality::medium, setting to orange";
-      //
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, check MCH TWiki");
-      msg->SetFillColor(kYellow);
-      //   h->SetFillColor(kOrange);
-    }
-    h->SetLineColor(kBlack);
-
-    for (Int_t i = 1; i <= h->GetNbinsX(); i += 1) {
-      TBox* b = new TBox(h->GetBinLowEdge(i),
-                         h->GetMinimum(),
-                         h->GetBinWidth(i) + h->GetBinLowEdge(i),
-                         h->GetBinContent(i));
-      b->SetFillColor(kGreen);
-      if (h->GetBinContent(i) < minPseudoeff || h->GetBinContent(i) > maxPseudoeff) {
-        b->SetFillColor(kRed);
-      }
-      h->GetListOfFunctions()->Add(b);
-    }
-  }
-
-  if (mo->getName().find("mMeanPseudoeffPerDE_DoesGoodNBHaveSomethingB_OnCycle") != std::string::npos) {
-    auto* h = dynamic_cast<TH1F*>(mo->getObject());
-    TPaveText* msg = new TPaveText(0.3, 0.9, 0.7, 0.95, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-
-    TLine* lmin = new TLine(0, minPseudoeff, 1100, minPseudoeff);
-    TLine* lmax = new TLine(0, maxPseudoeff, 1100, maxPseudoeff);
-
-    h->GetListOfFunctions()->Add(lmin);
-    h->GetListOfFunctions()->Add(lmax);
-
-    //      lmin->Draw();
-    //      lmax->Draw();
-    if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("Pseudo-efficiency consistently within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-      //
-      //   h->SetFillColor(kGreen);
-    } else if (checkResult == Quality::Bad) {
-      LOG(info) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Call MCH on-call.");
-      msg->SetFillColor(kRed);
-      //
-      //  h->SetFillColor(kRed);
-    } else if (checkResult == Quality::Medium) {
-      LOG(info) << "Quality::medium, setting to orange";
-      //
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, check MCH TWiki");
-      msg->SetFillColor(kYellow);
-      //   h->SetFillColor(kOrange);
-    }
-    h->SetLineColor(kBlack);
-
-    for (Int_t i = 1; i <= h->GetNbinsX(); i += 1) {
-      TBox* b = new TBox(h->GetBinLowEdge(i),
-                         h->GetMinimum(),
-                         h->GetBinWidth(i) + h->GetBinLowEdge(i),
-                         h->GetBinContent(i));
-      b->SetFillColor(kGreen);
-      if (h->GetBinContent(i) < minPseudoeff || h->GetBinContent(i) > maxPseudoeff) {
-        b->SetFillColor(kRed);
-      }
-      h->GetListOfFunctions()->Add(b);
-    }
-  }
-
-  if (mo->getName().find("QcMuonChambers_MPV_Mergeable_OnCycle") != std::string::npos) {
-    auto* h = dynamic_cast<TH1F*>(mo->getObject());
-    TPaveText* msg = new TPaveText(0.3, 0.9, 0.7, 0.95, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-
-    TLine* lmin = new TLine(0, minMPV, 1100, minMPV);
-    TLine* lmax = new TLine(0, maxMPV, 1100, maxMPV);
-
-    h->GetListOfFunctions()->Add(lmin);
-    h->GetListOfFunctions()->Add(lmax);
-
-    //      lmin->Draw();
-    //      lmax->Draw();
-    if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("MPV consistently within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-      //
-      //   h->SetFillColor(kGreen);
-    } else if (checkResult == Quality::Bad) {
-      LOG(info) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Call MCH on-call.");
-      msg->SetFillColor(kRed);
-      //
-      //  h->SetFillColor(kRed);
-    } else if (checkResult == Quality::Medium) {
-      LOG(info) << "Quality::medium, setting to orange";
-      //
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, check MCH TWiki");
-      msg->SetFillColor(kYellow);
-      //   h->SetFillColor(kOrange);
-    }
-    h->SetLineColor(kBlack);
-
-    for (Int_t i = 1; i <= h->GetNbinsX(); i += 1) {
-      TBox* b = new TBox(h->GetBinLowEdge(i),
-                         h->GetMinimum(),
-                         h->GetBinWidth(i) + h->GetBinLowEdge(i),
-                         h->GetBinContent(i));
-      b->SetFillColor(kGreen);
-      if (h->GetBinContent(i) < minMPV || h->GetBinContent(i) >= maxMPV) {
-        b->SetFillColor(kRed);
-      }
-      h->GetListOfFunctions()->Add(b);
-    }
   }
 }
 

--- a/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
@@ -39,15 +39,16 @@ using namespace std;
 using namespace o2::mch::raw;
 using namespace o2::quality_control::core;
 
-//#define QC_MCH_SAVE_TEMP_ROOTFILE 1
-
 namespace o2
 {
 namespace quality_control_modules
 {
 namespace muonchambers
 {
-PhysicsTaskPreclusters::PhysicsTaskPreclusters() : TaskInterface() {}
+PhysicsTaskPreclusters::PhysicsTaskPreclusters() : TaskInterface()
+{
+  mIsSignalDigit = o2::mch::createDigitFilter(20, true, true);
+}
 
 PhysicsTaskPreclusters::~PhysicsTaskPreclusters() {}
 
@@ -55,82 +56,120 @@ void PhysicsTaskPreclusters::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Info, Support) << "initialize PhysicsTaskPreclusters" << AliceO2::InfoLogger::InfoLogger::endm;
 
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
-
-    auto h = std::make_shared<TH2F>(TString::Format("%sCluster_Charge_DE%03d", getHistoPath(de).c_str(), de),
-                                    TString::Format("Cluster charge (DE%03d)", de), 1000, 0, 50000, 4, 0, 4);
-    h->GetYaxis()->SetBinLabel(1, "#splitline{ nB <= 1}{nNB <= 1}");
-    h->GetYaxis()->SetBinLabel(2, "#splitline{ nB >= 2}{nNB <= 1}");
-    h->GetYaxis()->SetBinLabel(3, "#splitline{ nB <= 1}{nNB >= 2}");
-    h->GetYaxis()->SetBinLabel(4, "#splitline{ nB >= 2}{nNB >= 2}");
-    mHistogramClchgDE.insert(make_pair(de, h));
-    getObjectsManager()->startPublishing(h.get());
-    mAllHistograms.push_back(h.get());
-
-    auto h1 = std::make_shared<TH1F>(TString::Format("%sCluster_Charge_OnCycle_DE%03d", getHistoPath(de).c_str(), de),
-                                     TString::Format("Cluster charge on cycle (DE%03d)", de), 1000, 0, 50000);
-    mHistogramClchgDEOnCycle.insert(make_pair(de, h1));
-
-    h = std::make_shared<TH2F>(TString::Format("%sCluster_Size_DE%03d", getHistoPath(de).c_str(), de),
-                               TString::Format("Cluster size (DE%03d)", de), 10, 0, 10, 3, 0, 3);
-    h->GetYaxis()->SetBinLabel(1, "B");
-    h->GetYaxis()->SetBinLabel(2, "NB");
-    h->GetYaxis()->SetBinLabel(3, "B+NB");
-    mHistogramClsizeDE.insert(make_pair(de, h));
-    getObjectsManager()->startPublishing(h.get());
-    mAllHistograms.push_back(h.get());
-
-    // Histograms using the XY Mapping
-    {
-      auto hXYPseudo0 = std::make_shared<MergeableTH2Ratio>(TString::Format("%sPseudoeff_B_XY_%03d", getHistoPath(de).c_str(), de),
-                                                            TString::Format("Pseudo-efficiency XY (DE%03d B)", de));
-      mHistogramPseudoeffXY[0].insert(make_pair(de, hXYPseudo0));
-      getObjectsManager()->startPublishing(hXYPseudo0.get());
-      mAllHistograms.push_back(hXYPseudo0.get());
-
-      auto hXYPseudo1 = std::make_shared<MergeableTH2Ratio>(TString::Format("%sPseudoeff_NB_XY_%03d", getHistoPath(de).c_str(), de),
-                                                            TString::Format("Pseudo-efficiency XY (DE%03d NB)", de));
-      mHistogramPseudoeffXY[1].insert(make_pair(de, hXYPseudo1));
-      getObjectsManager()->startPublishing(hXYPseudo1.get());
-      mAllHistograms.push_back(hXYPseudo1.get());
-
-      auto hXY0 = std::make_shared<DetectorHistogram>(TString::Format("%sPreclusters_den_B_XY_%03d", getHistoPath(de).c_str(), de),
-                                                      TString::Format("Preclusters XY (DE%03d B, den)", de), de, 0, hXYPseudo0->getDen());
-      mHistogramPreclustersXY[0].insert(make_pair(de, hXY0));
-      mAllHistograms.push_back(hXY0.get()->getHist());
-      auto hXY1 = std::make_shared<DetectorHistogram>(TString::Format("%sPreclusters_den_NB_XY_%03d", getHistoPath(de).c_str(), de),
-                                                      TString::Format("Preclusters XY (DE%03d NB, den)", de), de, 1, hXYPseudo1->getDen());
-      mHistogramPreclustersXY[1].insert(make_pair(de, hXY1));
-      mAllHistograms.push_back(hXY1.get()->getHist());
-      auto hXY2 = std::make_shared<DetectorHistogram>(TString::Format("%sPreclusters_num_B_XY_%03d", getHistoPath(de).c_str(), de),
-                                                      TString::Format("Preclusters XY (DE%03d B, num)", de), de, 0, hXYPseudo0->getNum());
-      mHistogramPreclustersXY[2].insert(make_pair(de, hXY2));
-      mAllHistograms.push_back(hXY2.get()->getHist());
-      auto hXY3 = std::make_shared<DetectorHistogram>(TString::Format("%sPreclusters_num_NB_XY_%03d", getHistoPath(de).c_str(), de),
-                                                      TString::Format("Preclusters XY (DE%03d NB, num)", de), de, 1, hXYPseudo1->getNum());
-      mHistogramPreclustersXY[3].insert(make_pair(de, hXY3));
-      mAllHistograms.push_back(hXY3.get()->getHist());
+  mDiagnostic = false;
+  if (auto param = mCustomParameters.find("Diagnostic"); param != mCustomParameters.end()) {
+    if (param->second == "true" || param->second == "True" || param->second == "TRUE") {
+      mDiagnostic = true;
     }
   }
 
+  mElec2DetMapper = createElec2DetMapper<ElectronicMapperGenerated>();
+  mDet2ElecMapper = createDet2ElecMapper<ElectronicMapperGenerated>();
+  mFeeLink2SolarMapper = createFeeLink2SolarMapper<ElectronicMapperGenerated>();
+  mSolar2FeeLinkMapper = createSolar2FeeLinkMapper<ElectronicMapperGenerated>();
+
+  const uint32_t nElecXbins = PhysicsTaskPreclusters::sMaxFeeId * PhysicsTaskPreclusters::sMaxLinkId * PhysicsTaskPreclusters::sMaxDsId;
+
+  // Histograms in electronics coordinates
+  mHistogramPseudoeffElec = std::make_shared<MergeableTH2Ratio>("Pseudoeff_Elec", "Pseudoeff", nElecXbins, 0, nElecXbins, 64, 0, 64, 1, true);
+  publishObject(mHistogramPseudoeffElec, "colz", false, false);
+
   // 1D histograms for mean pseudoeff per DE (integrated or per elapsed cycle) - Used in trending
-  mMeanPseudoeffPerDE[0] = std::make_shared<MergeableTH1PseudoEfficiencyPerDE>("MeanPseudoeffPerDE_B", "Mean Pseudoeff for each DE (B)");
-  getObjectsManager()->startPublishing(mMeanPseudoeffPerDE[0].get());
-  mAllHistograms.push_back(mMeanPseudoeffPerDE[0].get());
-  mMeanPseudoeffPerDE[1] = std::make_shared<MergeableTH1PseudoEfficiencyPerDE>("MeanPseudoeffPerDE_NB", "Mean Pseudoeff for each DE (NB)");
-  getObjectsManager()->startPublishing(mMeanPseudoeffPerDE[1].get());
-  mAllHistograms.push_back(mMeanPseudoeffPerDE[1].get());
+  mHistogramMeanPseudoeffPerDE[0] = std::make_shared<MergeableTH1Ratio>("MeanPseudoeffPerDE_B", "Mean Pseudoeff for each DE (B)", getDEindexMax(), 0, getDEindexMax());
+  publishObject(mHistogramMeanPseudoeffPerDE[0], "E", false, false);
+  mHistogramMeanPseudoeffPerDE[1] = std::make_shared<MergeableTH1Ratio>("MeanPseudoeffPerDE_NB", "Mean Pseudoeff for each DE (NB)", getDEindexMax(), 0, getDEindexMax());
+  publishObject(mHistogramMeanPseudoeffPerDE[1], "E", false, false);
 
-  /*
-  The code for the calculation of the on-cycle values is currently broken and therefore commented
-  mMeanPseudoeffPerDE_DoesGoodNBHaveSomethingB_Cycle = new MergeableTH1PseudoEfficiencyPerDECycle("MeanPseudoeffPerDE_DoesGoodNBHaveSomethingB_OnCycle", "Mean Pseudoeff of each DE during the cycle (Good clusters on NB associated with something on B)", mHistogramPreclustersXY[3], mHistogramPreclustersXY[1]);
-  getObjectsManager()->startPublishing(mMeanPseudoeffPerDE_DoesGoodNBHaveSomethingB_Cycle);
-  mMeanPseudoeffPerDE_DoesGoodBHaveSomethingNB_Cycle = new MergeableTH1PseudoEfficiencyPerDECycle("MeanPseudoeffPerDE_DoesGoodBHaveSomethingNB_OnCycle", "Mean Pseudoeff of each DE during the cycle (Good clusters on B associated with something on NB)", mHistogramPreclustersXY[2], mHistogramPreclustersXY[0]);
-  getObjectsManager()->startPublishing(mMeanPseudoeffPerDE_DoesGoodBHaveSomethingNB_Cycle);
+  mHistogramPreclustersPerDE = std::make_shared<MergeableTH1Ratio>("PreclustersPerDE", "Number of pre-clusters for each DE", getDEindexMax(), 0, getDEindexMax());
+  publishObject(mHistogramPreclustersPerDE, "hist", false, false);
+  mHistogramPreclustersSignalPerDE = std::make_shared<MergeableTH1Ratio>("PreclustersSignalPerDE", "Number of pre-clusters (with signal) for each DE", getDEindexMax(), 0, getDEindexMax());
+  publishObject(mHistogramPreclustersSignalPerDE, "hist", false, false);
 
-  mMPVCycle = new MergeableTH1MPVPerDECycle("MPV_Mergeable_OnCycle", "MPV of each DE cluster charge during the cycle", mHistogramClchgDEOnCycle);
-  getObjectsManager()->startPublishing(mMPVCycle);
-  */
+  // Histograms in global detector coordinates
+  mHistogramPseudoeffST12 = std::make_shared<MergeableTH2Ratio>("Pseudoeff_ST12", "ST12 Pseudoeff", 10, 0, 10, 10, 0, 10, 1, true);
+  publishObject(mHistogramPseudoeffST12, "colz", false, false);
+
+  mHistogramNumST12 = std::make_shared<GlobalHistogram>("Num_ST12", "Number of hits (ST12)", 0, mHistogramPseudoeffST12->getNum());
+  mHistogramNumST12->init();
+  mHistogramDenST12 = std::make_shared<GlobalHistogram>("Den_ST12", "Number of orbits (ST12)", 0, mHistogramPseudoeffST12->getDen());
+  mHistogramDenST12->init();
+  mAllHistograms.push_back(mHistogramDenST12->getHist());
+
+  mHistogramPseudoeffST345 = std::make_shared<MergeableTH2Ratio>("Pseudoeff_ST345", "ST345 Pseudoeff", 10, 0, 10, 10, 0, 10, 1, true);
+  publishObject(mHistogramPseudoeffST345, "colz", false, false);
+
+  mHistogramNumST345 = std::make_shared<GlobalHistogram>("Num_ST345", "Number of hits (ST345)", 1, mHistogramPseudoeffST345->getNum());
+  mHistogramNumST345->init();
+  mAllHistograms.push_back(mHistogramNumST345->getHist());
+  mHistogramDenST345 = std::make_shared<GlobalHistogram>("Den_ST345", "Number of orbits (ST345)", 1, mHistogramPseudoeffST345->getDen());
+  mHistogramDenST345->init();
+  mAllHistograms.push_back(mHistogramDenST345->getHist());
+
+  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+
+    auto h = std::make_shared<TH1F>(TString::Format("Expert/%sCluster_Charge_%03d", getHistoPath(de).c_str(), de),
+                                    TString::Format("Cluster charge (DE%03d)", de), 1000, 0, 50000);
+    mHistogramClchgDE.insert(make_pair(de, h));
+    publishObject(h, "hist", false, false);
+
+    auto h1 = std::make_shared<TH1F>(TString::Format("Expert/%sCluster_Charge_OnCycle_DE%03d", getHistoPath(de).c_str(), de),
+                                     TString::Format("Cluster charge on cycle (DE%03d)", de), 1000, 0, 50000);
+    mHistogramClchgDEOnCycle.insert(make_pair(de, h1));
+
+    h = std::make_shared<TH1F>(TString::Format("Expert/%sCluster_Size_%03d", getHistoPath(de).c_str(), de),
+                               TString::Format("Cluster size (DE%03d)", de), 10, 0, 10);
+    mHistogramClsizeDE.insert(make_pair(de, h));
+    publishObject(h, "hist", false, false);
+
+    h = std::make_shared<TH1F>(TString::Format("Expert/%sCluster_Size_B_%03d", getHistoPath(de).c_str(), de),
+                               TString::Format("Cluster size (DE%03d B)", de), 10, 0, 10);
+    mHistogramClsizeDE_B.insert(make_pair(de, h));
+    publishObject(h, "hist", false, false);
+
+    h = std::make_shared<TH1F>(TString::Format("Expert/%sCluster_Size_NB_%03d", getHistoPath(de).c_str(), de),
+                               TString::Format("Cluster size (DE%03d NB)", de), 10, 0, 10);
+    mHistogramClsizeDE_NB.insert(make_pair(de, h));
+    publishObject(h, "hist", false, false);
+
+    // Histograms using the XY Mapping
+    {
+      // Bending side
+      auto hmB = std::make_shared<MergeableTH2Ratio>(TString::Format("Expert/%sPseudoeff_B_XY_%03d", getHistoPath(de).c_str(), de),
+                                                     TString::Format("Pseudo-efficiency XY (DE%03d B)", de), 1, true);
+      mHistogramPseudoeffXY[0].insert(make_pair(de, hmB));
+      publishObject(hmB, "colz", false, true);
+
+      auto hNumB = std::make_shared<DetectorHistogram>(TString::Format("Expert/%sPreclusters_num_B_XY_%03d", getHistoPath(de).c_str(), de),
+                                                       TString::Format("Preclusters XY (DE%03d B, num)", de), de, 0,
+                                                       hmB->getNum());
+      mHistogramPreclustersXY[0].insert(make_pair(de, hNumB));
+      mAllHistograms.push_back(hNumB.get()->getHist());
+
+      auto hDenB = std::make_shared<DetectorHistogram>(TString::Format("Expert/%sPreclusters_den_B_XY_%03d", getHistoPath(de).c_str(), de),
+                                                       TString::Format("Preclusters XY (DE%03d B, den)", de), de, 0,
+                                                       hmB->getDen());
+      mHistogramPreclustersXY[1].insert(make_pair(de, hDenB));
+      mAllHistograms.push_back(hDenB.get()->getHist());
+
+      // Non-bending side
+      auto hmNB = std::make_shared<MergeableTH2Ratio>(TString::Format("Expert/%sPseudoeff_NB_XY_%03d", getHistoPath(de).c_str(), de),
+                                                      TString::Format("Pseudo-efficiency XY (DE%03d NB)", de), 1, true);
+      mHistogramPseudoeffXY[1].insert(make_pair(de, hmNB));
+      publishObject(hmNB, "colz", false, true);
+
+      auto hNumNB = std::make_shared<DetectorHistogram>(TString::Format("Expert/%sPreclusters_num_NB_XY_%03d", getHistoPath(de).c_str(), de),
+                                                        TString::Format("Preclusters XY (DE%03d NB, num)", de), de, 0,
+                                                        hmNB->getNum());
+      mHistogramPreclustersXY[2].insert(make_pair(de, hNumNB));
+      mAllHistograms.push_back(hNumNB.get()->getHist());
+
+      auto hDenNB = std::make_shared<DetectorHistogram>(TString::Format("Expert/%sPreclusters_den_NB_XY_%03d", getHistoPath(de).c_str(), de),
+                                                        TString::Format("Preclusters XY (DE%03d NB, den)", de), de, 0,
+                                                        hmNB->getDen());
+      mHistogramPreclustersXY[3].insert(make_pair(de, hDenNB));
+      mAllHistograms.push_back(hDenNB.get()->getHist());
+    }
+  }
 }
 
 void PhysicsTaskPreclusters::startOfActivity(Activity& /*activity*/)
@@ -143,6 +182,14 @@ void PhysicsTaskPreclusters::startOfCycle()
   ILOG(Info, Support) << "startOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 }
 
+static void updateTFcount(TH1D* hDen)
+{
+  for (int bin = 1; bin <= hDen->GetXaxis()->GetNbins(); bin++) {
+    auto x = hDen->GetXaxis()->GetBinCenter(bin);
+    hDen->Fill(x);
+  }
+}
+
 void PhysicsTaskPreclusters::monitorData(o2::framework::ProcessingContext& ctx)
 {
   bool verbose = false;
@@ -151,6 +198,9 @@ void PhysicsTaskPreclusters::monitorData(o2::framework::ProcessingContext& ctx)
   auto digits = ctx.inputs().get<gsl::span<o2::mch::Digit>>("preclusterdigits");
 
   ILOG(Info, Support) << fmt::format("Received {} pre-clusters and {} digits", preClusters.size(), digits.size()) << AliceO2::InfoLogger::InfoLogger::endm;
+
+  updateTFcount(mHistogramPreclustersPerDE->getDen());
+  updateTFcount(mHistogramPreclustersSignalPerDE->getDen());
 
   bool print = true;
   for (auto& p : preClusters) {
@@ -247,6 +297,37 @@ static void CoG(gsl::span<const o2::mch::Digit> precluster, double& Xcog, double
 }
 
 //_________________________________________________________________________________________________
+bool PhysicsTaskPreclusters::getFecChannel(int deId, int padId, int& fecId, int& channel)
+{
+  const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(deId);
+
+  channel = segment.padDualSampaChannel(padId);
+
+  int dsId = segment.padDualSampaId(padId);
+
+  // Using the mapping to go from Digit info (de, pad) to Elec info (fee, link) and fill Elec Histogram,
+  // where one bin is one physical pad
+  // get the unique solar ID and the DS address associated to this digit
+  std::optional<DsElecId> dsElecId = mDet2ElecMapper(DsDetId{ deId, dsId });
+  if (!dsElecId) {
+    return false;
+  }
+  uint32_t dsAddr = dsElecId->elinkId();
+  uint32_t solarId = dsElecId->solarId();
+
+  std::optional<FeeLinkId> feeLinkId = mSolar2FeeLinkMapper(solarId);
+  if (!feeLinkId) {
+    return false;
+  }
+  uint32_t feeId = feeLinkId->feeId();
+  uint32_t linkId = feeLinkId->linkId();
+
+  fecId = feeId * PhysicsTaskPreclusters::sMaxLinkId * PhysicsTaskPreclusters::sMaxDsId + (linkId % PhysicsTaskPreclusters::sMaxLinkId) * PhysicsTaskPreclusters::sMaxDsId + dsAddr;
+
+  return true;
+}
+
+//_________________________________________________________________________________________________
 bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluster, gsl::span<const o2::mch::Digit> digits)
 {
   // filter out single-pad clusters
@@ -263,6 +344,8 @@ bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluste
   float chargeSum[2] = { 0, 0 };
   // largest signal in each cathode
   float chargeMax[2] = { 0, 0 };
+  // whether the pre-cluster contains at least one signal-like digit in each cathode
+  float hasSignal[2] = { false, false };
   // number of digits in each cathode
   int multiplicity[2] = { 0, 0 };
 
@@ -282,6 +365,15 @@ bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluste
     if (digit.getADC() > chargeMax[cid]) {
       chargeMax[cid] = digit.getADC();
     }
+
+    if (mIsSignalDigit(digit)) {
+      hasSignal[cid] = true;
+    }
+  }
+
+  mHistogramPreclustersPerDE->getNum()->Fill(getDEindex(detid));
+  if (hasSignal[0] || hasSignal[1]) {
+    mHistogramPreclustersSignalPerDE->getNum()->Fill(getDEindex(detid));
   }
 
   // compute center-of-gravity of the charge distribution
@@ -289,19 +381,59 @@ bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluste
   bool isWide[2];
   CoG(preClusterDigits, Xcog, Ycog, isWide);
 
+  int padIdB = -1;
+  int padIdNB = -1;
+  int fecIdB = -1;
+  int channelB = -1;
+  int fecIdNB = -1;
+  int channelNB = -1;
+  if (segment.findPadPairByPosition(Xcog, Ycog, padIdB, padIdNB)) {
+    getFecChannel(detid, padIdB, fecIdB, channelB);
+    getFecChannel(detid, padIdNB, fecIdNB, channelNB);
+  }
+
   // criteria to define a "good" charge cluster in one cathode:
-  // - two or more digits
-  // - at least one digit with amplitude > 50 ADC
-  bool isGood[2] = { (chargeMax[0] > 50) && (isWide[0]), (chargeMax[1] > 50) && (isWide[1]) };
+  bool isGoodDen[2] = { hasSignal[1] && isWide[1], hasSignal[0] && isWide[0] };
+  bool isGoodNum[2] = { cathode[0] && isWide[0], cathode[1] };
 
   // Filling histograms to be used for Pseudo-efficiency computation
-  if (isGood[1]) {
+  if (isGoodDen[0]) {
     // good cluster on non-bending side, check if there is data from the bending side as well
-    auto hXY0 = mHistogramPreclustersXY[0].find(detid);
-    if ((hXY0 != mHistogramPreclustersXY[0].end()) && (hXY0->second != NULL)) {
+    mHistogramMeanPseudoeffPerDE[0]->getDen()->Fill(getDEindex(detid));
+    if (fecIdB >= 0 && channelB >= 0) {
+      mHistogramPseudoeffElec->getDen()->Fill(fecIdB, channelB);
+    }
+    auto hXY0 = mHistogramPreclustersXY[1].find(detid);
+    if ((hXY0 != mHistogramPreclustersXY[1].end()) && (hXY0->second != NULL)) {
       hXY0->second->Fill(Xcog, Ycog, 0.5, 0.5);
     }
-    if (cathode[0]) { //Check if associated to something on Bending
+    if (isGoodNum[0]) { // Check if associated to something on Bending
+      mHistogramMeanPseudoeffPerDE[0]->getNum()->Fill(getDEindex(detid));
+      if (fecIdB >= 0 && channelB >= 0) {
+        mHistogramPseudoeffElec->getNum()->Fill(fecIdB, channelB);
+      }
+      auto hXY1 = mHistogramPreclustersXY[0].find(detid);
+      if ((hXY1 != mHistogramPreclustersXY[0].end()) && (hXY1->second != NULL)) {
+        hXY1->second->Fill(Xcog, Ycog, 0.5, 0.5);
+      }
+    }
+  }
+
+  if (isGoodDen[1]) {
+    // good cluster on bending side, check if there is data from the non-bending side as well
+    mHistogramMeanPseudoeffPerDE[1]->getDen()->Fill(getDEindex(detid));
+    if (fecIdNB >= 0 && channelNB >= 0) {
+      mHistogramPseudoeffElec->getDen()->Fill(fecIdNB, channelNB);
+    }
+    auto hXY0 = mHistogramPreclustersXY[3].find(detid);
+    if ((hXY0 != mHistogramPreclustersXY[3].end()) && (hXY0->second != NULL)) {
+      hXY0->second->Fill(Xcog, Ycog, 0.5, 0.5);
+    }
+    if (isGoodNum[1]) { // Check if associated to something on Non-Bending
+      mHistogramMeanPseudoeffPerDE[1]->getNum()->Fill(getDEindex(detid));
+      if (fecIdNB >= 0 && channelNB >= 0) {
+        mHistogramPseudoeffElec->getNum()->Fill(fecIdNB, channelNB);
+      }
       auto hXY1 = mHistogramPreclustersXY[2].find(detid);
       if ((hXY1 != mHistogramPreclustersXY[2].end()) && (hXY1->second != NULL)) {
         hXY1->second->Fill(Xcog, Ycog, 0.5, 0.5);
@@ -309,57 +441,44 @@ bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluste
     }
   }
 
-  if (isGood[0]) {
-    // good cluster on bending side, check if there is data from the non-bending side as well
-    auto hXY0 = mHistogramPreclustersXY[1].find(detid);
-    if ((hXY0 != mHistogramPreclustersXY[1].end()) && (hXY0->second != NULL)) {
-      hXY0->second->Fill(Xcog, Ycog, 0.5, 0.5);
-    }
-    if (cathode[1]) { //Check if associated to something on Non-Bending
-      auto hXY1 = mHistogramPreclustersXY[3].find(detid);
-      if ((hXY1 != mHistogramPreclustersXY[3].end()) && (hXY1->second != NULL)) {
-        hXY1->second->Fill(Xcog, Ycog, 0.5, 0.5);
-      }
-    }
-  }
-
   // This code is slow. Will be re-introduced after some optimizations
-  //const o2::mch::mapping::CathodeSegmentation& csegment = segment.bending();
-  //o2::mch::contour::Contour<double> envelop = o2::mch::mapping::getEnvelop(csegment);
-  //std::vector<o2::mch::contour::Vertex<double>> vertices = envelop.getVertices();
-  //o2::mch::contour::BBox<double> bbox = o2::mch::mapping::getBBox(csegment);
+  // const o2::mch::mapping::CathodeSegmentation& csegment = segment.bending();
+  // o2::mch::contour::Contour<double> envelop = o2::mch::mapping::getEnvelop(csegment);
+  // std::vector<o2::mch::contour::Vertex<double>> vertices = envelop.getVertices();
+  // o2::mch::contour::BBox<double> bbox = o2::mch::mapping::getBBox(csegment);
 
   // skip a fiducial border around the active area, so that only fully-contained clusters are considered
-  //if(Xcog < (bbox.xmin() + 5)) return true;
-  //if(Xcog > (bbox.xmax() - 5)) return true;
-  //if(Ycog < (bbox.ymin() + 5)) return true;
-  //if(Ycog > (bbox.ymax() - 5)) return true;
+  // if(Xcog < (bbox.xmin() + 5)) return true;
+  // if(Xcog > (bbox.xmax() - 5)) return true;
+  // if(Ycog < (bbox.ymin() + 5)) return true;
+  // if(Ycog > (bbox.ymax() - 5)) return true;
 
-  // cluster size, separately on each cathode and combined
-  auto hSize = mHistogramClsizeDE.find(detid);
-  if ((hSize != mHistogramClsizeDE.end()) && (hSize->second != NULL)) {
-    hSize->second->Fill(multiplicity[0], 0);
-    hSize->second->Fill(multiplicity[1], 1);
-    hSize->second->Fill(multiplicity[0] + multiplicity[1], 2);
-  }
-
-  float chargeTot = chargeSum[0] + chargeSum[1];
-  auto hCharge = mHistogramClchgDE.find(detid);
-  if ((hCharge != mHistogramClchgDE.end()) && (hCharge->second != NULL)) {
-    if ((multiplicity[0] <= 1) && (multiplicity[1] <= 1)) {
-      hCharge->second->Fill(chargeTot, 0);
-    } else if ((multiplicity[0] > 1) && (multiplicity[1] == 1)) {
-      hCharge->second->Fill(chargeTot, 1);
-    } else if ((multiplicity[0] <= 1) && (multiplicity[1] > 1)) {
-      hCharge->second->Fill(chargeTot, 2);
-    } else if ((multiplicity[0] > 1) && (multiplicity[1] > 1)) {
-      hCharge->second->Fill(chargeTot, 3);
+  if (hasSignal[0] || hasSignal[1]) {
+    // cluster size, separately on each cathode and combined
+    auto hSize = mHistogramClsizeDE.find(detid);
+    if ((hSize != mHistogramClsizeDE.end()) && (hSize->second != NULL)) {
+      hSize->second->Fill(multiplicity[0] + multiplicity[1]);
     }
-  }
+    hSize = mHistogramClsizeDE_B.find(detid);
+    if ((hSize != mHistogramClsizeDE_B.end()) && (hSize->second != NULL)) {
+      hSize->second->Fill(multiplicity[0]);
+    }
+    hSize = mHistogramClsizeDE_NB.find(detid);
+    if ((hSize != mHistogramClsizeDE_NB.end()) && (hSize->second != NULL)) {
+      hSize->second->Fill(multiplicity[1]);
+    }
 
-  auto hChargeOnCycle = mHistogramClchgDEOnCycle.find(detid);
-  if ((hChargeOnCycle != mHistogramClchgDEOnCycle.end()) && (hChargeOnCycle->second != NULL)) {
-    hChargeOnCycle->second->Fill(chargeTot);
+    // total cluster charge
+    float chargeTot = chargeSum[0] + chargeSum[1];
+    auto hCharge = mHistogramClchgDE.find(detid);
+    if ((hCharge != mHistogramClchgDE.end()) && (hCharge->second != NULL)) {
+      hCharge->second->Fill(chargeTot);
+    }
+
+    auto hChargeOnCycle = mHistogramClchgDEOnCycle.find(detid);
+    if ((hChargeOnCycle != mHistogramClchgDEOnCycle.end()) && (hChargeOnCycle->second != NULL)) {
+      hChargeOnCycle->second->Fill(chargeTot);
+    }
   }
 
   return (cathode[0] && cathode[1]);
@@ -418,37 +537,32 @@ void PhysicsTaskPreclusters::printPreclusters(gsl::span<const o2::mch::PreCluste
 
 void PhysicsTaskPreclusters::computePseudoEfficiency()
 {
+  // update mergeable ratios
+  mHistogramPseudoeffElec->update();
+
   for (auto de : o2::mch::raw::deIdsForAllMCH) {
     for (int i = 0; i < 2; i++) {
-      auto ihp = mHistogramPseudoeffXY[i].find(de);
-      if (ihp == mHistogramPseudoeffXY[i].end() || ihp->second == nullptr) {
-        continue;
+      auto h = mHistogramPseudoeffXY[i].find(de);
+      if ((h != mHistogramPseudoeffXY[i].end()) && (h->second != nullptr)) {
+        h->second->update();
       }
-
-      // Computing the Pseudo-efficiency by dividing the distribution of clusters (either on B, NB, or B and NB) by the total distribution of all clusters.
-      ihp->second->update();
     }
   }
 
-  mMeanPseudoeffPerDE[0]->update(mHistogramPreclustersXY[2], mHistogramPreclustersXY[0]);
-  mMeanPseudoeffPerDE[1]->update(mHistogramPreclustersXY[3], mHistogramPreclustersXY[1]);
+  mHistogramNumST12->set(mHistogramPreclustersXY[0], mHistogramPreclustersXY[2]);
+  mHistogramDenST12->set(mHistogramPreclustersXY[1], mHistogramPreclustersXY[3]);
 
-  /*
-  mMeanPseudoeffPerDE_DoesGoodNBHaveSomethingB_Cycle->update();
-  mMeanPseudoeffPerDE_DoesGoodBHaveSomethingNB_Cycle->update();
-  mMPVCycle->update();
-  */
-}
+  mHistogramNumST345->set(mHistogramPreclustersXY[0], mHistogramPreclustersXY[2]);
+  mHistogramDenST345->set(mHistogramPreclustersXY[1], mHistogramPreclustersXY[3]);
 
-void PhysicsTaskPreclusters::writeHistos()
-{
-#ifdef QC_MCH_SAVE_TEMP_ROOTFILE
-  TFile f("mch-qc-preclusters.root", "RECREATE");
-  for (auto h : mAllHistograms) {
-    h->Write();
-  }
-  f.Close();
-#endif
+  mHistogramPseudoeffST12->update();
+  mHistogramPseudoeffST345->update();
+
+  mHistogramMeanPseudoeffPerDE[0]->update();
+  mHistogramMeanPseudoeffPerDE[1]->update();
+
+  mHistogramPreclustersPerDE->update();
+  mHistogramPreclustersSignalPerDE->update();
 }
 
 void PhysicsTaskPreclusters::endOfCycle()
@@ -456,7 +570,6 @@ void PhysicsTaskPreclusters::endOfCycle()
   ILOG(Info, Support) << "endOfCycle" << AliceO2::InfoLogger::InfoLogger::endm;
 
   computePseudoEfficiency();
-  writeHistos();
 }
 
 void PhysicsTaskPreclusters::endOfActivity(Activity& /*activity*/)
@@ -464,7 +577,6 @@ void PhysicsTaskPreclusters::endOfActivity(Activity& /*activity*/)
   ILOG(Info, Support) << "endOfActivity" << AliceO2::InfoLogger::InfoLogger::endm;
 
   computePseudoEfficiency();
-  writeHistos();
 }
 
 void PhysicsTaskPreclusters::reset()


### PR DESCRIPTION
This PR introduces several improvement to the analysis of pre-clusters:
- improved selection of pre-clusters for efficiency analysis
- added plots with number of pre-clusters per TF
- added plots with mean efficiency per detection element
- added efficiency plot in electronics coordinates
- improved beautify method in checker
- added mergeable TH1 ratio class

