### PR TITLE
MID: remove excessive logging

### DIFF
--- a/Modules/MUON/MID/src/RawQcTask.cxx
+++ b/Modules/MUON/MID/src/RawQcTask.cxx
@@ -169,7 +169,7 @@ void RawQcTask::startOfCycle()
 void RawQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
-  ILOG(Info, Support) << "startOfDataMonitoring" << ENDM;
+//  ILOG(Info, Support) << "startOfDataMonitoring" << ENDM;
 
   o2::framework::DPLRawParser parser(ctx.inputs());
   o2::InteractionRecord IntRecord;

--- a/Modules/MUON/MID/src/RawQcTask.cxx
+++ b/Modules/MUON/MID/src/RawQcTask.cxx
@@ -169,7 +169,7 @@ void RawQcTask::startOfCycle()
 void RawQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
-//  ILOG(Info, Support) << "startOfDataMonitoring" << ENDM;
+  //  ILOG(Info, Support) << "startOfDataMonitoring" << ENDM;
 
   o2::framework::DPLRawParser parser(ctx.inputs());
   o2::InteractionRecord IntRecord;


### PR DESCRIPTION
The method `monitorData` is called a lot. Therefore logging in the method should be avoided in order not to flood the infologger.

@ValerieRamillien 