### PR TITLE
TRD added tracklets per timeframe, remove ccdb server setting from unused code

### DIFF
--- a/Modules/TRD/TRDQC.json
+++ b/Modules/TRD/TRDQC.json
@@ -112,32 +112,6 @@
 	"saveObjectsToFile":"qcpulseheight.root"
       }
     },
-    "checks": {
-      "QcCheck": {
-        "active": "false",
-        "className": "o2::quality_control_modules::trd::RawDataCheck",
-        "moduleName": "QcTRD",
-        "policy": "OnAny",
-        "detectorName": "TRD",
-        "dataSource": [{
-          "type": "Task",
-          "name": "RawDataTask",
-          "MOs": ["trackletsperevent"]
-        }]
-      },
-      "PulseHeightCheck": {
-        "active": "true",
-        "className": "o2::quality_control_modules::trd::PulseHeightCheck",
-        "moduleName": "QcTRD",
-        "policy": "OnAny",
-        "detectorName": "TRD",
-        "dataSource": [{
-          "type": "Task",
-          "name": "RawDataTask",
-          "MOs": ["trackletsperevent"]
-        }]
-      }
-  },
   "dataSamplingPolicies": [
   ]
 }

--- a/Modules/TRD/include/TRD/DigitsTask.h
+++ b/Modules/TRD/include/TRD/DigitsTask.h
@@ -65,7 +65,8 @@ class DigitsTask final : public TaskInterface
   std::pair<float, float> mPulseHeightPeakRegion;
   long int mTimestamp;
 
-  std::shared_ptr<TH1F> mDigitsPerEvent = nullptr;
+  std::shared_ptr<TH1F> mDigitsPerEvent;
+  std::shared_ptr<TH2F> mDigitsSizevsTrackletSize;
   std::shared_ptr<TH1F> mDigitHCID = nullptr;
   std::shared_ptr<TH2F> mClusterAmplitudeChamber;
   std::array<std::shared_ptr<TH2F>, 6> mNClsLayer;

--- a/Modules/TRD/include/TRD/PulseHeight.h
+++ b/Modules/TRD/include/TRD/PulseHeight.h
@@ -55,6 +55,7 @@ class PulseHeight final : public TaskInterface
   void retrieveCCDBSettings();
 
  private:
+  long int mTimestamp;
   std::shared_ptr<TH1F> mPulseHeight = nullptr;
   std::shared_ptr<TH1F> mPulseHeightScaled = nullptr;
   std::shared_ptr<TH2F> mTotalPulseHeight2D = nullptr;

--- a/Modules/TRD/include/TRD/PulseHeightCheck.h
+++ b/Modules/TRD/include/TRD/PulseHeightCheck.h
@@ -37,6 +37,9 @@ class PulseHeightCheck : public o2::quality_control::checker::CheckInterface
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
+  long int mTimeStamp;
+  std::pair<float, float> mDriftRegion;
+  std::pair<float, float> mPulseHeightPeakRegion;
 
   ClassDefOverride(PulseHeightCheck, 1);
 };

--- a/Modules/TRD/include/TRD/TrackletsCheck.h
+++ b/Modules/TRD/include/TRD/TrackletsCheck.h
@@ -48,6 +48,9 @@ class TrackletsCheck : public o2::quality_control::checker::CheckInterface
   long int mTimestamp;
   std::vector<TH2F*> mLayersMask;
   o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
+  float mIntegralThreshold;
+  float mRatioThreshold;
+  float mZeroBinRatioThreshold;
 
  public:
   ClassDefOverride(TrackletsCheck, 1);

--- a/Modules/TRD/include/TRD/TrackletsTask.h
+++ b/Modules/TRD/include/TRD/TrackletsTask.h
@@ -53,9 +53,9 @@ class TrackletsTask final : public TaskInterface
   void retrieveCCDBSettings();
   void drawLinesMCM(TH2F* histo);
   void drawTrdLayersGrid(TH2F* hist);
-  void fillTrdMaskHistsPerLayer();
-  std::vector<TH2F*> createTrdMaskHistsPerLayer();
-  void buildCanvas();
+  void buildTrackletLayers();
+  void drawHashedOnHistsPerLayer(int layer); //, int hcid, int rowstart, int rowend);
+  void drawHashOnLayers(int layer, int hcid, int rowstart, int rowend);
 
  private:
   long int mTimestamp;
@@ -73,13 +73,17 @@ class TrackletsTask final : public TaskInterface
   std::shared_ptr<TH1F> mTrackletPositionn = nullptr;
   std::shared_ptr<TH1F> mTrackletPositionRawn = nullptr;
   std::shared_ptr<TH1F> mTrackletsPerEventn = nullptr;
+  std::shared_ptr<TH1F> mTrackletsPerTimeFrame = nullptr;
+  std::shared_ptr<TH1F> mTrackletsPerTimeFrameCycled = nullptr;
   std::shared_ptr<TCanvas> mCanvas = nullptr;
-  std::vector<TH2F*> mLayers;
+  std::array<std::shared_ptr<TH2F>, 6> mLayers;
 
+  int mMarkerSize;
+  int mMarkerStyle;
+
+  // data to pull from CCDB
   o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
-  std::vector<TH2F*> mLayersMask;
   o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
-  std::array<TH2F*, 2> mCanvasMembers = { nullptr };
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -5,7 +5,6 @@
 #include <TLine.h>
 #include <TH1F.h>
 #include <TH2F.h>
-#include <TLine.h>
 #include <TProfile.h>
 #include <TProfile2D.h>
 #include <TStopwatch.h>
@@ -126,6 +125,9 @@ void DigitsTask::buildHistograms()
   getObjectsManager()->startPublishing(mDigitHCID.get());
   mDigitsPerEvent.reset(new TH1F("digitsperevent", "Digits per Event", 10000, 0, 10000));
   getObjectsManager()->startPublishing(mDigitsPerEvent.get());
+
+  mDigitsSizevsTrackletSize.reset(new TH2F("digitsvstracklets", "Tracklets Count vs Digits Count; Number of Tracklets;Number Of Digits", 20000, 0, 20000,20000,0,20000));
+  getObjectsManager()->startPublishing(mDigitsSizevsTrackletSize.get());
 
   mClsAmpCh.reset(new TH1F("Cluster/ClsAmpCh", "Reconstructed mean amplitude;Amplitude (ADC);# chambers", 100, 25, 125));
   mClsAmpCh->GetXaxis()->SetTitle("Amplitude (ADC)");
@@ -436,6 +438,7 @@ void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
         } else {
           mDigitsPerEvent->Fill(trigger.getNumberOfDigits());
         }
+        mDigitsSizevsTrackletSize->Fill(trigger.getNumberOfTracklets(), trigger.getNumberOfDigits());
     int tbmax = 0;
     int tbhi = 0;
     int tblo = 0;

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -326,14 +326,14 @@ void DigitsTask::initialize(o2::framework::InitContext& /*ctx*/)
   ILOG(Info) << "initialize TRDDigitQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
 
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
-  if (auto param = mCustomParameters.find("peakregionstart"); param != mCustomParameters.end()) {
+  if (auto param = mCustomParameters.find("driftregionstart"); param != mCustomParameters.end()) {
     mDriftRegion.first = stof(param->second);
     ILOG(Info, Support) << "configure() : using peakregionstart = " << mDriftRegion.first << ENDM;
   } else {
     mDriftRegion.first = 7.0;
     ILOG(Info, Support) << "configure() : using default dritfregionstart = " << mDriftRegion.first << ENDM;
   }
-  if (auto param = mCustomParameters.find("peakregionend"); param != mCustomParameters.end()) {
+  if (auto param = mCustomParameters.find("driftregionend"); param != mCustomParameters.end()) {
     mDriftRegion.second = stof(param->second);
     ILOG(Info, Support) << "configure() : using peakregionstart = " << mDriftRegion.second << ENDM;
   } else {
@@ -489,10 +489,10 @@ void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
       }
       // illumination
       mNClsLayer[layer]->Fill(sm - 0.5 + col / 144., startRow[stack] + row);
+      int digitindex = digitsIndex[currentdigit];
+      int digitindexbelow = digitsIndex[currentdigit - 1];
+      int digitindexabove = digitsIndex[currentdigit + 1];
       for (int time = 1; time < o2::trd::constants::TIMEBINS - 1; ++time) {
-        int digitindex = digitsIndex[currentdigit];
-        int digitindexbelow = digitsIndex[currentdigit - 1];
-        int digitindexabove = digitsIndex[currentdigit + 1];
         int value = digits[digitsIndex[currentdigit]].getADC()[time];
         if (value > adcThresh)
           nADChigh++;
@@ -567,7 +567,6 @@ void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
               // mClsDetTimeN[idSM]->Fill(iChamber, k);
             }
 
-            // Fill pulse height plot according to demanded trigger
             // This is pulseheight lifted from run2, probably not what was used.
             mClsChargeTbTigg->Fill(time, sum);
 

--- a/Modules/TRD/src/PulseHeight.cxx
+++ b/Modules/TRD/src/PulseHeight.cxx
@@ -43,15 +43,15 @@ PulseHeight::~PulseHeight()
 
 void PulseHeight::retrieveCCDBSettings()
 {
-  //std::string a = mCustomParameters["noisetimestamp"];
-  //mTimestamp = a;//std::stol(a,nullptr,10);
-  //long int ts = mTimestamp ? mTimestamp : o2::ccdb::getCurrentTimestamp();
-  //TODO come back and all for different time stamps
-  long int ts = o2::ccdb::getCurrentTimestamp();
-  ILOG(Info, Support) << "Getting noisemap from ccdb - timestamp: " << ts << ENDM;
+  if (auto param = mCustomParameters.find("ccdbtimestamp"); param != mCustomParameters.end()) {
+    mTimestamp = std::stol(mCustomParameters["ccdbtimestamp"]);
+    ILOG(Info, Support) << "configure() : using ccdbtimestamp = " << mTimestamp << ENDM;
+  } else {
+    mTimestamp = o2::ccdb::getCurrentTimestamp();
+    ILOG(Info, Support) << "configure() : using default timestam of now = " << mTimestamp << ENDM;
+  }
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setURL("http://alice-ccdb.cern.ch");
-  mgr.setTimestamp(ts);
+  mgr.setTimestamp(mTimestamp);
   mNoiseMap = mgr.get<o2::trd::NoiseStatusMCM>("/TRD/Calib/NoiseMapMCM");
   if (mNoiseMap == nullptr) {
     ILOG(Info, Support) << "mNoiseMap is null, no noisy mcm reduction" << ENDM;

--- a/Modules/TRD/src/PulseHeightCheck.cxx
+++ b/Modules/TRD/src/PulseHeightCheck.cxx
@@ -26,6 +26,8 @@
 
 #include <DataFormatsQualityControl/FlagReasons.h>
 
+#include "CCDB/BasicCCDBManager.h"
+#include "TRDQC/StatusHelper.h"
 #include "TRD/PulseHeightCheck.h"
 
 using namespace std;
@@ -36,6 +38,44 @@ namespace o2::quality_control_modules::trd
 
 void PulseHeightCheck::configure()
 {
+  if (auto param = mCustomParameters.find("ccdbtimestamp"); param != mCustomParameters.end()) {
+    mTimeStamp = std::stol(mCustomParameters["ccdbtimestamp"]);
+    ILOG(Info, Support) << "configure() : using ccdbtimestamp = " << mTimeStamp << ENDM;
+  } else {
+    mTimeStamp = o2::ccdb::getCurrentTimestamp();
+    ILOG(Info, Support) << "configure() : using default timestam of now = " << mTimeStamp << ENDM;
+  }
+  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+  mgr.setTimestamp(mTimeStamp);
+  ILOG(Info, Support) << "initialize PulseHeight" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  if (auto param = mCustomParameters.find("driftregionstart"); param != mCustomParameters.end()) {
+    mDriftRegion.first = stof(param->second);
+    ILOG(Info, Support) << "configure() : using driftregionstart = " << mDriftRegion.first << ENDM;
+  } else {
+    mDriftRegion.first = 7.0;
+    ILOG(Info, Support) << "configure() : using default dritfregionstart = " << mDriftRegion.first << ENDM;
+  }
+  if (auto param = mCustomParameters.find("driftregionend"); param != mCustomParameters.end()) {
+    mDriftRegion.second = stof(param->second);
+    ILOG(Info, Support) << "configure() : using dritftregionend = " << mDriftRegion.second << ENDM;
+  } else {
+    mDriftRegion.second = 20.0;
+    ILOG(Info, Support) << "configure() : using default dritfregionend = " << mDriftRegion.second << ENDM;
+  }
+  if (auto param = mCustomParameters.find("peakregionstart"); param != mCustomParameters.end()) {
+    mPulseHeightPeakRegion.first = stof(param->second);
+    ILOG(Info, Support) << "configure() : using peakregionstart " << mPulseHeightPeakRegion.first << ENDM;
+  } else {
+    mPulseHeightPeakRegion.first = 1.0;
+    ILOG(Info, Support) << "configure() : using default peakregionstart  = " << mPulseHeightPeakRegion.first << ENDM;
+  }
+  if (auto param = mCustomParameters.find("peakregionend"); param != mCustomParameters.end()) {
+    mPulseHeightPeakRegion.second = stof(param->second);
+    ILOG(Info, Support) << "configure() : using peak region ends = " << mPulseHeightPeakRegion.second << ENDM;
+  } else {
+    mPulseHeightPeakRegion.second = 5.0;
+    ILOG(Info, Support) << "configure() : using default peak region end = " << mPulseHeightPeakRegion.second << ENDM;
+  }
 }
 
 Quality PulseHeightCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
@@ -73,30 +113,21 @@ std::string PulseHeightCheck::getAcceptedType() { return "TH1"; }
 
 void PulseHeightCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  if (mo->getName() == "pulseheightscaled") {
+  if (mo->getName() == "PulseHeight/mPulseHeight") {
     auto* h = dynamic_cast<TH1F*>(mo->getObject());
     TPaveText* msg = new TPaveText(0.3, 0.9, 0.7, 0.95, "NDC");
     h->GetListOfFunctions()->Add(msg);
     //std::string message = fmt::format("Pulseheight message");
     std::string message = "Pulseheight message";
     msg->SetName(message.c_str());
-    TLine* lmin = new TLine(1, 0, 1, 1100);
-    TLine* lmax = new TLine(7, 0, 7, 1100);
-
-    h->GetListOfFunctions()->Add(lmin);
-    h->GetListOfFunctions()->Add(lmax);
-    lmin->SetLineColor(kBlue);
-    lmin->Draw();
-    lmax->SetLineColor(kBlue);
-    lmax->Draw();
 
     if (checkResult == Quality::Good) {
       h->SetFillColor(kGreen);
     } else if (checkResult == Quality::Bad) {
-      ILOG(Info, Support) << "Quality::Bad, setting to red" << ENDM;
+      ILOG(Info, Support) << "Quality::Bad, something wrong with the pulseheight spectrum" << ENDM;
       h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
-      ILOG(Info, Support) << "Quality::medium, setting to orange" << ENDM;
+      ILOG(Info, Support) << "Quality::medium, pusleheight spectrum is a bit suspect" << ENDM;
       h->SetFillColor(kOrange);
     }
     h->SetLineColor(kBlack);

--- a/Modules/TRD/src/TrackletsCheck.cxx
+++ b/Modules/TRD/src/TrackletsCheck.cxx
@@ -43,6 +43,27 @@ void TrackletsCheck::retrieveCCDBSettings()
   }
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
   mgr.setTimestamp(mTimestamp);
+  if (auto param = mCustomParameters.find("integralthreshold"); param != mCustomParameters.end()) {
+    mIntegralThreshold = std::stol(mCustomParameters["integralthreshold"]);
+    ILOG(Info, Support) << "configure() : using integral threshold = " << mIntegralThreshold << ENDM;
+  } else {
+    mIntegralThreshold = 100;
+    ILOG(Info, Support) << "configure() : using default integral threshold of = " << mIntegralThreshold << ENDM;
+  }
+  if (auto param = mCustomParameters.find("ratiothreshold"); param != mCustomParameters.end()) {
+    mRatioThreshold = std::stol(mCustomParameters["ratiothreshold"]);
+    ILOG(Info, Support) << "configure() : using ratio threshold = " << mRatioThreshold << ENDM;
+  } else {
+    mRatioThreshold = 0.9; // 90% of counts must be above the threshold
+    ILOG(Info, Support) << "configure() : using default ratio threshold of = " << mRatioThreshold << ENDM;
+  }
+  if (auto param = mCustomParameters.find("zerobinratiotheshold"); param != mCustomParameters.end()) {
+    mZeroBinRatioThreshold = std::stol(mCustomParameters["zerobinratiothreshold"]);
+    ILOG(Info, Support) << "configure() : using ratio threshold = " << mZeroBinRatioThreshold << ENDM;
+  } else {
+    mZeroBinRatioThreshold = 0.9; // 90% of counts must be above the threshold
+    ILOG(Info, Support) << "configure() : using default ratio threshold of = " << mZeroBinRatioThreshold << ENDM;
+  }
 }
 
 void TrackletsCheck::configure()
@@ -50,7 +71,6 @@ void TrackletsCheck::configure()
   //get ccdb values
   //fill mask spectra
   retrieveCCDBSettings();
-  //fillTrdMaskHistsPerLayer();
 }
 
 Quality TrackletsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
@@ -60,10 +80,21 @@ Quality TrackletsCheck::check(std::map<std::string, std::shared_ptr<MonitorObjec
   for (auto& [moName, mo] : *moMap) {
 
     (void)moName;
-    if (mo->getName() == "example") {
+    if (mo->getName() == "trackletspertimeframe") {
       auto* h = dynamic_cast<TH1F*>(mo->getObject());
 
       result = Quality::Good;
+      float ratioabove;
+      if (h->Integral(0, mIntegralThreshold) > 0 && h->Integral(mIntegralThreshold, 1000) > 0) {
+        ratioabove = h->Integral(0, 100) / h->Integral(100, 1000);
+      }
+      if (ratioabove > mRatioThreshold) {
+        result = Quality::Good;
+      } else {
+        result = Quality::Bad;
+        result.addReason(FlagReasonFactory::Unknown(),
+                         "The Ratio of tracklet counts above " + std::to_string(mIntegralThreshold) + " is too low " + std::to_string(mRatioThreshold) + " %");
+      }
 
       for (int i = 0; i < h->GetNbinsX(); i++) {
         if (i > 0 && i < 8 && h->GetBinContent(i) == 0) {
@@ -125,7 +156,7 @@ void TrackletsCheck::fillTrdMaskHistsPerLayer()
 
 void TrackletsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  if (mo->getName() == "example") {
+  if (mo->getName() == "trackletspertimeframe") {
     auto* h = dynamic_cast<TH1F*>(mo->getObject());
 
     if (checkResult == Quality::Good) {
@@ -135,6 +166,20 @@ void TrackletsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
       h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
       ILOG(Info, Support) << "Quality::medium, setting to orange" << ENDM;
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+  if (mo->getName() == "trackletspertimeframecycled") {
+    auto* h = dynamic_cast<TH1F*>(mo->getObject());
+
+    if (checkResult == Quality::Good) {
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      ILOG(Info, Support) << "Quality::Bad, call on call" << ENDM;
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      ILOG(Info, Support) << "Quality::medium, something might be off" << ENDM;
       h->SetFillColor(kOrange);
     }
     h->SetLineColor(kBlack);


### PR DESCRIPTION
- add tracklet per time frame spectrum.
- overlays for digits is unmanagable so reverted to what is in master. Will have to find a quicker way to handle the canvases, because what I have is unworkable.
- remove alice-ccdb from pulseheight task which is no longer used.