### PR TITLE
TRD clean up code, add some spectra, sort spectra

### DIFF
--- a/Modules/TRD/include/TRD/DigitsCheck.h
+++ b/Modules/TRD/include/TRD/DigitsCheck.h
@@ -8,6 +8,8 @@
 
 #include "QualityControl/CheckInterface.h"
 #include <TFile.h>
+#include <TLine.h>
+#include <TH2.h>
 
 namespace o2::quality_control_modules::trd
 {

--- a/Modules/TRD/include/TRD/DigitsTask.h
+++ b/Modules/TRD/include/TRD/DigitsTask.h
@@ -25,6 +25,7 @@ class TH1F;
 class TH2F;
 class TH1D;
 class TH2D;
+class TLine;
 class TProfile;
 class TProfile2D;
 using namespace o2::quality_control::core;
@@ -52,65 +53,59 @@ class DigitsTask final : public TaskInterface
   void endOfActivity(Activity& activity) override;
   void reset() override;
   void buildHistograms();
-  void buildHistogramsPH();
   void drawLinesMCM(TH2F* histo);
+  void drawTrdLayersGrid(TH2F* hist);
   void retrieveCCDBSettings();
+  void drawLinesOnPulseHeight(TH1F* h);
 
  private:
   // limits
+  bool mSkipSharedDigits;
   std::pair<float, float> mDriftRegion;
   std::pair<float, float> mPulseHeightPeakRegion;
+  long int mTimestamp;
 
   std::shared_ptr<TH1F> mDigitsPerEvent = nullptr;
-  std::shared_ptr<TH1F> mTotalChargevsTimeBin = nullptr; //
   std::shared_ptr<TH1F> mDigitHCID = nullptr;
-  std::shared_ptr<TH1F> mParsingErrors = nullptr;
-
   std::shared_ptr<TH2F> mClusterAmplitudeChamber;
-  std::array<std::shared_ptr<TH2F>, 6> mNClsLayer;        ///[layer]->Fill(sm - 0.5 + col / 144., startRow[istack]+row);
-  std::shared_ptr<TH1D> mADCvalue;                        //->Fill(value);
-  std::array<std::shared_ptr<TH1F>, 18> mADC;             //[sm]->Fill(value);
-  std::array<std::shared_ptr<TH2F>, 18> mADCTB;           //[sm]->Fill(time, value);
-  std::array<std::shared_ptr<TH2F>, 18> mADCTBfull;       //[sm]->Fill(time, value);
-  std::shared_ptr<TH1F> mNCls;                            //->Fill(sm);
-  std::array<std::shared_ptr<TH2F>, 18> mHCMCM;           //[sm]->Fill(sum);
-  std::array<std::shared_ptr<TH1F>, 18> mClsSM;           //[sm]->Fill(sum);
-  std::array<std::shared_ptr<TH2F>, 18> mcLStBsm;         //[SM]->fILL(TIme, sum);
-  std::shared_ptr<TH2F> mClsTb;                           //->Fill(time, sum);
-  std::shared_ptr<TH2F> mClsChargeFirst;                  //->Fill(sum, (1.*sum/sumU) -1.);
-  std::shared_ptr<TH1F> mClsChargeTb;                     //->Fill(time, sum);
-  std::shared_ptr<TH1F> mClsChargeTbCycle;                //->Fill(time, sum);
-  std::shared_ptr<TH1F> mClsNTb;                          //->Fill(time);
-  std::shared_ptr<TH1F> mClsAmp;                          //->Fill(sum);
-  std::shared_ptr<TH1F> mClsAmpDrift;                     //->Fill(sum);
-  std::shared_ptr<TH1F> mClsAmpTb;                        //, "ClsAmpTb", "ClsAmpTb", 30, -0.5, 29.5);
-  std::shared_ptr<TH1F> mClsAmpCh;                        //
-  std::array<std::shared_ptr<TH2F>, 18> mClsDetAmp;       //[sm]->Fill(detLoc, sum);
-  std::shared_ptr<TH2F> mClsSector;                       //, "ClsSector", "ClsSector", nSMs, -0.5, 17.5, 500, -0.5, 999.5);
-  std::shared_ptr<TH2F> mClsStack;                        //, "ClsStack", "ClsStack", 5, -0.5, 4.5, 500, -0.5, 999.5);
-  std::array<std::shared_ptr<TH2F>, 18> mClsDetTime;      //[sm]->Fill(detLoc, time, sum);
-  std::array<std::shared_ptr<TH1F>, 10> mClsChargeTbTigg; //[trgg]->Fill(time, sum);
-  std::shared_ptr<TH2F> mClsChargeTbTrigHM;               //->Fill(time, sum);
-  std::shared_ptr<TH2F> mClsChargeTbTrigMinBias;          //->Fill(time, sum);
-  std::shared_ptr<TH2F> mClsChargeTbTrigTRDL1;            //->Fill(time, sum);
+  std::array<std::shared_ptr<TH2F>, 6> mNClsLayer;
+  std::shared_ptr<TH1D> mADCvalue;
+  std::array<std::shared_ptr<TH1F>, 18> mADC;
+  std::array<std::shared_ptr<TH2F>, 18> mADCTB;
+  std::array<std::shared_ptr<TH2F>, 18> mADCTBfull;
+  std::shared_ptr<TH1F> mNCls;
+  std::array<std::shared_ptr<TH2F>, 18> mHCMCM;
+  std::array<std::shared_ptr<TH1F>, 18> mClsSM;
+  std::shared_ptr<TH2F> mClsTb;
+  std::shared_ptr<TH2F> mClsChargeFirst;
+  std::shared_ptr<TH1F> mClsChargeTb;
+  std::shared_ptr<TH1F> mClsChargeTbCycle;
+  std::shared_ptr<TH1F> mClsNTb;
+  std::shared_ptr<TH1F> mClsAmp;
+  std::shared_ptr<TH1F> mNClsAmp;
+  std::shared_ptr<TH1F> mClsAmpDrift;
+  std::shared_ptr<TH1F> mClsAmpTb;
+  std::shared_ptr<TH1F> mClsAmpCh;
+  std::array<std::shared_ptr<TH2F>, 18> mClsDetAmp;
+  std::shared_ptr<TH2F> mClsSector;
+  std::shared_ptr<TH2F> mClsStack;
+  std::array<std::shared_ptr<TH2F>, 18> mClsDetTime;
+  std::shared_ptr<TH1F> mClsChargeTbTigg;
+  std::shared_ptr<TH2F> mClsChargeTbTrigHM;
+  std::shared_ptr<TH2F> mClsChargeTbTrigMinBias;
+  std::shared_ptr<TH2F> mClsChargeTbTrigTRDL1;
   std::array<std::shared_ptr<TH2F>, 18> mClsTbSM;
-
   std::shared_ptr<TH1F> mPulseHeight = nullptr;
   std::shared_ptr<TH1F> mPulseHeightScaled = nullptr;
   std::shared_ptr<TH2F> mTotalPulseHeight2D = nullptr;
-  std::array<std::shared_ptr<TH1F>, 18> mPulseHeight2DperSM; // ph2DSM;
-  std::shared_ptr<TH1F> mPulseHeight2 = nullptr;
-  std::shared_ptr<TH1F> mPulseHeight2n = nullptr;
-  std::shared_ptr<TH1F> mPulseHeightScaled2 = nullptr;
-  std::shared_ptr<TH2F> mTotalPulseHeight2D2 = nullptr;
-  std::array<std::shared_ptr<TH1F>, 18> mPulseHeight2DperSM2; // ph2DSM;
-  std::shared_ptr<TH1F> mPulseHeightDuration;
-  std::shared_ptr<TH1F> mPulseHeightDuration1;
-  std::shared_ptr<TH1F> mPulseHeightDurationDiff;
-  o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
+  std::array<std::shared_ptr<TH1F>, 18> mPulseHeight2DperSM;
+  std::shared_ptr<TH1F> mPulseHeightn = nullptr;
   std::shared_ptr<TProfile> mPulseHeightpro = nullptr;
   std::shared_ptr<TProfile2D> mPulseHeightperchamber = nullptr;
-  std::array<std::shared_ptr<TProfile>, 540> mPulseHeightPerChamber_1D; // ph2DSM;
+  std::array<std::shared_ptr<TH1F>, 540> mPulseHeightPerChamber_1D; // ph2DSM;
+  std::vector<TH2F*> mLayers;
+  // information pulled from ccdb
+  o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/include/TRD/RawData.h
+++ b/Modules/TRD/include/TRD/RawData.h
@@ -66,7 +66,6 @@ class RawData final : public TaskInterface
   std::array<TH2F*, 10> mLinkErrors;
   std::array<TH2F*, o2::trd::ParsingErrors::TRDLastParsingError> mParsingErrors2d;
 
-  std::array<TH1F*, 540> fClusterChamberAmplitude;
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/include/TRD/TrackletsCheck.h
+++ b/Modules/TRD/include/TRD/TrackletsCheck.h
@@ -18,6 +18,8 @@
 #define QC_MODULE_TRD_TRDTRACKLETSCHECK_H
 
 #include "QualityControl/CheckInterface.h"
+#include <TH2.h>
+#include "TRDQC/StatusHelper.h"
 
 namespace o2::quality_control_modules::trd
 {
@@ -38,6 +40,16 @@ class TrackletsCheck : public o2::quality_control::checker::CheckInterface
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
 
+  void retrieveCCDBSettings();
+  void fillTrdMaskHistsPerLayer();
+  std::vector<TH2F*> createTrdMaskHistsPerLayer();
+
+ private:
+  long int mTimestamp;
+  std::vector<TH2F*> mLayersMask;
+  o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
+
+ public:
   ClassDefOverride(TrackletsCheck, 1);
 };
 

--- a/Modules/TRD/include/TRD/TrackletsTask.h
+++ b/Modules/TRD/include/TRD/TrackletsTask.h
@@ -20,9 +20,11 @@
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/DatabaseInterface.h"
 #include "DataFormatsTRD/NoiseCalibration.h"
+#include "TRDQC/StatusHelper.h"
 
 class TH1F;
 class TH2F;
+class TCanvas;
 
 using namespace o2::quality_control::core;
 
@@ -50,6 +52,10 @@ class TrackletsTask final : public TaskInterface
   void buildHistograms();
   void retrieveCCDBSettings();
   void drawLinesMCM(TH2F* histo);
+  void drawTrdLayersGrid(TH2F* hist);
+  void fillTrdMaskHistsPerLayer();
+  std::vector<TH2F*> createTrdMaskHistsPerLayer();
+  void buildCanvas();
 
  private:
   long int mTimestamp;
@@ -67,7 +73,13 @@ class TrackletsTask final : public TaskInterface
   std::shared_ptr<TH1F> mTrackletPositionn = nullptr;
   std::shared_ptr<TH1F> mTrackletPositionRawn = nullptr;
   std::shared_ptr<TH1F> mTrackletsPerEventn = nullptr;
+  std::shared_ptr<TCanvas> mCanvas = nullptr;
+  std::vector<TH2F*> mLayers;
+
   o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
+  std::vector<TH2F*> mLayersMask;
+  o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
+  std::array<TH2F*, 2> mCanvasMembers = { nullptr };
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/src/DigitsCheck.cxx
+++ b/Modules/TRD/src/DigitsCheck.cxx
@@ -9,6 +9,8 @@
 #include "QualityControl/QcInfoLogger.h"
 // ROOT
 #include <TH1.h>
+#include <TH2.h>
+#include <TLine.h>
 
 using namespace std;
 

--- a/Modules/TRD/src/PulseHeight.cxx
+++ b/Modules/TRD/src/PulseHeight.cxx
@@ -101,8 +101,6 @@ void PulseHeight::buildHistograms()
     TH1F* h2 = new TH1F(label.c_str(), title.c_str(), 30, -0.5, 29.5);
     mPulseHeight2DperSM2[count].reset(h2);
     getObjectsManager()->startPublishing(h2);
-    getObjectsManager()->setDefaultDrawOptions(h->GetName(), "COLZ");
-    getObjectsManager()->setDefaultDrawOptions(h2->GetName(), "COLZ");
   }
 
   mPulseHeightDuration.reset(new TH1F("mPulseHeightDuration", "Pulse height duration", 10000, 0, 5.0));

--- a/Modules/TRD/src/RawData.cxx
+++ b/Modules/TRD/src/RawData.cxx
@@ -93,30 +93,29 @@ void RawData::buildHistograms()
     "TRDLastParsingError"
   };
 
-  mDataAcceptance = new TH1F("dataacceptance", "Data Accepted and Rejected", 2, 0, 2);
+  mDataAcceptance = new TH1F("dataacceptance", "Data Accepted and Rejected;Type;MBytes", 2, 0, 2);
   getObjectsManager()->startPublishing(mDataAcceptance);
-  mTimeFrameTime = new TH1F("timeframetime", "Time taken per time frame", 10000, 0, 10000);
+  mTimeFrameTime = new TH1F("timeframetime", "Time taken per time frame;Time taken [ms];Counts", 10000, 0, 10000);
   getObjectsManager()->startPublishing(mTimeFrameTime);
-  mTrackletParsingTime = new TH1F("tracklettime", "Time taken per tracklet block", 1000, 0, 1000);
+  mTrackletParsingTime = new TH1F("tracklettime", "Time taken per tracklet block;Time taken [ms];Counts", 1000, 0, 1000);
   getObjectsManager()->startPublishing(mTrackletParsingTime);
-  mDigitParsingTime = new TH1F("digittime", "Time taken per digit block", 1000, 0, 1000);
+  mDigitParsingTime = new TH1F("digittime", "Time taken per digit block;Time taken [ms];Counts", 1000, 0, 1000);
   getObjectsManager()->startPublishing(mDigitParsingTime);
-  mDataVersions = new TH1F("dataversions", "Data versions major.minor seen in data (half chamber header required)", 65000, 0, 65000);
+  mDataVersions = new TH1F("dataversions", "Data versions major.minor seen in data (half chamber header required);Version major.minor;Counts", 65000, 0, 65000);
   getObjectsManager()->startPublishing(mDataVersions);
-  mDataVersionsMajor = new TH1F("dataversionsmajor", "Data versions major seen in the data (half chamber header required)", 256, 0, 256);
+  mDataVersionsMajor = new TH1F("dataversionsmajor", "Data versions major seen in the data (half chamber header required);Version;Counts", 256, 0, 256);
   getObjectsManager()->startPublishing(mDataVersionsMajor);
-  mParsingErrors = new TH1F("parseerrors", "Parsing Errors seen in data", 256, 0, 256);
+  mParsingErrors = new TH1F("parseerrors", "Parsing Errors seen in data;Error Number;Counts", 256, 0, 256);
   getObjectsManager()->startPublishing(mParsingErrors);
 
-  mTotalChargevsTimeBin = new TH1F("totalchargevstimebin", "Total Charge vs Timebin", 30, 0, 30);
-  getObjectsManager()->startPublishing(mTotalChargevsTimeBin);
-  mDataVolumePerHalfSector = new TH2F("datavolumeperhalfsector", "Event size per half chamber, from parsing", 1080, 0, 1080, 1000, 0, 1000);
+  mDataVolumePerHalfSector = new TH2F("datavolumeperhalfsector", "Event size per half chamber, from parsing;Half Chamber ID;Data Volume [kB/event]", 1080, 0, 1080, 1000, 0, 1000);
   getObjectsManager()->startPublishing(mDataVolumePerHalfSector);
   getObjectsManager()->setDefaultDrawOptions("datavolumeperhalfsector", "COLZ");
-  mDataVolumePerHalfSectorCru = new TH2F("datavolumeperhalfsectorcru", "Event size per half chamber, from cru header", 1080, 0, 1080, 1000, 0, 1000);
+  mDataVolumePerHalfSectorCru = new TH2F("datavolumeperhalfsectorcru", "Event size per half chamber, from cru header; Half Chamber ID; Data Volume as per CRU [kB/event]", 1080, 0, 1080, 1000, 0, 1000);
+  getObjectsManager()->setDisplayHint(mDataVolumePerHalfSector->GetName(), "logz");
   getObjectsManager()->startPublishing(mDataVolumePerHalfSectorCru);
   getObjectsManager()->setDefaultDrawOptions("datavolumeperhalfsectorcru", "COLZ");
-  int count = 0;
+  getObjectsManager()->setDisplayHint(mDataVolumePerHalfSectorCru->GetName(), "logz");
   for (int count = 0; count < o2::trd::TRDLastParsingError; ++count) {
     std::string label = fmt::format("parsingerrors_{0}", count);
     std::string title = parsingerrortitle[count];
@@ -124,8 +123,8 @@ void RawData::buildHistograms()
     mParsingErrors2d[count] = h;
     getObjectsManager()->startPublishing(h);
     getObjectsManager()->setDefaultDrawOptions(h->GetName(), "COLZ");
+    getObjectsManager()->setDisplayHint(h->GetName(), "logz");
   }
-  count = 0;
   for (int count = 0; count < 10; ++count) {
     std::string label = fmt::format("linkstatus_{0}", count);
     std::string title = linkerrortitles[count];
@@ -133,27 +132,9 @@ void RawData::buildHistograms()
     mLinkErrors[count] = h;
     getObjectsManager()->startPublishing(h);
     getObjectsManager()->setDefaultDrawOptions(h->GetName(), "COLZ");
+    getObjectsManager()->setDisplayHint(h->GetName(), "logz");
   }
-  mDataAcceptance->GetXaxis()->SetTitle("Type");
-  mDataAcceptance->GetYaxis()->SetTitle("MBytes");
-  mTimeFrameTime->GetXaxis()->SetTitle("Time taken in ms");
-  mTimeFrameTime->GetYaxis()->SetTitle("Counts");
 
-  mTrackletParsingTime->GetXaxis()->SetTitle("Time taken in #mus");
-  mTrackletParsingTime->GetYaxis()->SetTitle("Counts");
-  mDigitParsingTime->GetXaxis()->SetTitle("Time taken in #mus");
-  mDigitParsingTime->GetYaxis()->SetTitle("Counts");
-  mDigitParsingTime->GetYaxis()->SetTitle("Counts");
-  mDataVersions->GetXaxis()->SetTitle("Version");
-  mDataVersions->GetYaxis()->SetTitle("Counts");
-  mDataVersionsMajor->GetYaxis()->SetTitle("Counts");
-  mDataVersionsMajor->GetXaxis()->SetTitle("Version major");
-  mParsingErrors->GetYaxis()->SetTitle("Counts");
-  mParsingErrors->GetXaxis()->SetTitle("Error Types");
-  mDataVolumePerHalfSector->GetXaxis()->SetTitle("half chamber");
-  mDataVolumePerHalfSectorCru->GetXaxis()->SetTitle("half chamber");
-  mDataVolumePerHalfSector->GetYaxis()->SetTitle("Data Volume [kB/event]");
-  mDataVolumePerHalfSectorCru->GetYaxis()->SetTitle("Data Volume [kB/event]");
   for (int i = 0; i < o2::trd::TRDLastParsingError; ++i) {
     std::string label = fmt::format("{0}_{1}", parsingerrortitle[i], i);
     mParsingErrors->GetXaxis()->SetBinLabel(i + 1, label.c_str());
@@ -170,6 +151,7 @@ void RawData::buildHistograms()
         int pos = s * o2::trd::constants::NLAYER + l + 1;
         h->GetYaxis()->SetBinLabel(pos, label.c_str());
       }
+      getObjectsManager()->setDisplayHint(h->GetName(), "logz");
     }
     for (int sm = 0; sm < o2::trd::constants::NSECTOR; ++sm) {
       for (int side = 0; side < 2; ++side) {
@@ -185,6 +167,7 @@ void RawData::buildHistograms()
     h->GetXaxis()->CenterTitle(kTRUE);
     h->GetYaxis()->SetTitle("Stack_Layer");
     h->GetYaxis()->CenterTitle(kTRUE);
+    getObjectsManager()->setDisplayHint(h->GetName(), "logz");
     for (int s = 0; s < o2::trd::constants::NSTACK; ++s) {
       for (int l = 0; l < o2::trd::constants::NLAYER; ++l) {
         std::string label = fmt::format("{0}.{1}", s, l);
@@ -201,9 +184,6 @@ void RawData::buildHistograms()
     }
   }
 
-  for (Int_t det = 0; det < 540; ++det) {
-    fClusterChamberAmplitude[det] = new TH1F(Form("clustramplitude_%d", det), "", 300, -0.5, 299.5);
-  }
 }
 
 void RawData::initialize(o2::framework::InitContext& /*ctx*/)
@@ -365,8 +345,6 @@ void RawData::resetHistograms()
   mParsingErrors->Reset();
   mDataVolumePerHalfSector->Reset();
   mDataVolumePerHalfSectorCru->Reset();
-  mTotalChargevsTimeBin->Reset();
-  //TODO come back and change the drawing of these and labels
 }
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/src/TrackletsCheck.cxx
+++ b/Modules/TRD/src/TrackletsCheck.cxx
@@ -20,16 +20,38 @@
 #include "QualityControl/QcInfoLogger.h"
 // ROOT
 #include <TH1.h>
+#include <TH2.h>
 
 #include <DataFormatsQualityControl/FlagReasons.h>
 
-using namespace std;
+#include "CCDB/BasicCCDBManager.h"
+#include "TRDQC/StatusHelper.h"
+
 using namespace o2::quality_control;
 
 namespace o2::quality_control_modules::trd
 {
 
-void TrackletsCheck::configure() {}
+void TrackletsCheck::retrieveCCDBSettings()
+{
+  if (auto param = mCustomParameters.find("ccdbtimestamp"); param != mCustomParameters.end()) {
+    mTimestamp = std::stol(mCustomParameters["ccdbtimestamp"]);
+    ILOG(Info, Support) << "configure() : using ccdbtimestamp = " << mTimestamp << ENDM;
+  } else {
+    mTimestamp = o2::ccdb::getCurrentTimestamp();
+    ILOG(Info, Support) << "configure() : using default timestam of now = " << mTimestamp << ENDM;
+  }
+  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+  mgr.setTimestamp(mTimestamp);
+}
+
+void TrackletsCheck::configure()
+{
+  //get ccdb values
+  //fill mask spectra
+  retrieveCCDBSettings();
+  //fillTrdMaskHistsPerLayer();
+}
 
 Quality TrackletsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
@@ -63,6 +85,43 @@ Quality TrackletsCheck::check(std::map<std::string, std::shared_ptr<MonitorObjec
 }
 
 std::string TrackletsCheck::getAcceptedType() { return "TH1"; }
+
+std::vector<TH2F*> TrackletsCheck::createTrdMaskHistsPerLayer()
+{
+  std::vector<TH2F*> hMask;
+  for (int iLayer = 0; iLayer < 6; ++iLayer) {
+    hMask.push_back(new TH2F(Form("layer%i_mask", iLayer), "", 76, -0.5, 75.5, 144, -0.5, 143.5));
+    hMask.back()->SetMarkerColor(kRed);
+    hMask.back()->SetMarkerSize(0.9);
+  }
+  return hMask;
+}
+
+void TrackletsCheck::fillTrdMaskHistsPerLayer()
+{
+  for (int iSec = 0; iSec < 18; ++iSec) {
+    for (int iStack = 0; iStack < 5; ++iStack) {
+      int rowMax = (iStack == 2) ? 12 : 16;
+      for (int iLayer = 0; iLayer < 6; ++iLayer) {
+        for (int iCol = 0; iCol < 8; ++iCol) {
+          int side = (iCol < 4) ? 0 : 1;
+          int det = iSec * 30 + iStack * 6 + iLayer;
+          int hcid = (side == 0) ? det * 2 : det * 2 + 1;
+          for (int iRow = 0; iRow < rowMax; ++iRow) {
+            int rowGlb = iStack < 3 ? iRow + iStack * 16 : iRow + 44 + (iStack - 3) * 16; // pad row within whole sector
+            int colGlb = iCol + iSec * 8;
+            // bin number 0 is underflow
+            rowGlb += 1;
+            colGlb += 1;
+            if (mChamberStatus->isMasked(hcid)) {
+              mLayersMask[iLayer]->SetBinContent(rowGlb, colGlb, 1);
+            }
+          }
+        }
+      }
+    }
+  }
+}
 
 void TrackletsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {


### PR DESCRIPTION
- remove excess pulseheight spectra, including double sorting etc.
- move most spectra to subdirectories.
- revert pulseheight per sector from plotting colz
- added digits per pad per layer and tracklets per mcm per layer.
- overlay code is there but not working at the moment, to mark the chambers that are expected to be offline, commented out for now, as it fails to get the data from ccdb as it seems halfchamberstatusqc is not in ccdb.
- added lines to the pulseheight spectra to demarcate where the peak should be the shifter.
- explicily reset spectra in reset method.
- remove the ccdb server hardcoding.

The layouts will have to be amended due to the new directory structure
/DigitsTask/Cluster
/DigitsTask/DigitsPerLayer
/DigitsTask/PulseHeight
/DigitsTask/PulseHeightPerChamber 1080 spectra.
/DigitsTask/DigitsPerLayer
/DigitsTask/DigitsPerMCM


