### PR TITLE
MCH: add task for monitoring tracks and their attached clusters

### DIFF
--- a/Modules/MUON/MCH/CMakeLists.txt
+++ b/Modules/MUON/MCH/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SRCS
   src/PhysicsOccupancyCheck.cxx
   src/PhysicsPreclustersCheck.cxx
   src/TH1MCHReductor.cxx
+  src/TracksTask.cxx
 )
 
 set(HEADERS
@@ -35,6 +36,7 @@ set(HEADERS
   include/MCH/MergeableTH1PseudoEfficiencyPerDE.h
   include/MCH/MergeableTH1PseudoEfficiencyPerDECycle.h
   include/MCH/MergeableTH1MPVPerDECycle.h
+  include/MCH/TracksTask.h
 )
 
 # ---- Library ----
@@ -48,7 +50,7 @@ target_include_directories(
 )
 
 target_link_libraries(${MODULE_NAME} PUBLIC O2QualityControl O2QcMUONCommon O2::CommonDataFormat O2::GPUCommon
-        $<TARGET_NAME_IF_EXISTS:O2::MCHMappingFactory> O2::MCHMappingImpl4 O2::MCHMappingSegContour O2::MCHBase O2::DataFormatsMCH O2::MCHRawDecoder O2::MCHCalibration O2::MCHDigitFiltering O2::MCHPreClustering)
+        $<TARGET_NAME_IF_EXISTS:O2::MCHMappingFactory> O2::MCHMappingImpl4 O2::MCHMappingSegContour O2::MCHBase O2::DataFormatsMCH O2::MCHRawDecoder O2::MCHCalibration O2::MCHDigitFiltering O2::MCHPreClustering O2::MCHTracking)
 
 target_compile_definitions(${MODULE_NAME} PRIVATE $<$<TARGET_EXISTS:O2::MCHMappingFactory>:MCH_HAS_MAPPING_FACTORY>)
 
@@ -95,6 +97,7 @@ add_root_dictionary(${MODULE_NAME}
                             include/MCH/MergeableTH1PseudoEfficiencyPerDE.h
                             include/MCH/MergeableTH1PseudoEfficiencyPerDECycle.h
                             include/MCH/MergeableTH1MPVPerDECycle.h
+                            include/MCH/TracksTask.h
                     LINKDEF include/MCH/LinkDef.h)
 
 # ---- Tests ----

--- a/Modules/MUON/MCH/etc/qc-tracks.json
+++ b/Modules/MUON/MCH/etc/qc-tracks.json
@@ -1,0 +1,39 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "http://ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      }
+    },
+    "tasks": {
+      "Tracks": {
+        "active": "true",
+        "className": "o2::quality_control_modules::muonchambers::TracksTask",
+        "moduleName": "QcMuonChambers",
+        "detectorName": "MCH",
+        "cycleDurationSeconds": "300",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query" : "tracks:MCH/TRACKS;trackrofs:MCH/TRACKROFS;trackclusters:MCH/TRACKCLUSTERS;trackdigits:MCH/CLUSTERDIGITS"
+        },
+        "taskParameters" : {
+                "maxTracksPerTF": "10"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+   }
+  },
+  "dataSamplingPolicies": [
+  ]
+}

--- a/Modules/MUON/MCH/include/MCH/LinkDef.h
+++ b/Modules/MUON/MCH/include/MCH/LinkDef.h
@@ -19,5 +19,6 @@
 #pragma link C++ class o2::quality_control_modules::muonchambers::MergeableTH1PseudoEfficiencyPerDE + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::MergeableTH1PseudoEfficiencyPerDECycle + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::MergeableTH1MPVPerDECycle + ;
+#pragma link C++ class o2::quality_control_modules::muonchambers::TracksTask + ;
 
 #endif

--- a/Modules/MUON/MCH/include/MCH/TracksTask.h
+++ b/Modules/MUON/MCH/include/MCH/TracksTask.h
@@ -1,0 +1,125 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QC_MODULE_MCH_TRACKS_TASK_H
+#define QC_MODULE_MCH_TRACKS_TASK_H
+
+#include "QualityControl/TaskInterface.h"
+#include <MCHRawElecMap/Mapper.h>
+#include <TH1F.h>
+#include <TProfile.h>
+#include <gsl/span>
+#include <memory>
+
+namespace o2::mch
+{
+class Cluster;
+class TrackMCH;
+} // namespace o2::mch
+
+using namespace o2::quality_control::core;
+
+class TH1F;
+
+namespace o2::quality_control_modules::muonchambers
+{
+
+class TracksTask /*final*/ : public TaskInterface
+{
+ public:
+  TracksTask();
+  ~TracksTask() override;
+
+  void initialize(o2::framework::InitContext& ctx) override;
+  void startOfActivity(Activity& activity) override;
+  void startOfCycle() override;
+  void monitorData(o2::framework::ProcessingContext& ctx) override;
+  void endOfCycle() override;
+  void endOfActivity(Activity& activity) override;
+  void reset() override;
+
+ private:
+  /** check whether all the expected inputs are present.*/
+  bool assertInputs(o2::framework::ProcessingContext& ctx);
+
+  /** create one histogram with relevant drawing options / stat box status.*/
+  template <typename T>
+  std::unique_ptr<T> createHisto(const char* name, const char* title,
+                                 int nbins, double xmin, double xmax,
+                                 bool statBox = false,
+                                 const char* drawOptions = "",
+                                 const char* displayHints = "");
+
+  /** create histograms related to clusters (those attached to tracks) */
+  void createClusterHistos();
+  /** create histograms related to tracks */
+  void createTrackHistos();
+  /** create histograms related to track pairs */
+  void createTrackPairHistos();
+
+  /** fill histogram related to each cluster */
+  void fillClusterHistos(gsl::span<const o2::mch::Cluster> clusters);
+
+  /** fill histograms related to a single track */
+  bool fillTrackHistos(const o2::mch::TrackMCH& track,
+                       gsl::span<const o2::mch::Cluster> clusters);
+
+  /** fill histograms for track pairs */
+  void fillTrackPairHistos(gsl::span<const o2::mch::TrackMCH> tracks);
+
+ private:
+  int dsbinx(int deid, int dsid) const;
+
+  std::unique_ptr<TH1F> mNofTracksPerTF;   ///< number of tracks per TF
+  std::unique_ptr<TH1F> mTrackBC;          ///< BC associated to the track
+  std::unique_ptr<TH1F> mTrackChi2OverNDF; ///< chi2/ndf for the track
+  std::unique_ptr<TH1F> mTrackDCA;         ///< DCA (cm) of the track
+  std::unique_ptr<TH1F> mTrackEta;         ///< eta of the track
+  std::unique_ptr<TH1F> mTrackPDCA;        ///< p (GeV/c) x DCA (cm) of the track
+  std::unique_ptr<TH1F> mTrackPhi;         ///< phi (in degrees) of the track
+  std::unique_ptr<TH1F> mTrackPt;          ///< Pt (Gev/c^2) of the track
+  std::unique_ptr<TH1F> mTrackRAbs;        ///< R at absorber end of the track
+
+  std::unique_ptr<TH1F> mNofClustersPerDualSampa;   //< aka cluster map
+  std::unique_ptr<TH1F> mNofClustersPerTrack;       ///< number of clusters per track
+  std::unique_ptr<TProfile> mClusterSizePerChamber; ///< mean cluster size per chamber
+  std::unique_ptr<TProfile> mNofClustersPerChamber; ///< mean number of clusters per chamber
+
+  std::unique_ptr<TH1F> mMinv; ///< invariant mass of unlike-sign track pairs
+
+  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
+  o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
+};
+
+template <typename T>
+std::unique_ptr<T> TracksTask::createHisto(const char* name, const char* title,
+                                           int nbins, double xmin, double xmax,
+                                           bool statBox,
+                                           const char* drawOptions,
+                                           const char* displayHints)
+{
+  auto h = std::make_unique<T>(name, title, nbins, xmin, xmax);
+  if (!statBox) {
+    h->SetStats(0);
+  }
+  getObjectsManager()->startPublishing(h.get());
+  if (drawOptions) {
+    getObjectsManager()->setDefaultDrawOptions(h.get(), drawOptions);
+  }
+  if (displayHints) {
+    getObjectsManager()->setDisplayHint(h.get(), displayHints);
+  }
+  return h;
+}
+
+} // namespace o2::quality_control_modules::muonchambers
+
+#endif

--- a/Modules/MUON/MCH/src/TracksTask.cxx
+++ b/Modules/MUON/MCH/src/TracksTask.cxx
@@ -1,0 +1,331 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCH/TracksTask.h"
+
+#include "CommonConstants/LHCConstants.h"
+#include <DataFormatsMCH/Cluster.h>
+#include <DataFormatsMCH/Digit.h>
+#include <DataFormatsMCH/ROFRecord.h>
+#include <DataFormatsMCH/TrackMCH.h>
+#include <DetectorsBase/GeometryManager.h>
+#include <Framework/DataRefUtils.h>
+#include <Framework/InputRecord.h>
+#include <MCHMappingInterface/Segmentation.h>
+#include <MCHTracking/TrackExtrap.h>
+#include <MCHTracking/TrackParam.h>
+#include <Math/Vector4Dfwd.h>
+#include <TH1F.h>
+#include <Math/Vector4D.h>
+#include <TMath.h>
+#include <gsl/span>
+
+namespace
+{
+
+constexpr double muonMass = 0.1056584;
+constexpr double muonMass2 = muonMass * muonMass;
+
+static void setXAxisLabels(TProfile* h)
+{
+  TAxis* axis = h->GetXaxis();
+  for (int i = 1; i <= 10; i++) {
+    auto label = fmt::format("CH{}", i);
+    axis->SetBinLabel(i, label.c_str());
+  }
+}
+
+uint16_t computeDsBinX(int feeId, int linkId, int elinkId)
+{
+  constexpr uint64_t maxLinkId = 12;
+  constexpr uint64_t maxElinkId = 40;
+
+  int v = feeId * maxLinkId * maxElinkId +
+          (linkId % maxLinkId) * maxElinkId + elinkId + 1;
+  return static_cast<uint16_t>(v & 0xFFFF);
+}
+
+std::array<int, 10> getClustersPerChamber(gsl::span<const o2::mch::Cluster> clusters)
+{
+  std::array<int, 10> clustersPerChamber;
+  clustersPerChamber.fill(0);
+  for (const auto& cluster : clusters) {
+    int chamberId = cluster.getChamberId();
+    clustersPerChamber[chamberId]++;
+  }
+  return clustersPerChamber;
+}
+
+} // namespace
+
+namespace o2::quality_control_modules::muonchambers
+{
+
+TracksTask::TracksTask()
+{
+}
+
+TracksTask::~TracksTask() = default;
+
+void TracksTask::createClusterHistos()
+{
+  mNofClustersPerTrack = createHisto<TH1F>("ClustersPerTrack", "Number of clusters per track;Mean number of clusters per track", 30, 0, 30);
+  mNofClustersPerDualSampa = createHisto<TH1F>("ClustersPerDualSampa", "Number of clusters per dual sampa;Number of clusters per DS", 30720, 0, 30719);
+
+  mNofClustersPerChamber = createHisto<TProfile>("ClustersPerChamber", "Clusters per chamber;;Number of clusters", 10, 1, 11);
+  setXAxisLabels(mNofClustersPerChamber.get());
+  mClusterSizePerChamber = createHisto<TProfile>("ClusterSizePerChamber", "Cluster size per chamber;;Mean number of pads per cluster", 10, 1, 11);
+  setXAxisLabels(mClusterSizePerChamber.get());
+}
+
+void TracksTask::createTrackHistos()
+{
+  double maxTracksPerTF = 400;
+
+  if (auto param = mCustomParameters.find("maxTracksPerTF"); param != mCustomParameters.end()) {
+    maxTracksPerTF = std::stof(param->second);
+  }
+
+  mNofTracksPerTF = createHisto<TH1F>("TracksPerTF", "Number of tracks per TimeFrame;Number of tracks per TF", maxTracksPerTF, 0, maxTracksPerTF - 1, true, "logy");
+
+  mTrackDCA = createHisto<TH1F>("TrackDCA", "Track DCA;DCA (cm)", 500, 0, 500);
+  mTrackPDCA = createHisto<TH1F>("TrackPDCA", "Track p#timesDCA;p#timesDCA (GeVcm/c)", 5000, 0, 5000);
+  mTrackPt = createHisto<TH1F>("TrackPt", "Track p_{T};p_{T} (GeV/c)", 300, 0, 30, false, "logy");
+  mTrackEta = createHisto<TH1F>("TrackEta", "Track #eta;#eta", 200, -4.5, -2);
+  mTrackPhi = createHisto<TH1F>("TrackPhi", "Track #phi;#phi (deg)", 360, 0, 360);
+  mTrackRAbs = createHisto<TH1F>("TrackRAbs", "Track R_{abs};R_{abs} (cm)", 1000, 0, 100);
+  mTrackBC = createHisto<TH1F>("TrackBC", "Track BC;BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches - 1);
+  mTrackChi2OverNDF = createHisto<TH1F>("TrackChi2OverNDF", "Track #chi^{2}/ndf;#chi^{2}/ndf", 500, 0, 50);
+}
+
+void TracksTask::createTrackPairHistos()
+{
+  mMinv = createHisto<TH1F>("Minv", "#mu^{+}#mu^{-} invariant mass;M_{#mu^{+}#mu^{-}} (GeV/c^{2})", 300, 0, 6);
+}
+
+void TracksTask::initialize(o2::framework::InitContext& /*ic*/)
+{
+  ILOG(Info, Support) << "initialize TracksTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+
+  if (!o2::base::GeometryManager::isGeometryLoaded()) {
+    TaskInterface::retrieveCondition("GLO/Config/Geometry");
+  }
+
+  createTrackHistos();
+  createClusterHistos();
+  createTrackPairHistos();
+
+  mDet2ElecMapper = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
+}
+
+int TracksTask::dsbinx(int deid, int dsid) const
+{
+  o2::mch::raw::DsDetId det{ deid, dsid };
+  auto elec = mDet2ElecMapper(det);
+  if (!elec.has_value()) {
+    ILOGE << "mapping is wrong somewhere...";
+    return -1;
+  }
+  auto eLinkId = elec->elinkId();
+  auto solarId = elec->solarId();
+  auto s2f = mSolar2FeeLinkMapper(solarId);
+  if (!s2f.has_value()) {
+    ILOGE << "mapping is wrong somewhere...";
+    return -1;
+  }
+  auto feeId = s2f->feeId();
+  auto linkId = s2f->linkId();
+
+  return computeDsBinX(feeId, linkId, eLinkId);
+}
+
+void TracksTask::startOfActivity(Activity& activity)
+{
+  ILOG(Info, Support) << "startOfActivity : " << activity.mId << ENDM;
+}
+
+void TracksTask::startOfCycle()
+{
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
+}
+
+ROOT::Math::PxPyPzMVector getMomentum4D(const o2::mch::TrackParam& trackParam)
+{
+  double px = trackParam.px();
+  double py = trackParam.py();
+  double pz = trackParam.pz();
+  return { px, py, pz, muonMass };
+}
+
+ROOT::Math::PxPyPzMVector getMomentum4D(const o2::mch::TrackMCH& track)
+{
+  o2::mch::TrackParam trackParamAtVertex(track.getZ(), track.getParameters());
+  double vz = 0.0;
+  if (!o2::mch::TrackExtrap::extrapToVertex(trackParamAtVertex, 0.0, 0.0, 0.0, 0.0, 0.0)) {
+    ILOG(Error, Support) << "Track extrap failed" << ENDM;
+    return { 0, 0, 0, 0 };
+  }
+  return getMomentum4D(trackParamAtVertex);
+}
+
+void TracksTask::fillClusterHistos(gsl::span<const o2::mch::Cluster> clusters)
+{
+  for (const auto& cluster : clusters) {
+    int deId = cluster.getDEId();
+    o2::mch::mapping::Segmentation seg(deId);
+    int b, nb;
+    seg.findPadPairByPosition(cluster.getX(), cluster.getY(), b, nb);
+    if (b >= 0) {
+      int dsId = seg.padDualSampaId(b);
+      mNofClustersPerDualSampa->Fill(dsbinx(deId, dsId));
+    }
+    if (nb >= 0) {
+      int dsId = seg.padDualSampaId(nb);
+      mNofClustersPerDualSampa->Fill(dsbinx(deId, dsId));
+    }
+    int chamberId = cluster.getChamberId();
+    mClusterSizePerChamber->Fill(chamberId + 1, cluster.nDigits);
+  }
+}
+
+bool TracksTask::assertInputs(o2::framework::ProcessingContext& ctx)
+{
+  if (!ctx.inputs().isValid("tracks")) {
+    ILOG(Info, Support) << "no mch tracks available on input" << ENDM;
+    return false;
+  }
+  if (!ctx.inputs().isValid("trackrofs")) {
+    ILOG(Info, Support) << "no mch track rofs available on input" << ENDM;
+    return false;
+  }
+  if (!ctx.inputs().isValid("trackclusters")) {
+    ILOG(Info, Support) << "no mch track clusters available on input" << ENDM;
+    return false;
+  }
+  return true;
+}
+
+void TracksTask::monitorData(o2::framework::ProcessingContext& ctx)
+{
+  if (!assertInputs(ctx)) {
+    return;
+  }
+
+  auto tracks = ctx.inputs().get<gsl::span<o2::mch::TrackMCH>>("tracks");
+  auto rofs = ctx.inputs().get<gsl::span<o2::mch::ROFRecord>>("trackrofs");
+  auto clusters = ctx.inputs().get<gsl::span<o2::mch::Cluster>>("trackclusters");
+
+  mNofTracksPerTF->Fill(tracks.size());
+
+  for (const auto& rof : rofs) {
+    if (rof.getNEntries() > 0) {
+      mTrackBC->Fill(rof.getBCData().bc);
+    }
+  }
+
+  decltype(tracks.size()) nok;
+
+  for (const auto& track : tracks) {
+    bool ok = fillTrackHistos(track, clusters);
+    if (ok) {
+      ++nok;
+    }
+  }
+
+  if (nok != tracks.size()) {
+    ILOG(Error, Support) << "Could only extrapolate " << nok << " tracks over " << tracks.size() << ENDM;
+  }
+
+  fillTrackPairHistos(tracks);
+}
+
+void TracksTask::fillTrackPairHistos(gsl::span<const o2::mch::TrackMCH> tracks)
+{
+  if (tracks.size() > 1) {
+    for (auto i = 0; i < tracks.size(); i++) {
+      auto ti = getMomentum4D(tracks[i]);
+      for (auto j = i + 1; j < tracks.size(); j++) {
+        if (tracks[i].getSign() == tracks[j].getSign()) {
+          continue;
+        }
+        auto tj = getMomentum4D(tracks[j]);
+        auto p = ti + tj;
+        mMinv->Fill(p.M());
+      }
+    }
+  }
+}
+
+bool TracksTask::fillTrackHistos(const o2::mch::TrackMCH& track,
+                                 gsl::span<const o2::mch::Cluster> clusters)
+{
+
+  mNofClustersPerTrack->Fill(track.getNClusters());
+  mTrackChi2OverNDF->Fill(track.getChi2OverNDF());
+
+  const auto trackClusters = clusters.subspan(track.getFirstClusterIdx(), track.getNClusters());
+  fillClusterHistos(trackClusters);
+
+  auto clustersPerChamber = getClustersPerChamber(trackClusters);
+
+  for (auto i = 0; i < clustersPerChamber.size(); i++) {
+    mNofClustersPerChamber->Fill(i + 1, clustersPerChamber[i]);
+  }
+
+  auto p = track.getP(); // uncorrected p
+
+  o2::mch::TrackParam trackParamAtDCA(track.getZ(), track.getParameters());
+  if (!o2::mch::TrackExtrap::extrapToVertexWithoutBranson(trackParamAtDCA, 0.0)) {
+    return false;
+  }
+
+  o2::mch::TrackParam trackParamAtOrigin(track.getZ(), track.getParameters());
+  if (!o2::mch::TrackExtrap::extrapToVertex(trackParamAtOrigin, 0.0, 0.0, 0.0, 0.0, 0.0)) {
+    return false;
+  }
+  double dcaX = trackParamAtDCA.getBendingCoor();
+  double dcaY = trackParamAtDCA.getNonBendingCoor();
+  double dca = std::sqrt(dcaX * dcaX + dcaY * dcaY);
+  mTrackDCA->Fill(dca);
+  mTrackPDCA->Fill(p * dca);
+
+  auto muon = getMomentum4D(trackParamAtOrigin);
+
+  mTrackEta->Fill(muon.eta());
+  mTrackPhi->Fill(muon.phi() * TMath::RadToDeg() + 180);
+  mTrackPt->Fill(muon.pt());
+
+  o2::mch::TrackExtrap::extrapToZ(trackParamAtOrigin, -505.);
+  double xAbs = trackParamAtOrigin.getNonBendingCoor();
+  double yAbs = trackParamAtOrigin.getBendingCoor();
+  auto rAbs = std::sqrt(xAbs * xAbs + yAbs * yAbs);
+  mTrackRAbs->Fill(rAbs);
+
+  return true;
+}
+
+void TracksTask::endOfCycle()
+{
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
+}
+
+void TracksTask::endOfActivity(Activity& /*activity*/)
+{
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
+}
+
+void TracksTask::reset()
+{
+  ILOG(Warning, Support) << "resetting the histograms is not implemented" << ENDM;
+}
+
+} // namespace o2::quality_control_modules::muonchambers


### PR DESCRIPTION
@aferrero2707 here's a first shot at QC plots for tracks (and their clusters). 
The set of plots (and their ranges) is heavily inspired by @pillot previous works (implementation mistakes in QC framework are all mine though :wink: )

There's no checker for the moment.

Samples plots (3005 TFs from 17 CTF root files from pilot run 517222) can be seen at https://qcg-test.cern.ch/?page=objectTree (under qc/MCH/MO/Tracks/) (btw, I realise I have no idea how to directly link to that subtree, if that's possible at all)