### PR TITLE
New method and features for FT0 laser QC

### DIFF
--- a/Modules/FT0/include/FT0/DigitQcTaskLaser.h
+++ b/Modules/FT0/include/FT0/DigitQcTaskLaser.h
@@ -95,6 +95,7 @@ class DigitQcTaskLaser final : public TaskInterface
 
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
+  std::set<unsigned int> mSetRefPMTChIDs;
   std::array<o2::InteractionRecord, o2::ft0::Constants::sNCHANNELS_PM> mStateLastIR2Ch;
   std::map<int, std::string> mMapDigitTrgNames;
   std::map<o2::ft0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
@@ -127,6 +128,7 @@ class DigitQcTaskLaser final : public TaskInterface
   std::map<unsigned int, TH1F*> mMapHistTime1D;
   std::map<unsigned int, TH1F*> mMapHistPMbits;
   std::map<unsigned int, TH2F*> mMapHistAmpVsTime;
+  std::map<unsigned int, TH2F*> mMapHistAmpVsBC;
   std::map<unsigned int, TH2F*> mMapTrgBcOrbit;
   std::map<std::string, TH2F*> mMapPmModuleBcOrbit;
 };

--- a/Modules/FT0/include/FT0/TH1ReductorLaser.h
+++ b/Modules/FT0/include/FT0/TH1ReductorLaser.h
@@ -38,13 +38,14 @@ class TH1ReductorLaser : public quality_control::postprocessing::Reductor
 
  private:
   struct {
+    Double_t validity1;
+    Double_t validity2;
     Double_t mean;
-    Double_t mean1fit;
-    Double_t mean2fit;
+    Double_t mean1;
+    Double_t mean2;
     Double_t stddev;
-    Double_t stddev1fit;
-    Double_t stddev2fit;
-    Double_t entries;
+    Double_t stddev1;
+    Double_t stddev2;
   } mStats;
 };
 

--- a/Modules/FT0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FT0/src/DigitQcTaskLaser.cxx
@@ -78,6 +78,10 @@ void DigitQcTaskLaser::rebinFromConfig()
         std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
         rebinHisto(hNameCur, binning);
       }
+      for (const auto& chID : mSetRefPMTChIDs) {
+        std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
+        rebinHisto(hNameCur, binning);
+      }
     } else if (!gROOT->FindObject(hName.data())) {
       ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
       continue;
@@ -195,6 +199,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
   mHistCycleDurationRange = std::make_unique<TH1D>("CycleDurationRange", "Cycle Duration (total cycle range);;time [ns]", 1, 0, 2);
 
   std::vector<unsigned int> vecChannelIDs;
+  std::vector<unsigned int> vecRefPMTChannelIDs;
   if (auto param = mCustomParameters.find("ChannelIDs"); param != mCustomParameters.end()) {
     const auto chIDs = param->second;
     const std::string del = ",";
@@ -203,8 +208,29 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
     for (unsigned int iCh = 0; iCh < o2::ft0::Constants::sNCHANNELS_PM; iCh++)
       vecChannelIDs.push_back(iCh);
   }
+  if (auto param = mCustomParameters.find("RefPMTChannelIDs"); param != mCustomParameters.end()) {
+    const auto chIDs = param->second;
+    const std::string del = ",";
+    vecRefPMTChannelIDs = parseParameters<unsigned int>(chIDs, del);
+  } 
   for (const auto& entry : vecChannelIDs) {
     mSetAllowedChIDs.insert(entry);
+  }
+  for (const auto& entry : vecRefPMTChannelIDs) {
+    mSetRefPMTChIDs.insert(entry);
+  }
+
+  for (const auto& RefPMTChID : mSetRefPMTChIDs) {
+    auto pairHistAmp = mMapHistAmp1D.insert({ RefPMTChID, new TH1F(Form("Amp_channel%i", RefPMTChID), Form("Amplitude, channel %i", RefPMTChID), 4200, -100, 4100) });
+    auto pairHistAmpVsBC = mMapHistAmpVsBC.insert({ RefPMTChID, new TH2F(Form("Amp_vs_BC_channel%i", RefPMTChID), Form("Amplitude vs BC, channel %i;Amp;BC", RefPMTChID), 1000, 0, 1000, 1000, 0, 1000) });
+    if (pairHistAmp.second) {
+      getObjectsManager()->startPublishing(pairHistAmp.first->second);
+      mListHistGarbage->Add(pairHistAmp.first->second);
+    }    
+    if (pairHistAmpVsBC.second) {
+      mListHistGarbage->Add(pairHistAmpVsBC.first->second);
+      getObjectsManager()->startPublishing(pairHistAmpVsBC.first->second);
+    }
   }
 
   for (const auto& chID : mSetAllowedChIDs) {
@@ -212,6 +238,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
     auto pairHistTime = mMapHistTime1D.insert({ chID, new TH1F(Form("Time_channel%i", chID), Form("Time, channel %i", chID), 4100, -2050, 2050) });
     auto pairHistBits = mMapHistPMbits.insert({ chID, new TH1F(Form("Bits_channel%i", chID), Form("Bits, channel %i", chID), mMapChTrgNames.size(), 0, mMapChTrgNames.size()) });
     auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
+    
     for (const auto& entry : mMapChTrgNames) {
       pairHistBits.first->second->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     }
@@ -294,6 +321,9 @@ void DigitQcTaskLaser::startOfActivity(Activity& activity)
   for (auto& entry : mMapHistAmpVsTime) {
     entry.second->Reset();
   }
+  for (auto& entry : mMapHistAmpVsBC) {
+    entry.second->Reset();
+  }
   for (auto& entry : mMapTrgBcOrbit) {
     entry.second->Reset();
   }
@@ -343,33 +373,39 @@ void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
       curTfTimeMin = mTimeCurNS;
     if (mTimeCurNS > curTfTimeMax)
       curTfTimeMax = mTimeCurNS;
-
-    if (digit.mTriggers.amplA == -5000 && digit.mTriggers.amplC == -5000 && digit.mTriggers.timeA == -5000 && digit.mTriggers.timeC == -5000)
+    
+    if (digit.mTriggers.amplA == digit.mTriggers.DEFAULT_AMP && digit.mTriggers.amplC == digit.mTriggers.DEFAULT_AMP && digit.mTriggers.timeA == digit.mTriggers.DEFAULT_TIME && digit.mTriggers.timeC == digit.mTriggers.DEFAULT_TIME)
+    // if (digit.mTriggers.amplA == -5000 && digit.mTriggers.amplC == -5000 && digit.mTriggers.timeA == -5000 && digit.mTriggers.timeC == -5000)
       isTCM = false;
+
     mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
     mHistBC->Fill(digit.getBC());
 
-    if (isTCM && !digit.mTriggers.getLaserBit()) {
-      mHistNchA->Fill(digit.mTriggers.nChanA);
-      mHistNchC->Fill(digit.mTriggers.nChanC);
-      mHistSumAmpA->Fill(digit.mTriggers.amplA);
-      mHistSumAmpC->Fill(digit.mTriggers.amplC);
-      mHistAverageTimeA->Fill(digit.mTriggers.timeA);
-      mHistAverageTimeC->Fill(digit.mTriggers.timeC);
-      mHistTimeSum2Diff->Fill((digit.mTriggers.timeC - digit.mTriggers.timeA) * mCFDChannel2NS / 2, (digit.mTriggers.timeC + digit.mTriggers.timeA) * mCFDChannel2NS / 2);
-      for (const auto& entry : mMapDigitTrgNames) {
-        if (digit.mTriggers.triggersignals & (1 << entry.first))
-          mHistTriggers->Fill(static_cast<Double_t>(entry.first));
-        for (const auto& entry2 : mMapDigitTrgNames) {
-          if ((digit.mTriggers.triggersignals & (1 << entry.first)) && (digit.mTriggers.triggersignals & (1 << entry2.first)))
-            mHistTriggersCorrelation->Fill(static_cast<Double_t>(entry.first), static_cast<Double_t>(entry2.first));
+    if (isTCM && digit.mTriggers.getOutputsAreBlocked() && digit.mTriggers.getDataIsValid()) {
+    // if (isTCM && digit.mTriggers.triggersignals & (1 << 6)) {
+    // if (isTCM) {
+      // if(!digit.mTriggers.getLaserBit()) {
+        mHistNchA->Fill(digit.mTriggers.nChanA);
+        mHistNchC->Fill(digit.mTriggers.nChanC);
+        mHistSumAmpA->Fill(digit.mTriggers.amplA);
+        mHistSumAmpC->Fill(digit.mTriggers.amplC);
+        mHistAverageTimeA->Fill(digit.mTriggers.timeA);
+        mHistAverageTimeC->Fill(digit.mTriggers.timeC);
+        mHistTimeSum2Diff->Fill((digit.mTriggers.timeC - digit.mTriggers.timeA) * mCFDChannel2NS / 2, (digit.mTriggers.timeC + digit.mTriggers.timeA) * mCFDChannel2NS / 2);
+        for (const auto& entry : mMapDigitTrgNames) {
+          if (digit.mTriggers.triggersignals & (1 << entry.first))
+            mHistTriggers->Fill(static_cast<Double_t>(entry.first));
+          for (const auto& entry2 : mMapDigitTrgNames) {
+            if ((digit.mTriggers.triggersignals & (1 << entry.first)) && (digit.mTriggers.triggersignals & (1 << entry2.first)))
+              mHistTriggersCorrelation->Fill(static_cast<Double_t>(entry.first), static_cast<Double_t>(entry2.first));
+          }
         }
-      }
-      for (auto& entry : mMapTrgBcOrbit) {
-        if (digit.mTriggers.triggersignals & (1 << entry.first)) {
-          entry.second->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
+        for (auto& entry : mMapTrgBcOrbit) {
+          if (digit.mTriggers.triggersignals & (1 << entry.first)) {
+            entry.second->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
+          }
         }
-      }
+      // }
     }
 
     for (auto& entry : mMapPmModuleChannels) {
@@ -390,6 +426,7 @@ void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
       mHistEventDensity2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(digit.mIntRecord.differenceInBC(mStateLastIR2Ch[chData.ChId])));
       mStateLastIR2Ch[chData.ChId] = digit.mIntRecord;
       mHistChannelID->Fill(chData.ChId);
+
       if (chData.QTCAmpl > 0)
         mHistNumADC->Fill(chData.ChId);
       mHistNumCFD->Fill(chData.ChId);
@@ -403,6 +440,11 @@ void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
           }
         }
       }
+
+      if (mSetRefPMTChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetRefPMTChIDs.end()) {
+        mMapHistAmpVsBC[chData.ChId]->Fill(chData.QTCAmpl,digit.getIntRecord().bc);
+      }
+
       for (const auto& entry : mMapChTrgNames) {
         if ((chData.ChainQTC & (1 << entry.first))) {
           mHistChDataBits->Fill(chData.ChId, entry.first);
@@ -469,6 +511,9 @@ void DigitQcTaskLaser::reset()
     entry.second->Reset();
   }
   for (auto& entry : mMapHistAmpVsTime) {
+    entry.second->Reset();
+  }
+  for (auto& entry : mMapHistAmpVsBC) {
     entry.second->Reset();
   }
   for (auto& entry : mMapTrgBcOrbit) {

--- a/Modules/FT0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FT0/src/DigitQcTaskLaser.cxx
@@ -212,7 +212,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
     const auto chIDs = param->second;
     const std::string del = ",";
     vecRefPMTChannelIDs = parseParameters<unsigned int>(chIDs, del);
-  } 
+  }
   for (const auto& entry : vecChannelIDs) {
     mSetAllowedChIDs.insert(entry);
   }
@@ -226,7 +226,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
     if (pairHistAmp.second) {
       getObjectsManager()->startPublishing(pairHistAmp.first->second);
       mListHistGarbage->Add(pairHistAmp.first->second);
-    }    
+    }
     if (pairHistAmpVsBC.second) {
       mListHistGarbage->Add(pairHistAmpVsBC.first->second);
       getObjectsManager()->startPublishing(pairHistAmpVsBC.first->second);
@@ -238,7 +238,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
     auto pairHistTime = mMapHistTime1D.insert({ chID, new TH1F(Form("Time_channel%i", chID), Form("Time, channel %i", chID), 4100, -2050, 2050) });
     auto pairHistBits = mMapHistPMbits.insert({ chID, new TH1F(Form("Bits_channel%i", chID), Form("Bits, channel %i", chID), mMapChTrgNames.size(), 0, mMapChTrgNames.size()) });
     auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
-    
+
     for (const auto& entry : mMapChTrgNames) {
       pairHistBits.first->second->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     }
@@ -373,39 +373,34 @@ void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
       curTfTimeMin = mTimeCurNS;
     if (mTimeCurNS > curTfTimeMax)
       curTfTimeMax = mTimeCurNS;
-    
+
     if (digit.mTriggers.amplA == digit.mTriggers.DEFAULT_AMP && digit.mTriggers.amplC == digit.mTriggers.DEFAULT_AMP && digit.mTriggers.timeA == digit.mTriggers.DEFAULT_TIME && digit.mTriggers.timeC == digit.mTriggers.DEFAULT_TIME)
-    // if (digit.mTriggers.amplA == -5000 && digit.mTriggers.amplC == -5000 && digit.mTriggers.timeA == -5000 && digit.mTriggers.timeC == -5000)
       isTCM = false;
 
     mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
     mHistBC->Fill(digit.getBC());
 
     if (isTCM && digit.mTriggers.getOutputsAreBlocked() && digit.mTriggers.getDataIsValid()) {
-    // if (isTCM && digit.mTriggers.triggersignals & (1 << 6)) {
-    // if (isTCM) {
-      // if(!digit.mTriggers.getLaserBit()) {
-        mHistNchA->Fill(digit.mTriggers.nChanA);
-        mHistNchC->Fill(digit.mTriggers.nChanC);
-        mHistSumAmpA->Fill(digit.mTriggers.amplA);
-        mHistSumAmpC->Fill(digit.mTriggers.amplC);
-        mHistAverageTimeA->Fill(digit.mTriggers.timeA);
-        mHistAverageTimeC->Fill(digit.mTriggers.timeC);
-        mHistTimeSum2Diff->Fill((digit.mTriggers.timeC - digit.mTriggers.timeA) * mCFDChannel2NS / 2, (digit.mTriggers.timeC + digit.mTriggers.timeA) * mCFDChannel2NS / 2);
-        for (const auto& entry : mMapDigitTrgNames) {
-          if (digit.mTriggers.triggersignals & (1 << entry.first))
-            mHistTriggers->Fill(static_cast<Double_t>(entry.first));
-          for (const auto& entry2 : mMapDigitTrgNames) {
-            if ((digit.mTriggers.triggersignals & (1 << entry.first)) && (digit.mTriggers.triggersignals & (1 << entry2.first)))
-              mHistTriggersCorrelation->Fill(static_cast<Double_t>(entry.first), static_cast<Double_t>(entry2.first));
-          }
+      mHistNchA->Fill(digit.mTriggers.nChanA);
+      mHistNchC->Fill(digit.mTriggers.nChanC);
+      mHistSumAmpA->Fill(digit.mTriggers.amplA);
+      mHistSumAmpC->Fill(digit.mTriggers.amplC);
+      mHistAverageTimeA->Fill(digit.mTriggers.timeA);
+      mHistAverageTimeC->Fill(digit.mTriggers.timeC);
+      mHistTimeSum2Diff->Fill((digit.mTriggers.timeC - digit.mTriggers.timeA) * mCFDChannel2NS / 2, (digit.mTriggers.timeC + digit.mTriggers.timeA) * mCFDChannel2NS / 2);
+      for (const auto& entry : mMapDigitTrgNames) {
+        if (digit.mTriggers.triggersignals & (1 << entry.first))
+          mHistTriggers->Fill(static_cast<Double_t>(entry.first));
+        for (const auto& entry2 : mMapDigitTrgNames) {
+          if ((digit.mTriggers.triggersignals & (1 << entry.first)) && (digit.mTriggers.triggersignals & (1 << entry2.first)))
+            mHistTriggersCorrelation->Fill(static_cast<Double_t>(entry.first), static_cast<Double_t>(entry2.first));
         }
-        for (auto& entry : mMapTrgBcOrbit) {
-          if (digit.mTriggers.triggersignals & (1 << entry.first)) {
-            entry.second->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
-          }
+      }
+      for (auto& entry : mMapTrgBcOrbit) {
+        if (digit.mTriggers.triggersignals & (1 << entry.first)) {
+          entry.second->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
         }
-      // }
+      }
     }
 
     for (auto& entry : mMapPmModuleChannels) {
@@ -442,7 +437,7 @@ void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
       }
 
       if (mSetRefPMTChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetRefPMTChIDs.end()) {
-        mMapHistAmpVsBC[chData.ChId]->Fill(chData.QTCAmpl,digit.getIntRecord().bc);
+        mMapHistAmpVsBC[chData.ChId]->Fill(chData.QTCAmpl, digit.getIntRecord().bc);
       }
 
       for (const auto& entry : mMapChTrgNames) {

--- a/Modules/FT0/src/TH1ReductorLaser.cxx
+++ b/Modules/FT0/src/TH1ReductorLaser.cxx
@@ -31,59 +31,55 @@ const char* TH1ReductorLaser::getBranchLeafList()
 void TH1ReductorLaser::update(TObject* obj)
 {
   if (auto histo = dynamic_cast<TH2*>(obj)) {
-    TH1 * bc_projection = histo->ProjectionY("bc_projection",0,-1);
+    TH1* bc_projection = histo->ProjectionY("bc_projection",0,-1);
     int ibc = 0;
     int ibc_max = 0;
     if ( bc_projection->GetEntries() > 0 ) {
-      ibc = bc_projection->GetMean()-2.*bc_projection->GetStdDev();
-      ibc_max = bc_projection->GetMean()+2.*bc_projection->GetStdDev();
+      ibc = bc_projection->GetMean()-2. * bc_projection->GetStdDev();
+      ibc_max = bc_projection->GetMean()+2. * bc_projection->GetStdDev();
     }     
     
-    TH1 * slice_first_peak;
+    TH1* slice_first_peak;
     bool gotFirstPeak = false;
     mStats.mean1 = 0.;
     mStats.stddev1 = 0.;
     mStats.validity1 = 0.;
-    while( !gotFirstPeak && ibc < ibc_max) {
-      slice_first_peak = histo->ProjectionX(Form("first peak in BC #%d",ibc),ibc,ibc+1);
-      if( slice_first_peak->GetEntries() > 1000 ) {
-          mStats.mean1 = slice_first_peak->GetMean();         /// Use this for the first from the two peaks
-          mStats.stddev1 = slice_first_peak->GetStdDev();
-          mStats.validity1 = 1.;
-          gotFirstPeak = true;
-          ibc+=2;
-          break;
-      }
-      else
+    while (!gotFirstPeak && ibc < ibc_max) {
+      slice_first_peak = histo->ProjectionX(Form("first peak in BC #%d", ibc), ibc, ibc+1);
+      if (slice_first_peak->GetEntries() > 1000) {
+        mStats.mean1 = slice_first_peak->GetMean();
+        mStats.stddev1 = slice_first_peak->GetStdDev();
+        mStats.validity1 = 1.;
+        gotFirstPeak = true;
+        ibc+=2;
+        break;
+      } else
         ibc++;
     }
 
-    TH1 * slice_second_peak;    
+    TH1* slice_second_peak;    
     bool gotSecondPeak = false;
     mStats.mean2 = 0.;
     mStats.stddev2 = 0.;
     mStats.validity2 = 0.;
-    while( !gotSecondPeak && gotFirstPeak && ibc < ibc_max ) {
-      slice_second_peak = histo->ProjectionX(Form("second peak in BC #%d",ibc),ibc,ibc+1);
-      if( slice_second_peak->GetEntries() > 1000 ) {
-        mStats.mean2 = slice_second_peak->GetMean();         /// Use this for the first from the two peaks
+    while (!gotSecondPeak && gotFirstPeak && ibc < ibc_max) {
+      slice_second_peak = histo->ProjectionX(Form("second peak in BC #%d", ibc), ibc, ibc+1);
+      if (slice_second_peak->GetEntries() > 1000) {
+        mStats.mean2 = slice_second_peak->GetMean();
         mStats.stddev2 = slice_second_peak->GetStdDev();
         mStats.validity2 = 1.;
         gotSecondPeak = true;
         break;
-      }
-      else
+      } else
         ibc++;
     }
-        
-    if( !gotSecondPeak )
-      ILOG(Warning) << "TH1ReductorLaser: one of the peaks of the reference PMT is missing!" << ENDM;
-    if( !gotFirstPeak && !gotSecondPeak )
-      ILOG(Warning) << "TH1ReductorLaser: cannot find peaks of the reference PMT distribution at all !" << ENDM;
 
-  }
-  else if (auto histo = dynamic_cast<TH1*>(obj)) {
-    mStats.mean = histo->GetMean();                     /// Use this for one peak
+    if (!gotSecondPeak)
+      ILOG(Warning) << "TH1ReductorLaser: one of the peaks of the reference PMT is missing!" << ENDM;
+    if (!gotFirstPeak && !gotSecondPeak)
+      ILOG(Warning) << "TH1ReductorLaser: cannot find peaks of the reference PMT distribution at all !" << ENDM;
+  } else if (auto histo = dynamic_cast<TH1*>(obj)) {
+    mStats.mean = histo->GetMean();
     mStats.stddev = histo->GetMean();
   }
 }

--- a/Modules/FT0/src/TH1ReductorLaser.cxx
+++ b/Modules/FT0/src/TH1ReductorLaser.cxx
@@ -31,39 +31,39 @@ const char* TH1ReductorLaser::getBranchLeafList()
 void TH1ReductorLaser::update(TObject* obj)
 {
   if (auto histo = dynamic_cast<TH2*>(obj)) {
-    TH1* bc_projection = histo->ProjectionY("bc_projection",0,-1);
+    TH1* bc_projection = histo->ProjectionY("bc_projection", 0, -1);
     int ibc = 0;
     int ibc_max = 0;
-    if ( bc_projection->GetEntries() > 0 ) {
-      ibc = bc_projection->GetMean()-2. * bc_projection->GetStdDev();
-      ibc_max = bc_projection->GetMean()+2. * bc_projection->GetStdDev();
-    }     
-    
+    if (bc_projection->GetEntries() > 0) {
+      ibc = bc_projection->GetMean() - 2. * bc_projection->GetStdDev();
+      ibc_max = bc_projection->GetMean() + 2. * bc_projection->GetStdDev();
+    }
+
     TH1* slice_first_peak;
     bool gotFirstPeak = false;
     mStats.mean1 = 0.;
     mStats.stddev1 = 0.;
     mStats.validity1 = 0.;
     while (!gotFirstPeak && ibc < ibc_max) {
-      slice_first_peak = histo->ProjectionX(Form("first peak in BC #%d", ibc), ibc, ibc+1);
+      slice_first_peak = histo->ProjectionX(Form("first peak in BC #%d", ibc), ibc, ibc + 1);
       if (slice_first_peak->GetEntries() > 1000) {
         mStats.mean1 = slice_first_peak->GetMean();
         mStats.stddev1 = slice_first_peak->GetStdDev();
         mStats.validity1 = 1.;
         gotFirstPeak = true;
-        ibc+=2;
+        ibc += 2;
         break;
       } else
         ibc++;
     }
 
-    TH1* slice_second_peak;    
+    TH1* slice_second_peak;
     bool gotSecondPeak = false;
     mStats.mean2 = 0.;
     mStats.stddev2 = 0.;
     mStats.validity2 = 0.;
     while (!gotSecondPeak && gotFirstPeak && ibc < ibc_max) {
-      slice_second_peak = histo->ProjectionX(Form("second peak in BC #%d", ibc), ibc, ibc+1);
+      slice_second_peak = histo->ProjectionX(Form("second peak in BC #%d", ibc), ibc, ibc + 1);
       if (slice_second_peak->GetEntries() > 1000) {
         mStats.mean2 = slice_second_peak->GetMean();
         mStats.stddev2 = slice_second_peak->GetStdDev();

--- a/Modules/FT0/src/TH1ReductorLaser.cxx
+++ b/Modules/FT0/src/TH1ReductorLaser.cxx
@@ -16,83 +16,75 @@
 ///
 
 #include "FT0/TH1ReductorLaser.h"
-#include <TF1.h>
-#include <TH1.h>
+#include "QualityControl/QcInfoLogger.h"
+#include <TF2.h>
+#include <TH2.h>
+
 namespace o2::quality_control_modules::ft0
 {
 void* TH1ReductorLaser::getBranchAddress() { return &mStats; }
 const char* TH1ReductorLaser::getBranchLeafList()
 {
-  return "mean/D:mean1fit/D:mean2fit/D:stddev:stddev1fit:stddev2fit:entries";
-}
-double Gauss(double* x, double* par)
-{
-  double arg = 0;
-  const double PI = 3.1415926536;
-  if (par[2] != 0) {
-    arg = (x[0] - par[1]) / par[2];
-  }
-  double fitval = par[0] / (par[2] * sqrt(2 * PI)) * exp(-0.5 * arg * arg);
-  return fitval;
+  return "validity1/D:validity2/D:mean/D:mean1/D:mean2/D:stddev:stddev1:stddev2:entries";
 }
 
 void TH1ReductorLaser::update(TObject* obj)
 {
-  auto histo = dynamic_cast<TH1*>(obj);
-  if (histo) {
-    /// Store the mean and the stddev (makes sense if there is one peak)
-    if (histo->GetBinCenter(1) != 0)
-      histo->GetXaxis()->SetRangeUser(1, histo->GetEntries() - 1);
+  if (auto histo = dynamic_cast<TH2*>(obj)) {
+    TH1 * bc_projection = histo->ProjectionY("bc_projection",0,-1);
+    int ibc = 0;
+    int ibc_max = 0;
+    if ( bc_projection->GetEntries() > 0 ) {
+      ibc = bc_projection->GetMean()-2.*bc_projection->GetStdDev();
+      ibc_max = bc_projection->GetMean()+2.*bc_projection->GetStdDev();
+    }     
+    
+    TH1 * slice_first_peak;
+    bool gotFirstPeak = false;
+    mStats.mean1 = 0.;
+    mStats.stddev1 = 0.;
+    mStats.validity1 = 0.;
+    while( !gotFirstPeak && ibc < ibc_max) {
+      slice_first_peak = histo->ProjectionX(Form("first peak in BC #%d",ibc),ibc,ibc+1);
+      if( slice_first_peak->GetEntries() > 1000 ) {
+          mStats.mean1 = slice_first_peak->GetMean();         /// Use this for the first from the two peaks
+          mStats.stddev1 = slice_first_peak->GetStdDev();
+          mStats.validity1 = 1.;
+          gotFirstPeak = true;
+          ibc+=2;
+          break;
+      }
+      else
+        ibc++;
+    }
 
-    double origMean = histo->GetMean();
-    double origStddev = histo->GetStdDev();
-    mStats.entries = histo->GetEntries();
-    /// Set parameters for single peak
-    mStats.mean = origMean;
-    mStats.stddev = origStddev;
+    TH1 * slice_second_peak;    
+    bool gotSecondPeak = false;
+    mStats.mean2 = 0.;
+    mStats.stddev2 = 0.;
+    mStats.validity2 = 0.;
+    while( !gotSecondPeak && gotFirstPeak && ibc < ibc_max ) {
+      slice_second_peak = histo->ProjectionX(Form("second peak in BC #%d",ibc),ibc,ibc+1);
+      if( slice_second_peak->GetEntries() > 1000 ) {
+        mStats.mean2 = slice_second_peak->GetMean();         /// Use this for the first from the two peaks
+        mStats.stddev2 = slice_second_peak->GetStdDev();
+        mStats.validity2 = 1.;
+        gotSecondPeak = true;
+        break;
+      }
+      else
+        ibc++;
+    }
+        
+    if( !gotSecondPeak )
+      ILOG(Warning) << "TH1ReductorLaser: one of the peaks of the reference PMT is missing!" << ENDM;
+    if( !gotFirstPeak && !gotSecondPeak )
+      ILOG(Warning) << "TH1ReductorLaser: cannot find peaks of the reference PMT distribution at all !" << ENDM;
 
-    /// Store the original xmin and xmax
-    double origLowerLimit = histo->GetBinCenter(1);
-    double origUpperLimit = histo->GetBinCenter(histo->GetEntries() - 1);
-
-    /// Get the first peak and have a guess of its Gaussian parameters
-    /// The parameters from the fit cannot be too far from the initial guess
-    /// After that the original limits of the histo must be restored
-    histo->GetXaxis()->SetRangeUser(histo->GetMean() - 1.25 * histo->GetStdDev(), histo->GetMean() - 0.25 * histo->GetStdDev());
-    double peak1Amp = histo->GetBin(histo->GetMean());
-    double peak1Pos = histo->GetMean();
-    double peak1Wid = histo->GetStdDev();
-
-    TF1* GaussFit1 = new TF1("gauss1", Gauss, histo->GetStdDev(), histo->GetStdDev(), 3);
-
-    GaussFit1->SetParameter(0, peak1Amp);
-    GaussFit1->SetParameter(1, peak1Pos);
-    GaussFit1->SetParameter(2, peak1Wid);
-    histo->Fit("gauss1");
-
-    mStats.mean1fit = GaussFit1->GetParameter(1);
-    mStats.stddev1fit = GaussFit1->GetParameter(2);
-
-    /// Restoring the original limits
-    histo->GetXaxis()->SetRangeUser(origLowerLimit, origUpperLimit);
-
-    /// Get the second peak and have a guess of its Gaussian parameters
-    /// The parameters from the fit cannot be too far from the initial guess
-    /// After that the original limits of the histo must be restored
-    histo->GetXaxis()->SetRangeUser(histo->GetMean() + 0.25 * histo->GetStdDev(), histo->GetMean() + 1.25 * histo->GetStdDev());
-    double peak2Amp = histo->GetBin(histo->GetMean());
-    double peak2Pos = histo->GetMean();
-    double peak2Wid = histo->GetStdDev();
-
-    TF1* GaussFit2 = new TF1("gauss2", Gauss, histo->GetStdDev(), histo->GetStdDev(), 3);
-
-    GaussFit2->SetParameter(0, peak2Amp);
-    GaussFit2->SetParameter(1, peak2Pos);
-    GaussFit2->SetParameter(2, peak2Wid);
-    histo->Fit("gauss2");
-
-    mStats.mean2fit = GaussFit2->GetParameter(1);
-    mStats.stddev2fit = GaussFit2->GetParameter(2);
+  }
+  else if (auto histo = dynamic_cast<TH1*>(obj)) {
+    mStats.mean = histo->GetMean();                     /// Use this for one peak
+    mStats.stddev = histo->GetMean();
   }
 }
 } // namespace o2::quality_control_modules::ft0


### PR DESCRIPTION
The costume reductor has a new method to find the peaks from the ref. PMTs

This new method needs a new histogram: ampl vs BC which is added to DigitQcTaskLaser

Besides RefPMTChannelIDs is also added to DigitQcTaskLaser so the channels of the reference PMTs can be specified separately from other channels.