### PR TITLE
fix for geo path in TOF ME

### DIFF
--- a/Modules/TOF/src/TOFMatchedTracks.cxx
+++ b/Modules/TOF/src/TOFMatchedTracks.cxx
@@ -94,6 +94,14 @@ void TOFMatchedTracks::initialize(o2::framework::InitContext& /*ctx*/)
     ILOG(Info, Devel) << "Custom parameter - minDCACutY (for track selection): " << param->second << ENDM;
     setMinDCAtoBeamPipeYCut(atof(param->second.c_str()));
   }
+  if (auto param = mCustomParameters.find("geomFileName"); param != mCustomParameters.end()) {
+    ILOG(Info, Devel) << "Custom parameter - geomFileName: " << param->second << ENDM;
+    mGeomFileName = param->second.c_str();
+  }
+  if (auto param = mCustomParameters.find("grpFileName"); param != mCustomParameters.end()) {
+    ILOG(Info, Devel) << "Custom parameter - grpFileName: " << param->second << ENDM;
+    mGRPFileName = param->second.c_str();
+  }
 
   // for track type selection
   if (auto param = mCustomParameters.find("GID"); param != mCustomParameters.end()) {


### PR DESCRIPTION
Geo and Grp path can be configured via json file parameters

@ercolessi @njacazio: consul jsons have to point to this path -> /home/epn/odc/
both for geo and grp

@davidrohr @chiarazampolli @shahor02 

Tested locally with geo and grp in a dir different from local dir
