### PR TITLE
Provisionary fix for configKeyValues option

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -82,7 +82,8 @@ add_library(O2QualityControl
   src/RootFileSink.cxx
   src/RootFileSource.cxx
   src/UpdatePolicyType.cxx
-  src/RootClassFactory.cxx)
+  src/RootClassFactory.cxx
+  src/ConfigParamGlo.cxx)
 
 target_include_directories(
   O2QualityControl

--- a/Framework/include/QualityControl/ConfigParamGlo.h
+++ b/Framework/include/QualityControl/ConfigParamGlo.h
@@ -1,0 +1,29 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QUALITYCONTROL_CONFIGPARAMGLO_H
+#define QUALITYCONTROL_CONFIGPARAMGLO_H
+
+#include <string>
+
+// Quick and dirty way to pass the ConfigurableParam string parsed as a global
+// option of the o2-qc workflow to device init methods
+
+namespace o2::quality_control
+{
+
+struct ConfigParamGlo {
+  static std::string keyValues;
+};
+
+} // namespace o2::quality_control
+
+#endif

--- a/Framework/src/AggregatorRunner.cxx
+++ b/Framework/src/AggregatorRunner.cxx
@@ -38,6 +38,7 @@
 #include "QualityControl/InfrastructureSpecReader.h"
 #include "QualityControl/AggregatorRunnerFactory.h"
 #include "QualityControl/RootClassFactory.h"
+#include "QualityControl/ConfigParamGlo.h"
 
 using namespace AliceO2::Common;
 using namespace AliceO2::InfoLogger;
@@ -150,10 +151,9 @@ void AggregatorRunner::init(framework::InitContext& iCtx)
   try {
     initLibraries(); // we have to load libraries before we load ConfigurableParams, otherwise the corresponding ROOT dictionaries won't be found
     // load config params
-    if (iCtx.options().isSet("configKeyValues")) {
-      conf::ConfigurableParam::updateFromString(iCtx.options().get<std::string>("configKeyValues"));
+    if (!ConfigParamGlo::keyValues.empty()) {
+      conf::ConfigurableParam::updateFromString(ConfigParamGlo::keyValues);
     }
-
     initDatabase();
     initMonitoring();
     initServiceDiscovery();

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -33,6 +33,7 @@
 #include "QualityControl/InfrastructureSpecReader.h"
 #include "QualityControl/CheckRunnerFactory.h"
 #include "QualityControl/RootClassFactory.h"
+#include "QualityControl/ConfigParamGlo.h"
 
 #include <TSystem.h>
 
@@ -215,10 +216,9 @@ void CheckRunner::init(framework::InitContext& iCtx)
     initServiceDiscovery();
     initLibraries(); // we have to load libraries before we load ConfigurableParams, otherwise the corresponding ROOT dictionaries won't be found
 
-    if (iCtx.options().isSet("configKeyValues")) {
-      conf::ConfigurableParam::updateFromString(iCtx.options().get<std::string>("configKeyValues"));
+    if (!ConfigParamGlo::keyValues.empty()) {
+      conf::ConfigurableParam::updateFromString(ConfigParamGlo::keyValues);
     }
-
     // registering state machine callbacks
     iCtx.services().get<CallbackService>().set(CallbackService::Id::Start, [this, &services = iCtx.services()]() { start(services); });
     iCtx.services().get<CallbackService>().set(CallbackService::Id::Reset, [this]() { reset(); });

--- a/Framework/src/ConfigParamGlo.cxx
+++ b/Framework/src/ConfigParamGlo.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "QualityControl/ConfigParamGlo.h"
+
+namespace o2::quality_control
+{
+std::string ConfigParamGlo::keyValues = {};
+}

--- a/Framework/src/PostProcessingRunner.cxx
+++ b/Framework/src/PostProcessingRunner.cxx
@@ -21,6 +21,7 @@
 #include "QualityControl/Activity.h"
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/runnerUtils.h"
+#include "QualityControl/ConfigParamGlo.h"
 
 #include <boost/property_tree/ptree.hpp>
 #include <utility>
@@ -69,8 +70,8 @@ void PostProcessingRunner::init(const PostProcessingRunnerConfig& runnerConfig, 
   ILOG(Info, Support) << "Initializing PostProcessingRunner" << ENDM;
 
   root_class_factory::loadLibrary(mTaskConfig.moduleName);
-  if (!mRunnerConfig.configKeyValues.empty()) {
-    conf::ConfigurableParam::updateFromString(mRunnerConfig.configKeyValues);
+  if (!ConfigParamGlo::keyValues.empty()) {
+    conf::ConfigurableParam::updateFromString(ConfigParamGlo::keyValues);
   }
 
   // configuration of the database

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -38,6 +38,7 @@
 #include "QualityControl/runnerUtils.h"
 #include "QualityControl/InfrastructureSpecReader.h"
 #include "QualityControl/TaskRunnerFactory.h"
+#include "QualityControl/ConfigParamGlo.h"
 
 #include <string>
 #include <TFile.h>
@@ -153,8 +154,8 @@ void TaskRunner::init(InitContext& iCtx)
   mTask->setMonitoring(mCollector);
 
   // load config params
-  if (iCtx.options().isSet("configKeyValues")) {
-    conf::ConfigurableParam::updateFromString(iCtx.options().get<std::string>("configKeyValues"));
+  if (!ConfigParamGlo::keyValues.empty()) {
+    conf::ConfigurableParam::updateFromString(ConfigParamGlo::keyValues);
   }
 
   // init user's task

--- a/Framework/src/runQC.cxx
+++ b/Framework/src/runQC.cxx
@@ -36,6 +36,7 @@
 #include "QualityControl/runnerUtils.h"
 #include "QualityControl/InfrastructureGenerator.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/ConfigParamGlo.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -144,6 +145,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
   if (!validateArguments(config)) {
     return {};
   }
+  quality_control::ConfigParamGlo::keyValues = config.options().get<std::string>("configKeyValues");
 
   auto qcConfigurationSource = config.options().get<std::string>("config");
   try {


### PR DESCRIPTION
@knopers8 @Barthelemy as a follow-up of my email: given that the QC initializations are quite convoluted and we need to fix the ConfigurableParam functionality urgently in QC, here is the least invasive patch to pass the globally defined option to devices init. I would consider this as a temporary fix until the global/local options conflict will be fixed.