### PR TITLE
MCH: improved computation of average pseudo-efficiencies

### DIFF
--- a/Modules/MUON/MCH/include/MCH/PhysicsPreclustersCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsPreclustersCheck.h
@@ -19,6 +19,8 @@
 #include "QualityControl/CheckInterface.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
+#include "MCHRawCommon/DataFormats.h"
+#include "MCHRawElecMap/Mapper.h"
 #include <string>
 
 namespace o2::quality_control_modules::muonchambers
@@ -42,9 +44,23 @@ class PhysicsPreclustersCheck : public o2::quality_control::checker::CheckInterf
   std::string getAcceptedType() override;
 
  private:
+  int checkPadMapping(uint16_t feeId, uint8_t linkId, uint8_t eLinkId, o2::mch::raw::DualSampaChannelId channel, int& cathode);
+
   double mMinPseudoeff;
   double mMaxPseudoeff;
-  ClassDefOverride(PhysicsPreclustersCheck, 3);
+  double mMinGoodFraction;
+  double mPseudoeffPlotScaleMin;
+  double mPseudoeffPlotScaleMax;
+  bool mVerbose;
+
+  std::vector<double> mDePseudoeff[2];
+
+  o2::mch::raw::Elec2DetMapper mElec2DetMapper;
+  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
+  o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
+  o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
+
+  ClassDefOverride(PhysicsPreclustersCheck, 4);
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskPreclusters.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskPreclusters.h
@@ -113,7 +113,7 @@ class PhysicsTaskPreclusters /*final*/ : public o2::quality_control::core::TaskI
   std::shared_ptr<GlobalHistogram> mHistogramDenST345;         // Histogram of Number of orbits (global XY view)
   std::shared_ptr<MergeableTH2Ratio> mHistogramPseudoeffST345; // Mergeable object, Occupancy histogram (global XY view)
 
-  std::shared_ptr<MergeableTH1Ratio> mHistogramMeanPseudoeffPerDE[2]; // Pseudoefficiency of B and NB
+  std::shared_ptr<TH1F> mHistogramMeanPseudoeffPerDE[2]; // Pseudoefficiency of B and NB
 
   std::shared_ptr<MergeableTH1Ratio> mHistogramPreclustersPerDE;       // number of pre-clusters per DE and per TF
   std::shared_ptr<MergeableTH1Ratio> mHistogramPreclustersSignalPerDE; // number of pre-clusters with signal per DE and per TF

--- a/Modules/MUON/MCH/src/PhysicsPreclustersCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsPreclustersCheck.cxx
@@ -13,10 +13,11 @@
 /// \author Andrea Ferrero, Sebastien Perrin
 ///
 
+#include "MCH/PhysicsPreclustersCheck.h"
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHMappingSegContour/CathodeSegmentationContours.h"
-#include "MCH/PhysicsPreclustersCheck.h"
 #include "MCH/GlobalHistogram.h"
+#include "MUONCommon/MergeableTH2Ratio.h"
 
 // ROOT
 #include <fairlogger/Logger.h>
@@ -31,12 +32,20 @@
 #include <string>
 
 using namespace std;
+using namespace o2::quality_control_modules::muon;
 
 namespace o2::quality_control_modules::muonchambers
 {
 
 PhysicsPreclustersCheck::PhysicsPreclustersCheck() : mMinPseudoeff(0.5), mMaxPseudoeff(1.0)
 {
+  mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mDet2ElecMapper = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mFeeLink2SolarMapper = o2::mch::raw::createFeeLink2SolarMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
+
+  mDePseudoeff[0].resize(getDEindexMax() + 1);
+  mDePseudoeff[1].resize(getDEindexMax() + 1);
 }
 
 PhysicsPreclustersCheck::~PhysicsPreclustersCheck() {}
@@ -49,6 +58,61 @@ void PhysicsPreclustersCheck::configure()
   if (auto param = mCustomParameters.find("MaxPseudoefficiency"); param != mCustomParameters.end()) {
     mMaxPseudoeff = std::stof(param->second);
   }
+  if (auto param = mCustomParameters.find("MinGoodFraction"); param != mCustomParameters.end()) {
+    mMinGoodFraction = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("PseudoeffPlotScaleMin"); param != mCustomParameters.end()) {
+    mPseudoeffPlotScaleMin = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("PseudoeffPlotScaleMax"); param != mCustomParameters.end()) {
+    mPseudoeffPlotScaleMax = std::stof(param->second);
+  }
+  if (auto param = mCustomParameters.find("Verbose"); param != mCustomParameters.end()) {
+    if (param->second == "true" || param->second == "True" || param->second == "TRUE") {
+      mVerbose = true;
+    }
+  }
+}
+
+int PhysicsPreclustersCheck::checkPadMapping(uint16_t feeId, uint8_t linkId, uint8_t eLinkId, o2::mch::raw::DualSampaChannelId channel, int& cathode)
+{
+  uint16_t solarId = -1;
+  int deId = -1;
+  int dsIddet = -1;
+  int padId = -1;
+  cathode = -1;
+
+  o2::mch::raw::FeeLinkId feeLinkId{ feeId, linkId };
+
+  if (auto opt = mFeeLink2SolarMapper(feeLinkId); opt.has_value()) {
+    solarId = opt.value();
+  }
+  if (solarId < 0 || solarId > 1023) {
+    return -1;
+  }
+
+  o2::mch::raw::DsElecId dsElecId{ solarId, static_cast<uint8_t>(eLinkId / 5), static_cast<uint8_t>(eLinkId % 5) };
+
+  if (auto opt = mElec2DetMapper(dsElecId); opt.has_value()) {
+    o2::mch::raw::DsDetId dsDetId = opt.value();
+    dsIddet = dsDetId.dsId();
+    deId = dsDetId.deId();
+  }
+
+  if (deId < 0 || dsIddet < 0) {
+    return -1;
+  }
+
+  const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(deId);
+  padId = segment.findPadByFEE(dsIddet, int(channel));
+
+  if (padId < 0) {
+    return -1;
+  }
+
+  cathode = segment.isBendingPad(padId) ? 0 : 1;
+
+  return deId;
 }
 
 Quality PhysicsPreclustersCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
@@ -58,9 +122,24 @@ Quality PhysicsPreclustersCheck::check(std::map<std::string, std::shared_ptr<Mon
   for (auto& [moName, mo] : *moMap) {
 
     (void)moName;
-    if ((mo->getName().find("MeanPseudoeffPerDE_B") != std::string::npos) ||
-        (mo->getName().find("MeanPseudoeffPerDE_NB") != std::string::npos)) {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
+    if (mo->getName().find("Pseudoeff_Elec") != std::string::npos) {
+
+      // cumulative numerators and denominators for the computation of
+      // the average pseudoeff over one detection element
+      std::vector<double> dePseudoeffNum[2];
+      std::vector<double> dePseudoeffDen[2];
+      for (int i = 0; i < 2; i++) {
+        dePseudoeffNum[i].resize(getDEindexMax() + 1);
+        dePseudoeffDen[i].resize(getDEindexMax() + 1);
+        std::fill(dePseudoeffNum[i].begin(), dePseudoeffNum[i].end(), 0);
+        std::fill(dePseudoeffDen[i].begin(), dePseudoeffDen[i].end(), 0);
+      }
+
+      auto* hr = dynamic_cast<MergeableTH2Ratio*>(mo->getObject());
+      if (!hr) {
+        return result;
+      }
+      auto* h = dynamic_cast<TH2F*>(mo->getObject());
       if (!h) {
         return result;
       }
@@ -69,19 +148,62 @@ Quality PhysicsPreclustersCheck::check(std::map<std::string, std::shared_ptr<Mon
         result = Quality::Medium;
       } else {
         int nbinsx = h->GetXaxis()->GetNbins();
-        int nbad = 0;
+        int nbinsy = h->GetYaxis()->GetNbins();
+        int ngood = 0;
+        int npads = 0;
         for (int i = 1; i <= nbinsx; i++) {
-          Float_t eff = h->GetBinContent(i);
-          if (eff < mMinPseudoeff || eff > mMaxPseudoeff) {
-            nbad += 1;
+          int index = i - 1;
+          int ds_addr = (index % 40);
+          int link_id = (index / 40) % 12;
+          int fee_id = index / (12 * 40);
+
+          for (int j = 1; j <= nbinsy; j++) {
+            int chan_addr = j - 1;
+
+            int cathode;
+            int de = checkPadMapping(fee_id, link_id, ds_addr, chan_addr, cathode);
+            if (de < 0) {
+              continue;
+            }
+
+            Float_t stat = hr->getDen()->GetBinContent(i, j);
+            if (stat < 1) {
+              continue;
+            }
+
+            Float_t pseudoeff = h->GetBinContent(i, j);
+            npads += 1;
+            if (pseudoeff >= mMinPseudoeff && pseudoeff <= mMaxPseudoeff) {
+              ngood += 1;
+            }
+
+            int deIndex = getDEindex(de);
+            if (deIndex >= 0) {
+              dePseudoeffNum[cathode][deIndex] += pseudoeff;
+              dePseudoeffDen[cathode][deIndex] += 1;
+            }
           }
         }
-        if (nbad < 1) {
+        if (mVerbose) {
+          LOGP(debug, "Npads {}  Ngood {}   Frac {}", npads, ngood, float(ngood) / float(npads));
+        }
+
+        if (ngood >= mMinGoodFraction * npads)
           result = Quality::Good;
-          std::cout << "GOOD" << endl;
-        } else {
+        else
           result = Quality::Bad;
-          std::cout << "BAD" << endl;
+      }
+
+      // update the average pseudoeff values that will be copied
+      // into the histogram bins in the beutify() method
+      for (int i = 0; i < 2; i++) {
+        for (size_t de = 0; de < dePseudoeffDen[i].size(); de++) {
+          std::cout << fmt::format("xxxx DE{}  num {}  den {}", de, dePseudoeffNum[i][de], dePseudoeffDen[i][de]) << std::endl;
+          if (dePseudoeffDen[i][de] > 0) {
+            mDePseudoeff[i][de] = dePseudoeffNum[i][de] / dePseudoeffDen[i][de];
+          } else {
+            mDePseudoeff[i][de] = 0;
+          }
         }
       }
     }
@@ -134,22 +256,32 @@ void PhysicsPreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Qualit
     h->GetYaxis()->SetTickLength(0);
     h->GetYaxis()->SetTitle("efficiency");
 
-    h->SetMinimum(0);
-    if ((mo->getName().find("MeanPseudoeffPerDE_B") != std::string::npos) ||
-        (mo->getName().find("MeanPseudoeffPerDE_NB") != std::string::npos)) {
-      h->SetMaximum(2);
-    }
-
     TText* xtitle = new TText();
     xtitle->SetNDC();
     xtitle->SetText(0.87, 0.03, "chamber #");
     xtitle->SetTextSize(15);
     h->GetListOfFunctions()->Add(xtitle);
 
+    h->SetMinimum(0);
+    if ((mo->getName().find("MeanPseudoeffPerDE_B") != std::string::npos) ||
+        (mo->getName().find("MeanPseudoeffPerDE_NB") != std::string::npos)) {
+      int cathode = 0;
+      if (mo->getName().find("MeanPseudoeffPerDE_NB") != std::string::npos) {
+        cathode = 1;
+      }
+
+      for (size_t deIndex = 0; deIndex < mDePseudoeff[cathode].size(); deIndex++) {
+        h->SetBinContent(deIndex + 1, mDePseudoeff[cathode][deIndex]);
+        h->SetBinError(deIndex + 1, 0);
+      }
+
+      h->SetMaximum(2);
+    }
+
     // draw chamber delimiters
     for (int demin = 200; demin <= 1000; demin += 100) {
       float xpos = static_cast<float>(getDEindex(demin));
-      TLine* delimiter = new TLine(xpos, 0, xpos, 2);
+      TLine* delimiter = new TLine(xpos, 0, xpos, h->GetMaximum());
       delimiter->SetLineColor(kBlack);
       delimiter->SetLineStyle(kDashed);
       h->GetListOfFunctions()->Add(delimiter);

--- a/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
@@ -399,7 +399,6 @@ bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluste
   // Filling histograms to be used for Pseudo-efficiency computation
   if (isGoodDen[0]) {
     // good cluster on non-bending side, check if there is data from the bending side as well
-    mHistogramMeanPseudoeffPerDE[0]->getDen()->Fill(getDEindex(detid));
     if (fecIdB >= 0 && channelB >= 0) {
       mHistogramPseudoeffElec->getDen()->Fill(fecIdB, channelB);
     }
@@ -408,7 +407,6 @@ bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluste
       hXY0->second->Fill(Xcog, Ycog, 0.5, 0.5);
     }
     if (isGoodNum[0]) { // Check if associated to something on Bending
-      mHistogramMeanPseudoeffPerDE[0]->getNum()->Fill(getDEindex(detid));
       if (fecIdB >= 0 && channelB >= 0) {
         mHistogramPseudoeffElec->getNum()->Fill(fecIdB, channelB);
       }
@@ -421,7 +419,6 @@ bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluste
 
   if (isGoodDen[1]) {
     // good cluster on bending side, check if there is data from the non-bending side as well
-    mHistogramMeanPseudoeffPerDE[1]->getDen()->Fill(getDEindex(detid));
     if (fecIdNB >= 0 && channelNB >= 0) {
       mHistogramPseudoeffElec->getDen()->Fill(fecIdNB, channelNB);
     }
@@ -430,7 +427,6 @@ bool PhysicsTaskPreclusters::plotPrecluster(const o2::mch::PreCluster& preCluste
       hXY0->second->Fill(Xcog, Ycog, 0.5, 0.5);
     }
     if (isGoodNum[1]) { // Check if associated to something on Non-Bending
-      mHistogramMeanPseudoeffPerDE[1]->getNum()->Fill(getDEindex(detid));
       if (fecIdNB >= 0 && channelNB >= 0) {
         mHistogramPseudoeffElec->getNum()->Fill(fecIdNB, channelNB);
       }
@@ -557,9 +553,6 @@ void PhysicsTaskPreclusters::computePseudoEfficiency()
 
   mHistogramPseudoeffST12->update();
   mHistogramPseudoeffST345->update();
-
-  mHistogramMeanPseudoeffPerDE[0]->update();
-  mHistogramMeanPseudoeffPerDE[1]->update();
 
   mHistogramPreclustersPerDE->update();
   mHistogramPreclustersSignalPerDE->update();


### PR DESCRIPTION
The average pseudo-efficiencies per detection element are now computed by averaging the pseudo-efficiency from each pad.
Compared to the previous method, the new code gives the same weight to each pad, regardless of the corresponding statistics.
Previously the pads with large statistics where dominating the computation of the average.