### PR TITLE
Remove checks since they are not used and are misconfigured.

### DIFF
--- a/Modules/GLO/ITSTPCmatchedTracks.json
+++ b/Modules/GLO/ITSTPCmatchedTracks.json
@@ -54,20 +54,6 @@
         "saveObjectsToFile" : "ITSTPCmatched.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
-    },
-    "checks" : {
-      "QcCheck" : {
-        "active" : "false",
-        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
-        "moduleName" : "QcSkeleton",
-        "policy" : "OnAny",
-        "detectorName" : "TOF",
-        "dataSource" : [ {
-          "type" : "Task",
-          "name" : "QcTask",
-          "MOs" : ["example"]
-        } ]
-      }
     }
   },
          "dataSamplingPolicies" : [

--- a/Modules/GLO/ITSTPCmatchedTracks_direct.json
+++ b/Modules/GLO/ITSTPCmatchedTracks_direct.json
@@ -55,20 +55,6 @@
         "saveObjectsToFile" : "ITSTPCmatched.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
-    },
-    "checks" : {
-      "QcCheck" : {
-        "active" : "false",
-        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
-        "moduleName" : "QcSkeleton",
-        "policy" : "OnAny",
-        "detectorName" : "TOF",
-        "dataSource" : [ {
-          "type" : "Task",
-          "name" : "QcTask",
-          "MOs" : ["example"]
-        } ]
-      }
     }
   },
          "dataSamplingPolicies" : [

--- a/Modules/TOF/tofMatchedTracks_AllTypes_direct_MC.json
+++ b/Modules/TOF/tofMatchedTracks_AllTypes_direct_MC.json
@@ -56,20 +56,6 @@
         "saveObjectsToFile" : "TOFmatchedITSTPC_TPC_ITSTPCTRD_TPCTRD_MC.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
-    },
-    "checks" : {
-      "QcCheck" : {
-        "active" : "false",
-        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
-        "moduleName" : "QcSkeleton",
-        "policy" : "OnAny",
-        "detectorName" : "TOF",
-        "dataSource" : [ {
-          "type" : "Task",
-          "name" : "QcTask",
-          "MOs" : ["example"]
-        } ]
-      }
     }
   },
          "dataSamplingPolicies" : []

--- a/Modules/TOF/tofMatchedTracks_ITSTPCTOF.json
+++ b/Modules/TOF/tofMatchedTracks_ITSTPCTOF.json
@@ -55,20 +55,6 @@
         "saveObjectsToFile" : "TOFmatchedITSTPCTOF.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
-    },
-    "checks" : {
-      "QcCheck" : {
-        "active" : "false",
-        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
-        "moduleName" : "QcSkeleton",
-        "policy" : "OnAny",
-        "detectorName" : "TOF",
-        "dataSource" : [ {
-          "type" : "Task",
-          "name" : "QcTask",
-          "MOs" : ["example"]
-        } ]
-      }
     }
   },
          "dataSamplingPolicies" : []

--- a/Modules/TOF/tofMatchedTracks_ITSTPCTOF_TPCTOF.json
+++ b/Modules/TOF/tofMatchedTracks_ITSTPCTOF_TPCTOF.json
@@ -54,20 +54,6 @@
         "saveObjectsToFile" : "TOFmatchedITSTPCTOF_TPCTOF.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
-    },
-    "checks" : {
-      "QcCheck" : {
-        "active" : "false",
-        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
-        "moduleName" : "QcSkeleton",
-        "policy" : "OnAny",
-        "detectorName" : "TOF",
-        "dataSource" : [ {
-          "type" : "Task",
-          "name" : "QcTask",
-          "MOs" : ["example"]
-        } ]
-      }
     }
   },
          "dataSamplingPolicies" : [

--- a/Modules/TOF/tofMatchedTracks_ITSTPCTOF_TPCTOF_MC.json
+++ b/Modules/TOF/tofMatchedTracks_ITSTPCTOF_TPCTOF_MC.json
@@ -55,20 +55,6 @@
         "saveObjectsToFile" : "TOFmatchedITSTPCTOF_TPCTOF_MC.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
-    },
-    "checks" : {
-      "QcCheck" : {
-        "active" : "false",
-        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
-        "moduleName" : "QcSkeleton",
-        "policy" : "OnAny",
-        "detectorName" : "TOF",
-        "dataSource" : [ {
-          "type" : "Task",
-          "name" : "QcTask",
-          "MOs" : ["example"]
-        } ]
-      }
     }
   },
          "dataSamplingPolicies" : [

--- a/Modules/TOF/tofMatchedTracks_ITSTPCTOF_TPCTOF_direct.json
+++ b/Modules/TOF/tofMatchedTracks_ITSTPCTOF_TPCTOF_direct.json
@@ -55,20 +55,6 @@
         "saveObjectsToFile" : "TOFmatchedITSTPCTOF_TPCTOF.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
-    },
-    "checks" : {
-      "QcCheck" : {
-        "active" : "false",
-        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
-        "moduleName" : "QcSkeleton",
-        "policy" : "OnAny",
-        "detectorName" : "TOF",
-        "dataSource" : [ {
-          "type" : "Task",
-          "name" : "QcTask",
-          "MOs" : ["example"]
-        } ]
-      }
     }
   },
          "dataSamplingPolicies" : []

--- a/Modules/TOF/tofMatchedTracks_ITSTPCTOF_TPCTOF_direct_MC.json
+++ b/Modules/TOF/tofMatchedTracks_ITSTPCTOF_TPCTOF_direct_MC.json
@@ -56,20 +56,6 @@
         "saveObjectsToFile" : "TOFmatchedITSTPCTOF_TPCTOF_MC.root",
         "" : "For debugging, path to the file where to save. If empty or missing it won't save."
       }
-    },
-    "checks" : {
-      "QcCheck" : {
-        "active" : "false",
-        "className" : "o2::quality_control_modules::skeleton::SkeletonCheck",
-        "moduleName" : "QcSkeleton",
-        "policy" : "OnAny",
-        "detectorName" : "TOF",
-        "dataSource" : [ {
-          "type" : "Task",
-          "name" : "QcTask",
-          "MOs" : ["example"]
-        } ]
-      }
     }
   },
          "dataSamplingPolicies" : []


### PR DESCRIPTION
Being misconfigured, they make QC crash.

@noferini 