### PR TITLE
FT0: hotfix for DigitQCtask

### DIFF
--- a/Modules/FT0/src/DigitQcTask.cxx
+++ b/Modules/FT0/src/DigitQcTask.cxx
@@ -321,7 +321,7 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
   for (auto& digit : digits) {
     const auto& vecChData = digit.getBunchChannelData(channels);
     bool isTCM = true;
-    if (digit.mTriggers.amplA == -5000 /*&& digit.mTriggers.amplC == -5000 && digit.mTriggers.timeA == -5000 && digit.mTriggers.timeC == -5000*/) {
+    if (digit.mTriggers.timeA == -5000 && digit.mTriggers.timeC == -5000) {
       isTCM = false;
     }
     mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);


### PR DESCRIPTION
Trivial hotfix, TCM presence condition is fixed and reduced. No need in waiting CICD to be finished.