### PR TITLE
Revert "Invert the logic for the ServiceDiscovery flag (#1247)"

### DIFF
--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -113,10 +113,10 @@ void ServiceDiscovery::runHealthServer(unsigned int port)
   threadInfoLogger.setContext(context);
 
   // temporary switch to test the fix for the online mode
-  const char* env_var = std::getenv("QC_SD_DISABLE_RUN");
-  bool disableRun = env_var && strlen(env_var) > 0;
-  if (disableRun) {
-    threadInfoLogger << "QC_SD_DISABLE_RUN set" << ENDM;
+  const char* env_var = std::getenv("QC_TEST_FIX_ONLINE");
+  bool testFixOnline = env_var && strlen(env_var) > 0;
+  if (testFixOnline) {
+    threadInfoLogger << "QC_TEST_FIX_ONLINE set" << ENDM;
   }
 
   try {
@@ -139,7 +139,7 @@ void ServiceDiscovery::runHealthServer(unsigned int port)
           timer.cancel();
         }
       });
-      if (!disableRun) {
+      if (testFixOnline) {
         io_service.run();
       }
       std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/doc/DevelopersTips.md
+++ b/doc/DevelopersTips.md
@@ -117,7 +117,7 @@ When we don't see the monitoring data in grafana, here is what to do to pinpoint
 ### Monitoring setup for building the grafana dashboard
 
 1. Go to `root@flptest1`
-2. Edit telegraf config file by executing these lines :
+2. Edit telegraf config file, add following lines:
 ```
 echo "[[inputs.socket_listener]]    
    service_address = \"udp://:8089\"" >> /etc/telegraf/telegraf.conf
@@ -131,9 +131,9 @@ firewall-cmd --reload
 5. Go to Grafana (flptest1.cern.ch:3000) and login as `admin`, the password is in here: https://gitlab.cern.ch/AliceO2Group/system-configuration/-/blob/dev/ansible/roles/grafana/vars/main.yml#L2
 6. Go to "Explore" tab (4th icon from top), and select `qc` as data source
 7. Run your workflow with `--monitoring-backend influxdb-udp://flptest1.cern.ch:8089 --resources-monitoring 2`
-10. Set the monitoring url to `"url": "stdout://?qc,influxdb-udp://flptest1.cern.ch:8089"`
 8. The metrics should be there 
 9. Make a copy of the QC dashboard that you can edit.
+10. Set the monitoring url to `"url": "stdout://?qc,influxdb-udp://flptest1.cern.ch:8089"`
 11. Once the dashboard is ready, tell Adam.
 
 


### PR DESCRIPTION
This reverts commit d58b27a3d57fc8f3440f8721224a7f4b4d062c2f.

It fails on CC7. Until I understand why, I keep it optional.