### PR TITLE
Fix in MID digits ROFs binding

### DIFF
--- a/Modules/MUON/MID/src/DigitsQcTask.cxx
+++ b/Modules/MUON/MID/src/DigitsQcTask.cxx
@@ -273,7 +273,7 @@ static std::pair<uint32_t, uint32_t> getROFSize(const o2::mid::ROFRecord& rof, g
 void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
   auto digits = o2::mid::specs::getData(ctx, "digits", o2::mid::EventType::Standard);
-  auto rofs = o2::mid::specs::getRofs(ctx, "digits", o2::mid::EventType::Standard);
+  auto rofs = o2::mid::specs::getRofs(ctx, "digitrofs", o2::mid::EventType::Standard);
 
   int multHitMT11B = 0;
   int multHitMT12B = 0;


### PR DESCRIPTION
@dstocco The fullCI is failing with https://ali-ci.cern.ch/alice-build-logs/AliceO2Group/AliceO2/9036/40689a74e6fe534f9a51a27002226eaa90dfc6c0/build_O2_fullCI/pretty.html, I assume this is a reason.