### PR TITLE
TOF: Correct loading of geometry

### DIFF
--- a/Modules/PID/include/PID/TaskFT0TOF.h
+++ b/Modules/PID/include/PID/TaskFT0TOF.h
@@ -112,7 +112,7 @@ class TaskFT0TOF final : public TaskInterface
   float mMinDCAtoBeamPipeCut = 100.f;
   float mMinDCAtoBeamPipeCutY = 10.f;
   std::string mGRPFileName = "o2sim_grp.root";
-  std::string mGeomFileName = "o2sim_geometry.root";
+  std::string mSimPrefix = "o2sim";
   float mBz = 0; ///< nominal Bz
   int mTF = -1;  // to count the number of processed TFs
   const float cinv = 33.35641;

--- a/Modules/PID/src/TaskFT0TOF.cxx
+++ b/Modules/PID/src/TaskFT0TOF.cxx
@@ -123,7 +123,7 @@ void TaskFT0TOF::initialize(o2::framework::InitContext& /*ctx*/)
   mHistT0ResEvTimeMult = new TH2F("T0ResEvTimeMult", "0.7 < p < 1.1 GeV/#it{c};TOF multiplicity;TOF event time resolution (ps)", 100, 0., 100, 200, 0, 200);
 
   // initialize B field and geometry for track selection
-  o2::base::GeometryManager::loadGeometry(mGeomFileName);
+  o2::base::GeometryManager::loadGeometry(mSimPrefix); // loads aligned geom by default
   o2::base::Propagator::initFieldFromGRP(mGRPFileName);
   mBz = o2::base::Propagator::Instance()->getNominalBz();
 

--- a/Modules/TOF/include/TOF/TOFMatchedTracks.h
+++ b/Modules/TOF/include/TOF/TOFMatchedTracks.h
@@ -119,7 +119,7 @@ class TOFMatchedTracks final : public TaskInterface
   float mDCACut = 100.f;
   float mDCACutY = 10.f;
   std::string mGRPFileName = "o2sim_grp.root";
-  std::string mGeomFileName = "o2sim_geometry-aligned.root";
+  std::string mSimPrefix = "o2sim";
   float mBz = 0; ///< nominal Bz
 
   int mTF = -1; // to count the number of processed TFs

--- a/Modules/TOF/src/TOFMatchedTracks.cxx
+++ b/Modules/TOF/src/TOFMatchedTracks.cxx
@@ -156,7 +156,7 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
   }
 
   // initialize B field and geometry for track selection
-  o2::base::GeometryManager::loadGeometry(mGeomFileName);
+  o2::base::GeometryManager::loadGeometry(mSimPrefix); // loads aligned geom by default
   o2::base::Propagator::initFieldFromGRP(mGRPFileName);
   mBz = o2::base::Propagator::Instance()->getNominalBz();
 


### PR DESCRIPTION
To load a geometry, we need to give the simulation prefix
and not the complete filename.
The geometry manager will construct the filename itself.
(Unfortunately the interface definition/documentation was
not precise in this regard.)