### PR TITLE
Use utility to correctly get the MID digits

### DIFF
--- a/Modules/MUON/MID/CMakeLists.txt
+++ b/Modules/MUON/MID/CMakeLists.txt
@@ -2,17 +2,24 @@
 
 add_library(O2QcMID)
 
-target_sources(O2QcMID PRIVATE src/RawQcCheck.cxx src/RawQcTask.cxx 
-                               src/DigitsQcCheck.cxx src/DigitsQcTask.cxx
-                               src/ClustQcCheck.cxx src/ClustQcTask.cxx
-                               src/TracksQcCheck.cxx src/TracksQcTask.cxx)
+target_sources(
+  O2QcMID
+  PRIVATE src/RawQcCheck.cxx
+          src/RawQcTask.cxx
+          src/DigitsQcCheck.cxx
+          src/DigitsQcTask.cxx
+          src/ClustQcCheck.cxx
+          src/ClustQcTask.cxx
+          src/TracksQcCheck.cxx
+          src/TracksQcTask.cxx)
 
 target_include_directories(
   O2QcMID
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcMID PUBLIC O2QualityControl O2QcMUONCommon O2::MIDRaw O2::MIDQC O2::MIDSimulation)
+target_link_libraries(O2QcMID PUBLIC O2QualityControl O2QcMUONCommon O2::MIDRaw O2::MIDQC O2::MIDSimulation
+                                     O2::MIDWorkflow)
 
 install(
   TARGETS O2QcMID
@@ -24,17 +31,16 @@ add_root_dictionary(
   O2QcMID
   HEADERS include/MID/RawQcCheck.h
           include/MID/RawQcTask.h
-	  include/MID/DigitsQcCheck.h
-	  include/MID/DigitsQcTask.h
-	  include/MID/ClustQcCheck.h
-	  include/MID/ClustQcTask.h
-	  include/MID/TracksQcCheck.h
-	  include/MID/TracksQcTask.h
+          include/MID/DigitsQcCheck.h
+          include/MID/DigitsQcTask.h
+          include/MID/ClustQcCheck.h
+          include/MID/ClustQcTask.h
+          include/MID/TracksQcCheck.h
+          include/MID/TracksQcTask.h
   LINKDEF include/MID/LinkDef.h
   BASENAME O2QcMID)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/MID
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/QualityControl")
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/MID DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/QualityControl")
 
 # ---- Test(s) ----
 
@@ -64,6 +70,3 @@ endforeach()
 # install( TARGETS ${EXE_NAMES} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
 install(FILES mid-raw.json mid-digits.json DESTINATION etc)
-
-
-

--- a/Modules/MUON/MID/mid-digits.json
+++ b/Modules/MUON/MID/mid-digits.json
@@ -30,21 +30,19 @@
     }
   },
   "dataSamplingPolicies": [
-  {
-    "id": "digits",
-    "active": "true",
-    "machines": [],
-    "query" : "digits:MID/DATA/0;digitrofs:MID/DATAROF/0",
-    "samplingConditions": [
-      {
-        "condition": "random",
-        "fraction": "1",
-        "seed": "1441"
-      }
-    ],
-    "blocking": "false"
-  }
+    {
+      "id": "digits",
+      "active": "true",
+      "machines": [],
+      "query": "digits:MID/DATA;digits_rof:MID/DATAROF",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    }
   ]
 }
-
-

--- a/Modules/MUON/MID/src/DigitsQcTask.cxx
+++ b/Modules/MUON/MID/src/DigitsQcTask.cxx
@@ -37,6 +37,7 @@
 #include "MIDRaw/FEEIdConfig.h"
 #include "MIDBase/DetectorParameters.h"
 #include "MIDBase/GeometryParameters.h"
+#include "MIDWorkflow/ColumnDataSpecsUtils.h"
 
 #define MID_NDE 72
 #define MID_NCOL 7
@@ -271,8 +272,8 @@ static std::pair<uint32_t, uint32_t> getROFSize(const o2::mid::ROFRecord& rof, g
 
 void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  auto digits = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("digits");
-  auto rofs = ctx.inputs().get<gsl::span<o2::mid::ROFRecord>>("digitrofs");
+  auto digits = o2::mid::specs::getData(ctx, "digits", o2::mid::EventType::Standard);
+  auto rofs = o2::mid::specs::getRofs(ctx, "digits", o2::mid::EventType::Standard);
 
   int multHitMT11B = 0;
   int multHitMT12B = 0;


### PR DESCRIPTION
The decoding sends three subspecs:
- data
- calibration events
- fet events

The QC should match all of them via concrete matcher (without specifying the subspecs) and then get the desired digits internally. This ensures that:
- the workflow matches all outputs
- the workflow can be built even in the case where some of the subspecs are missing (e.g. in simulation we do not have calibration or fet events).

This is a common issue with all workflows reading MID digits. To avoid code duplication, a dedicated class is used to handle MID digits.
This PR uses such a class in the MID QC.