### PR TITLE
MFT: trending update

### DIFF
--- a/Modules/MFT/CMakeLists.txt
+++ b/Modules/MFT/CMakeLists.txt
@@ -12,7 +12,8 @@ target_sources(O2QcMFT PRIVATE
                src/QcMFTAsyncTask.cxx
                src/QcMFTReadoutCheck.cxx
                src/QcMFTReadoutTask.cxx
-               src/QcMFTReadoutTrend.cxx)
+               src/QcMFTReadoutTrend.cxx
+               src/QcMFTOccupancyTrend.cxx)
 
 target_include_directories(
   O2QcMFT
@@ -40,6 +41,7 @@ add_root_dictionary(O2QcMFT
                     include/MFT/QcMFTReadoutTask.h
                     include/MFT/QcMFTReadoutTrend.h
                     include/MFT/QcMFTUtilTables.h
+                    include/MFT/QcMFTOccupancyTrend.h
                     LINKDEF include/MFT/LinkDef.h
                     BASENAME O2QcMFT)
 
@@ -102,4 +104,5 @@ install(FILES qc-mft-digit.json
               qc-mft-async.json
               qc-mft-async_direct.json
               qc-mft-readout-trend.json
+              qc-mft-occupancy-trend.json
         DESTINATION etc)

--- a/Modules/MFT/include/MFT/LinkDef.h
+++ b/Modules/MFT/include/MFT/LinkDef.h
@@ -13,4 +13,5 @@
 #pragma link C++ class o2::quality_control_modules::mft::QcMFTReadoutCheck + ;
 #pragma link C++ class o2::quality_control_modules::mft::QcMFTReadoutTask + ;
 #pragma link C++ class o2::quality_control_modules::mft::QcMFTReadoutTrend + ;
+#pragma link C++ class o2::quality_control_modules::mft::QcMFTOccupancyTrend + ;
 #endif

--- a/Modules/MFT/include/MFT/QcMFTOccupancyTrend.h
+++ b/Modules/MFT/include/MFT/QcMFTOccupancyTrend.h
@@ -1,0 +1,51 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   QcMFTOccupancyTrend.h
+/// \author Tomas Herman
+/// \author Guillermo Contreras
+/// \author Katarina Krizkova Gajdosova
+/// \author Diana Maria Krupova
+///
+#ifndef MFT_OCCUPANCY_TREND_H
+#define MFT_OCCUPANCY_TREND_H
+
+#include "QualityControl/Reductor.h"
+
+namespace o2::quality_control_modules::mft
+{
+
+/// \brief A Reductor which obtains the  bin content of a TH1.
+/// A Reductor which obtains the bin content of a  TH1.
+
+class QcMFTOccupancyTrend : public quality_control::postprocessing::Reductor
+{
+ public:
+  QcMFTOccupancyTrend() = default;
+  ~QcMFTOccupancyTrend() = default;
+
+  void* getBranchAddress() override;
+  const char* getBranchLeafList() override;
+  void update(TObject* obj) override;
+
+ private:
+  struct {
+    float binContentOverflow;
+    Double_t mean;
+    Double_t stddev;
+    Double_t entries;
+  } mStats;
+};
+
+} // namespace o2::quality_control_modules::mft
+
+#endif // QC_MFT_OCCUPANCY_TREND_H

--- a/Modules/MFT/qc-mft-occupancy-trend.json
+++ b/Modules/MFT/qc-mft-occupancy-trend.json
@@ -1,0 +1,77 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "0"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "postprocessing": {
+      "MFTOccupancyTrend": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::TrendingTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTDigitTask",
+            "names": [ "mDigitChipOccupancy" ],
+            "reductorName": "o2::quality_control_modules::mft::QcMFTOccupancyTrend",
+            "moduleName": "QcMFT"
+          },
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTClusterTask",
+            "names": [ "mClusterOccupancy" ],
+            "reductorName": "o2::quality_control_modules::mft::QcMFTOccupancyTrend",
+            "moduleName": "QcMFT"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mDigitEmptyChipsTrend",
+            "title": "Trend of total number of chips with no digits",
+            "varexp": "mDigitChipOccupancy.binContentOverflow:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Chips with no digits:time"
+          },
+          {
+            "name": "mClusterEmptyChipsTrend",
+            "title": "Trend of total number of chips with no clusters",
+            "varexp": "mClusterOccupancy.binContentOverflow:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Chips with no clusters:time"
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "60 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    }
+  }
+}

--- a/Modules/MFT/qc-mft-trend-slices.json
+++ b/Modules/MFT/qc-mft-trend-slices.json
@@ -1,0 +1,96 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "0"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "postprocessing": {
+      "MFTTrendSlices": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::SliceTrendingTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTDigitTask",
+            "names": [ "mDigitChipOccupancy" ],
+            "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
+            "axisDivision": [ [ "1", "468", "936" ] ],
+            "moduleName": "QcMFT"
+          },
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTClusterTask",
+            "names": [ "mClusterPatternIndex" ],
+            "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
+            "axisDivision": [ [ "0", "4", "11", "300" ] ],
+            "moduleName": "QcMFT"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mMeanDigitOccupancyPerHalfMFTTrend",
+            "title": "Mean digit occupancy trend for each MFT half",
+            "varexp": "mDigitChipOccupancy.meanY:multigraphtime",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanY:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "Mean digit occupancy for H0 (blue) and H1 (yellow):time"
+          },
+          {
+            "name": "mClusterPatternIDMeanTrend",
+            "title": "Mean cluster pattern ID trend for different regions",
+            "varexp": "mClusterPatternIndex.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "Mean cluster pattern ID:time"
+          },
+          {
+            "name": "mClusterPatternIDStdDevTrend",
+            "title": "StdDev of cluster pattern ID trend for different regions",
+            "varexp": "mClusterPatternIndex.stddevX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "StdDev of cluster pattern ID:time"
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "60 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    }
+  }
+}

--- a/Modules/MFT/src/QcMFTOccupancyTrend.cxx
+++ b/Modules/MFT/src/QcMFTOccupancyTrend.cxx
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   QcMFTOccupancyTrend.cxx
+/// \author Tomas Herman
+/// \author Guillermo Contreras
+/// \author Katarina Krizkova Gajdosova
+/// \author Diana Maria Krupova
+///
+
+#include <TH1.h>
+#include "MFT/QcMFTOccupancyTrend.h"
+
+namespace o2::quality_control_modules::mft
+{
+
+void* QcMFTOccupancyTrend::getBranchAddress()
+{
+  return &mStats;
+}
+
+const char* QcMFTOccupancyTrend::getBranchLeafList()
+{
+  return "binContentOverflow:mean/D:stddev:entries";
+}
+
+void QcMFTOccupancyTrend::update(TObject* obj)
+{
+  auto histo = dynamic_cast<TH1*>(obj);
+  if (histo) {
+    mStats.binContentOverflow = histo->GetBinContent(937);
+    mStats.entries = histo->GetEntries();
+    mStats.stddev = histo->GetStdDev();
+    mStats.mean = histo->GetMean();
+  }
+}
+
+} // namespace o2::quality_control_modules::mft


### PR DESCRIPTION
new MFT trending plots using the slicer: trend of chips with no digits and clusters, trend of occupancy separately for H0 and H1, trend of cluster pattern ID mean and stddev divided into regions