### PR TITLE
CPV: make sure configure() was called in PedestalCheck

### DIFF
--- a/Modules/CPV/include/CPV/PedestalCheck.h
+++ b/Modules/CPV/include/CPV/PedestalCheck.h
@@ -42,16 +42,17 @@ class PedestalCheck : public o2::quality_control::checker::CheckInterface
  private:
   int getRunNumberFromMO(std::shared_ptr<MonitorObject> mo);
 
-  //configurable parameters and their default values
-  //see config example in Modules/CPV/etc/pedestal-task-no-sampling.json
+  // configurable parameters and their default values
+  // see config example in Modules/CPV/etc/pedestal-task-no-sampling.json
   int mMinGoodPedestalValueM[3] = { 1, 1, 1 };
   float mMaxGoodPedestalSigmaM[3] = { 2., 2., 2. };
   float mMinGoodPedestalEfficiencyM[3] = { 0.7, 0.7, 0.7 };
   float mMaxGoodPedestalEfficiencyM[3] = { 1., 1., 1. };
-  int mToleratedBadPedestalValueChannelsM[3] = { 10, 10, 10 };      //pedestal value < mMinGoodPedestalValue or > 512
-  int mToleratedBadChannelsM[3] = { 20, 20, 20 };                   //double peaks or empty or channels
-  int mToleratedBadPedestalSigmaChannelsM[3] = { 20, 20, 20 };      //pedestal value < mMinGoodPedestalValue or > 512
-  int mToleratedBadPedestalEfficiencyChannelsM[3] = { 20, 20, 20 }; //efficiency < min or > max
+  int mToleratedBadPedestalValueChannelsM[3] = { 10, 10, 10 };      // pedestal value < mMinGoodPedestalValue or > 512
+  int mToleratedBadChannelsM[3] = { 20, 20, 20 };                   // double peaks or empty or channels
+  int mToleratedBadPedestalSigmaChannelsM[3] = { 20, 20, 20 };      // pedestal value < mMinGoodPedestalValue or > 512
+  int mToleratedBadPedestalEfficiencyChannelsM[3] = { 20, 20, 20 }; // efficiency < min or > max
+  bool mIsConfigured = false;                                       // had configure() been called already?
 
   ClassDefOverride(PedestalCheck, 2);
 };

--- a/Modules/CPV/src/PedestalCheck.cxx
+++ b/Modules/CPV/src/PedestalCheck.cxx
@@ -31,6 +31,11 @@ namespace o2::quality_control_modules::cpv
 
 void PedestalCheck::configure()
 {
+  ILOG(Info, Support) << "PedestalCheck::configure() : I have been called with following custom parameters" << ENDM;
+  for (auto [key, value] : mCustomParameters) {
+    ILOG(Info, Support) << key << ": " << value << ENDM;
+  }
+
   for (int mod = 0; mod < 3; mod++) {
     // mMinGoodPedestalValueM
     if (auto param = mCustomParameters.find(Form("mMinGoodPedestalValueM%d", mod + 2));
@@ -130,10 +135,17 @@ void PedestalCheck::configure()
                         << " = "
                         << mToleratedBadPedestalEfficiencyChannelsM[mod] << ENDM;
   }
+  ILOG(Info, Support) << "PedestalCheck::configure() : configuring is done." << ENDM;
+  mIsConfigured = true;
 }
 
 Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
+  if (!mIsConfigured) {
+    ILOG(Info, Support) << "PedestalCheck::check() : I'm about to check already but configure() had not been called yet. So I call it now." << ENDM;
+    configure();
+  }
+
   Quality result = Quality::Good;
 
   for (auto& [moName, mo] : *moMap) {


### PR DESCRIPTION
Hello! I noticed that configure() was not called in pedestal run due to some reason. So decided to make it sure that it was called at least once before check() anything.