### PR TITLE
Forcing updating the denominator in vtx QC

### DIFF
--- a/Modules/GLO/src/VertexingQcTask.cxx
+++ b/Modules/GLO/src/VertexingQcTask.cxx
@@ -251,7 +251,7 @@ void VertexingQcTask::endOfCycle()
 
   if (mUseMC) {
 
-    if (!mVtxEffVsMult->SetTotalHistogram(*mNPrimaryMCGen, "") ||
+    if (!mVtxEffVsMult->SetTotalHistogram(*mNPrimaryMCGen, "f") ||
         !mVtxEffVsMult->SetPassedHistogram(*mNPrimaryMCEvWithVtx, "")) {
       ILOG(Fatal, Support) << "Something went wrong in defining the efficiency histograms!!";
     } else {


### PR DESCRIPTION
Needed when we have more cycles: the previous one can then impact on
the following one.