### PR TITLE
Always use FLP/DISTSUBTIMEFRAME/0 with '/0'

### DIFF
--- a/Modules/ITS/itsFLP.json
+++ b/Modules/ITS/itsFLP.json
@@ -96,7 +96,7 @@
             "id": "RAWDATA",
             "active": "true",
             "machines": [],
-            "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME",
+            "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME/0",
             "samplingConditions": [
                 {
                     "condition": "random",
@@ -110,7 +110,7 @@
             "id": "feedata",
             "active": "true",
             "machines": [],
-            "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME",
+            "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME/0",
             "samplingConditions": [
                 {
                     "condition": "random",

--- a/Modules/ITS/itsFee-no-ds.json
+++ b/Modules/ITS/itsFee-no-ds.json
@@ -32,7 +32,7 @@
                 "maxNumberCycles": "-1",
                 "dataSource": {
                     "type": "direct",
-                    "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME"
+                    "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME/0"
                 },
                 "location": "remote",
                 "taskParameters": {

--- a/Modules/ITS/itsFee.json
+++ b/Modules/ITS/itsFee.json
@@ -32,7 +32,7 @@
                 "maxNumberCycles": "-1",
                 "dataSource": {
                     "type": "direct",
-                    "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME"
+                    "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME/0"
                 },
                 "location": "local",
                 "taskParameters": {
@@ -74,7 +74,7 @@
             "id": "RAWDATA",
             "active": "true",
             "machines": [],
-            "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME",
+            "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME/0",
             "samplingConditions": [
                 {
                     "condition": "random",

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -75,7 +75,7 @@
             "id": "RAWDATA",
             "active": "true",
             "machines": [],
-            "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME",
+            "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME/0",
             "samplingConditions": [
                 {
                     "condition": "random",


### PR DESCRIPTION
Whenever one subscribes to FLP/DISTSUBTIMEFRAME, one needs to request subspec 0, otherwise there is a problem with the matching.