### PR TITLE
CPV: add monitoring Pedestal calibratior output to PedestalTask

### DIFF
--- a/Modules/CPV/include/CPV/LinkDef.h
+++ b/Modules/CPV/include/CPV/LinkDef.h
@@ -3,7 +3,9 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::quality_control_modules::cpv::PedestalTask+;
-#pragma link C++ class o2::quality_control_modules::cpv::PedestalCheck+;
+#pragma link C++ class o2::quality_control_modules::cpv::PedestalTask + ;
+#pragma link C++ class o2::quality_control_modules::cpv::PedestalCheck + ;
 #pragma link C++ class o2::quality_control_modules::cpv::PhysicsTask + ;
+#pragma link C++ class o2::quality_control_modules::cpv::IntensiveTH2F + ;
+
 #endif

--- a/Modules/CPV/include/CPV/PedestalTask.h
+++ b/Modules/CPV/include/CPV/PedestalTask.h
@@ -21,7 +21,7 @@
 #include <memory>
 #include <array>
 #include <gsl/span>
-#include "CPVBase/Geometry.h"
+#include <CPVBase/Geometry.h>
 
 class TH1F;
 class TH2F;
@@ -37,7 +37,7 @@ class PedestalTask final : public TaskInterface
 {
  public:
   /// \brief Constructor
-  PedestalTask() = default;
+  PedestalTask();
   /// Destructor
   ~PedestalTask() override;
 
@@ -52,11 +52,12 @@ class PedestalTask final : public TaskInterface
 
  private:
   void initHistograms();
-  void fillHistograms();
+  void fillDigitsHistograms();
   void resetHistograms();
 
-  static constexpr short kNHist1D = 14;
-  enum Histos1D { H1DInputPayloadSize,
+  static constexpr short kNHist1D = 27;
+  enum Histos1D { H1DRawErrors,
+                  H1DInputPayloadSize,
                   H1DNInputs,
                   H1DNValidInputs,
                   H1DNDigitsPerInput,
@@ -69,10 +70,19 @@ class PedestalTask final : public TaskInterface
                   H1DPedestalSigmaM4,
                   H1DPedestalEfficiencyM2,
                   H1DPedestalEfficiencyM3,
-                  H1DPedestalEfficiencyM4
+                  H1DPedestalEfficiencyM4,
+                  H1DPedestalValueInDigitsM2,
+                  H1DPedestalValueInDigitsM3,
+                  H1DPedestalValueInDigitsM4,
+                  H1DPedestalSigmaInDigitsM2,
+                  H1DPedestalSigmaInDigitsM3,
+                  H1DPedestalSigmaInDigitsM4,
+                  H1DPedestalEfficiencyInDigitsM2,
+                  H1DPedestalEfficiencyInDigitsM3,
+                  H1DPedestalEfficiencyInDigitsM4
   };
 
-  static constexpr short kNHist2D = 16;
+  static constexpr short kNHist2D = 34;
   enum Histos2D { H2DErrorType,
                   H2DDigitMapM2,
                   H2DDigitMapM3,
@@ -86,25 +96,42 @@ class PedestalTask final : public TaskInterface
                   H2DPedestalEfficiencyMapM2,
                   H2DPedestalEfficiencyMapM3,
                   H2DPedestalEfficiencyMapM4,
-                  H2DPedestalNPeaksMapM2,
-                  H2DPedestalNPeaksMapM3,
-                  H2DPedestalNPeaksMapM4
+                  H2DFEEThresholdsMapM2,
+                  H2DFEEThresholdsMapM3,
+                  H2DFEEThresholdsMapM4,
+                  H2DHighThresholdMapM2,
+                  H2DHighThresholdMapM3,
+                  H2DHighThresholdMapM4,
+                  H2DDeadChanelsMapM2,
+                  H2DDeadChanelsMapM3,
+                  H2DDeadChanelsMapM4,
+                  H2DPedestalNPeaksMapInDigitsM2,
+                  H2DPedestalNPeaksMapInDigitsM3,
+                  H2DPedestalNPeaksMapInDigitsM4,
+                  H2DPedestalValueMapInDigitsM2,
+                  H2DPedestalValueMapInDigitsM3,
+                  H2DPedestalValueMapInDigitsM4,
+                  H2DPedestalSigmaMapInDigitsM2,
+                  H2DPedestalSigmaMapInDigitsM3,
+                  H2DPedestalSigmaMapInDigitsM4,
+                  H2DPedestalEfficiencyMapInDigitsM2,
+                  H2DPedestalEfficiencyMapInDigitsM3,
+                  H2DPedestalEfficiencyMapInDigitsM4
   };
 
-  static constexpr short kNModules = 3;
-  static constexpr short kNChannels = 23040;
-  o2::cpv::Geometry mCPVGeometry;
-
-  int mNEventsTotal;
+  int mNEventsTotal = 0;
   int mNEventsFromLastFillHistogramsCall;
   int mMinNEventsToUpdatePedestals = 1000; ///< min number of events needed to update pedestals
   int mRunNumber = 0;                      ///< Run number of current activity
+  bool mMonitorPedestalCalibrator = true;  ///< monitor results of pedestal calibrator
+  int mNtimesCCDBPayloadFetched = 0;       ///< how many times non-empty CCDB payload fetched
+  bool mMonitorDigits = false;             ///< monitor digits
 
   std::array<TH1F*, kNHist1D> mHist1D = { nullptr }; ///< Array of 1D histograms
   std::array<TH2F*, kNHist2D> mHist2D = { nullptr }; ///< Array of 2D histograms
 
-  std::array<TH1F*, kNChannels> mHistAmplitudes = { nullptr };  ///< Array of amplitude spectra
-  std::array<bool, kNChannels> mIsUpdatedAmplitude = { false }; ///< Array of isUpdatedAmplitude bools
+  std::array<TH1F*, o2::cpv::Geometry::kNCHANNELS> mHistAmplitudes = { nullptr };  ///< Array of amplitude spectra
+  std::array<bool, o2::cpv::Geometry::kNCHANNELS> mIsUpdatedAmplitude = { false }; ///< Array of isUpdatedAmplitude bools
 };
 
 } // namespace o2::quality_control_modules::cpv

--- a/Modules/CPV/include/CPV/PhysicsTask.h
+++ b/Modules/CPV/include/CPV/PhysicsTask.h
@@ -18,18 +18,55 @@
 #define QC_MODULE_CPV_CPVPHYSICSTASK_H
 
 #include "QualityControl/TaskInterface.h"
+#include <Mergers/MergeInterface.h>
 #include <memory>
 #include <array>
 #include <gsl/span>
-#include "CPVBase/Geometry.h"
+#include <CPVBase/Geometry.h>
+#include <TH2F.h>
 
 class TH1F;
-class TH2F;
 
 using namespace o2::quality_control::core;
 
 namespace o2::quality_control_modules::cpv
 {
+
+// this is 2D histogram which is not additive: when merge() is being called, it is just updated with new incoming value rather than merging
+// update or not is decided by cycle counter: if this->mCycleNumber < incoming.mCycleNumber then *this = incoming
+class IntensiveTH2F : public TH2F, public o2::mergers::MergeInterface
+{
+ public:
+  /// \brief Constructor.
+  IntensiveTH2F(const char* name, const char* title, int nbinsx, double xlow, double xup, int nbinsy, double ylow, double yup)
+    : TH2F(name, title, nbinsx, xlow, xup, nbinsy, ylow, yup)
+  {
+  }
+  IntensiveTH2F() = default;
+  /// \brief Default destructor
+  ~IntensiveTH2F() override = default;
+
+  const char* GetName() const override
+  {
+    return TH2F::GetName();
+  }
+
+  void setCycleNumber(uint32_t cycleNumber) { mCycleNumber = cycleNumber; }
+
+  void merge(MergeInterface* const other) override
+  {
+    if (mCycleNumber < dynamic_cast<IntensiveTH2F*>(other)->mCycleNumber) {
+      LOG(info) << "IntensiveTH2F::merge() :" << GetName() << "is updating!";
+      *this = *(dynamic_cast<IntensiveTH2F*>(other));
+    }
+  }
+
+ private:
+  std::string mTreatMeAs = "TH2F"; // the name of the class this object should be considered as when drawing in QCG.
+  uint32_t mCycleNumber = 0;       // cycle number of last udate
+
+  ClassDefOverride(IntensiveTH2F, 1);
+};
 
 /// \brief Task for CPV Physics monitoring
 /// \author Sergey Evdokimov
@@ -87,7 +124,7 @@ class PhysicsTask final : public TaskInterface
                   H1DNDigitsInClusterM4
   };
 
-  static constexpr short kNHist2D = 24;
+  static constexpr short kNHist2D = 12;
   enum Histos2D { H2DDigitMapM2,
                   H2DDigitMapM3,
                   H2DDigitMapM4,
@@ -99,27 +136,31 @@ class PhysicsTask final : public TaskInterface
                   H2DDigitFreqM4,
                   H2DClusterMapM2,
                   H2DClusterMapM3,
-                  H2DClusterMapM4,
-                  H2DPedestalValueM2,
-                  H2DPedestalValueM3,
-                  H2DPedestalValueM4,
-                  H2DPedestalSigmaM2,
-                  H2DPedestalSigmaM3,
-                  H2DPedestalSigmaM4,
-                  H2DBadChannelMapM2,
-                  H2DBadChannelMapM3,
-                  H2DBadChannelMapM4,
-                  H2DGainsM2,
-                  H2DGainsM3,
-                  H2DGainsM4
+                  H2DClusterMapM4
+  };
+  static constexpr short kNIntensiveHist2D = 12;
+  enum IntensiveHistos2D { H2DPedestalValueM2,
+                           H2DPedestalValueM3,
+                           H2DPedestalValueM4,
+                           H2DPedestalSigmaM2,
+                           H2DPedestalSigmaM3,
+                           H2DPedestalSigmaM4,
+                           H2DBadChannelMapM2,
+                           H2DBadChannelMapM3,
+                           H2DBadChannelMapM4,
+                           H2DGainsM2,
+                           H2DGainsM3,
+                           H2DGainsM4
   };
 
   static constexpr short kNModules = 3;
   static constexpr short kNChannels = 23040;
   int mNEventsTotal = 0;
-  int mCcdbCheckIntervalInMinutes = 10;
-  std::array<TH1F*, kNHist1D> mHist1D = { nullptr }; ///< Array of 1D histograms
-  std::array<TH2F*, kNHist2D> mHist2D = { nullptr }; ///< Array of 2D histograms
+  int mCcdbCheckIntervalInMinutes = 1;
+  std::array<TH1F*, kNHist1D> mHist1D = { nullptr };                            ///< Array of 1D histograms
+  std::array<TH2F*, kNHist2D> mHist2D = { nullptr };                            ///< Array of 2D histograms
+  std::array<IntensiveTH2F*, kNIntensiveHist2D> mIntensiveHist2D = { nullptr }; ///< Array of 2D histograms
+  uint32_t mCycleNumber = 0;
 };
 
 } // namespace o2::quality_control_modules::cpv

--- a/Modules/CPV/src/PedestalCheck.cxx
+++ b/Modules/CPV/src/PedestalCheck.cxx
@@ -32,11 +32,11 @@ namespace o2::quality_control_modules::cpv
 void PedestalCheck::configure()
 {
   for (int mod = 0; mod < 3; mod++) {
-    //mMinGoodPedestalValueM
+    // mMinGoodPedestalValueM
     if (auto param = mCustomParameters.find(Form("mMinGoodPedestalValueM%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Info, Devel) << "configure() : Custom parameter "
-                        << Form("mMinGoodPedestalValueM%d", mod + 2)
+                        << Form("mMinGoodPedestalValueM%d = ", mod + 2)
                         << param->second << ENDM;
       mMinGoodPedestalValueM[mod] = stoi(param->second);
     }
@@ -44,11 +44,11 @@ void PedestalCheck::configure()
                         << Form("mMinGoodPedestalValueM%d", mod + 2)
                         << " = "
                         << mMinGoodPedestalValueM[mod] << ENDM;
-    //mMaxGoodPedestalSigmaM
+    // mMaxGoodPedestalSigmaM
     if (auto param = mCustomParameters.find(Form("mMaxGoodPedestalSigmaM%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Info, Devel) << "configure() : Custom parameter "
-                        << Form("mMaxGoodPedestalSigmaM%d", mod + 2)
+                        << Form("mMaxGoodPedestalSigmaM%d = ", mod + 2)
                         << param->second << ENDM;
       mMaxGoodPedestalSigmaM[mod] = stof(param->second);
     }
@@ -56,11 +56,11 @@ void PedestalCheck::configure()
                         << Form("mMaxGoodPedestalSigmaM%d", mod + 2)
                         << " = "
                         << mMaxGoodPedestalSigmaM[mod] << ENDM;
-    //mMinGoodPedestalEfficiencyM
+    // mMinGoodPedestalEfficiencyM
     if (auto param = mCustomParameters.find(Form("mMinGoodPedestalEfficiencyM%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Info, Devel) << "configure() : Custom parameter "
-                        << Form("mMinGoodPedestalEfficiencyM%d", mod + 2)
+                        << Form("mMinGoodPedestalEfficiencyM%d = ", mod + 2)
                         << param->second << ENDM;
       mMinGoodPedestalEfficiencyM[mod] = stof(param->second);
     }
@@ -68,11 +68,11 @@ void PedestalCheck::configure()
                         << Form("mMinGoodPedestalEfficiencyM%d", mod + 2)
                         << " = "
                         << mMinGoodPedestalEfficiencyM[mod] << ENDM;
-    //mMaxGoodPedestalEfficiencyM
+    // mMaxGoodPedestalEfficiencyM
     if (auto param = mCustomParameters.find(Form("mMaxGoodPedestalEfficiencyM%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Info, Devel) << "configure() : Custom parameter "
-                        << Form("mMaxGoodPedestalEfficiencyM%d", mod + 2)
+                        << Form("mMaxGoodPedestalEfficiencyM%d = ", mod + 2)
                         << param->second << ENDM;
       mMaxGoodPedestalEfficiencyM[mod] = stof(param->second);
     }
@@ -80,11 +80,11 @@ void PedestalCheck::configure()
                         << Form("mMaxGoodPedestalEfficiencyM%d", mod + 2)
                         << " = "
                         << mMaxGoodPedestalEfficiencyM[mod] << ENDM;
-    //mToleratedBadPedestalValueChannelsM
+    // mToleratedBadPedestalValueChannelsM
     if (auto param = mCustomParameters.find(Form("mToleratedBadPedestalValueChannelsM%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Info, Devel) << "configure() : Custom parameter "
-                        << Form("mToleratedBadPedestalValueChannelsM%d", mod + 2)
+                        << Form("mToleratedBadPedestalValueChannelsM%d = ", mod + 2)
                         << param->second << ENDM;
       mToleratedBadPedestalValueChannelsM[mod] = stoi(param->second);
     }
@@ -92,11 +92,24 @@ void PedestalCheck::configure()
                         << Form("mToleratedBadPedestalValueChannelsM%d", mod + 2)
                         << " = "
                         << mToleratedBadPedestalValueChannelsM[mod] << ENDM;
-    //mToleratedBadChannelsM
+    // mToleratedBadPedestalSigmaChannelsM
+    if (auto param = mCustomParameters.find(Form("mToleratedBadPedestalSigmaChannelsM%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Info, Devel) << "configure() : Custom parameter "
+                        << Form("mToleratedBadPedestalSigmaChannelsM%d = ", mod + 2)
+                        << param->second << ENDM;
+      mToleratedBadPedestalSigmaChannelsM[mod] = stoi(param->second);
+    }
+    ILOG(Info, Support) << "configure() : I use "
+                        << Form("mToleratedBadPedestalSigmaChannelsM%d", mod + 2)
+                        << " = "
+                        << mToleratedBadPedestalSigmaChannelsM[mod] << ENDM;
+
+    // mToleratedBadChannelsM
     if (auto param = mCustomParameters.find(Form("mToleratedBadChannelsM%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Info, Devel) << "configure() : Custom parameter "
-                        << Form("mToleratedBadChannelsM%d", mod + 2)
+                        << Form("mToleratedBadChannelsM%d = ", mod + 2)
                         << param->second << ENDM;
       mToleratedBadChannelsM[mod] = stoi(param->second);
     }
@@ -104,11 +117,11 @@ void PedestalCheck::configure()
                         << Form("mToleratedBadChannelsM%d", mod + 2)
                         << " = "
                         << mToleratedBadChannelsM[mod] << ENDM;
-    //mToleratedBadPedestalEfficiencyChannelsM
+    // mToleratedBadPedestalEfficiencyChannelsM
     if (auto param = mCustomParameters.find(Form("mToleratedBadPedestalEfficiencyChannelsM%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Info, Devel) << "configure() : Custom parameter "
-                        << Form("mToleratedBadPedestalEfficiencyChannelsM%d", mod + 2)
+                        << Form("mToleratedBadPedestalEfficiencyChannelsM%d = ", mod + 2)
                         << param->second << ENDM;
       mToleratedBadPedestalEfficiencyChannelsM[mod] = stoi(param->second);
     }
@@ -126,19 +139,19 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
   for (auto& [moName, mo] : *moMap) {
 
     (void)moName;                          // trick the compiler about not used variable
-    for (int iMod = 0; iMod < 3; iMod++) { //loop modules
+    for (int iMod = 0; iMod < 3; iMod++) { // loop modules
       if (mo->getName() == Form("PedestalValueM%d", iMod + 2)) {
         bool isGoodMO = true;
 
         auto* h = dynamic_cast<TH1F*>(mo->getObject());
-        result = Quality::Good; //default
+        result = Quality::Good; // default
         TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
         msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
-        //count number of too small pedestals + too big pedestals
-        int nOfBadPedestalValues = h->Integral(1, mMinGoodPedestalValueM[iMod]) + h->GetBinContent(h->GetNbinsX() + 1); //underflow + small pedestals + overflow
+        // count number of too small pedestals + too big pedestals
+        int nOfBadPedestalValues = h->Integral(0, mMinGoodPedestalValueM[iMod]) + h->GetBinContent(h->GetNbinsX() + 1); // underflow + small pedestals + overflow
         if (nOfBadPedestalValues > mToleratedBadPedestalValueChannelsM[iMod]) {
           result = Quality::Bad;
           msg->AddText(Form("Too many bad ped values: %d", nOfBadPedestalValues));
@@ -147,7 +160,7 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
           h->SetFillColor(kRed);
           isGoodMO = false;
         }
-        //count number of bad pedestals (double peaked and so)
+        // count number of bad pedestals (double peaked and so)
         int nOfBadPedestals = 7680 - h->GetEntries();
         if (nOfBadPedestals > mToleratedBadChannelsM[iMod]) {
           result = Quality::Bad;
@@ -161,22 +174,22 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
           msg->AddText("OK");
           msg->SetFillColor(kGreen);
         }
-        break; //exit modules loop for this particular object
+        break; // exit modules loop for this particular object
       }
 
       if (mo->getName() == Form("PedestalSigmaM%d", iMod + 2)) {
 
         auto* h = dynamic_cast<TH1F*>(mo->getObject());
-        result = Quality::Good; //default
+        result = Quality::Good; // default
         TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
         msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
-        //count number of too small pedestals + too big pedestals
+        // count number of too small pedestals + too big pedestals
         float binWidth = h->GetBinWidth(1);
         int nOfBadPedestalSigmas = h->Integral(mMaxGoodPedestalSigmaM[iMod] / binWidth + 1,
-                                               h->GetNbinsX() + 1); //big sigmas + overflow
+                                               h->GetNbinsX() + 1); // big sigmas + overflow
 
         if (nOfBadPedestalSigmas > mToleratedBadPedestalSigmaChannelsM[iMod]) {
           result = Quality::Bad;
@@ -189,23 +202,23 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
           msg->AddText("OK");
           msg->SetFillColor(kGreen);
         }
-        break; //exit modules loop for this particular object
+        break; // exit modules loop for this particular object
       }
 
       if (mo->getName() == Form("PedestalEfficiencyM%d", iMod + 2)) {
 
         auto* h = dynamic_cast<TH1F*>(mo->getObject());
-        result = Quality::Good; //default
+        result = Quality::Good; // default
         TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
         msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
-        //count number of too small pedestals + too big pedestals
+        // count number of too small pedestals + too big pedestals
         float binWidth = h->GetBinWidth(1);
         int nOfBadPedestalEfficiencies = 7680 -
                                          h->Integral(mMinGoodPedestalEfficiencyM[iMod] / binWidth + 1,
-                                                     mMaxGoodPedestalEfficiencyM[iMod] / binWidth); //big sigmas + overflow
+                                                     mMaxGoodPedestalEfficiencyM[iMod] / binWidth); // big sigmas + overflow
 
         if (nOfBadPedestalEfficiencies > mToleratedBadPedestalEfficiencyChannelsM[iMod]) {
           result = Quality::Bad;
@@ -218,22 +231,22 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
           msg->AddText("OK");
           msg->SetFillColor(kGreen);
         }
-        break; //exit modules loop for this particular object
+        break; // exit modules loop for this particular object
       }
 
-    } //iMod cycle
-  }   //moMap cycle
+    } // iMod cycle
+  }   // moMap cycle
 
   return result;
 }
 
-//std::string PedestalCheck::getAcceptedType() { return "TObject"; }
+// std::string PedestalCheck::getAcceptedType() { return "TObject"; }
 std::string PedestalCheck::getAcceptedType() { return "TH1"; }
 
 void PedestalCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  return;                                //do noting for the time being. Maybe in the future we will do something sofisticated
-  for (int iMod = 0; iMod < 3; iMod++) { //loop over modules
+  return;                                // do noting for the time being. Maybe in the future we will do something sofisticated
+  for (int iMod = 0; iMod < 3; iMod++) { // loop over modules
     if (mo->getName() == Form("PedestalValueM%d", iMod + 2)) {
       auto* h = dynamic_cast<TH1F*>(mo->getObject());
 
@@ -249,7 +262,7 @@ void PedestalCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
         ILOG(Error, Support) << "beautify() : unexpected quality for " << mo->GetName() << ENDM;
         h->SetFillColor(kOrange);
       }
-      return; //exit when object is processed
+      return; // exit when object is processed
     }
   }
 }

--- a/Modules/CPV/src/PedestalTask.cxx
+++ b/Modules/CPV/src/PedestalTask.cxx
@@ -23,12 +23,28 @@
 #include "CPV/PedestalTask.h"
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
+#include <Framework/DataRef.h>
 #include <Framework/DataRefUtils.h>
-#include "DataFormatsCPV/TriggerRecord.h"
-#include "DataFormatsCPV/Digit.h"
+#include <DataFormatsCPV/TriggerRecord.h>
+#include <DataFormatsCPV/Digit.h>
+#include <DataFormatsCPV/Pedestals.h>
+#include <CPVReconstruction/RawDecoder.h>
 
 namespace o2::quality_control_modules::cpv
 {
+
+PedestalTask::PedestalTask()
+{
+  for (int i = 0; i < kNHist1D; i++) {
+    mHist1D[i] = nullptr;
+  }
+  for (int i = 0; i < kNHist2D; i++) {
+    mHist2D[i] = nullptr;
+  }
+  for (int i = 0; i < o2::cpv::Geometry::kNCHANNELS; i++) {
+    mHistAmplitudes[i] = nullptr;
+  }
+}
 
 PedestalTask::~PedestalTask()
 {
@@ -44,7 +60,7 @@ PedestalTask::~PedestalTask()
       mHist2D[i] = nullptr;
     }
   }
-  for (int i = 0; i < kNChannels; i++) {
+  for (int i = 0; i < o2::cpv::Geometry::kNCHANNELS; i++) {
     if (mHistAmplitudes[i]) {
       mHistAmplitudes[i]->Delete();
       mHistAmplitudes[i] = nullptr;
@@ -61,7 +77,31 @@ void PedestalTask::initialize(o2::framework::InitContext& /*ctx*/)
     ILOG(Info, Devel) << "Custom parameter : minNEventsToUpdatePedestals " << param->second << ENDM;
     mMinNEventsToUpdatePedestals = stoi(param->second);
     ILOG(Info, Devel) << "I set minNEventsToUpdatePedestals = " << mMinNEventsToUpdatePedestals << ENDM;
+  } else {
+    ILOG(Info, Devel) << "Default parameter : minNEventsToUpdatePedestals = " << mMinNEventsToUpdatePedestals << ENDM;
   }
+  if (auto param = mCustomParameters.find("monitorPedestalCalibrator"); param != mCustomParameters.end()) {
+    ILOG(Info, Devel) << "Custom parameter : monitorPedestalCalibrator " << param->second << ENDM;
+    mMonitorPedestalCalibrator = stoi(param->second);
+    ILOG(Info, Devel) << "I set mMonitorPedestalCalibrator = " << mMonitorPedestalCalibrator << ENDM;
+  } else {
+    ILOG(Info, Devel) << "Default parameter : monitorPedestalCalibrator = " << mMonitorPedestalCalibrator << ENDM;
+  }
+  if (auto param = mCustomParameters.find("monitorDigits"); param != mCustomParameters.end()) {
+    ILOG(Info, Devel) << "Custom parameter : monitorDigits " << param->second << ENDM;
+    mMonitorDigits = stoi(param->second);
+    ILOG(Info, Devel) << "I set mMonitorDigits = " << mMonitorDigits << ENDM;
+  } else {
+    ILOG(Info, Devel) << "Default parameter : monitorDigits = " << mMonitorDigits << ENDM;
+  }
+
+  if (mMonitorPedestalCalibrator) {
+    ILOG(Info, Devel) << "Results of pedestal calibrator sent to CCDB will be monitored" << ENDM;
+  }
+  if (mMonitorDigits) {
+    ILOG(Info, Devel) << "Digits will be monitored. Look at *FromDigits MOs." << ENDM;
+  }
+
   initHistograms();
   mNEventsTotal = 0;
   mNEventsFromLastFillHistogramsCall = 0;
@@ -89,13 +129,17 @@ void PedestalTask::startOfActivity(Activity& activity)
 void PedestalTask::startOfCycle()
 {
   ILOG(Info, Devel) << "startOfCycle" << ENDM;
-  //at at the startOfCycle all HistAmplitudes are not updated by definition
-  for (int i = 0; i < kNChannels; i++)
-    mIsUpdatedAmplitude[i] = false;
+  // at at the startOfCycle all HistAmplitudes are not updated by definition
+  if (mMonitorDigits) {
+    for (int i = 0; i < o2::cpv::Geometry::kNCHANNELS; i++) {
+      mIsUpdatedAmplitude[i] = false;
+    }
+  }
 }
 
 void PedestalTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
+  LOG(info) << "PedestalTask::monitorData()";
   // In this function you can access data inputs specified in the JSON config file, for example:
   //   "query": "random:ITS/RAWDATA/0"
   // which is correspondingly <binding>:<dataOrigin>/<dataDescription>/<subSpecification
@@ -114,61 +158,179 @@ void PedestalTask::monitorData(o2::framework::ProcessingContext& ctx)
   int nValidInputs = ctx.inputs().countValidInputs();
   mHist1D[H1DNValidInputs]->Fill(nValidInputs);
 
+  bool hasRawErrors = false, hasDigits = false;
+  bool hasPedestalsCLP = false, hasPedEffsCLP = false, hasFEEThrsCLP = false, hasDeadChnlsCLP = false, hasHighThrsCLP = false;
   for (auto&& input : o2::framework::InputRecordWalker(ctx.inputs())) {
     // get message header
     if (input.header != nullptr && input.payload != nullptr) {
       auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(input);
       // get payload of a specific input, which is a char array.
       // const char* payload = input.payload;
-
-      // for the sake of an example, let's fill the histogram with payload sizes
       mHist1D[H1DInputPayloadSize]->Fill(payloadSize);
+      const auto* header = o2::framework::DataRefUtils::getHeader<header::DataHeader*>(input);
+      if (payloadSize) {
+        if ((strcmp(header->dataOrigin.str, "CPV") == 0) && (strcmp(header->dataDescription.str, "DIGITS") == 0)) {
+          // LOG(info) << "monitorData() : I found digits in inputs";
+          hasDigits = true;
+        }
+        if ((strcmp(header->dataOrigin.str, "CLP") == 0) && (strcmp(header->dataDescription.str, "CPV_Pedestals") == 0)) {
+          // LOG(info) << "monitorData() : I found CPV_Pedestals in inputs";
+          hasPedestalsCLP = true;
+        }
+        if ((strcmp(header->dataOrigin.str, "CLP") == 0) && (strcmp(header->dataDescription.str, "CPV_FEEThrs") == 0)) {
+          // LOG(info) << "monitorData() : I found CPV_FEEThrs in inputs";
+          hasFEEThrsCLP = true;
+        }
+        if ((strcmp(header->dataOrigin.str, "CLP") == 0) && (strcmp(header->dataDescription.str, "CPV_DeadChnls") == 0)) {
+          // LOG(info) << "monitorData() : I found CPV_DeadChnls in inputs";
+          hasDeadChnlsCLP = true;
+        }
+        if ((strcmp(header->dataOrigin.str, "CLP") == 0) && (strcmp(header->dataDescription.str, "CPV_HighThrs") == 0)) {
+          // LOG(info) << "monitorData() : I found CPV_HighThrs in inputs";
+          hasHighThrsCLP = true;
+        }
+        if ((strcmp(header->dataOrigin.str, "CLP") == 0) && (strcmp(header->dataDescription.str, "CPV_PedEffs") == 0)) {
+          // LOG(info) << "monitorData() : I found CPV_PedEffs in inputs";
+          hasPedEffsCLP = true;
+        }
+        if ((strcmp(header->dataOrigin.str, "CPV") == 0) && (strcmp(header->dataDescription.str, "RAWHWERRORS") == 0)) {
+          // LOG(info) << "monitorData() : I found rawhwerrors in inputs";
+          hasRawErrors = true;
+        }
+      }
     }
   }
 
   // 2. Using get("<binding>")
-  auto digits = ctx.inputs().get<gsl::span<o2::cpv::Digit>>("digits");
-  mHist1D[H1DNDigitsPerInput]->Fill(digits.size());
+  // raw errors
+  if (hasRawErrors) {
+    auto rawErrors = ctx.inputs().get<gsl::span<o2::cpv::RawDecoderError>>("rawerrors");
+    for (const auto& rawError : rawErrors) {
+      mHist1D[H1DRawErrors]->Fill(rawError.errortype);
+    }
+  }
 
-  auto digitsTR = ctx.inputs().get<gsl::span<o2::cpv::TriggerRecord>>("dtrigrec");
-  //mNEventsTotal += digitsTR.size();//number of events in the current input
-  for (const auto& trigRecord : digitsTR) {
-    LOG(debug) << " monitorData() : trigger record #" << mNEventsTotal
-               << " contains " << trigRecord.getNumberOfObjects() << " objects.";
-    if (trigRecord.getNumberOfObjects() > 0) { //at least 1 digit -> pedestal event
-      mNEventsTotal++;
-      mNEventsFromLastFillHistogramsCall++;
-      for (int iDig = trigRecord.getFirstEntry(); iDig < trigRecord.getFirstEntry() + trigRecord.getNumberOfObjects(); iDig++) {
-        mHist1D[H1DDigitIds]->Fill(digits[iDig].getAbsId());
-        short relId[3];
-        if (mCPVGeometry.absToRelNumbering(digits[iDig].getAbsId(), relId)) {
-          //reminder: relId[3]={Module, phi col, z row} where Module=2..4, phi col=0..127, z row=0..59
-          mHist2D[H2DDigitMapM2 + relId[0] - 2]->Fill(relId[1], relId[2]);
-          mHistAmplitudes[digits[iDig].getAbsId()]->Fill(digits[iDig].getAmplitude());
-          mIsUpdatedAmplitude[digits[iDig].getAbsId()] = true;
+  // digits monitoring
+  if (hasDigits && mMonitorDigits) {
+    auto digits = ctx.inputs().get<gsl::span<o2::cpv::Digit>>("digits");
+    mHist1D[H1DNDigitsPerInput]->Fill(digits.size());
+    auto digitsTR = ctx.inputs().get<gsl::span<o2::cpv::TriggerRecord>>("dtrigrec");
+    // mNEventsTotal += digitsTR.size();//number of events in the current input
+    for (const auto& trigRecord : digitsTR) {
+      LOG(debug) << " monitorData() : trigger record #" << mNEventsTotal
+                 << " contains " << trigRecord.getNumberOfObjects() << " objects.";
+      if (trigRecord.getNumberOfObjects() > 0) { // at least 1 digit -> pedestal event
+        mNEventsTotal++;
+        mNEventsFromLastFillHistogramsCall++;
+        for (int iDig = trigRecord.getFirstEntry(); iDig < trigRecord.getFirstEntry() + trigRecord.getNumberOfObjects(); iDig++) {
+          mHist1D[H1DDigitIds]->Fill(digits[iDig].getAbsId());
+          short relId[3];
+          if (o2::cpv::Geometry::absToRelNumbering(digits[iDig].getAbsId(), relId)) {
+            // reminder: relId[3]={Module, phi col, z row} where Module=2..4, phi col=0..127, z row=0..59
+            mHist2D[H2DDigitMapM2 + relId[0] - 2]->Fill(relId[1], relId[2]);
+            mHistAmplitudes[digits[iDig].getAbsId()]->Fill(digits[iDig].getAmplitude());
+            mIsUpdatedAmplitude[digits[iDig].getAbsId()] = true;
+          }
         }
       }
     }
+  }
+
+  // pedestal calibrator output monitoring
+  if (mMonitorPedestalCalibrator) {
+    // o2::cpv::Pedestals object
+    if (hasPedestalsCLP) {
+      auto peds = o2::framework::DataRefUtils::as<o2::framework::CCDBSerialized<o2::cpv::Pedestals>>(ctx.inputs().get<o2::framework::DataRef>("peds"));
+      if (peds) {
+        mNtimesCCDBPayloadFetched++;
+        LOG(info) << "PedestalTask::monitorData() : Extracted o2::cpv::Pedestals from CLP payload";
+        short relId[3];
+        for (int ch = 0; ch < o2::cpv::Geometry::kNCHANNELS; ch++) {
+          o2::cpv::Geometry::absToRelNumbering(ch, relId);
+          mHist2D[H2DPedestalValueMapM2 + relId[0] - 2]->SetBinContent(relId[1] + 1, relId[2] + 1, peds->getPedestal(ch));
+          mHist1D[H1DPedestalValueM2 + relId[0] - 2]->Fill(peds->getPedestal(ch));
+          mHist2D[H2DPedestalSigmaMapM2 + relId[0] - 2]->SetBinContent(relId[1] + 1, relId[2] + 1, peds->getPedSigma(ch));
+          mHist1D[H1DPedestalSigmaM2 + relId[0] - 2]->Fill(peds->getPedSigma(ch));
+        }
+      }
+    }
+    // FEE thresolds
+    if (hasFEEThrsCLP) {
+      auto feethrs = o2::framework::DataRefUtils::as<o2::framework::CCDBSerialized<std::vector<int>>>(ctx.inputs().get<o2::framework::DataRef>("feethrs"));
+      if (feethrs) {
+        LOG(info) << "PedestalTask::monitorData() : Extracted FEE thresholds std::vector<int> of size " << feethrs->size() << "from CLP payload";
+        short relId[3];
+        for (int ch = 0; ch < o2::cpv::Geometry::kNCHANNELS; ch++) {
+          o2::cpv::Geometry::absToRelNumbering(ch, relId);
+          mHist2D[H2DFEEThresholdsMapM2 + relId[0] - 2]->SetBinContent(relId[1] + 1, relId[2] + 1, float(feethrs->at(ch) & 0xffff));
+        }
+      }
+    }
+    // Dead channels
+    if (hasDeadChnlsCLP) {
+      auto deadchs = o2::framework::DataRefUtils::as<o2::framework::CCDBSerialized<std::vector<int>>>(ctx.inputs().get<o2::framework::DataRef>("deadchs"));
+      if (deadchs) {
+        LOG(info) << "PedestalTask::monitorData() : Extracted dead channels std::vector<int> of size " << deadchs->size() << "from CLP payload";
+        short relId[3];
+        for (int ch : *deadchs) {
+          o2::cpv::Geometry::absToRelNumbering(ch, relId);
+          mHist2D[H2DDeadChanelsMapM2 + relId[0] - 2]->SetBinContent(relId[1] + 1, relId[2] + 1, 1.);
+        }
+      }
+    }
+    // High threshold channels
+    if (hasHighThrsCLP) {
+      auto highthrs = o2::framework::DataRefUtils::as<o2::framework::CCDBSerialized<std::vector<int>>>(ctx.inputs().get<o2::framework::DataRef>("highthrs"));
+      if (highthrs) {
+        LOG(info) << "PedestalTask::monitorData() : Extracted high threshold channels std::vector<int> of size " << highthrs->size() << "from CLP payload";
+        short relId[3];
+        for (int ch : *highthrs) {
+          o2::cpv::Geometry::absToRelNumbering(ch, relId);
+        }
+      }
+    }
+    // Efficiencies
+    if (hasPedEffsCLP) {
+      auto pedeffs = o2::framework::DataRefUtils::as<o2::framework::CCDBSerialized<std::vector<float>>>(ctx.inputs().get<o2::framework::DataRef>("pedeffs"));
+      if (pedeffs) {
+        LOG(info) << "PedestalTask::monitorData() : Extracted pedesta efficiencies std::vector<float> of size " << pedeffs->size() << "from CLP payload";
+        short relId[3];
+        for (int ch = 0; ch < o2::cpv::Geometry::kNCHANNELS; ch++) {
+          o2::cpv::Geometry::absToRelNumbering(ch, relId);
+          mHist2D[H2DPedestalEfficiencyMapM2 + relId[0] - 2]->SetBinContent(relId[1] + 1, relId[2] + 1, pedeffs->at(ch));
+          mHist1D[H1DPedestalEfficiencyM2 + relId[0] - 2]->Fill(pedeffs->at(ch));
+        }
+      }
+    }
+    LOG(info) << "PedestalTask::monitorData() : I fetched o2::cpv::Pedestals CLP payload " << mNtimesCCDBPayloadFetched << " times.";
   }
 }
 
 void PedestalTask::endOfCycle()
 {
-  ILOG(Info, Devel) << "endOfCycle. I call fillHistograms()" << ENDM;
-  //fit histograms if have sufficient increment of event number
-  if (mNEventsFromLastFillHistogramsCall >= mMinNEventsToUpdatePedestals) {
-    fillHistograms();
-    mNEventsFromLastFillHistogramsCall = 0;
+  ILOG(Info, Devel) << "PedestalTask::endOfCycle()" << ENDM;
+  if (mMonitorDigits) {
+    // fit histograms if have sufficient increment of event number
+    if (mNEventsFromLastFillHistogramsCall >= mMinNEventsToUpdatePedestals) {
+      ILOG(Info, Devel) << "I call fillDigitsHistograms()" << ENDM;
+      fillDigitsHistograms();
+      mNEventsFromLastFillHistogramsCall = 0;
+    } else {
+      ILOG(Info, Devel) << "Not enough events (" << mNEventsFromLastFillHistogramsCall << ") to call fillDigitsHistograms(). Min "
+                        << mMinNEventsToUpdatePedestals << " needed." << ENDM;
+    }
   }
 }
 
 void PedestalTask::endOfActivity(Activity& /*activity*/)
 {
   ILOG(Info, Support) << "endOfActivity" << ENDM;
-  //do a final fill of histograms (if needed)
-  if (mNEventsFromLastFillHistogramsCall) {
-    ILOG(Info, Devel) << "Final call of fillHistograms() " << ENDM;
-    fillHistograms();
+  if (!mMonitorDigits) {
+    // do a final fill of histograms (if needed)
+    if (mNEventsFromLastFillHistogramsCall) {
+      ILOG(Info, Devel) << "Final call of fillDigitsHistograms() " << ENDM;
+      fillDigitsHistograms();
+    }
   }
 }
 
@@ -185,22 +347,31 @@ void PedestalTask::initHistograms()
 {
   ILOG(Info, Devel) << "initing histograms" << ENDM;
 
-  //create monitoring histograms (or reset, if they already exist)
-  for (int i = 0; i < kNChannels; i++) {
-    if (!mHistAmplitudes[i]) {
-      mHistAmplitudes[i] =
-        new TH1F(Form("HistAmplitude%d", i), Form("HistAmplitude%d", i), 4096, 0., 4096.);
-      //publish some of them
-      if (i % 1000 == 0) {
-        getObjectsManager()->startPublishing(mHistAmplitudes[i]);
-      }
-    } else {
-      mHistAmplitudes[i]->Reset();
-    }
-    mIsUpdatedAmplitude[i] = false;
+  if (!mHist1D[H1DRawErrors]) {
+    mHist1D[H1DRawErrors] =
+      new TH1F("RawErrors", "Raw Errors", 20, 0., 20.);
+    getObjectsManager()->startPublishing(mHist1D[H1DRawErrors]);
+  } else {
+    mHist1D[H1DRawErrors]->Reset();
   }
 
-  //1D Histos
+  if (mMonitorDigits) {
+    // create monitoring histograms (or reset, if they already exist)
+    for (int i = 0; i < o2::cpv::Geometry::kNCHANNELS; i++) {
+      if (!mHistAmplitudes[i]) {
+        mHistAmplitudes[i] =
+          new TH1F(Form("HistAmplitude%d", i), Form("HistAmplitude%d", i), 4096, 0., 4096.);
+        // publish some of them
+        if (i % 1000 == 0) {
+          getObjectsManager()->startPublishing(mHistAmplitudes[i]);
+        }
+      } else {
+        mHistAmplitudes[i]->Reset();
+      }
+      mIsUpdatedAmplitude[i] = false;
+    }
+  }
+  // 1D Histos
   if (!mHist1D[H1DInputPayloadSize]) {
     mHist1D[H1DInputPayloadSize] =
       new TH1F("InputPayloadSize", "Input Payload Size", 30000, 0, 30000000);
@@ -210,7 +381,7 @@ void PedestalTask::initHistograms()
   }
 
   if (!mHist1D[H1DNInputs]) {
-    mHist1D[H1DNInputs] = new TH1F("NInputs", "Number of inputs", 10, -0.5, 9.5);
+    mHist1D[H1DNInputs] = new TH1F("NInputs", "Number of inputs", 20, -0.5, 19.5);
     getObjectsManager()->startPublishing(mHist1D[H1DNInputs]);
   } else {
     mHist1D[H1DNInputs]->Reset();
@@ -218,66 +389,111 @@ void PedestalTask::initHistograms()
 
   if (!mHist1D[H1DNValidInputs]) {
     mHist1D[H1DNValidInputs] =
-      new TH1F("NValidInputs", "Number of valid inputs", 10, -0.5, 9.5);
+      new TH1F("NValidInputs", "Number of valid inputs", 20, -0.5, 19.5);
     getObjectsManager()->startPublishing(mHist1D[H1DNValidInputs]);
   } else {
     mHist1D[H1DNValidInputs]->Reset();
   }
 
-  if (!mHist1D[H1DNDigitsPerInput]) {
-    mHist1D[H1DNDigitsPerInput] =
-      new TH1F("NDigitsPerInput", "Number of digits per input", 30000, 0, 300000);
-    getObjectsManager()->startPublishing(mHist1D[H1DNDigitsPerInput]);
-  } else {
-    mHist1D[H1DNDigitsPerInput]->Reset();
-  }
-
-  if (!mHist1D[H1DDigitIds]) {
-    mHist1D[H1DDigitIds] = new TH1F("DigitIds", "Digit Ids", 30000, -0.5, 29999.5);
-    getObjectsManager()->startPublishing(mHist1D[H1DDigitIds]);
-  } else {
-    mHist1D[H1DDigitIds]->Reset();
-  }
-
-  for (int mod = 0; mod < kNModules; mod++) {
-    if (!mHist1D[H1DPedestalValueM2 + mod]) {
-      mHist1D[H1DPedestalValueM2 + mod] =
-        new TH1F(
-          Form("PedestalValueM%d", mod + 2),
-          Form("Pedestal value distribution M%d", mod + 2),
-          512, 0, 512);
-      mHist1D[H1DPedestalValueM2 + mod]->GetXaxis()->SetTitle("Pedestal value");
-      getObjectsManager()->startPublishing(mHist1D[H1DPedestalValueM2 + mod]);
+  if (mMonitorDigits) {
+    if (!mHist1D[H1DNDigitsPerInput]) {
+      mHist1D[H1DNDigitsPerInput] =
+        new TH1F("NDigitsPerInput", "Number of digits per input", 30000, 0, 300000);
+      if (mMonitorDigits) {
+        getObjectsManager()->startPublishing(mHist1D[H1DNDigitsPerInput]);
+      }
     } else {
-      mHist1D[H1DPedestalValueM2 + mod]->Reset();
+      mHist1D[H1DNDigitsPerInput]->Reset();
     }
 
-    if (!mHist1D[H1DPedestalSigmaM2 + mod]) {
-      mHist1D[H1DPedestalSigmaM2 + mod] =
-        new TH1F(
-          Form("PedestalSigmaM%d", mod + 2),
-          Form("Pedestal sigma distribution M%d", mod + 2),
-          200, 0, 20);
-      mHist1D[H1DPedestalSigmaM2 + mod]->GetXaxis()->SetTitle("Pedestal sigma");
-      getObjectsManager()->startPublishing(mHist1D[H1DPedestalSigmaM2 + mod]);
+    if (!mHist1D[H1DDigitIds]) {
+      mHist1D[H1DDigitIds] = new TH1F("DigitIds", "Digit Ids", 30000, -0.5, 29999.5);
+      if (mMonitorDigits) {
+        getObjectsManager()->startPublishing(mHist1D[H1DDigitIds]);
+      }
     } else {
-      mHist1D[H1DPedestalSigmaM2 + mod]->Reset();
-    }
-
-    if (!mHist1D[H1DPedestalEfficiencyM2 + mod]) {
-      mHist1D[H1DPedestalEfficiencyM2 + mod] =
-        new TH1F(
-          Form("PedestalEfficiencyM%d", mod + 2),
-          Form("Pedestal efficiency distribution M%d", mod + 2),
-          500, 0., 5.);
-      mHist1D[H1DPedestalEfficiencyM2 + mod]->GetXaxis()->SetTitle("Pedestal efficiency");
-      getObjectsManager()->startPublishing(mHist1D[H1DPedestalEfficiencyM2 + mod]);
-    } else {
-      mHist1D[H1DPedestalEfficiencyM2 + mod]->Reset();
+      mHist1D[H1DDigitIds]->Reset();
     }
   }
 
-  //2D Histos
+  for (int mod = 0; mod < 3; mod++) {
+    if (mMonitorPedestalCalibrator) { // MOs to appear in pedestal calibrator monitoring mode
+      if (!mHist1D[H1DPedestalValueM2 + mod]) {
+        mHist1D[H1DPedestalValueM2 + mod] =
+          new TH1F(
+            Form("PedestalValueM%d", mod + 2),
+            Form("Pedestal value distribution M%d", mod + 2),
+            512, 0, 512);
+        mHist1D[H1DPedestalValueM2 + mod]->GetXaxis()->SetTitle("Pedestal value");
+        getObjectsManager()->startPublishing(mHist1D[H1DPedestalValueM2 + mod]);
+      } else {
+        mHist1D[H1DPedestalValueM2 + mod]->Reset();
+      }
+
+      if (!mHist1D[H1DPedestalSigmaM2 + mod]) {
+        mHist1D[H1DPedestalSigmaM2 + mod] =
+          new TH1F(
+            Form("PedestalSigmaM%d", mod + 2),
+            Form("Pedestal sigma distribution M%d", mod + 2),
+            200, 0, 20);
+        mHist1D[H1DPedestalSigmaM2 + mod]->GetXaxis()->SetTitle("Pedestal sigma");
+        getObjectsManager()->startPublishing(mHist1D[H1DPedestalSigmaM2 + mod]);
+      } else {
+        mHist1D[H1DPedestalSigmaM2 + mod]->Reset();
+      }
+
+      if (!mHist1D[H1DPedestalEfficiencyM2 + mod]) {
+        mHist1D[H1DPedestalEfficiencyM2 + mod] =
+          new TH1F(
+            Form("PedestalEfficiencyM%d", mod + 2),
+            Form("Pedestal efficiency distribution M%d", mod + 2),
+            500, 0., 5.);
+        mHist1D[H1DPedestalEfficiencyM2 + mod]->GetXaxis()->SetTitle("Pedestal efficiency");
+        getObjectsManager()->startPublishing(mHist1D[H1DPedestalEfficiencyM2 + mod]);
+      } else {
+        mHist1D[H1DPedestalEfficiencyM2 + mod]->Reset();
+      }
+    }
+    if (mMonitorDigits) { // MOs to appear in digits monitoring mode
+      if (!mHist1D[H1DPedestalValueInDigitsM2 + mod]) {
+        mHist1D[H1DPedestalValueInDigitsM2 + mod] =
+          new TH1F(
+            Form("PedestalValueInDigitsM%d", mod + 2),
+            Form("Pedestal value distribution M%d", mod + 2),
+            512, 0, 512);
+        mHist1D[H1DPedestalValueInDigitsM2 + mod]->GetXaxis()->SetTitle("Pedestal value");
+        getObjectsManager()->startPublishing(mHist1D[H1DPedestalValueInDigitsM2 + mod]);
+      } else {
+        mHist1D[H1DPedestalValueInDigitsM2 + mod]->Reset();
+      }
+
+      if (!mHist1D[H1DPedestalSigmaInDigitsM2 + mod]) {
+        mHist1D[H1DPedestalSigmaInDigitsM2 + mod] =
+          new TH1F(
+            Form("PedestalSigmaInDigitsM%d", mod + 2),
+            Form("Pedestal sigma distribution M%d", mod + 2),
+            200, 0, 20);
+        mHist1D[H1DPedestalSigmaInDigitsM2 + mod]->GetXaxis()->SetTitle("Pedestal sigma");
+        getObjectsManager()->startPublishing(mHist1D[H1DPedestalSigmaInDigitsM2 + mod]);
+      } else {
+        mHist1D[H1DPedestalSigmaInDigitsM2 + mod]->Reset();
+      }
+
+      if (!mHist1D[H1DPedestalEfficiencyInDigitsM2 + mod]) {
+        mHist1D[H1DPedestalEfficiencyInDigitsM2 + mod] =
+          new TH1F(
+            Form("PedestalEfficiencyInDigitsM%d", mod + 2),
+            Form("Pedestal efficiency distribution M%d", mod + 2),
+            500, 0., 5.);
+        mHist1D[H1DPedestalEfficiencyInDigitsM2 + mod]->GetXaxis()->SetTitle("Pedestal efficiency");
+        getObjectsManager()->startPublishing(mHist1D[H1DPedestalEfficiencyInDigitsM2 + mod]);
+      } else {
+        mHist1D[H1DPedestalEfficiencyInDigitsM2 + mod]->Reset();
+      }
+    }
+  }
+
+  // 2D Histos
   if (!mHist2D[H2DErrorType]) {
     mHist2D[H2DErrorType] = new TH2F("ErrorType", "ErrorType", 50, 0, 50, 5, 0, 5);
     mHist2D[H2DErrorType]->SetStats(0);
@@ -286,120 +502,218 @@ void PedestalTask::initHistograms()
     mHist2D[H2DErrorType]->Reset();
   }
 
-  //per-module histos
-  int nPadsX = mCPVGeometry.kNumberOfCPVPadsPhi;
-  int nPadsZ = mCPVGeometry.kNumberOfCPVPadsZ;
+  // per-module histos
+  int nPadsX = o2::cpv::Geometry::kNumberOfCPVPadsPhi;
+  int nPadsZ = o2::cpv::Geometry::kNumberOfCPVPadsZ;
 
-  for (int mod = 0; mod < kNModules; mod++) {
-    if (!mHist2D[H2DDigitMapM2 + mod]) {
-      mHist2D[H2DDigitMapM2 + mod] =
-        new TH2F(
-          Form("DigitMapM%d", 2 + mod),
-          Form("Digit Map in M%d", mod + 2),
-          nPadsX, -0.5, nPadsX - 0.5,
-          nPadsZ, -0.5, nPadsZ - 0.5);
-      mHist2D[H2DDigitMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
-      mHist2D[H2DDigitMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
-      mHist2D[H2DDigitMapM2 + mod]->SetStats(0);
-      getObjectsManager()->startPublishing(mHist2D[H2DDigitMapM2 + mod]);
-    } else {
-      mHist2D[H2DDigitMapM2 + mod]->Reset();
+  for (int mod = 0; mod < 3; mod++) {
+    if (mMonitorPedestalCalibrator) { // MOs to appear in pedestal calibrator monitoring mode
+      if (!mHist2D[H2DPedestalValueMapM2 + mod]) {
+        mHist2D[H2DPedestalValueMapM2 + mod] =
+          new TH2F(
+            Form("PedestalValueMapM%d", 2 + mod),
+            Form("PedestalValue Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DPedestalValueMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DPedestalValueMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DPedestalValueMapM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DPedestalValueMapM2 + mod]);
+      } else {
+        mHist2D[H2DPedestalValueMapM2 + mod]->Reset();
+      }
+
+      if (!mHist2D[H2DPedestalSigmaMapM2 + mod]) {
+        mHist2D[H2DPedestalSigmaMapM2 + mod] =
+          new TH2F(
+            Form("PedestalSigmaMapM%d", 2 + mod),
+            Form("PedestalSigma Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DPedestalSigmaMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DPedestalSigmaMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DPedestalSigmaMapM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DPedestalSigmaMapM2 + mod]);
+      } else {
+        mHist2D[H2DPedestalSigmaMapM2 + mod]->Reset();
+      }
+
+      if (!mHist2D[H2DPedestalEfficiencyMapM2 + mod]) {
+        mHist2D[H2DPedestalEfficiencyMapM2 + mod] =
+          new TH2F(
+            Form("PedestalEfficiencyMapM%d", 2 + mod),
+            Form("Pedestal Efficiency Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DPedestalEfficiencyMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DPedestalEfficiencyMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DPedestalEfficiencyMapM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DPedestalEfficiencyMapM2 + mod]);
+      } else {
+        mHist2D[H2DPedestalEfficiencyMapM2 + mod]->Reset();
+      }
+      if (!mHist2D[H2DFEEThresholdsMapM2 + mod]) {
+        mHist2D[H2DFEEThresholdsMapM2 + mod] =
+          new TH2F(
+            Form("FEEThresholdsMapM%d", 2 + mod),
+            Form("FEE Thresholds Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DFEEThresholdsMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DFEEThresholdsMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DFEEThresholdsMapM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DFEEThresholdsMapM2 + mod]);
+      } else {
+        mHist2D[H2DFEEThresholdsMapM2 + mod]->Reset();
+      }
+      if (!mHist2D[H2DDeadChanelsMapM2 + mod]) {
+        mHist2D[H2DDeadChanelsMapM2 + mod] =
+          new TH2F(
+            Form("DeadChanelsMapM%d", 2 + mod),
+            Form("Daed channels map Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DDeadChanelsMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DDeadChanelsMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DDeadChanelsMapM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DDeadChanelsMapM2 + mod]);
+      } else {
+        mHist2D[H2DDeadChanelsMapM2 + mod]->Reset();
+      }
+      if (!mHist2D[H2DHighThresholdMapM2 + mod]) {
+        mHist2D[H2DHighThresholdMapM2 + mod] =
+          new TH2F(
+            Form("HighThresholdMapM%d", 2 + mod),
+            Form("High threshold Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DHighThresholdMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DHighThresholdMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DHighThresholdMapM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DHighThresholdMapM2 + mod]);
+      } else {
+        mHist2D[H2DHighThresholdMapM2 + mod]->Reset();
+      }
     }
 
-    if (!mHist2D[H2DPedestalValueMapM2 + mod]) {
-      mHist2D[H2DPedestalValueMapM2 + mod] =
-        new TH2F(
-          Form("PedestalValueMapM%d", 2 + mod),
-          Form("PedestalValue Map in M%d", mod + 2),
-          nPadsX, -0.5, nPadsX - 0.5,
-          nPadsZ, -0.5, nPadsZ - 0.5);
-      mHist2D[H2DPedestalValueMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
-      mHist2D[H2DPedestalValueMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
-      mHist2D[H2DPedestalValueMapM2 + mod]->SetStats(0);
-      getObjectsManager()->startPublishing(mHist2D[H2DPedestalValueMapM2 + mod]);
-    } else {
-      mHist2D[H2DPedestalValueMapM2 + mod]->Reset();
-    }
+    if (mMonitorDigits) { // MOs to appear in digits monitoring mode
+      if (!mHist2D[H2DDigitMapM2 + mod]) {
+        mHist2D[H2DDigitMapM2 + mod] =
+          new TH2F(
+            Form("DigitMapM%d", 2 + mod),
+            Form("Digit Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DDigitMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DDigitMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DDigitMapM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DDigitMapM2 + mod]);
+      } else {
+        mHist2D[H2DDigitMapM2 + mod]->Reset();
+      }
+      if (!mHist2D[H2DPedestalValueMapInDigitsM2 + mod]) {
+        mHist2D[H2DPedestalValueMapInDigitsM2 + mod] =
+          new TH2F(
+            Form("PedestalValueMapInDigitsM%d", 2 + mod),
+            Form("PedestalValue Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DPedestalValueMapInDigitsM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DPedestalValueMapInDigitsM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DPedestalValueMapInDigitsM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DPedestalValueMapInDigitsM2 + mod]);
+      } else {
+        mHist2D[H2DPedestalValueMapInDigitsM2 + mod]->Reset();
+      }
 
-    if (!mHist2D[H2DPedestalSigmaMapM2 + mod]) {
-      mHist2D[H2DPedestalSigmaMapM2 + mod] =
-        new TH2F(
-          Form("PedestalSigmaMapM%d", 2 + mod),
-          Form("PedestalSigma Map in M%d", mod + 2),
-          nPadsX, -0.5, nPadsX - 0.5,
-          nPadsZ, -0.5, nPadsZ - 0.5);
-      mHist2D[H2DPedestalSigmaMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
-      mHist2D[H2DPedestalSigmaMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
-      mHist2D[H2DPedestalSigmaMapM2 + mod]->SetStats(0);
-      getObjectsManager()->startPublishing(mHist2D[H2DPedestalSigmaMapM2 + mod]);
-    } else {
-      mHist2D[H2DPedestalSigmaMapM2 + mod]->Reset();
-    }
+      if (!mHist2D[H2DPedestalSigmaMapInDigitsM2 + mod]) {
+        mHist2D[H2DPedestalSigmaMapInDigitsM2 + mod] =
+          new TH2F(
+            Form("PedestalSigmaMapInDigitsM%d", 2 + mod),
+            Form("PedestalSigma Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DPedestalSigmaMapInDigitsM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DPedestalSigmaMapInDigitsM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DPedestalSigmaMapInDigitsM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DPedestalSigmaMapInDigitsM2 + mod]);
+      } else {
+        mHist2D[H2DPedestalSigmaMapInDigitsM2 + mod]->Reset();
+      }
 
-    if (!mHist2D[H2DPedestalEfficiencyMapM2 + mod]) {
-      mHist2D[H2DPedestalEfficiencyMapM2 + mod] =
-        new TH2F(
-          Form("PedestalEfficiencyMapM%d", 2 + mod),
-          Form("Pedestal Efficiency Map in M%d", mod + 2),
-          nPadsX, -0.5, nPadsX - 0.5,
-          nPadsZ, -0.5, nPadsZ - 0.5);
-      mHist2D[H2DPedestalEfficiencyMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
-      mHist2D[H2DPedestalEfficiencyMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
-      mHist2D[H2DPedestalEfficiencyMapM2 + mod]->SetStats(0);
-      getObjectsManager()->startPublishing(mHist2D[H2DPedestalEfficiencyMapM2 + mod]);
-    } else {
-      mHist2D[H2DPedestalEfficiencyMapM2 + mod]->Reset();
-    }
-    if (!mHist2D[H2DPedestalNPeaksMapM2 + mod]) {
-      mHist2D[H2DPedestalNPeaksMapM2 + mod] =
-        new TH2F(
-          Form("PedestalNPeaksMapM%d", 2 + mod),
-          Form("Number of pedestal peaks Map in M%d", mod + 2),
-          nPadsX, -0.5, nPadsX - 0.5, nPadsZ, -0.5, nPadsZ - 0.5);
-      mHist2D[H2DPedestalNPeaksMapM2 + mod]->GetXaxis()->SetTitle("x, pad");
-      mHist2D[H2DPedestalNPeaksMapM2 + mod]->GetYaxis()->SetTitle("z, pad");
-      mHist2D[H2DPedestalNPeaksMapM2 + mod]->SetStats(0);
-      getObjectsManager()->startPublishing(mHist2D[H2DPedestalNPeaksMapM2 + mod]);
-    } else {
-      mHist2D[H2DPedestalNPeaksMapM2 + mod]->Reset();
+      if (!mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + mod]) {
+        mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + mod] =
+          new TH2F(
+            Form("PedestalEfficiencyMapInDigitsM%d", 2 + mod),
+            Form("Pedestal Efficiency Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5,
+            nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + mod]);
+      } else {
+        mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + mod]->Reset();
+      }
+
+      if (!mHist2D[H2DPedestalNPeaksMapInDigitsM2 + mod]) {
+        mHist2D[H2DPedestalNPeaksMapInDigitsM2 + mod] =
+          new TH2F(
+            Form("PedestalNPeaksMapInDigitsM%d", 2 + mod),
+            Form("Number of pedestal peaks Map in M%d", mod + 2),
+            nPadsX, -0.5, nPadsX - 0.5, nPadsZ, -0.5, nPadsZ - 0.5);
+        mHist2D[H2DPedestalNPeaksMapInDigitsM2 + mod]->GetXaxis()->SetTitle("x, pad");
+        mHist2D[H2DPedestalNPeaksMapInDigitsM2 + mod]->GetYaxis()->SetTitle("z, pad");
+        mHist2D[H2DPedestalNPeaksMapInDigitsM2 + mod]->SetStats(0);
+        getObjectsManager()->startPublishing(mHist2D[H2DPedestalNPeaksMapInDigitsM2 + mod]);
+      } else {
+        mHist2D[H2DPedestalNPeaksMapInDigitsM2 + mod]->Reset();
+      }
     }
   }
 }
 
-void PedestalTask::fillHistograms()
+void PedestalTask::fillDigitsHistograms()
 {
+  LOG(info) << "fillDigitsHistograms()";
+
+  if (!mMonitorDigits) {
+    LOG(info) << "fillDigitsHistograms(): monitor digits mode is off. So do nothing.";
+    return;
+  } else {
+    LOG(info) << "fillDigitsHistograms(): starting analyzing digit data ";
+  }
   // count pedestals and update MOs
   float pedestalValue, pedestalSigma, pedestalEfficiency;
   short relId[3];
   TF1* functionGaus = new TF1("functionGaus", "gaus", 0., 4095.);
-  TSpectrum* peakSearcher = new TSpectrum(5); //find up to 5 pedestal peaks
-  int numberOfPeaks;                          //number of pedestal peaks in channel. Normaly it's 1, otherwise channel is bad
+  TSpectrum* peakSearcher = new TSpectrum(5); // find up to 5 pedestal peaks
+  int numberOfPeaks;                          // number of pedestal peaks in channel. Normaly it's 1, otherwise channel is bad
   double *xPeaks, yPeaks[5];                  // arrays of x-position of the peaks and their heights
 
-  //first, reset pedestal histograms
+  // first, reset pedestal histograms
   for (int mod = 0; mod < 3; mod++) {
-    mHist2D[H2DPedestalNPeaksMapM2 + mod]->Reset();
-    mHist2D[H2DPedestalValueMapM2 + mod]->Reset();
-    mHist2D[H2DPedestalSigmaMapM2 + mod]->Reset();
-    mHist2D[H2DPedestalEfficiencyMapM2 + mod]->Reset();
-    mHist1D[H1DPedestalValueM2 + mod]->Reset();
-    mHist1D[H1DPedestalSigmaM2 + mod]->Reset();
-    mHist1D[H1DPedestalEfficiencyM2 + mod]->Reset();
+    mHist2D[H2DPedestalNPeaksMapInDigitsM2 + mod]->Reset();
+    mHist2D[H2DPedestalValueMapInDigitsM2 + mod]->Reset();
+    mHist2D[H2DPedestalSigmaMapInDigitsM2 + mod]->Reset();
+    mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + mod]->Reset();
+    mHist1D[H1DPedestalValueInDigitsM2 + mod]->Reset();
+    mHist1D[H1DPedestalSigmaInDigitsM2 + mod]->Reset();
+    mHist1D[H1DPedestalEfficiencyInDigitsM2 + mod]->Reset();
   }
 
-  //then fill them with actual values
-  for (int channel = 0; channel < kNChannels; channel++) {
+  // then fill them with actual values
+  for (int channel = 0; channel < o2::cpv::Geometry::kNCHANNELS; channel++) {
     if (!mHistAmplitudes[channel]) {
-      ILOG(Error, Devel) << "fillHistograms() : histo mHistAmplitudes[" << channel
+      ILOG(Error, Devel) << "fillDigitsHistograms() : histo mHistAmplitudes[" << channel
                          << "] does not exist! Something is going wrong." << ENDM;
       continue;
     }
     if (!mIsUpdatedAmplitude[channel])
-      continue; //no data in channel, skipping it
+      continue; // no data in channel, skipping it
 
     if (channel % 1000 == 0) {
-      ILOG(Info, Devel) << "fillHistograms(): Start to search peaks in channel " << channel << ENDM;
-      LOG(info) << "fillHistograms(): Start to search peaks in channel " << channel;
+      ILOG(Info, Devel) << "fillDigitsHistograms(): Start to search peaks in channel " << channel << ENDM;
     }
 
     numberOfPeaks = peakSearcher->Search(mHistAmplitudes[channel], 10., "nobackground", 0.2);
@@ -412,22 +726,22 @@ void PedestalTask::fillHistograms()
       mHistAmplitudes[channel]->Fit(functionGaus, "WWQ", "", xPeaks[0] - 20., xPeaks[0] + 20.);
       pedestalValue = functionGaus->GetParameter(1);
       pedestalSigma = functionGaus->GetParameter(2);
-      //stop publish this amplitude as it's OK (that fails due to some unclear reason)
-      //if (getObjectsManager()->isBeingPublished(mHistAmplitudes[channel]->GetName())){
-      //getObjectsManager()->stopPublishing(mHistAmplitudes[channel]->GetName());
-      //}
+      // stop publish this amplitude as it's OK (that fails due to some unclear reason)
+      // if (getObjectsManager()->isBeingPublished(mHistAmplitudes[channel]->GetName())){
+      // getObjectsManager()->stopPublishing(mHistAmplitudes[channel]->GetName());
+      // }
     } else {
       if (numberOfPeaks > 1) { // >1 peaks, no fit. Just use mean and stddev as ped value & sigma
         pedestalValue = mHistAmplitudes[channel]->GetMean();
         if (pedestalValue > 0)
-          pedestalValue = -pedestalValue; //let it be negative so we can know it's bad later
+          pedestalValue = -pedestalValue; // let it be negative so we can know it's bad later
         pedestalSigma = mHistAmplitudes[channel]->GetStdDev();
-        //let's publish this bad amplitude
+        // let's publish this bad amplitude
         if (!getObjectsManager()->isBeingPublished(mHistAmplitudes[channel]->GetName())) {
           getObjectsManager()->startPublishing(mHistAmplitudes[channel]);
         }
-      } else { //numberOfPeaks < 1 - what is it?
-        //no peaks found((( OK let's show the spectrum to the world...
+      } else { // numberOfPeaks < 1 - what is it?
+        // no peaks found((( OK let's show the spectrum to the world...
         if (!getObjectsManager()->isBeingPublished(mHistAmplitudes[channel]->GetName())) {
           getObjectsManager()->startPublishing(mHistAmplitudes[channel]);
         }
@@ -436,43 +750,48 @@ void PedestalTask::fillHistograms()
     }
 
     pedestalEfficiency = mHistAmplitudes[channel]->GetEntries() / mNEventsTotal;
-    mCPVGeometry.absToRelNumbering(channel, relId);
-    mHist2D[H2DPedestalValueMapM2 + relId[0] - 2]
+    o2::cpv::Geometry::absToRelNumbering(channel, relId);
+    mHist2D[H2DPedestalValueMapInDigitsM2 + relId[0] - 2]
       ->SetBinContent(relId[1] + 1, relId[2] + 1, pedestalValue);
-    mHist2D[H2DPedestalSigmaMapM2 + relId[0] - 2]
+    mHist2D[H2DPedestalSigmaMapInDigitsM2 + relId[0] - 2]
       ->SetBinContent(relId[1] + 1, relId[2] + 1, pedestalSigma);
-    mHist2D[H2DPedestalEfficiencyMapM2 + relId[0] - 2]
+    mHist2D[H2DPedestalEfficiencyMapInDigitsM2 + relId[0] - 2]
       ->SetBinContent(relId[1] + 1, relId[2] + 1, pedestalEfficiency);
-    mHist2D[H2DPedestalNPeaksMapM2 + relId[0] - 2]
+    mHist2D[H2DPedestalNPeaksMapInDigitsM2 + relId[0] - 2]
       ->SetBinContent(relId[1] + 1, relId[2] + 1, numberOfPeaks);
 
-    mHist1D[H1DPedestalValueM2 + relId[0] - 2]->Fill(pedestalValue);
-    mHist1D[H1DPedestalSigmaM2 + relId[0] - 2]->Fill(pedestalSigma);
-    mHist1D[H1DPedestalEfficiencyM2 + relId[0] - 2]->Fill(pedestalEfficiency);
+    mHist1D[H1DPedestalValueInDigitsM2 + relId[0] - 2]->Fill(pedestalValue);
+    mHist1D[H1DPedestalSigmaInDigitsM2 + relId[0] - 2]->Fill(pedestalSigma);
+    mHist1D[H1DPedestalEfficiencyInDigitsM2 + relId[0] - 2]->Fill(pedestalEfficiency);
   }
 
-  //show some info to developer
-  ILOG(Info, Devel) << "fillHistograms() : at this time, N events = " << mNEventsTotal << ENDM;
-  LOG(info) << "fillPedestals() : I finished filling of histograms";
+  // show some info to developer
+  ILOG(Info, Devel) << "fillDigitsHistograms() : at this time, N events = " << mNEventsTotal << ENDM;
 }
 
 void PedestalTask::resetHistograms()
 {
   // clean all histograms
   ILOG(Info, Support) << "Resetting amplitude histograms" << ENDM;
-  for (int i = 0; i < kNChannels; i++) {
-    mHistAmplitudes[i]->Reset();
+  for (int i = 0; i < o2::cpv::Geometry::kNCHANNELS; i++) {
+    if (mHistAmplitudes[i]) {
+      mHistAmplitudes[i]->Reset();
+    }
     mIsUpdatedAmplitude[i] = false;
   }
 
   ILOG(Info, Support) << "Resetting the 1D Histograms" << ENDM;
-  for (int itHist1D = H1DInputPayloadSize; itHist1D < kNHist1D; itHist1D++) {
-    mHist1D[itHist1D]->Reset();
+  for (int iHist1D = 0; iHist1D < kNHist1D; iHist1D++) {
+    if (mHist1D[iHist1D]) {
+      mHist1D[iHist1D]->Reset();
+    }
   }
 
   ILOG(Info, Support) << "Resetting the 2D Histograms" << ENDM;
-  for (int itHist2D = H2DErrorType; itHist2D < kNHist2D; itHist2D++) {
-    mHist2D[itHist2D]->Reset();
+  for (int iHist2D = 0; iHist2D < kNHist2D; iHist2D++) {
+    if (mHist2D[iHist2D]) {
+      mHist2D[iHist2D]->Reset();
+    }
   }
 }
 


### PR DESCRIPTION
Hello! A possibility to monitor CPV PedestalCalibrator output is added. It should be used by default in order to get rid of fitting 23K histograms and publishing those which are bad. It will help to reduce number of published objects greatly. However the possibility to monitor digits (and fit 23K histos) is preserved for expert use. The expert will be able to switch it on in the json config file. 
Also TH2F histos for monitoring of current CCDB objects in PhysicsTask are modified in such way that they are not simply merged in merger but updated only once per cycle when new one comes.