### PR TITLE
MCH: fix tracks QC performance issue

### DIFF
--- a/Modules/MUON/MCH/src/TracksTask.cxx
+++ b/Modules/MUON/MCH/src/TracksTask.cxx
@@ -181,7 +181,7 @@ void TracksTask::fillClusterHistos(gsl::span<const o2::mch::Cluster> clusters)
 {
   for (const auto& cluster : clusters) {
     int deId = cluster.getDEId();
-    o2::mch::mapping::Segmentation seg(deId);
+    const o2::mch::mapping::Segmentation& seg = o2::mch::mapping::segmentation(deId);
     int b, nb;
     seg.findPadPairByPosition(cluster.getX(), cluster.getY(), b, nb);
     if (b >= 0) {


### PR DESCRIPTION
Detector mapping segmentation was created for each cluster, which was obviously a terrible idea... Sorry about that.

@aferrero2707 