### PR TITLE
Fix ITS Fhr task bugs and issue in THnSparse filling with large events

### DIFF
--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -113,6 +113,7 @@ class ITSFhrTask final : public TaskInterface
   int mGetTFFromBinding = 0;
   int mHitCutForNoisyPixel = 1024;        // Hit number cut for noisy pixel, this number should be define according how many TF will be accumulated before reset(one can reference the cycle time)
   float mOccupancyCutForNoisyPixel = 0.1; // Occupancy cut for noisy pixel. check if the hit/event value over this cut. similar with mHitCutForNoisyPixel
+  double mCutTrgForSparse = 1000;         // cut to stop THnSparse filling after mCutTrgForSparse triggers
 
   std::unordered_map<unsigned int, int>*** mHitPixelID_InStave /* = new std::unordered_map<unsigned int, int>**[NStaves[lay]]*/;
   int** mHitnumberLane /* = new int*[NStaves[lay]]*/;       // IB : hitnumber[stave][chip]; OB : hitnumber[stave][lane]

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -49,7 +49,8 @@
                     "MinGeneralNoisyAxisRange": "0",
 		    "Etabins": "130",
                     "Phibins": "240",
-		    "geomPath": "./"
+		    "geomPath": "./",
+		    "CutSparseTriggers": "1000"
                 }
             }
         },


### PR DESCRIPTION
Fixes:
- Fill noisy pix plot (TH2Poly) only if reasonable statistics is reached (1M events) and do it for the next 10000 events. The cut on the occupancy still allow to cut very high in case of pp or Pb-Pb collisions. 
- Dead chip maps filled with 0s: now filled with 1s. 
- THnSparse filled only up to a selectable (from json) number of events. Important for Pb-Pb, pp collisions. 