### PR TITLE
[FIT] Changes in DigitQcTask and DigitQcTaskLaser - proper distribution of data between them + minor formatting

### DIFF
--- a/Modules/FDD/CMakeLists.txt
+++ b/Modules/FDD/CMakeLists.txt
@@ -2,7 +2,11 @@
 
 add_library(O2QcFDD)
 
-target_sources(O2QcFDD PRIVATE src/DigitQcTask.cxx src/DigitQcTaskLaser.cxx src/RecPointsQcTask.cxx )
+target_sources(O2QcFDD PRIVATE
+                               src/DigitQcTaskLaser.cxx
+                               src/DigitQcTask.cxx
+                               src/RecPointsQcTask.cxx
+                               )
 
 target_include_directories(
   O2QcFDD
@@ -18,13 +22,13 @@ install(TARGETS O2QcFDD
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_root_dictionary(O2QcFDD
-                    HEADERS
-  include/FDD/DigitQcTask.h
-  include/FDD/DigitQcTaskLaser.h
-  include/FDD/RecPointsQcTask.h
-  include/FDD/Helper.h
-                    LINKDEF include/FDD/LinkDef.h
-                    BASENAME O2QcFDD)
+  HEADERS
+          include/FDD/DigitQcTaskLaser.h
+          include/FDD/DigitQcTask.h
+          include/FDD/RecPointsQcTask.h
+          include/FDD/Helper.h
+  LINKDEF include/FDD/LinkDef.h
+  BASENAME O2QcFDD)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/FDD
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/QualityControl")
@@ -45,4 +49,3 @@ foreach(test ${TEST_SRCS})
     PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
   set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
 endforeach()
-

--- a/Modules/FDD/src/DigitQcTask.cxx
+++ b/Modules/FDD/src/DigitQcTask.cxx
@@ -305,6 +305,10 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
   int mPMChargeTotalAside, mPMChargeTotalCside;
   for (auto& digit : digits) {
+    // Exclude all BCs, in which laser signals are expected (and trigger outputs are blocked)
+    if (digit.mTriggers.getOutputsAreBlocked()) {
+      continue;
+    }
     mPMChargeTotalAside = 0;
     mPMChargeTotalCside = 0;
     const auto& vecChData = digit.getBunchChannelData(channels);
@@ -338,7 +342,7 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
     mHistBC->Fill(digit.getIntRecord().bc);
 
-    if (isTCM && !digit.mTriggers.getLaser()) {
+    if (isTCM && digit.mTriggers.getDataIsValid() && !digit.mTriggers.getOutputsAreBlocked()) {
       // mHistNchA->Fill(digit.mTriggers.nChanA); ak
       mHistNchA->Fill(digit.mTriggers.getNChanA());
       mHistNchC->Fill(digit.mTriggers.getNChanC());

--- a/Modules/FDD/src/DigitQcTaskLaser.cxx
+++ b/Modules/FDD/src/DigitQcTaskLaser.cxx
@@ -242,7 +242,7 @@ void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
   uint32_t firstOrbit;
 
   for (auto& digit : digits) {
-    // Exclude all BCs, in which laser signals are not expected (and trigger outputs are not blocked)
+    // Exclude all BCs, in which laser signals are NOT expected (and trigger outputs are NOT blocked)
     if (!digit.mTriggers.getOutputsAreBlocked()) {
       continue;
     }

--- a/Modules/FT0/include/FT0/DigitQcTask.h
+++ b/Modules/FT0/include/FT0/DigitQcTask.h
@@ -12,8 +12,7 @@
 ///
 /// \file   DigitQcTask.h
 /// \author Artur Furs afurs@cern.ch
-/// modified by Sebastin Bysiak sbysiak@cern.ch
-/// QC Task for FT0 detector, mostly for data visualisation during FEE tests
+/// \brief Quality Control DPL Task for FT0's digit visualization for non-laser events only
 
 #ifndef QC_MODULE_FT0_FT0DIGITQCTASK_H
 #define QC_MODULE_FT0_FT0DIGITQCTASK_H
@@ -43,7 +42,6 @@ using namespace o2::quality_control::core;
 
 namespace o2::quality_control_modules::ft0
 {
-
 class DigitQcTask final : public TaskInterface
 {
  public:
@@ -59,6 +57,7 @@ class DigitQcTask final : public TaskInterface
   void endOfCycle() override;
   void endOfActivity(Activity& activity) override;
   void reset() override;
+  constexpr static std::size_t sNCHANNELS_PM = o2::ft0::Constants::sNCHANNELS_PM;
   constexpr static std::size_t sOrbitsPerTF = 256;
   constexpr static std::size_t sBCperOrbit = 3564;
 
@@ -100,9 +99,9 @@ class DigitQcTask final : public TaskInterface
 
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
-  std::array<o2::InteractionRecord, o2::ft0::Constants::sNCHANNELS_PM> mStateLastIR2Ch;
-  std::array<uint8_t, o2::ft0::Constants::sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
-  uint8_t mTCMhash;                                                    // hash value for TCM, and bin position in hist
+  std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
+  std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
+  uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist
   std::map<int, std::string> mMapDigitTrgNames;
   std::map<o2::ft0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
   std::unique_ptr<TH1F> mHistNumADC;
@@ -138,11 +137,12 @@ class DigitQcTask final : public TaskInterface
   std::unique_ptr<TH2F> mHistOrbitVsFEEmodules;
 
   // Hashed maps
-  const std::array<std::vector<double>, 256> mHashedBitBinPos;                        // map with bit position for 1 byte trg signal, for 1 Dim hists;
-  const std::array<std::vector<std::pair<double, double>>, 256> mHashedPairBitBinPos; // map with paired bit position for 1 byte trg signal, for 1 Dim hists;
-  static std::array<std::vector<double>, 256> fillHashedBitBinPos()
+  static const size_t mapSize = 256;
+  const std::array<std::vector<double>, mapSize> mHashedBitBinPos;                        // map with bit position for 1 byte trg signal, for 1 Dim hists;
+  const std::array<std::vector<std::pair<double, double>>, mapSize> mHashedPairBitBinPos; // map with paired bit position for 1 byte trg signal, for 1 Dim hists;
+  static std::array<std::vector<double>, mapSize> fillHashedBitBinPos()
   {
-    std::array<std::vector<double>, 256> hashedBitBinPos{};
+    std::array<std::vector<double>, mapSize> hashedBitBinPos{};
     for (int iByteValue = 0; iByteValue < hashedBitBinPos.size(); iByteValue++) {
       auto& vec = hashedBitBinPos[iByteValue];
       for (int iBit = 0; iBit < 8; iBit++) {
@@ -153,10 +153,10 @@ class DigitQcTask final : public TaskInterface
     }
     return hashedBitBinPos;
   }
-  static std::array<std::vector<std::pair<double, double>>, 256> fillHashedPairBitBinPos()
+  static std::array<std::vector<std::pair<double, double>>, mapSize> fillHashedPairBitBinPos()
   {
-    const std::array<std::vector<double>, 256> hashedBitBinPos = fillHashedBitBinPos();
-    std::array<std::vector<std::pair<double, double>>, 256> hashedPairBitBinPos{};
+    const std::array<std::vector<double>, mapSize> hashedBitBinPos = fillHashedBitBinPos();
+    std::array<std::vector<std::pair<double, double>>, mapSize> hashedPairBitBinPos{};
     for (int iByteValue = 0; iByteValue < hashedBitBinPos.size(); iByteValue++) {
       const auto& vecBits = hashedBitBinPos[iByteValue];
       auto& vecPairBits = hashedPairBitBinPos[iByteValue];
@@ -172,4 +172,4 @@ class DigitQcTask final : public TaskInterface
 
 } // namespace o2::quality_control_modules::ft0
 
-#endif // QC_MODULE_FT0_FT0DigitQcTask_H
+#endif // QC_MODULE_FT0_FT0DIGITQCTASK_H

--- a/Modules/FT0/include/FT0/DigitQcTaskLaser.h
+++ b/Modules/FT0/include/FT0/DigitQcTaskLaser.h
@@ -11,40 +11,42 @@
 
 ///
 /// \file   DigitQcTaskLaser.h
-/// \author Artur Furs afurs@cern.ch
-/// modified by Sebastin Bysiak sbysiak@cern.ch
-/// QC Task for FT0 detector, mostly for data visualisation during FEE tests
-/// copied by Sandor Lokos sandor.lokos@cern.ch
+/// \author Artur Furs afurs@cern.ch, developed further for laser QC by Sandor Lokos (sandor.lokos@cern.ch)
+/// \brief Quality Control DPL Task for FT0's digit visualization for laser events only
 
 #ifndef QC_MODULE_FT0_FT0DIGITQCTASKLASER_H
 #define QC_MODULE_FT0_FT0DIGITQCTASKLASER_H
 
-#include <Framework/InputRecord.h>
-
-#include "QualityControl/QcInfoLogger.h"
-#include "FT0Base/Constants.h"
-#include "DataFormatsFT0/Digit.h"
-#include "DataFormatsFT0/ChannelData.h"
-#include "QualityControl/TaskInterface.h"
 #include <memory>
 #include <regex>
 #include <type_traits>
+#include <set>
+#include <map>
+#include <vector>
+#include <array>
 #include <boost/algorithm/string.hpp>
+
 #include "TH1.h"
 #include "TH2.h"
 #include "TList.h"
 #include "Rtypes.h"
 
+#include "QualityControl/TaskInterface.h"
+#include "QualityControl/QcInfoLogger.h"
+
+#include "FT0Base/Constants.h"
+#include "DataFormatsFT0/Digit.h"
+#include "DataFormatsFT0/ChannelData.h"
+
 using namespace o2::quality_control::core;
 
 namespace o2::quality_control_modules::ft0
 {
-
 class DigitQcTaskLaser final : public TaskInterface
 {
  public:
   /// \brief Constructor
-  DigitQcTaskLaser() = default;
+  DigitQcTaskLaser() : mHashedBitBinPos(fillHashedBitBinPos()) {}
   /// Destructor
   ~DigitQcTaskLaser() override;
   // Definition of the methods for the template method pattern
@@ -55,25 +57,17 @@ class DigitQcTaskLaser final : public TaskInterface
   void endOfCycle() override;
   void endOfActivity(Activity& activity) override;
   void reset() override;
+  constexpr static std::size_t sNCHANNELS_PM = o2::ft0::Constants::sNCHANNELS_PM;
   constexpr static std::size_t sOrbitsPerTF = 256;
-  constexpr static uint8_t sDataIsValidBitPos = 7;
+  constexpr static std::size_t sBCperOrbit = 3564;
+
+  constexpr static float sCFDChannel2NS = 0.01302; // CFD channel width in ns
 
  private:
-  // three ways of computing cycle duration:
-  // 1) number of time frames
-  // 2) time in ns from InteractionRecord: total range (totalMax - totalMin)
-  // 3) time in ns from InteractionRecord: sum of each TF duration
-  // later on choose the best and remove others
-  double mTimeMinNS = 0.;
-  double mTimeMaxNS = 0.;
-  double mTimeCurNS = 0.;
-  int mTfCounter = 0;
-  double mTimeSum = 0.;
-  const float mCFDChannel2NS = 0.01302; // CFD channel width in ns
-
   template <typename Param_t,
             typename = typename std::enable_if<std::is_floating_point<Param_t>::value ||
-                                               std::is_same<std::string, Param_t>::value || (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>
+                                               std::is_same<std::string, Param_t>::value ||
+                                               (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>
   auto parseParameters(const std::string& param, const std::string& del)
   {
     std::regex reg(del);
@@ -95,11 +89,11 @@ class DigitQcTaskLaser final : public TaskInterface
 
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
-  std::set<unsigned int> mSetRefPMTChIDs;
-  std::array<o2::InteractionRecord, o2::ft0::Constants::sNCHANNELS_PM> mStateLastIR2Ch;
+  std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
+  std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
+  uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist
   std::map<int, std::string> mMapDigitTrgNames;
   std::map<o2::ft0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
-  std::map<std::string, std::vector<int>> mMapPmModuleChannels; // PM name to its channels
   std::unique_ptr<TH1F> mHistNumADC;
   std::unique_ptr<TH1F> mHistNumCFD;
 
@@ -107,14 +101,35 @@ class DigitQcTaskLaser final : public TaskInterface
   std::unique_ptr<TH2F> mHistAmp2Ch;
   std::unique_ptr<TH2F> mHistTime2Ch;
   std::unique_ptr<TH2F> mHistChDataBits;
-  std::unique_ptr<TH2F> mHistOrbit2BC;
   std::unique_ptr<TH1F> mHistBC;
   std::unique_ptr<TH1F> mHistCFDEff;
-  std::unique_ptr<TH1D> mHistCycleDuration;
-  std::map<unsigned int, TH2F*> mMapHistAmpVsBC;
-  std::map<std::string, TH2F*> mMapPmModuleBcOrbit;
+  std::unique_ptr<TH2F> mHistTimeSum2Diff;
+  std::map<unsigned int, TH1F*> mMapHistAmp1D;
+  std::map<unsigned int, TH1F*> mMapHistTime1D;
+  std::map<unsigned int, TH1F*> mMapHistPMbits;
+  std::map<unsigned int, TH2F*> mMapHistAmpVsTime;
+  std::unique_ptr<TH2F> mHistBCvsFEEmodules;
+  std::unique_ptr<TH2F> mHistOrbitVsTrg;
+  std::unique_ptr<TH2F> mHistOrbitVsFEEmodules;
+
+  // Hashed maps
+  static const size_t mapSize = 256;
+  const std::array<std::vector<double>, mapSize> mHashedBitBinPos; // map with bit position for 1 byte trg signal, for 1 Dim hists;
+  static std::array<std::vector<double>, mapSize> fillHashedBitBinPos()
+  {
+    std::array<std::vector<double>, mapSize> hashedBitBinPos{};
+    for (int iByteValue = 0; iByteValue < hashedBitBinPos.size(); iByteValue++) {
+      auto& vec = hashedBitBinPos[iByteValue];
+      for (int iBit = 0; iBit < 8; iBit++) {
+        if (iByteValue & (1 << iBit)) {
+          vec.push_back(iBit);
+        }
+      }
+    }
+    return hashedBitBinPos;
+  }
 };
 
 } // namespace o2::quality_control_modules::ft0
 
-#endif // QC_MODULE_FT0_FT0DigitQcTaskLaser_H
+#endif // QC_MODULE_FT0_FT0DIGITQCTASKLASER_H

--- a/Modules/FT0/src/DigitQcTask.cxx
+++ b/Modules/FT0/src/DigitQcTask.cxx
@@ -84,7 +84,7 @@ void DigitQcTask::rebinFromConfig()
 
 void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info, Support) << "initialize DigitQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  ILOG(Info) << "initialize DigitQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
   mStateLastIR2Ch = {};
   mMapChTrgNames.insert({ o2::ft0::ChannelData::kNumberADC, "NumberADC" });
   mMapChTrgNames.insert({ o2::ft0::ChannelData::kIsDoubleEvent, "IsDoubleEvent" });
@@ -103,30 +103,34 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mMapDigitTrgNames.insert({ o2::fit::Triggers::bitLaser, "Laser" });
   mMapDigitTrgNames.insert({ o2::fit::Triggers::bitOutputsAreBlocked, "OutputsAreBlocked" });
   mMapDigitTrgNames.insert({ o2::fit::Triggers::bitDataIsValid, "DataIsValid" });
-  mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM, 4100, -2050, 2050);
-  mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM, 4200, -100, 4100);
-  mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", sOrbitsPerTF, 0, sOrbitsPerTF, sBCperOrbit, 0, sBCperOrbit);
+  mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4100, -2050, 2050);
+  mHistTime2Ch->SetOption("colz");
+  mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4200, -100, 4100);
+  mHistAmp2Ch->SetOption("colz");
   mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
-
-  mHistEventDensity2Ch = std::make_unique<TH2F>("EventDensityPerChannel", "Event density(in BC) per Channel;Channel;BC;", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM, 10000, 0, 1e5);
-
-  mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
+  mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
+  mHistChDataBits->SetOption("colz");
   for (const auto& entry : mMapChTrgNames) {
     mHistChDataBits->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
   }
-  mHistTriggersCorrelation = std::make_unique<TH2F>("TriggersCorrelation", "Correlation of triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size(), mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-
-  mHistBCvsTrg = std::make_unique<TH2F>("BCvsTriggers", "BC vs Triggers;BC;Trg", sBCperOrbit, 0, sBCperOrbit, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
   mHistOrbitVsTrg = std::make_unique<TH2F>("OrbitVsTriggers", "Orbit vs Triggers;Orbit;Trg", sOrbitsPerTF, 0, sOrbitsPerTF, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-
-  mListHistGarbage = new TList();
-  mListHistGarbage->SetOwner(kTRUE);
+  mHistOrbitVsTrg->SetOption("colz");
+  mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", sOrbitsPerTF, 0, sOrbitsPerTF, sBCperOrbit, 0, sBCperOrbit);
+  mHistOrbit2BC->SetOption("colz");
+  mHistEventDensity2Ch = std::make_unique<TH2F>("EventDensityPerChannel", "Event density(in BC) per Channel;Channel;BC;", sNCHANNELS_PM, 0, sNCHANNELS_PM, 10000, 0, 1e5);
+  mHistEventDensity2Ch->SetOption("colz");
+  mHistTriggersCorrelation = std::make_unique<TH2F>("TriggersCorrelation", "Correlation of triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size(), mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistTriggersCorrelation->SetOption("colz");
+  mHistBCvsTrg = std::make_unique<TH2F>("BCvsTriggers", "BC vs Triggers;BC;Trg", sBCperOrbit, 0, sBCperOrbit, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistBCvsTrg->SetOption("colz");
   for (const auto& entry : mMapDigitTrgNames) {
+    mHistOrbitVsTrg->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     mHistTriggersCorrelation->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     mHistTriggersCorrelation->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     mHistBCvsTrg->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
-    mHistOrbitVsTrg->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
   }
+  mListHistGarbage = new TList();
+  mListHistGarbage->SetOwner(kTRUE);
 
   std::map<std::string, uint8_t> mapFEE2hash;
   const auto& lut = o2::ft0::SingleLUT::Instance().getVecMetadataFEE();
@@ -143,7 +147,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
     }
     if (std::regex_match(strChID, std::regex("[[\\d]{1,3}"))) {
       int chID = std::stoi(strChID);
-      if (chID < o2::ft0::Constants::sNCHANNELS_PM) {
+      if (chID < sNCHANNELS_PM) {
         mChID2PMhash[chID] = mapFEE2hash[moduleName];
       } else {
         LOG(error) << "Incorrect LUT entry: chID " << strChID << " | " << moduleName;
@@ -161,17 +165,17 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
     mHistOrbitVsFEEmodules->GetYaxis()->SetBinLabel(entry.second + 1, entry.first.c_str());
   }
 
-  mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
-  mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
-  mHistSumAmpA = std::make_unique<TH1F>("SumAmpA", "Sum of amplitudes(TCM), side A;", 1000, 0, 1e4);
-  mHistSumAmpC = std::make_unique<TH1F>("SumAmpC", "Sum of amplitudes(TCM), side C;", 1000, 0, 1e4);
+  mHistTimeSum2Diff = std::make_unique<TH2F>("timeSumVsDiff", "time A/C side: sum VS diff;(TOC-TOA)/2 [ns];(TOA+TOC)/2 [ns]", 400, -52.08, 52.08, 400, -52.08, 52.08); // range of 52.08 ns = 4000*13.02ps = 4000 channels
+  mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistSumAmpA = std::make_unique<TH1F>("SumAmpA", "Sum of amplitudes(TCM), side A;", 1e4, 0, 1e4);
+  mHistSumAmpC = std::make_unique<TH1F>("SumAmpC", "Sum of amplitudes(TCM), side C;", 1e4, 0, 1e4);
   mHistAverageTimeA = std::make_unique<TH1F>("AverageTimeA", "Average time(TCM), side A", 4100, -2050, 2050);
   mHistAverageTimeC = std::make_unique<TH1F>("AverageTimeC", "Average time(TCM), side C", 4100, -2050, 2050);
-  mHistTimeSum2Diff = std::make_unique<TH2F>("timeSumVsDiff", "time A/C side: sum VS diff;(TOC-TOA)/2 [ns];(TOA+TOC)/2 [ns]", 400, -52.08, 52.08, 400, -52.08, 52.08); // range of 52.08 ns = 4000*13.02ps = 4000 channels
-  mHistChannelID = std::make_unique<TH1F>("StatChannelID", "ChannelID statistics;ChannelID", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
-  mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
-  mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
-  mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
+  mHistChannelID = std::make_unique<TH1F>("StatChannelID", "ChannelID statistics;ChannelID", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistCycleDuration = std::make_unique<TH1D>("CycleDuration", "Cycle Duration;;time [ns]", 1, 0, 2);
   mHistCycleDurationNTF = std::make_unique<TH1D>("CycleDurationNTF", "Cycle Duration;;time [TimeFrames]", 1, 0, 2);
   mHistCycleDurationRange = std::make_unique<TH1D>("CycleDurationRange", "Cycle Duration (total cycle range);;time [ns]", 1, 0, 2);
@@ -214,6 +218,8 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   rebinFromConfig(); // after all histos are created
   // 1-dim hists
+  getObjectsManager()->startPublishing(mHistCFDEff.get());
+  getObjectsManager()->startPublishing(mHistBC.get());
   getObjectsManager()->startPublishing(mHistNchA.get());
   getObjectsManager()->startPublishing(mHistNchC.get());
   getObjectsManager()->startPublishing(mHistSumAmpA.get());
@@ -221,45 +227,55 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mHistAverageTimeA.get());
   getObjectsManager()->startPublishing(mHistAverageTimeC.get());
   getObjectsManager()->startPublishing(mHistChannelID.get());
-  getObjectsManager()->startPublishing(mHistCFDEff.get());
   getObjectsManager()->startPublishing(mHistCycleDuration.get());
   getObjectsManager()->startPublishing(mHistCycleDurationNTF.get());
   getObjectsManager()->startPublishing(mHistCycleDurationRange.get());
-  getObjectsManager()->startPublishing(mHistBC.get());
   // 2-dim hists
   getObjectsManager()->startPublishing(mHistTime2Ch.get());
   getObjectsManager()->setDefaultDrawOptions(mHistTime2Ch.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistAmp2Ch.get());
   getObjectsManager()->setDefaultDrawOptions(mHistAmp2Ch.get(), "COLZ");
-  getObjectsManager()->startPublishing(mHistOrbit2BC.get());
-  getObjectsManager()->setDefaultDrawOptions(mHistOrbit2BC.get(), "COLZ");
-  getObjectsManager()->startPublishing(mHistBCvsTrg.get());
-  getObjectsManager()->setDefaultDrawOptions(mHistBCvsTrg.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistBCvsFEEmodules.get());
   getObjectsManager()->setDefaultDrawOptions(mHistBCvsFEEmodules.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistOrbitVsTrg.get());
   getObjectsManager()->setDefaultDrawOptions(mHistOrbitVsTrg.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistOrbitVsFEEmodules.get());
   getObjectsManager()->setDefaultDrawOptions(mHistOrbitVsFEEmodules.get(), "COLZ");
-  getObjectsManager()->startPublishing(mHistEventDensity2Ch.get());
-  getObjectsManager()->setDefaultDrawOptions(mHistEventDensity2Ch.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistChDataBits.get());
   getObjectsManager()->setDefaultDrawOptions(mHistChDataBits.get(), "COLZ");
-  getObjectsManager()->startPublishing(mHistTriggersCorrelation.get());
-  getObjectsManager()->setDefaultDrawOptions(mHistTriggersCorrelation.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistTimeSum2Diff.get());
   getObjectsManager()->setDefaultDrawOptions(mHistTimeSum2Diff.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistOrbit2BC.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistOrbit2BC.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistBCvsTrg.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistBCvsTrg.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistEventDensity2Ch.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistEventDensity2Ch.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistTriggersCorrelation.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistTriggersCorrelation.get(), "COLZ");
 }
 
 void DigitQcTask::startOfActivity(Activity& activity)
 {
-  ILOG(Info, Support) << "startOfActivity" << activity.mId << ENDM;
+  ILOG(Info) << "startOfActivity" << activity.mId << ENDM;
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
-  mHistOrbit2BC->Reset();
   mHistBC->Reset();
-  mHistEventDensity2Ch->Reset();
   mHistChDataBits->Reset();
+  mHistCFDEff->Reset();
+  mHistNumADC->Reset();
+  mHistNumCFD->Reset();
+  mHistTimeSum2Diff->Reset();
+  mHistBCvsFEEmodules->Reset();
+  mHistOrbitVsTrg->Reset();
+  mHistOrbitVsFEEmodules->Reset();
+  mHistTriggersCorrelation->Reset();
+  mHistCycleDuration->Reset();
+  mHistCycleDurationNTF->Reset();
+  mHistCycleDurationRange->Reset();
+  mHistBCvsTrg->Reset();
+  mHistOrbit2BC->Reset();
+  mHistEventDensity2Ch->Reset();
   mHistNchA->Reset();
   mHistNchC->Reset();
   mHistSumAmpA->Reset();
@@ -267,18 +283,6 @@ void DigitQcTask::startOfActivity(Activity& activity)
   mHistAverageTimeA->Reset();
   mHistAverageTimeC->Reset();
   mHistChannelID->Reset();
-  mHistCFDEff->Reset();
-  mHistNumADC->Reset();
-  mHistNumCFD->Reset();
-  mHistTriggersCorrelation->Reset();
-  mHistTimeSum2Diff->Reset();
-  mHistCycleDuration->Reset();
-  mHistCycleDurationNTF->Reset();
-  mHistCycleDurationRange->Reset();
-  mHistBCvsTrg->Reset();
-  mHistBCvsFEEmodules->Reset();
-  mHistOrbitVsTrg->Reset();
-  mHistOrbitVsFEEmodules->Reset();
   for (auto& entry : mMapHistAmp1D) {
     entry.second->Reset();
   }
@@ -295,7 +299,7 @@ void DigitQcTask::startOfActivity(Activity& activity)
 
 void DigitQcTask::startOfCycle()
 {
-  ILOG(Info, Support) << "startOfCycle" << ENDM;
+  ILOG(Info) << "startOfCycle" << ENDM;
   mTimeMinNS = -1;
   mTimeMaxNS = 0.;
   mTimeCurNS = 0.;
@@ -319,14 +323,18 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     mTimeSum += timeMaxNS - timeMinNS;
   }
   for (auto& digit : digits) {
+    // Exclude all BCs, in which laser signals are expected (and trigger outputs are blocked)
+    if (digit.mTriggers.getOutputsAreBlocked()) {
+      continue;
+    }
     const auto& vecChData = digit.getBunchChannelData(channels);
     bool isTCM = true;
-    if (digit.mTriggers.timeA == -5000 && digit.mTriggers.timeC == -5000) {
+    if (digit.mTriggers.timeA == o2::fit::Triggers::DEFAULT_TIME && digit.mTriggers.timeC == o2::fit::Triggers::DEFAULT_TIME) {
       isTCM = false;
     }
     mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
     mHistBC->Fill(digit.getBC());
-    if (isTCM && !digit.mTriggers.getLaserBit()) {
+    if (isTCM && digit.mTriggers.getDataIsValid() && !digit.mTriggers.getOutputsAreBlocked()) {
       if (digit.mTriggers.nChanA > 0) {
         mHistNchA->Fill(digit.mTriggers.nChanA);
         mHistSumAmpA->Fill(digit.mTriggers.amplA);
@@ -373,7 +381,7 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
       setFEEmodules.insert(mChID2PMhash[chData.ChId]);
     }
-    if (isTCM /* && (digit.getTriggers().triggersignals & (1 << o2::ft0::Triggers::bitDataIsValid))*/) {
+    if (isTCM) {
       setFEEmodules.insert(mTCMhash);
     }
     for (const auto& feeHash : setFEEmodules) {
@@ -385,22 +393,22 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void DigitQcTask::endOfCycle()
 {
-  ILOG(Info, Support) << "endOfCycle" << ENDM;
+  ILOG(Info) << "endOfCycle" << ENDM;
   // one has to set num. of entries manually because
   // default TH1Reductor gets only mean,stddev and entries (no integral)
+  mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());
   mHistCycleDurationRange->SetBinContent(1., mTimeMaxNS - mTimeMinNS);
   mHistCycleDurationRange->SetEntries(mTimeMaxNS - mTimeMinNS);
   mHistCycleDurationNTF->SetBinContent(1., mTfCounter);
   mHistCycleDurationNTF->SetEntries(mTfCounter);
   mHistCycleDuration->SetBinContent(1., mTimeSum);
   mHistCycleDuration->SetEntries(mTimeSum);
-  mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());
   ILOG(Debug) << "Cycle duration: NTF=" << mTfCounter << ", range = " << (mTimeMaxNS - mTimeMinNS) / 1e6 / mTfCounter << " ms/TF, sum = " << mTimeSum / 1e6 / mTfCounter << " ms/TF" << ENDM;
 }
 
 void DigitQcTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Support) << "endOfActivity" << ENDM;
+  ILOG(Info) << "endOfActivity" << ENDM;
 }
 
 void DigitQcTask::reset()
@@ -408,10 +416,14 @@ void DigitQcTask::reset()
   // clean all the monitor objects here
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
-  mHistOrbit2BC->Reset();
   mHistBC->Reset();
-  mHistEventDensity2Ch->Reset();
   mHistChDataBits->Reset();
+  mHistCFDEff->Reset();
+  mHistNumADC->Reset();
+  mHistNumCFD->Reset();
+  mHistTimeSum2Diff->Reset();
+  mHistOrbit2BC->Reset();
+  mHistEventDensity2Ch->Reset();
   mHistNchA->Reset();
   mHistNchC->Reset();
   mHistSumAmpA->Reset();
@@ -419,11 +431,7 @@ void DigitQcTask::reset()
   mHistAverageTimeA->Reset();
   mHistAverageTimeC->Reset();
   mHistChannelID->Reset();
-  mHistCFDEff->Reset();
-  mHistNumADC->Reset();
-  mHistNumCFD->Reset();
   mHistTriggersCorrelation->Reset();
-  mHistTimeSum2Diff->Reset();
   mHistCycleDuration->Reset();
   mHistCycleDurationNTF->Reset();
   mHistCycleDurationRange->Reset();

--- a/Modules/FT0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FT0/src/DigitQcTaskLaser.cxx
@@ -11,23 +11,18 @@
 
 ///
 /// \file   DigitQcTaskLaser.cxx
-/// \author Artur Furs afurs@cern.ch
-/// modified by Sebastin Bysiak sbysiak@cern.ch
-/// copied by Sandor Lokos sandor.lokos@cern.ch
+/// \brief  Based on the existing DigitQcTask
+/// \author Sandor Lokos sandor.lokos@cern.ch
+
+#include "FT0/DigitQcTaskLaser.h"
 
 #include "TCanvas.h"
-#include "TH1.h"
-#include "TH2.h"
 #include "TROOT.h"
 
 #include "QualityControl/QcInfoLogger.h"
-#include "FT0/DigitQcTaskLaser.h"
-#include "DataFormatsFT0/Digit.h"
-#include "DataFormatsFT0/ChannelData.h"
+#include "DataFormatsFIT/Triggers.h"
 #include "Framework/InputRecord.h"
-
-#include <DataFormatsFT0/LookUpTable.h>
-#include <vector>
+#include "DataFormatsFT0/LookUpTable.h"
 
 namespace o2::quality_control_modules::ft0
 {
@@ -78,10 +73,6 @@ void DigitQcTaskLaser::rebinFromConfig()
         std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
         rebinHisto(hNameCur, binning);
       }
-      for (const auto& chID : mSetRefPMTChIDs) {
-        std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
-        rebinHisto(hNameCur, binning);
-      }
     } else if (!gROOT->FindObject(hName.data())) {
       ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
       continue;
@@ -93,7 +84,7 @@ void DigitQcTaskLaser::rebinFromConfig()
 
 void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info, Support) << "initialize DigitQcTaskLaser" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  ILOG(Info) << "initialize DigitQcTaskLaser" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
   mStateLastIR2Ch = {};
   mMapChTrgNames.insert({ o2::ft0::ChannelData::kNumberADC, "NumberADC" });
   mMapChTrgNames.insert({ o2::ft0::ChannelData::kIsDoubleEvent, "IsDoubleEvent" });
@@ -104,221 +95,228 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
   mMapChTrgNames.insert({ o2::ft0::ChannelData::kIsEventInTVDC, "IsEventInTVDC" });
   mMapChTrgNames.insert({ o2::ft0::ChannelData::kIsTimeInfoLost, "IsTimeInfoLost" });
 
-  mMapDigitTrgNames.insert({ o2::ft0::Triggers::bitA, "OrA" });
-  mMapDigitTrgNames.insert({ o2::ft0::Triggers::bitC, "OrC" });
-  mMapDigitTrgNames.insert({ o2::ft0::Triggers::bitVertex, "Vertex" });
-  mMapDigitTrgNames.insert({ o2::ft0::Triggers::bitCen, "Central" });
-  mMapDigitTrgNames.insert({ o2::ft0::Triggers::bitSCen, "SemiCentral" });
-  mMapDigitTrgNames.insert({ 5, "Laser" });
-  mMapDigitTrgNames.insert({ 6, "OutputsAreBlocked" });
-  mMapDigitTrgNames.insert({ 7, "DataIsValid" });
-
-  mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM, 4100, -2050, 2050);
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitA, "OrA" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitC, "OrC" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitVertex, "Vertex" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitCen, "Central" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitSCen, "SemiCentral" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitLaser, "Laser" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitOutputsAreBlocked, "OutputsAreBlocked" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitDataIsValid, "DataIsValid" });
+  mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4100, -2050, 2050);
   mHistTime2Ch->SetOption("colz");
-  mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM, 4200, -100, 4100);
+  mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4200, -100, 4100);
   mHistAmp2Ch->SetOption("colz");
-  mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", 256, 0, 256, 3564, 0, 3564);
-  mHistOrbit2BC->SetOption("colz");
-  mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", 3564, 0, 3564);
-
-  mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
+  mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
+  mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
   mHistChDataBits->SetOption("colz");
-
   for (const auto& entry : mMapChTrgNames) {
     mHistChDataBits->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
   }
+  mHistOrbitVsTrg = std::make_unique<TH2F>("OrbitVsTriggers", "Orbit vs Triggers;Orbit;Trg", sOrbitsPerTF, 0, sOrbitsPerTF, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistOrbitVsTrg->SetOption("colz");
 
+  for (const auto& entry : mMapDigitTrgNames) {
+    mHistOrbitVsTrg->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
+  }
   mListHistGarbage = new TList();
   mListHistGarbage->SetOwner(kTRUE);
 
-  char* p;
-  for (const auto& lutEntry : o2::ft0::SingleLUT::Instance().getVecMetadataFEE()) {
-    int chId = std::strtol(lutEntry.mChannelID.c_str(), &p, 10);
-    if (*p) {
-      // lutEntry.mChannelID is not a number
-      continue;
+  std::map<std::string, uint8_t> mapFEE2hash;
+  const auto& lut = o2::ft0::SingleLUT::Instance().getVecMetadataFEE();
+  auto lutSorted = lut;
+  std::sort(lutSorted.begin(), lutSorted.end(), [](const auto& first, const auto& second) { return first.mModuleName < second.mModuleName; });
+  uint8_t binPos{ 0 };
+  for (const auto& lutEntry : lutSorted) {
+    const auto& moduleName = lutEntry.mModuleName;
+    const auto& moduleType = lutEntry.mModuleType;
+    const auto& strChID = lutEntry.mChannelID;
+    const auto& pairIt = mapFEE2hash.insert({ moduleName, binPos });
+    if (pairIt.second) {
+      binPos++;
     }
-    auto moduleName = lutEntry.mModuleName;
-    if (moduleName == "TCM") {
-      if (mMapPmModuleChannels.find(moduleName) == mMapPmModuleChannels.end()) {
-        mMapPmModuleChannels.insert({ moduleName, std::vector<int>{} });
+    if (std::regex_match(strChID, std::regex("[[\\d]{1,3}"))) {
+      int chID = std::stoi(strChID);
+      if (chID < sNCHANNELS_PM) {
+        mChID2PMhash[chID] = mapFEE2hash[moduleName];
+      } else {
+        LOG(error) << "Incorrect LUT entry: chID " << strChID << " | " << moduleName;
       }
-      continue;
-    }
-    if (mMapPmModuleChannels.find(moduleName) != mMapPmModuleChannels.end()) {
-      mMapPmModuleChannels[moduleName].push_back(chId);
-    } else {
-      std::vector<int> vChId = {
-        chId,
-      };
-      mMapPmModuleChannels.insert({ moduleName, vChId });
+    } else if (moduleType != "TCM") {
+      LOG(error) << "Non-TCM module w/o numerical chID: chID " << strChID << " | " << moduleName;
+    } else if (moduleType == "TCM") {
+      mTCMhash = mapFEE2hash[moduleName];
     }
   }
-
-  for (const auto& entry : mMapPmModuleChannels) {
-    auto pairModuleBcOrbit = mMapPmModuleBcOrbit.insert({ entry.first, new TH2F(Form("BcOrbitMap_%s", entry.first.c_str()), Form("BC-orbit map for %s;Orbit;BC", entry.first.c_str()), 256, 0, 256, 3564, 0, 3564) });
+  mHistBCvsFEEmodules = std::make_unique<TH2F>("BCvsFEEmodules", "BC vs FEE module;BC;FEE", sBCperOrbit, 0, sBCperOrbit, mapFEE2hash.size(), 0, mapFEE2hash.size());
+  mHistOrbitVsFEEmodules = std::make_unique<TH2F>("OrbitVsFEEmodules", "Orbit vs FEE module;Orbit;FEE", sOrbitsPerTF, 0, sOrbitsPerTF, mapFEE2hash.size(), 0, mapFEE2hash.size());
+  for (const auto& entry : mapFEE2hash) {
+    mHistBCvsFEEmodules->GetYaxis()->SetBinLabel(entry.second + 1, entry.first.c_str());
+    mHistOrbitVsFEEmodules->GetYaxis()->SetBinLabel(entry.second + 1, entry.first.c_str());
   }
 
-  mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
-  mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
-  mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", o2::ft0::Constants::sNCHANNELS_PM, 0, o2::ft0::Constants::sNCHANNELS_PM);
-  mHistCycleDuration = std::make_unique<TH1D>("CycleDuration", "Cycle Duration;;time [ns]", 1, 0, 2);
+  mHistTimeSum2Diff = std::make_unique<TH2F>("timeSumVsDiff", "time A/C side: sum VS diff;(TOC-TOA)/2 [ns];(TOA+TOC)/2 [ns]", 400, -52.08, 52.08, 400, -52.08, 52.08); // range of 52.08 ns = 4000*13.02ps = 4000 channels
+  mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", sNCHANNELS_PM, 0, sNCHANNELS_PM);
 
   std::vector<unsigned int> vecChannelIDs;
-  std::vector<unsigned int> vecRefPMTChannelIDs;
   if (auto param = mCustomParameters.find("ChannelIDs"); param != mCustomParameters.end()) {
     const auto chIDs = param->second;
     const std::string del = ",";
     vecChannelIDs = parseParameters<unsigned int>(chIDs, del);
-  } else {
-    for (unsigned int iCh = 0; iCh < o2::ft0::Constants::sNCHANNELS_PM; iCh++)
-      vecChannelIDs.push_back(iCh);
-  }
-  if (auto param = mCustomParameters.find("RefPMTChannelIDs"); param != mCustomParameters.end()) {
-    const auto chIDs = param->second;
-    const std::string del = ",";
-    vecRefPMTChannelIDs = parseParameters<unsigned int>(chIDs, del);
   }
   for (const auto& entry : vecChannelIDs) {
     mSetAllowedChIDs.insert(entry);
   }
-  for (const auto& entry : vecRefPMTChannelIDs) {
-    mSetRefPMTChIDs.insert(entry);
-  }
 
-  for (const auto& RefPMTChID : mSetRefPMTChIDs) {
-    auto pairHistAmpVsBC = mMapHistAmpVsBC.insert({ RefPMTChID, new TH2F(Form("Amp_vs_BC_channel%i", RefPMTChID), Form("Amplitude vs BC, channel %i;Amp;BC", RefPMTChID), 1000, 0, 1000, 1000, 0, 1000) });
-    if (pairHistAmpVsBC.second) {
-      mListHistGarbage->Add(pairHistAmpVsBC.first->second);
-      getObjectsManager()->startPublishing(pairHistAmpVsBC.first->second);
+  for (const auto& chID : mSetAllowedChIDs) {
+    auto pairHistAmp = mMapHistAmp1D.insert({ chID, new TH1F(Form("Amp_channel%i", chID), Form("Amplitude, channel %i", chID), 4200, -100, 4100) });
+    auto pairHistTime = mMapHistTime1D.insert({ chID, new TH1F(Form("Time_channel%i", chID), Form("Time, channel %i", chID), 4100, -2050, 2050) });
+    auto pairHistBits = mMapHistPMbits.insert({ chID, new TH1F(Form("Bits_channel%i", chID), Form("Bits, channel %i", chID), mMapChTrgNames.size(), 0, mMapChTrgNames.size()) });
+    auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
+    for (const auto& entry : mMapChTrgNames) {
+      pairHistBits.first->second->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
+    }
+    if (pairHistAmp.second) {
+      getObjectsManager()->startPublishing(pairHistAmp.first->second);
+      mListHistGarbage->Add(pairHistAmp.first->second);
+    }
+    if (pairHistTime.second) {
+      mListHistGarbage->Add(pairHistTime.first->second);
+      getObjectsManager()->startPublishing(pairHistTime.first->second);
+    }
+    if (pairHistBits.second) {
+      mListHistGarbage->Add(pairHistBits.first->second);
+      getObjectsManager()->startPublishing(pairHistBits.first->second);
+    }
+    if (pairHistAmpVsTime.second) {
+      mListHistGarbage->Add(pairHistAmpVsTime.first->second);
+      getObjectsManager()->startPublishing(pairHistAmpVsTime.first->second);
     }
   }
 
   rebinFromConfig(); // after all histos are created
-
-  getObjectsManager()->startPublishing(mHistTime2Ch.get());
-  getObjectsManager()->startPublishing(mHistAmp2Ch.get());
-  getObjectsManager()->startPublishing(mHistOrbit2BC.get());
-  getObjectsManager()->startPublishing(mHistBC.get());
+  // 1-dim hists
   getObjectsManager()->startPublishing(mHistCFDEff.get());
-  getObjectsManager()->startPublishing(mHistCycleDuration.get());
+  getObjectsManager()->startPublishing(mHistBC.get());
+  // 2-dim hists
+  getObjectsManager()->startPublishing(mHistTime2Ch.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistTime2Ch.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistAmp2Ch.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistAmp2Ch.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistBCvsFEEmodules.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistBCvsFEEmodules.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistOrbitVsTrg.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistOrbitVsTrg.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistOrbitVsFEEmodules.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistOrbitVsFEEmodules.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistChDataBits.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistChDataBits.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistTimeSum2Diff.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistTimeSum2Diff.get(), "COLZ");
 }
 
 void DigitQcTaskLaser::startOfActivity(Activity& activity)
 {
-  ILOG(Info, Support) << "startOfActivity" << activity.mId << ENDM;
+  ILOG(Info) << "startOfActivity" << activity.mId << ENDM;
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
-  mHistOrbit2BC->Reset();
   mHistBC->Reset();
+  mHistChDataBits->Reset();
   mHistCFDEff->Reset();
   mHistNumADC->Reset();
   mHistNumCFD->Reset();
-  mHistCycleDuration->Reset();
-  for (auto& entry : mMapHistAmpVsBC) {
+  mHistTimeSum2Diff->Reset();
+  mHistBCvsFEEmodules->Reset();
+  mHistOrbitVsTrg->Reset();
+  mHistOrbitVsFEEmodules->Reset();
+  for (auto& entry : mMapHistAmp1D) {
     entry.second->Reset();
   }
-  for (auto& entry : mMapPmModuleBcOrbit) {
+  for (auto& entry : mMapHistTime1D) {
+    entry.second->Reset();
+  }
+  for (auto& entry : mMapHistPMbits) {
+    entry.second->Reset();
+  }
+  for (auto& entry : mMapHistAmpVsTime) {
     entry.second->Reset();
   }
 }
 
 void DigitQcTaskLaser::startOfCycle()
 {
-  ILOG(Info, Support) << "startOfCycle" << ENDM;
-  mTimeMinNS = -1;
-  mTimeMaxNS = 0.;
-  mTimeCurNS = 0.;
-  mTfCounter = 0;
-  mTimeSum = 0.;
+  ILOG(Info) << "startOfCycle" << ENDM;
 }
 
 void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  double curTfTimeMin = -1;
-  double curTfTimeMax = 0;
-  mTfCounter++;
   auto channels = ctx.inputs().get<gsl::span<o2::ft0::ChannelData>>("channels");
   auto digits = ctx.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
-  bool isFirst = true;
-  uint32_t firstOrbit;
-
   for (auto& digit : digits) {
+    // Exclude all BCs, in which laser signals are NOT expected (and trigger outputs are NOT blocked)
+    if (!digit.mTriggers.getOutputsAreBlocked()) {
+      continue;
+    }
     const auto& vecChData = digit.getBunchChannelData(channels);
     bool isTCM = true;
-    mTimeCurNS = o2::InteractionRecord::bc2ns(digit.getBC(), digit.getOrbit());
-    if (mTimeMinNS < 0)
-      mTimeMinNS = mTimeCurNS;
-    if (isFirst == true) {
-      firstOrbit = digit.getOrbit();
-      isFirst = false;
-    }
-    if (mTimeCurNS < mTimeMinNS)
-      mTimeMinNS = mTimeCurNS;
-    if (mTimeCurNS > mTimeMaxNS)
-      mTimeMaxNS = mTimeCurNS;
-
-    if (curTfTimeMin < 0)
-      curTfTimeMin = mTimeCurNS;
-    if (mTimeCurNS < curTfTimeMin)
-      curTfTimeMin = mTimeCurNS;
-    if (mTimeCurNS > curTfTimeMax)
-      curTfTimeMax = mTimeCurNS;
-
-    if (digit.mTriggers.amplA == digit.mTriggers.DEFAULT_AMP && digit.mTriggers.amplC == digit.mTriggers.DEFAULT_AMP && digit.mTriggers.timeA == digit.mTriggers.DEFAULT_TIME && digit.mTriggers.timeC == digit.mTriggers.DEFAULT_TIME)
+    if (digit.mTriggers.timeA == o2::fit::Triggers::DEFAULT_TIME && digit.mTriggers.timeC == o2::fit::Triggers::DEFAULT_TIME) {
       isTCM = false;
-
-    mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
+    }
     mHistBC->Fill(digit.getBC());
-
-    for (auto& entry : mMapPmModuleChannels) {
-      for (const auto& chData : vecChData) {
-        if (std::find(entry.second.begin(), entry.second.end(), chData.ChId) != entry.second.end()) {
-          mMapPmModuleBcOrbit[entry.first]->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
-          break;
-        }
-      }
-      if (entry.first == "TCM" && isTCM && (digit.getTriggers().triggersignals & (1 << sDataIsValidBitPos))) {
-        mMapPmModuleBcOrbit[entry.first]->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
+    if (isTCM && digit.mTriggers.getDataIsValid() && digit.mTriggers.getOutputsAreBlocked()) {
+      mHistTimeSum2Diff->Fill((digit.mTriggers.timeC - digit.mTriggers.timeA) * sCFDChannel2NS / 2, (digit.mTriggers.timeC + digit.mTriggers.timeA) * sCFDChannel2NS / 2);
+      for (const auto& binPos : mHashedBitBinPos[digit.mTriggers.triggersignals]) {
+        mHistOrbitVsTrg->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, binPos);
       }
     }
-
+    std::set<uint8_t> setFEEmodules{};
     for (const auto& chData : vecChData) {
       mHistTime2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(chData.CFDTime));
       mHistAmp2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(chData.QTCAmpl));
       mStateLastIR2Ch[chData.ChId] = digit.mIntRecord;
-
-      if (chData.QTCAmpl > 0)
+      if (chData.QTCAmpl > 0) {
         mHistNumADC->Fill(chData.ChId);
-      mHistNumCFD->Fill(chData.ChId);
-
-      if (mSetRefPMTChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetRefPMTChIDs.end()) {
-        mMapHistAmpVsBC[chData.ChId]->Fill(chData.QTCAmpl, digit.getIntRecord().bc);
       }
-
-      for (const auto& entry : mMapChTrgNames) {
-        if ((chData.ChainQTC & (1 << entry.first))) {
-          mHistChDataBits->Fill(chData.ChId, entry.first);
+      mHistNumCFD->Fill(chData.ChId);
+      if (mSetAllowedChIDs.size() != 0 && mSetAllowedChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDs.end()) {
+        mMapHistAmp1D[chData.ChId]->Fill(chData.QTCAmpl);
+        mMapHistTime1D[chData.ChId]->Fill(chData.CFDTime);
+        mMapHistAmpVsTime[chData.ChId]->Fill(chData.QTCAmpl, chData.CFDTime);
+        for (const auto& entry : mMapChTrgNames) {
+          if ((chData.ChainQTC & (1 << entry.first))) {
+            mMapHistPMbits[chData.ChId]->Fill(entry.first);
+          }
         }
       }
+      for (const auto& binPos : mHashedBitBinPos[chData.ChainQTC]) {
+        mHistChDataBits->Fill(chData.ChId, binPos);
+      }
+
+      setFEEmodules.insert(mChID2PMhash[chData.ChId]);
     }
-    mHistCFDEff->Reset();
-    mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());
+    if (isTCM) {
+      setFEEmodules.insert(mTCMhash);
+    }
+    for (const auto& feeHash : setFEEmodules) {
+      mHistBCvsFEEmodules->Fill(static_cast<double>(digit.getIntRecord().bc), static_cast<double>(feeHash));
+      mHistOrbitVsFEEmodules->Fill(static_cast<double>(digit.getIntRecord().orbit % sOrbitsPerTF), static_cast<double>(feeHash));
+    }
   }
-  mTimeSum += curTfTimeMax - curTfTimeMin;
 }
 
 void DigitQcTaskLaser::endOfCycle()
 {
-  ILOG(Info, Support) << "endOfCycle" << ENDM;
-  mHistCycleDuration->SetBinContent(1., mTimeSum);
-  mHistCycleDuration->SetEntries(mTimeSum);
-  ILOG(Debug) << "Cycle duration: NTF=" << mTfCounter << ", range = " << (mTimeMaxNS - mTimeMinNS) / 1e6 / mTfCounter << " ms/TF, sum = " << mTimeSum / 1e6 / mTfCounter << " ms/TF" << ENDM;
+  ILOG(Info) << "endOfCycle" << ENDM;
+  // one has to set num. of entries manually because
+  // default TH1Reductor gets only mean,stddev and entries (no integral)
+  mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());
 }
 
 void DigitQcTaskLaser::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Support) << "endOfActivity" << ENDM;
+  ILOG(Info) << "endOfActivity" << ENDM;
 }
 
 void DigitQcTaskLaser::reset()
@@ -326,17 +324,26 @@ void DigitQcTaskLaser::reset()
   // clean all the monitor objects here
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
-  mHistOrbit2BC->Reset();
   mHistBC->Reset();
   mHistChDataBits->Reset();
   mHistCFDEff->Reset();
   mHistNumADC->Reset();
   mHistNumCFD->Reset();
-  mHistCycleDuration->Reset();
-  for (auto& entry : mMapHistAmpVsBC) {
+  mHistTimeSum2Diff->Reset();
+  mHistBCvsFEEmodules->Reset();
+  mHistOrbitVsTrg->Reset();
+  mHistOrbitVsFEEmodules->Reset();
+
+  for (auto& entry : mMapHistAmp1D) {
     entry.second->Reset();
   }
-  for (auto& entry : mMapPmModuleBcOrbit) {
+  for (auto& entry : mMapHistTime1D) {
+    entry.second->Reset();
+  }
+  for (auto& entry : mMapHistPMbits) {
+    entry.second->Reset();
+  }
+  for (auto& entry : mMapHistAmpVsTime) {
     entry.second->Reset();
   }
 }

--- a/Modules/FV0/include/FV0/DigitQcTask.h
+++ b/Modules/FV0/include/FV0/DigitQcTask.h
@@ -12,7 +12,7 @@
 ///
 /// \file   DigitQcTask.h
 /// \author Artur Furs afurs@cern.ch
-///
+/// \brief Quality Control DPL Task for FV0's digit visualization
 
 #ifndef QC_MODULE_FV0_FV0DIGITQCTASK_H
 #define QC_MODULE_FV0_FV0DIGITQCTASK_H
@@ -42,8 +42,6 @@ using namespace o2::quality_control::core;
 
 namespace o2::quality_control_modules::fv0
 {
-/// \brief Quality Control DPL Task for FV0's digit visualization
-/// \author Artur Furs afurs@cern.ch
 class DigitQcTask final : public TaskInterface
 {
  public:

--- a/Modules/FV0/include/FV0/DigitQcTaskLaser.h
+++ b/Modules/FV0/include/FV0/DigitQcTaskLaser.h
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -11,44 +11,44 @@
 
 ///
 /// \file   DigitQcTaskLaser.h
-/// \author Artur Furs afurs@cern.ch, developed further for laser QC by Sandor
-/// Lokos (sandor.lokos@cern.ch)
-///
+/// \author Artur Furs afurs@cern.ch, developed further for laser QC by Sandor Lokos (sandor.lokos@cern.ch)
+/// \brief Quality Control DPL Task for FT0's digit visualization for laser events only
 
 #ifndef QC_MODULE_FV0_FV0DIGITQCTASKLASER_H
 #define QC_MODULE_FV0_FV0DIGITQCTASKLASER_H
 
-#include <Framework/InputRecord.h>
-#include "QualityControl/QcInfoLogger.h"
-//#include "FT0Base/Constants.h"
-#include "DataFormatsFV0/Digit.h"
-#include "DataFormatsFV0/ChannelData.h"
-#include "QualityControl/TaskInterface.h"
 #include <memory>
 #include <regex>
 #include <type_traits>
+#include <set>
+#include <map>
+#include <vector>
+#include <array>
 #include <boost/algorithm/string.hpp>
+
 #include "TH1.h"
 #include "TH2.h"
 #include "TList.h"
 #include "Rtypes.h"
 
+#include "QualityControl/TaskInterface.h"
+#include "QualityControl/QcInfoLogger.h"
+
+#include "FV0Base/Constants.h"
+#include "DataFormatsFV0/Digit.h"
+#include "DataFormatsFV0/ChannelData.h"
+
 using namespace o2::quality_control::core;
 
 namespace o2::quality_control_modules::fv0
 {
-using ChannelData = o2::fv0::ChannelData;
-using Digit = o2::fv0::Digit;
-/// \brief Quality Control DPL Task for FV0's digit visualization
-/// \author Artur Furs afurs@cern.ch
 class DigitQcTaskLaser final : public TaskInterface
 {
  public:
   /// \brief Constructor
-  DigitQcTaskLaser() = default;
+  DigitQcTaskLaser() : mHashedBitBinPos(fillHashedBitBinPos()) {}
   /// Destructor
   ~DigitQcTaskLaser() override;
-
   // Definition of the methods for the template method pattern
   void initialize(o2::framework::InitContext& ctx) override;
   void startOfActivity(Activity& activity) override;
@@ -57,27 +57,17 @@ class DigitQcTaskLaser final : public TaskInterface
   void endOfCycle() override;
   void endOfActivity(Activity& activity) override;
   void reset() override;
-  constexpr static std::size_t sNCHANNELS_PM = 60; // 48(for PM) + 12(just in case for possible PM-LCS)
+  constexpr static std::size_t sNCHANNELS_PM = o2::fv0::Constants::nPms * o2::fv0::Constants::nChannelsPerPm;
   constexpr static std::size_t sOrbitsPerTF = 256;
-  constexpr static uint8_t sLaserBitPos = 5;
-  constexpr static uint8_t sDataIsValidBitPos = 7;
+  constexpr static std::size_t sBCperOrbit = 3564;
+
+  constexpr static float sCFDChannel2NS = 0.01302; // CFD channel width in ns
 
  private:
-  // three ways of computing cycle duration:
-  // 1) number of time frames
-  // 2) time in ns from InteractionRecord: total range (totalMax - totalMin)
-  // 3) time in ns from InteractionRecord: sum of each TF duration
-  // later on choose the best and remove others
-  double mTimeMinNS = 0.;
-  double mTimeMaxNS = 0.;
-  double mTimeCurNS = 0.;
-  int mTfCounter = 0;
-  double mTimeSum = 0.;
-  const float mCFDChannel2NS = 0.01302; // CFD channel width in ns
-
   template <typename Param_t,
             typename = typename std::enable_if<std::is_floating_point<Param_t>::value ||
-                                               std::is_same<std::string, Param_t>::value || (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>
+                                               std::is_same<std::string, Param_t>::value ||
+                                               (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>
   auto parseParameters(const std::string& param, const std::string& del)
   {
     std::regex reg(del);
@@ -100,47 +90,44 @@ class DigitQcTaskLaser final : public TaskInterface
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
   std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
+  std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
+  uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist
   std::map<int, std::string> mMapDigitTrgNames;
-  std::map<int, std::string> mMapChTrgNames;
-  std::map<std::string, std::vector<int>> mMapPmModuleChannels; // PM name to its channels
+  std::map<o2::fv0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
   std::unique_ptr<TH1F> mHistNumADC;
   std::unique_ptr<TH1F> mHistNumCFD;
 
-  // temp
-  enum ETrgMenu { kMinBias,
-                  kOuterRing,
-                  kNChannels,
-                  kCharge,
-                  kInnerRing
-  };
-
-  // Object which will be published
+  // Objects which will be published
   std::unique_ptr<TH2F> mHistAmp2Ch;
   std::unique_ptr<TH2F> mHistTime2Ch;
-  std::unique_ptr<TH2F> mHistEventDensity2Ch;
   std::unique_ptr<TH2F> mHistChDataBits;
-  std::unique_ptr<TH2F> mHistOrbit2BC;
   std::unique_ptr<TH1F> mHistBC;
-  std::unique_ptr<TH1F> mHistTriggers;
-  std::unique_ptr<TH1F> mHistNchA;
-  std::unique_ptr<TH1F> mHistNchC;
-  std::unique_ptr<TH1F> mHistSumAmpA;
-  std::unique_ptr<TH1F> mHistSumAmpC;
-  std::unique_ptr<TH1F> mHistAverageTimeA;
-  std::unique_ptr<TH1F> mHistAverageTimeC;
-  std::unique_ptr<TH1F> mHistChannelID;
   std::unique_ptr<TH1F> mHistCFDEff;
   //  std::unique_ptr<TH2F> mHistTimeSum2Diff;
-  std::unique_ptr<TH2F> mHistTriggersCorrelation;
-  std::unique_ptr<TH1D> mHistCycleDuration;
-  std::unique_ptr<TH1D> mHistCycleDurationNTF;
-  std::unique_ptr<TH1D> mHistCycleDurationRange;
   std::map<unsigned int, TH1F*> mMapHistAmp1D;
   std::map<unsigned int, TH1F*> mMapHistTime1D;
   std::map<unsigned int, TH1F*> mMapHistPMbits;
   std::map<unsigned int, TH2F*> mMapHistAmpVsTime;
-  std::map<unsigned int, TH2F*> mMapTrgBcOrbit;
-  std::map<std::string, TH2F*> mMapPmModuleBcOrbit;
+  std::unique_ptr<TH2F> mHistBCvsFEEmodules;
+  std::unique_ptr<TH2F> mHistOrbitVsTrg;
+  std::unique_ptr<TH2F> mHistOrbitVsFEEmodules;
+
+  // Hashed maps
+  static const size_t mapSize = 256;
+  const std::array<std::vector<double>, mapSize> mHashedBitBinPos; // map with bit position for 1 byte trg signal, for 1 Dim hists;
+  static std::array<std::vector<double>, mapSize> fillHashedBitBinPos()
+  {
+    std::array<std::vector<double>, mapSize> hashedBitBinPos{};
+    for (int iByteValue = 0; iByteValue < hashedBitBinPos.size(); iByteValue++) {
+      auto& vec = hashedBitBinPos[iByteValue];
+      for (int iBit = 0; iBit < 8; iBit++) {
+        if (iByteValue & (1 << iBit)) {
+          vec.push_back(iBit);
+        }
+      }
+    }
+    return hashedBitBinPos;
+  }
 };
 
 } // namespace o2::quality_control_modules::fv0

--- a/Modules/FV0/src/DigitQcTask.cxx
+++ b/Modules/FV0/src/DigitQcTask.cxx
@@ -84,7 +84,7 @@ void DigitQcTask::rebinFromConfig()
 
 void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info, Support) << "initialize DigitQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  ILOG(Info) << "initialize DigitQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
   mStateLastIR2Ch = {};
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kNumberADC, "NumberADC" });
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kIsDoubleEvent, "IsDoubleEvent" });
@@ -104,29 +104,33 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mMapDigitTrgNames.insert({ o2::fit::Triggers::bitOutputsAreBlocked, "OutputsAreBlocked" });
   mMapDigitTrgNames.insert({ o2::fit::Triggers::bitDataIsValid, "DataIsValid" });
   mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4100, -2050, 2050);
+  mHistTime2Ch->SetOption("colz");
   mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4200, -100, 4100);
-  mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", sOrbitsPerTF, 0, sOrbitsPerTF, sBCperOrbit, 0, sBCperOrbit);
+  mHistAmp2Ch->SetOption("colz");
   mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
-
-  mHistEventDensity2Ch = std::make_unique<TH2F>("EventDensityPerChannel", "Event density(in BC) per Channel;Channel;BC;", sNCHANNELS_PM, 0, sNCHANNELS_PM, 10000, 0, 1e5);
-
   mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
+  mHistChDataBits->SetOption("colz");
   for (const auto& entry : mMapChTrgNames) {
     mHistChDataBits->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
   }
-  mHistTriggersCorrelation = std::make_unique<TH2F>("TriggersCorrelation", "Correlation of triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size(), mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-
-  mHistBCvsTrg = std::make_unique<TH2F>("BCvsTriggers", "BC vs Triggers;BC;Trg", sBCperOrbit, 0, sBCperOrbit, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
   mHistOrbitVsTrg = std::make_unique<TH2F>("OrbitVsTriggers", "Orbit vs Triggers;Orbit;Trg", sOrbitsPerTF, 0, sOrbitsPerTF, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-
-  mListHistGarbage = new TList();
-  mListHistGarbage->SetOwner(kTRUE);
+  mHistOrbitVsTrg->SetOption("colz");
+  mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", sOrbitsPerTF, 0, sOrbitsPerTF, sBCperOrbit, 0, sBCperOrbit);
+  mHistOrbit2BC->SetOption("colz");
+  mHistEventDensity2Ch = std::make_unique<TH2F>("EventDensityPerChannel", "Event density(in BC) per Channel;Channel;BC;", sNCHANNELS_PM, 0, sNCHANNELS_PM, 10000, 0, 1e5);
+  mHistEventDensity2Ch->SetOption("colz");
+  mHistTriggersCorrelation = std::make_unique<TH2F>("TriggersCorrelation", "Correlation of triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size(), mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistTriggersCorrelation->SetOption("colz");
+  mHistBCvsTrg = std::make_unique<TH2F>("BCvsTriggers", "BC vs Triggers;BC;Trg", sBCperOrbit, 0, sBCperOrbit, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistBCvsTrg->SetOption("colz");
   for (const auto& entry : mMapDigitTrgNames) {
+    mHistOrbitVsTrg->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     mHistTriggersCorrelation->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     mHistTriggersCorrelation->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     mHistBCvsTrg->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
-    mHistOrbitVsTrg->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
   }
+  mListHistGarbage = new TList();
+  mListHistGarbage->SetOwner(kTRUE);
 
   std::map<std::string, uint8_t> mapFEE2hash;
   const auto& lut = o2::fv0::SingleLUT::Instance().getVecMetadataFEE();
@@ -161,17 +165,17 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
     mHistOrbitVsFEEmodules->GetYaxis()->SetBinLabel(entry.second + 1, entry.first.c_str());
   }
 
-  mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  // mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistSumAmpA = std::make_unique<TH1F>("SumAmpA", "Sum of amplitudes(TCM), side A;", 1000, 0, 1e4);
-  // mHistSumAmpC = std::make_unique<TH1F>("SumAmpC", "Sum of amplitudes(TCM), side C;", 1000, 0, 1e4);
-  mHistAverageTimeA = std::make_unique<TH1F>("AverageTimeA", "Average time(TCM), side A", 4100, -2050, 2050);
-  // mHistAverageTimeC = std::make_unique<TH1F>("AverageTimeC", "Average time(TCM), side C", 4100, -2050, 2050);
   // mHistTimeSum2Diff = std::make_unique<TH2F>("timeSumVsDiff", "time A/C side: sum VS diff;(TOC-TOA)/2 [ns];(TOA+TOC)/2 [ns]", 400, -52.08, 52.08, 400, -52.08, 52.08); // range of 52.08 ns = 4000*13.02ps = 4000 channels
-  mHistChannelID = std::make_unique<TH1F>("StatChannelID", "ChannelID statistics;ChannelID", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  // mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistSumAmpA = std::make_unique<TH1F>("SumAmpA", "Sum of amplitudes(TCM), side A;", 1e4, 0, 1e4);
+  // mHistSumAmpC = std::make_unique<TH1F>("SumAmpC", "Sum of amplitudes(TCM), side C;", 1e4, 0, 1e4);
+  mHistAverageTimeA = std::make_unique<TH1F>("AverageTimeA", "Average time(TCM), side A", 4100, -2050, 2050);
+  // mHistAverageTimeC = std::make_unique<TH1F>("AverageTimeC", "Average time(TCM), side C", 4100, -2050, 2050);
+  mHistChannelID = std::make_unique<TH1F>("StatChannelID", "ChannelID statistics;ChannelID", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistCycleDuration = std::make_unique<TH1D>("CycleDuration", "Cycle Duration;;time [ns]", 1, 0, 2);
   mHistCycleDurationNTF = std::make_unique<TH1D>("CycleDurationNTF", "Cycle Duration;;time [TimeFrames]", 1, 0, 2);
   mHistCycleDurationRange = std::make_unique<TH1D>("CycleDurationRange", "Cycle Duration (total cycle range);;time [ns]", 1, 0, 2);
@@ -214,6 +218,8 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   rebinFromConfig(); // after all histos are created
   // 1-dim hists
+  getObjectsManager()->startPublishing(mHistCFDEff.get());
+  getObjectsManager()->startPublishing(mHistBC.get());
   getObjectsManager()->startPublishing(mHistNchA.get());
   // getObjectsManager()->startPublishing(mHistNchC.get());
   getObjectsManager()->startPublishing(mHistSumAmpA.get());
@@ -221,45 +227,55 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mHistAverageTimeA.get());
   // getObjectsManager()->startPublishing(mHistAverageTimeC.get());
   getObjectsManager()->startPublishing(mHistChannelID.get());
-  getObjectsManager()->startPublishing(mHistCFDEff.get());
   getObjectsManager()->startPublishing(mHistCycleDuration.get());
   getObjectsManager()->startPublishing(mHistCycleDurationNTF.get());
   getObjectsManager()->startPublishing(mHistCycleDurationRange.get());
-  getObjectsManager()->startPublishing(mHistBC.get());
   // 2-dim hists
   getObjectsManager()->startPublishing(mHistTime2Ch.get());
   getObjectsManager()->setDefaultDrawOptions(mHistTime2Ch.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistAmp2Ch.get());
   getObjectsManager()->setDefaultDrawOptions(mHistAmp2Ch.get(), "COLZ");
-  getObjectsManager()->startPublishing(mHistOrbit2BC.get());
-  getObjectsManager()->setDefaultDrawOptions(mHistOrbit2BC.get(), "COLZ");
-  getObjectsManager()->startPublishing(mHistBCvsTrg.get());
-  getObjectsManager()->setDefaultDrawOptions(mHistBCvsTrg.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistBCvsFEEmodules.get());
   getObjectsManager()->setDefaultDrawOptions(mHistBCvsFEEmodules.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistOrbitVsTrg.get());
   getObjectsManager()->setDefaultDrawOptions(mHistOrbitVsTrg.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistOrbitVsFEEmodules.get());
   getObjectsManager()->setDefaultDrawOptions(mHistOrbitVsFEEmodules.get(), "COLZ");
-  getObjectsManager()->startPublishing(mHistEventDensity2Ch.get());
-  getObjectsManager()->setDefaultDrawOptions(mHistEventDensity2Ch.get(), "COLZ");
   getObjectsManager()->startPublishing(mHistChDataBits.get());
   getObjectsManager()->setDefaultDrawOptions(mHistChDataBits.get(), "COLZ");
-  getObjectsManager()->startPublishing(mHistTriggersCorrelation.get());
-  getObjectsManager()->setDefaultDrawOptions(mHistTriggersCorrelation.get(), "COLZ");
   // getObjectsManager()->startPublishing(mHistTimeSum2Diff.get());
   // getObjectsManager()->setDefaultDrawOptions(mHistTimeSum2Diff.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistOrbit2BC.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistOrbit2BC.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistBCvsTrg.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistBCvsTrg.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistEventDensity2Ch.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistEventDensity2Ch.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistTriggersCorrelation.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistTriggersCorrelation.get(), "COLZ");
 }
 
 void DigitQcTask::startOfActivity(Activity& activity)
 {
-  ILOG(Info, Support) << "startOfActivity" << activity.mId << ENDM;
+  ILOG(Info) << "startOfActivity" << activity.mId << ENDM;
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
-  mHistOrbit2BC->Reset();
   mHistBC->Reset();
-  mHistEventDensity2Ch->Reset();
   mHistChDataBits->Reset();
+  mHistCFDEff->Reset();
+  mHistNumADC->Reset();
+  mHistNumCFD->Reset();
+  // mHistTimeSum2Diff->Reset();
+  mHistBCvsFEEmodules->Reset();
+  mHistOrbitVsTrg->Reset();
+  mHistOrbitVsFEEmodules->Reset();
+  mHistTriggersCorrelation->Reset();
+  mHistCycleDuration->Reset();
+  mHistCycleDurationNTF->Reset();
+  mHistCycleDurationRange->Reset();
+  mHistBCvsTrg->Reset();
+  mHistOrbit2BC->Reset();
+  mHistEventDensity2Ch->Reset();
   mHistNchA->Reset();
   // mHistNchC->Reset();
   mHistSumAmpA->Reset();
@@ -267,18 +283,6 @@ void DigitQcTask::startOfActivity(Activity& activity)
   mHistAverageTimeA->Reset();
   // mHistAverageTimeC->Reset();
   mHistChannelID->Reset();
-  mHistCFDEff->Reset();
-  mHistNumADC->Reset();
-  mHistNumCFD->Reset();
-  mHistTriggersCorrelation->Reset();
-  // mHistTimeSum2Diff->Reset();
-  mHistCycleDuration->Reset();
-  mHistCycleDurationNTF->Reset();
-  mHistCycleDurationRange->Reset();
-  mHistBCvsTrg->Reset();
-  mHistBCvsFEEmodules->Reset();
-  mHistOrbitVsTrg->Reset();
-  mHistOrbitVsFEEmodules->Reset();
   for (auto& entry : mMapHistAmp1D) {
     entry.second->Reset();
   }
@@ -295,7 +299,7 @@ void DigitQcTask::startOfActivity(Activity& activity)
 
 void DigitQcTask::startOfCycle()
 {
-  ILOG(Info, Support) << "startOfCycle" << ENDM;
+  ILOG(Info) << "startOfCycle" << ENDM;
   mTimeMinNS = -1;
   mTimeMaxNS = 0.;
   mTimeCurNS = 0.;
@@ -319,6 +323,10 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     mTimeSum += timeMaxNS - timeMinNS;
   }
   for (auto& digit : digits) {
+    // Exclude all BCs, in which laser signals are expected (and trigger outputs are blocked)
+    if (digit.mTriggers.getOutputsAreBlocked()) {
+      continue;
+    }
     const auto& vecChData = digit.getBunchChannelData(channels);
     bool isTCM = true;
     if (digit.mTriggers.timeA == o2::fit::Triggers::DEFAULT_TIME && digit.mTriggers.timeC == o2::fit::Triggers::DEFAULT_TIME) {
@@ -326,7 +334,7 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     }
     mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
     mHistBC->Fill(digit.getBC());
-    if (isTCM && !digit.mTriggers.getLaserBit()) {
+    if (isTCM && digit.mTriggers.getDataIsValid() && !digit.mTriggers.getOutputsAreBlocked()) {
       if (digit.mTriggers.nChanA > 0) {
         mHistNchA->Fill(digit.mTriggers.nChanA);
         mHistSumAmpA->Fill(digit.mTriggers.amplA);
@@ -368,7 +376,7 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
       setFEEmodules.insert(mChID2PMhash[chData.ChId]);
     }
-    if (isTCM /* && (digit.getTriggers().triggersignals & (1 << o2::fit::Triggers::bitDataIsValid))*/) {
+    if (isTCM) {
       setFEEmodules.insert(mTCMhash);
     }
     for (const auto& feeHash : setFEEmodules) {
@@ -380,22 +388,22 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void DigitQcTask::endOfCycle()
 {
-  ILOG(Info, Support) << "endOfCycle" << ENDM;
+  ILOG(Info) << "endOfCycle" << ENDM;
   // one has to set num. of entries manually because
   // default TH1Reductor gets only mean,stddev and entries (no integral)
+  mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());
   mHistCycleDurationRange->SetBinContent(1., mTimeMaxNS - mTimeMinNS);
   mHistCycleDurationRange->SetEntries(mTimeMaxNS - mTimeMinNS);
   mHistCycleDurationNTF->SetBinContent(1., mTfCounter);
   mHistCycleDurationNTF->SetEntries(mTfCounter);
   mHistCycleDuration->SetBinContent(1., mTimeSum);
   mHistCycleDuration->SetEntries(mTimeSum);
-  mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());
   ILOG(Debug) << "Cycle duration: NTF=" << mTfCounter << ", range = " << (mTimeMaxNS - mTimeMinNS) / 1e6 / mTfCounter << " ms/TF, sum = " << mTimeSum / 1e6 / mTfCounter << " ms/TF" << ENDM;
 }
 
 void DigitQcTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Support) << "endOfActivity" << ENDM;
+  ILOG(Info) << "endOfActivity" << ENDM;
 }
 
 void DigitQcTask::reset()
@@ -403,10 +411,14 @@ void DigitQcTask::reset()
   // clean all the monitor objects here
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
-  mHistOrbit2BC->Reset();
   mHistBC->Reset();
-  mHistEventDensity2Ch->Reset();
   mHistChDataBits->Reset();
+  mHistCFDEff->Reset();
+  mHistNumADC->Reset();
+  mHistNumCFD->Reset();
+  // mHistTimeSum2Diff->Reset();
+  mHistOrbit2BC->Reset();
+  mHistEventDensity2Ch->Reset();
   mHistNchA->Reset();
   // mHistNchC->Reset();
   mHistSumAmpA->Reset();
@@ -414,11 +426,7 @@ void DigitQcTask::reset()
   mHistAverageTimeA->Reset();
   // mHistAverageTimeC->Reset();
   mHistChannelID->Reset();
-  mHistCFDEff->Reset();
-  mHistNumADC->Reset();
-  mHistNumCFD->Reset();
   mHistTriggersCorrelation->Reset();
-  // mHistTimeSum2Diff->Reset();
   mHistCycleDuration->Reset();
   mHistCycleDurationNTF->Reset();
   mHistCycleDurationRange->Reset();

--- a/Modules/FV0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FV0/src/DigitQcTaskLaser.cxx
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -11,20 +11,18 @@
 
 ///
 /// \file   DigitQcTaskLaser.cxx
-/// \author Based on the existing DigitQcTask.cxx, developed by Sandor Lokos
-/// (sandor.lokos@cern.ch)
-///
+/// \brief  Based on the existing DigitQcTask
+/// \author Sandor Lokos sandor.lokos@cern.ch
 
-#include <TCanvas.h>
-#include <TH1.h>
-#include <TROOT.h>
+#include "FV0/DigitQcTaskLaser.h"
+
+#include "TCanvas.h"
+#include "TROOT.h"
 
 #include "QualityControl/QcInfoLogger.h"
-#include "FV0/DigitQcTaskLaser.h"
-#include <Framework/InputRecord.h>
-#include <Framework/InputRecordWalker.h>
-
-#include <DataFormatsFV0/LookUpTable.h>
+#include "DataFormatsFIT/Triggers.h"
+#include "Framework/InputRecord.h"
+#include "DataFormatsFV0/LookUpTable.h"
 
 namespace o2::quality_control_modules::fv0
 {
@@ -50,16 +48,16 @@ void DigitQcTaskLaser::rebinFromConfig()
     std::vector<std::string> tokenizedBinning;
     boost::split(tokenizedBinning, binning, boost::is_any_of(","));
     if (tokenizedBinning.size() == 3) { // TH1
-      ILOG(Debug, Support) << "config: rebinning TH1 " << hName << " -> " << binning << ENDM;
+      ILOG(Debug) << "config: rebinning TH1 " << hName << " -> " << binning << ENDM;
       auto htmp = (TH1F*)gROOT->FindObject(hName.data());
       htmp->SetBins(std::atof(tokenizedBinning[0].c_str()), std::atof(tokenizedBinning[1].c_str()), std::atof(tokenizedBinning[2].c_str()));
     } else if (tokenizedBinning.size() == 6) { // TH2
       auto htmp = (TH2F*)gROOT->FindObject(hName.data());
-      ILOG(Debug, Support) << "config: rebinning TH2 " << hName << " -> " << binning << ENDM;
+      ILOG(Debug) << "config: rebinning TH2 " << hName << " -> " << binning << ENDM;
       htmp->SetBins(std::atof(tokenizedBinning[0].c_str()), std::atof(tokenizedBinning[1].c_str()), std::atof(tokenizedBinning[2].c_str()),
                     std::atof(tokenizedBinning[3].c_str()), std::atof(tokenizedBinning[4].c_str()), std::atof(tokenizedBinning[5].c_str()));
     } else {
-      ILOG(Warning, Support) << "config: invalid binning parameter: " << hName << " -> " << binning << ENDM;
+      ILOG(Warning) << "config: invalid binning parameter: " << hName << " -> " << binning << ENDM;
     }
   };
 
@@ -76,7 +74,7 @@ void DigitQcTaskLaser::rebinFromConfig()
         rebinHisto(hNameCur, binning);
       }
     } else if (!gROOT->FindObject(hName.data())) {
-      ILOG(Warning, Support) << "config: histogram named \"" << hName << "\" not found" << ENDM;
+      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
       continue;
     } else {
       rebinHisto(hName, binning);
@@ -86,10 +84,8 @@ void DigitQcTaskLaser::rebinFromConfig()
 
 void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info, Support) << "initialize DigitQcTaskLaser" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+  ILOG(Info) << "initialize DigitQcTaskLaser" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
   mStateLastIR2Ch = {};
-  // Not ready yet
-  /*
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kNumberADC, "NumberADC" });
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kIsDoubleEvent, "IsDoubleEvent" });
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kIsTimeInfoNOTvalid, "IsTimeInfoNOTvalid" });
@@ -98,123 +94,77 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kIsAmpHigh, "IsAmpHigh" });
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kIsEventInTVDC, "IsEventInTVDC" });
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kIsTimeInfoLost, "IsTimeInfoLost" });
-  mMapDigitTrgNames.insert({ o2::fv0::Triggers::bitA, "OrA" });
-  mMapDigitTrgNames.insert({ o2::fv0::Triggers::bitC, "OrC" });
-  mMapDigitTrgNames.insert({ o2::fv0::Triggers::bitVertex, "Vertex" });
-  mMapDigitTrgNames.insert({ o2::fv0::Triggers::bitCen, "Central" });
-  mMapDigitTrgNames.insert({ o2::fv0::Triggers::bitSCen, "SemiCentral" });
-  */
-  mMapChTrgNames.insert({ 0, "NumberADC" });
-  mMapChTrgNames.insert({ 1, "IsDoubleEvent" });
-  mMapChTrgNames.insert({ 2, "IsTimeInfoNOTvalid" });
-  mMapChTrgNames.insert({ 3, "IsCFDinADCgate" });
-  mMapChTrgNames.insert({ 4, "IsTimeInfoLate" });
-  mMapChTrgNames.insert({ 5, "IsAmpHigh" });
-  mMapChTrgNames.insert({ 6, "IsEventInTVDC" });
-  mMapChTrgNames.insert({ 7, "IsTimeInfoLost" });
 
-  mMapDigitTrgNames.insert({ ETrgMenu::kMinBias, "MinBias" });
-  mMapDigitTrgNames.insert({ ETrgMenu::kOuterRing, "OuterRing" });
-  mMapDigitTrgNames.insert({ ETrgMenu::kNChannels, "NChannels" });
-  mMapDigitTrgNames.insert({ ETrgMenu::kCharge, "Charge" });
-  mMapDigitTrgNames.insert({ ETrgMenu::kInnerRing, "InnerRing" });
-  mMapDigitTrgNames.insert({ 5, "Laser" });
-  mMapDigitTrgNames.insert({ 6, "OutputsAreBlocked" });
-  mMapDigitTrgNames.insert({ 7, "DataIsValid" });
-
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitA, "OrA" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitAOut, "OrAOut" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitTrgNchan, "TrgNChan" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitTrgCharge, "TrgCharge" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitAIn, "OrAIn" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitLaser, "Laser" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitOutputsAreBlocked, "OutputsAreBlocked" });
+  mMapDigitTrgNames.insert({ o2::fit::Triggers::bitDataIsValid, "DataIsValid" });
   mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4100, -2050, 2050);
   mHistTime2Ch->SetOption("colz");
   mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4200, -100, 4100);
   mHistAmp2Ch->SetOption("colz");
-  mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", 256, 0, 256, 3564, 0, 3564);
-  mHistOrbit2BC->SetOption("colz");
-  mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", 3564, 0, 3564);
-
-  mHistEventDensity2Ch = std::make_unique<TH2F>("EventDensityPerChannel", "Event density(in BC) per Channel;Channel;BC;", sNCHANNELS_PM, 0, sNCHANNELS_PM, 10000, 0, 1e5);
-  mHistEventDensity2Ch->SetOption("colz");
-
+  mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
   mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
   mHistChDataBits->SetOption("colz");
-
   for (const auto& entry : mMapChTrgNames) {
     mHistChDataBits->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
   }
-  mHistTriggersCorrelation = std::make_unique<TH2F>("TriggersCorrelation", "Correlation of triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size(), mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-  mHistTriggersCorrelation->SetOption("colz");
-  mHistTriggers = std::make_unique<TH1F>("Triggers", "Triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistOrbitVsTrg = std::make_unique<TH2F>("OrbitVsTriggers", "Orbit vs Triggers;Orbit;Trg", sOrbitsPerTF, 0, sOrbitsPerTF, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistOrbitVsTrg->SetOption("colz");
 
+  for (const auto& entry : mMapDigitTrgNames) {
+    mHistOrbitVsTrg->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
+  }
   mListHistGarbage = new TList();
   mListHistGarbage->SetOwner(kTRUE);
-  for (const auto& entry : mMapDigitTrgNames) {
-    mHistTriggers->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
-    mHistTriggersCorrelation->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
-    mHistTriggersCorrelation->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
 
-    auto pairTrgBcOrbit = mMapTrgBcOrbit.insert({ entry.first, new TH2F(Form("BcOrbitMap_Trg%s", entry.second.c_str()), Form("BC-orbit map: %s fired;Orbit;BC", entry.second.c_str()), 256, 0, 256, 3564, 0, 3564) });
-    if (pairTrgBcOrbit.second) {
-      getObjectsManager()->startPublishing(pairTrgBcOrbit.first->second);
-      pairTrgBcOrbit.first->second->SetOption("colz");
-      mListHistGarbage->Add(pairTrgBcOrbit.first->second);
+  std::map<std::string, uint8_t> mapFEE2hash;
+  const auto& lut = o2::fv0::SingleLUT::Instance().getVecMetadataFEE();
+  auto lutSorted = lut;
+  std::sort(lutSorted.begin(), lutSorted.end(), [](const auto& first, const auto& second) { return first.mModuleName < second.mModuleName; });
+  uint8_t binPos{ 0 };
+  for (const auto& lutEntry : lutSorted) {
+    const auto& moduleName = lutEntry.mModuleName;
+    const auto& moduleType = lutEntry.mModuleType;
+    const auto& strChID = lutEntry.mChannelID;
+    const auto& pairIt = mapFEE2hash.insert({ moduleName, binPos });
+    if (pairIt.second) {
+      binPos++;
     }
-  }
-
-  char* p;
-  for (const auto& lutEntry : o2::fv0::SingleLUT::Instance().getVecMetadataFEE()) {
-    int chId = std::strtol(lutEntry.mChannelID.c_str(), &p, 10);
-    if (*p) {
-      // lutEntry.mChannelID is not a number
-      continue;
-    }
-    auto moduleName = lutEntry.mModuleName;
-    if (moduleName == "TCM") {
-      if (mMapPmModuleChannels.find(moduleName) == mMapPmModuleChannels.end()) {
-        mMapPmModuleChannels.insert({ moduleName, std::vector<int>{} });
+    if (std::regex_match(strChID, std::regex("[[\\d]{1,3}"))) {
+      int chID = std::stoi(strChID);
+      if (chID < sNCHANNELS_PM) {
+        mChID2PMhash[chID] = mapFEE2hash[moduleName];
+      } else {
+        LOG(error) << "Incorrect LUT entry: chID " << strChID << " | " << moduleName;
       }
-      continue;
-    }
-    if (mMapPmModuleChannels.find(moduleName) != mMapPmModuleChannels.end()) {
-      mMapPmModuleChannels[moduleName].push_back(chId);
-    } else {
-      std::vector<int> vChId = {
-        chId,
-      };
-      mMapPmModuleChannels.insert({ moduleName, vChId });
+    } else if (moduleType != "TCM") {
+      LOG(error) << "Non-TCM module w/o numerical chID: chID " << strChID << " | " << moduleName;
+    } else if (moduleType == "TCM") {
+      mTCMhash = mapFEE2hash[moduleName];
     }
   }
-
-  for (const auto& entry : mMapPmModuleChannels) {
-    auto pairModuleBcOrbit = mMapPmModuleBcOrbit.insert({ entry.first, new TH2F(Form("BcOrbitMap_%s", entry.first.c_str()), Form("BC-orbit map for %s;Orbit;BC", entry.first.c_str()), 256, 0, 256, 3564, 0, 3564) });
-    if (pairModuleBcOrbit.second) {
-      getObjectsManager()->startPublishing(pairModuleBcOrbit.first->second);
-      pairModuleBcOrbit.first->second->SetOption("colz");
-      mListHistGarbage->Add(pairModuleBcOrbit.first->second);
-    }
+  mHistBCvsFEEmodules = std::make_unique<TH2F>("BCvsFEEmodules", "BC vs FEE module;BC;FEE", sBCperOrbit, 0, sBCperOrbit, mapFEE2hash.size(), 0, mapFEE2hash.size());
+  mHistOrbitVsFEEmodules = std::make_unique<TH2F>("OrbitVsFEEmodules", "Orbit vs FEE module;Orbit;FEE", sOrbitsPerTF, 0, sOrbitsPerTF, mapFEE2hash.size(), 0, mapFEE2hash.size());
+  for (const auto& entry : mapFEE2hash) {
+    mHistBCvsFEEmodules->GetYaxis()->SetBinLabel(entry.second + 1, entry.first.c_str());
+    mHistOrbitVsFEEmodules->GetYaxis()->SetBinLabel(entry.second + 1, entry.first.c_str());
   }
 
-  mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistSumAmpA = std::make_unique<TH1F>("SumAmpA", "Sum of amplitudes(TCM), side A;", 1000, 0, 1e4);
-  mHistSumAmpC = std::make_unique<TH1F>("SumAmpC", "Sum of amplitudes(TCM), side C;", 1000, 0, 1e4);
-  mHistAverageTimeA = std::make_unique<TH1F>("AverageTimeA", "Average time(TCM), side A", 4100, -2050, 2050);
-  mHistAverageTimeC = std::make_unique<TH1F>("AverageTimeC", "Average time(TCM), side C", 4100, -2050, 2050);
   // mHistTimeSum2Diff = std::make_unique<TH2F>("timeSumVsDiff", "time A/C side: sum VS diff;(TOC-TOA)/2 [ns];(TOA+TOC)/2 [ns]", 400, -52.08, 52.08, 400, -52.08, 52.08); // range of 52.08 ns = 4000*13.02ps = 4000 channels
-  // mHistTimeSum2Diff->SetOption("colz");
-  mHistChannelID = std::make_unique<TH1F>("StatChannelID", "ChannelID statistics;ChannelID", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistCycleDuration = std::make_unique<TH1D>("CycleDuration", "Cycle Duration;;time [ns]", 1, 0, 2);
-  mHistCycleDurationNTF = std::make_unique<TH1D>("CycleDurationNTF", "Cycle Duration;;time [TimeFrames]", 1, 0, 2);
-  mHistCycleDurationRange = std::make_unique<TH1D>("CycleDurationRange", "Cycle Duration (total cycle range);;time [ns]", 1, 0, 2);
 
   std::vector<unsigned int> vecChannelIDs;
   if (auto param = mCustomParameters.find("ChannelIDs"); param != mCustomParameters.end()) {
     const auto chIDs = param->second;
     const std::string del = ",";
     vecChannelIDs = parseParameters<unsigned int>(chIDs, del);
-  } else {
-    for (unsigned int iCh = 0; iCh < sNCHANNELS_PM; iCh++)
-      vecChannelIDs.push_back(iCh);
   }
   for (const auto& entry : vecChannelIDs) {
     mSetAllowedChIDs.insert(entry);
@@ -238,7 +188,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
     }
     if (pairHistBits.second) {
       mListHistGarbage->Add(pairHistBits.first->second);
-      // getObjectsManager()->startPublishing(pairHistBits.first->second); // TODO: why commented out
+      getObjectsManager()->startPublishing(pairHistBits.first->second);
     }
     if (pairHistAmpVsTime.second) {
       mListHistGarbage->Add(pairHistAmpVsTime.first->second);
@@ -247,54 +197,40 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
   }
 
   rebinFromConfig(); // after all histos are created
-
-  getObjectsManager()->startPublishing(mHistTime2Ch.get());
-  getObjectsManager()->startPublishing(mHistAmp2Ch.get());
-  getObjectsManager()->startPublishing(mHistOrbit2BC.get());
-  getObjectsManager()->startPublishing(mHistBC.get());
-  getObjectsManager()->startPublishing(mHistEventDensity2Ch.get());
-  // getObjectsManager()->startPublishing(mHistChDataBits.get());
-  getObjectsManager()->startPublishing(mHistTriggers.get());
-  getObjectsManager()->startPublishing(mHistNchA.get());
-  // getObjectsManager()->startPublishing(mHistNchC.get());
-  getObjectsManager()->startPublishing(mHistSumAmpA.get());
-  // getObjectsManager()->startPublishing(mHistSumAmpC.get());
-  // getObjectsManager()->startPublishing(mHistAverageTimeA.get());
-  // getObjectsManager()->startPublishing(mHistAverageTimeC.get());
-  getObjectsManager()->startPublishing(mHistChannelID.get());
+  // 1-dim hists
   getObjectsManager()->startPublishing(mHistCFDEff.get());
-  getObjectsManager()->startPublishing(mHistTriggersCorrelation.get());
+  getObjectsManager()->startPublishing(mHistBC.get());
+  // 2-dim hists
+  getObjectsManager()->startPublishing(mHistTime2Ch.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistTime2Ch.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistAmp2Ch.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistAmp2Ch.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistBCvsFEEmodules.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistBCvsFEEmodules.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistOrbitVsTrg.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistOrbitVsTrg.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistOrbitVsFEEmodules.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistOrbitVsFEEmodules.get(), "COLZ");
+  getObjectsManager()->startPublishing(mHistChDataBits.get());
+  getObjectsManager()->setDefaultDrawOptions(mHistChDataBits.get(), "COLZ");
   // getObjectsManager()->startPublishing(mHistTimeSum2Diff.get());
-  getObjectsManager()->startPublishing(mHistCycleDuration.get());
-  getObjectsManager()->startPublishing(mHistCycleDurationNTF.get());
-  getObjectsManager()->startPublishing(mHistCycleDurationRange.get());
+  // getObjectsManager()->setDefaultDrawOptions(mHistTimeSum2Diff.get(), "COLZ");
 }
 
 void DigitQcTaskLaser::startOfActivity(Activity& activity)
 {
-  ILOG(Info, Support) << "startOfActivity " << activity.mId << ENDM;
+  ILOG(Info) << "startOfActivity" << activity.mId << ENDM;
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
-  mHistOrbit2BC->Reset();
   mHistBC->Reset();
-  mHistEventDensity2Ch->Reset();
   mHistChDataBits->Reset();
-  mHistTriggers->Reset();
-  mHistNchA->Reset();
-  mHistNchC->Reset();
-  mHistSumAmpA->Reset();
-  mHistSumAmpC->Reset();
-  mHistAverageTimeA->Reset();
-  mHistAverageTimeC->Reset();
-  mHistChannelID->Reset();
   mHistCFDEff->Reset();
   mHistNumADC->Reset();
   mHistNumCFD->Reset();
-  mHistTriggersCorrelation->Reset();
   // mHistTimeSum2Diff->Reset();
-  mHistCycleDuration->Reset();
-  mHistCycleDurationNTF->Reset();
-  mHistCycleDurationRange->Reset();
+  mHistBCvsFEEmodules->Reset();
+  mHistOrbitVsTrg->Reset();
+  mHistOrbitVsFEEmodules->Reset();
   for (auto& entry : mMapHistAmp1D) {
     entry.second->Reset();
   }
@@ -305,181 +241,99 @@ void DigitQcTaskLaser::startOfActivity(Activity& activity)
     entry.second->Reset();
   }
   for (auto& entry : mMapHistAmpVsTime) {
-    entry.second->Reset();
-  }
-  for (auto& entry : mMapTrgBcOrbit) {
-    entry.second->Reset();
-  }
-  for (auto& entry : mMapPmModuleBcOrbit) {
     entry.second->Reset();
   }
 }
 
 void DigitQcTaskLaser::startOfCycle()
 {
-  ILOG(Info, Support) << "startOfCycle" << ENDM;
-  mTimeMinNS = -1;
-  mTimeMaxNS = 0.;
-  mTimeCurNS = 0.;
-  mTfCounter = 0;
-  mTimeSum = 0.;
+  ILOG(Info) << "startOfCycle" << ENDM;
 }
 
 void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  double curTfTimeMin = -1;
-  double curTfTimeMax = 0;
-  mTfCounter++;
-  auto channels = ctx.inputs().get<gsl::span<ChannelData>>("channels");
-  auto digits = ctx.inputs().get<gsl::span<Digit>>("digits");
-  // bool isFirst = true;
-  // uint32_t firstOrbit;
-
+  auto channels = ctx.inputs().get<gsl::span<o2::fv0::ChannelData>>("channels");
+  auto digits = ctx.inputs().get<gsl::span<o2::fv0::Digit>>("digits");
   for (auto& digit : digits) {
+    // Exclude all BCs, in which laser signals are NOT expected (and trigger outputs are NOT blocked)
+    if (!digit.mTriggers.getOutputsAreBlocked()) {
+      continue;
+    }
     const auto& vecChData = digit.getBunchChannelData(channels);
     bool isTCM = true;
-    mTimeCurNS = o2::InteractionRecord::bc2ns(digit.getBC(), digit.getOrbit());
-    if (mTimeMinNS < 0)
-      mTimeMinNS = mTimeCurNS;
-    /*
-    if (isFirst == true) {
-      //firstOrbit = digit.getOrbit();
-      isFirst = false;
-    }
-    */
-    if (mTimeCurNS < mTimeMinNS)
-      mTimeMinNS = mTimeCurNS;
-    if (mTimeCurNS > mTimeMaxNS)
-      mTimeMaxNS = mTimeCurNS;
-
-    if (curTfTimeMin < 0)
-      curTfTimeMin = mTimeCurNS;
-    if (mTimeCurNS < curTfTimeMin)
-      curTfTimeMin = mTimeCurNS;
-    if (mTimeCurNS > curTfTimeMax)
-      curTfTimeMax = mTimeCurNS;
-    /*
-    if (digit.mTriggers.amplA == -5000 && digit.mTriggers.amplC == -5000 && digit.mTriggers.timeA == -5000 && digit.mTriggers.timeC == -5000)
+    if (digit.mTriggers.timeA == o2::fit::Triggers::DEFAULT_TIME && digit.mTriggers.timeC == o2::fit::Triggers::DEFAULT_TIME) {
       isTCM = false;
-    */
-    mHistOrbit2BC->Fill(digit.getOrbit() % sOrbitsPerTF, digit.getBC());
+    }
     mHistBC->Fill(digit.getBC());
-
-    if (isTCM && digit.mTriggers.triggersignals & (1 << 6)) {
-      mHistNchA->Fill(digit.mTriggers.nChanA);
-      // mHistNchC->Fill(digit.mTriggers.nChanC);
-      mHistSumAmpA->Fill(digit.mTriggers.amplA);
-      // mHistSumAmpC->Fill(digit.mTriggers.amplC);
-      // mHistAverageTimeA->Fill(digit.mTriggers.timeA);
-      // mHistAverageTimeC->Fill(digit.mTriggers.timeC);
-      // mHistTimeSum2Diff->Fill((digit.mTriggers.timeC - digit.mTriggers.timeA) * mCFDChannel2NS / 2, (digit.mTriggers.timeC + digit.mTriggers.timeA) * mCFDChannel2NS / 2);
-      for (const auto& entry : mMapDigitTrgNames) {
-        if (digit.mTriggers.triggersignals & (1 << entry.first))
-          mHistTriggers->Fill(static_cast<Double_t>(entry.first));
-        for (const auto& entry2 : mMapDigitTrgNames) {
-          if ((digit.mTriggers.triggersignals & (1 << entry.first)) && (digit.mTriggers.triggersignals & (1 << entry2.first)))
-            mHistTriggersCorrelation->Fill(static_cast<Double_t>(entry.first), static_cast<Double_t>(entry2.first));
-        }
-      }
-      for (auto& entry : mMapTrgBcOrbit) {
-        if (digit.mTriggers.triggersignals & (1 << entry.first)) {
-          entry.second->Fill(digit.getOrbit() % sOrbitsPerTF, digit.getBC());
-        }
+    if (isTCM && digit.mTriggers.getDataIsValid() && digit.mTriggers.getOutputsAreBlocked()) {
+      // mHistTimeSum2Diff->Fill((digit.mTriggers.timeC - digit.mTriggers.timeA) * sCFDChannel2NS / 2, (digit.mTriggers.timeC + digit.mTriggers.timeA) * sCFDChannel2NS / 2);
+      for (const auto& binPos : mHashedBitBinPos[digit.mTriggers.triggersignals]) {
+        mHistOrbitVsTrg->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, binPos);
       }
     }
-
-    for (auto& entry : mMapPmModuleChannels) {
-      for (const auto& chData : vecChData) {
-        if (std::find(entry.second.begin(), entry.second.end(), chData.ChId) != entry.second.end()) {
-          mMapPmModuleBcOrbit[entry.first]->Fill(digit.getOrbit() % sOrbitsPerTF, digit.getBC());
-          break;
-        }
-      }
-      if (entry.first == "TCM" && isTCM && (digit.getTriggers().triggersignals & (1 << sDataIsValidBitPos))) {
-        mMapPmModuleBcOrbit[entry.first]->Fill(digit.getOrbit() % sOrbitsPerTF, digit.getBC());
-      }
-    }
-
+    std::set<uint8_t> setFEEmodules{};
     for (const auto& chData : vecChData) {
       mHistTime2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(chData.CFDTime));
       mHistAmp2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(chData.QTCAmpl));
-      mHistEventDensity2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(digit.mIntRecord.differenceInBC(mStateLastIR2Ch[chData.ChId])));
       mStateLastIR2Ch[chData.ChId] = digit.mIntRecord;
-      mHistChannelID->Fill(chData.ChId);
-      if (chData.QTCAmpl > 0)
+      if (chData.QTCAmpl > 0) {
         mHistNumADC->Fill(chData.ChId);
+      }
       mHistNumCFD->Fill(chData.ChId);
-      if (mSetAllowedChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDs.end()) {
+      if (mSetAllowedChIDs.size() != 0 && mSetAllowedChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDs.end()) {
         mMapHistAmp1D[chData.ChId]->Fill(chData.QTCAmpl);
         mMapHistTime1D[chData.ChId]->Fill(chData.CFDTime);
         mMapHistAmpVsTime[chData.ChId]->Fill(chData.QTCAmpl, chData.CFDTime);
-        /*
         for (const auto& entry : mMapChTrgNames) {
-          if ((chData.QTCAmpl & (1 << entry.first))) {
+          if ((chData.ChainQTC & (1 << entry.first))) {
             mMapHistPMbits[chData.ChId]->Fill(entry.first);
           }
         }
-        */
       }
-      /*
-      for (const auto& entry : mMapChTrgNames) {
-        if ((chData.ChainQTC & (1 << entry.first))) {
-          mHistChDataBits->Fill(chData.ChId, entry.first);
-        }
+      for (const auto& binPos : mHashedBitBinPos[chData.ChainQTC]) {
+        mHistChDataBits->Fill(chData.ChId, binPos);
       }
-      */
+
+      setFEEmodules.insert(mChID2PMhash[chData.ChId]);
     }
-    mHistCFDEff->Reset();
-    mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());
+    if (isTCM) {
+      setFEEmodules.insert(mTCMhash);
+    }
+    for (const auto& feeHash : setFEEmodules) {
+      mHistBCvsFEEmodules->Fill(static_cast<double>(digit.getIntRecord().bc), static_cast<double>(feeHash));
+      mHistOrbitVsFEEmodules->Fill(static_cast<double>(digit.getIntRecord().orbit % sOrbitsPerTF), static_cast<double>(feeHash));
+    }
   }
-  mTimeSum += curTfTimeMax - curTfTimeMin;
 }
 
 void DigitQcTaskLaser::endOfCycle()
 {
-  ILOG(Info, Support) << "endOfCycle" << ENDM;
+  ILOG(Info) << "endOfCycle" << ENDM;
   // one has to set num. of entries manually because
   // default TH1Reductor gets only mean,stddev and entries (no integral)
-  mHistCycleDurationRange->SetBinContent(1., mTimeMaxNS - mTimeMinNS);
-  mHistCycleDurationRange->SetEntries(mTimeMaxNS - mTimeMinNS);
-  mHistCycleDurationNTF->SetBinContent(1., mTfCounter);
-  mHistCycleDurationNTF->SetEntries(mTfCounter);
-  mHistCycleDuration->SetBinContent(1., mTimeSum);
-  mHistCycleDuration->SetEntries(mTimeSum);
-  ILOG(Debug, Support) << "Cycle duration: NTF=" << mTfCounter << ", range = " << (mTimeMaxNS - mTimeMinNS) / 1e6 / mTfCounter << " ms/TF, sum = " << mTimeSum / 1e6 / mTfCounter << " ms/TF" << ENDM;
+  mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());
 }
 
 void DigitQcTaskLaser::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Support) << "endOfActivity" << ENDM;
+  ILOG(Info) << "endOfActivity" << ENDM;
 }
 
 void DigitQcTaskLaser::reset()
 {
   // clean all the monitor objects here
-  ILOG(Info, Support) << "Resetting the histogram" << ENDM;
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
-  mHistOrbit2BC->Reset();
   mHistBC->Reset();
-  mHistEventDensity2Ch->Reset();
   mHistChDataBits->Reset();
-  mHistTriggers->Reset();
-  mHistNchA->Reset();
-  mHistNchC->Reset();
-  mHistSumAmpA->Reset();
-  mHistSumAmpC->Reset();
-  mHistAverageTimeA->Reset();
-  mHistAverageTimeC->Reset();
-  mHistChannelID->Reset();
   mHistCFDEff->Reset();
   mHistNumADC->Reset();
   mHistNumCFD->Reset();
-  mHistTriggersCorrelation->Reset();
   // mHistTimeSum2Diff->Reset();
-  mHistCycleDuration->Reset();
-  mHistCycleDurationNTF->Reset();
-  mHistCycleDurationRange->Reset();
+  mHistBCvsFEEmodules->Reset();
+  mHistOrbitVsTrg->Reset();
+  mHistOrbitVsFEEmodules->Reset();
+
   for (auto& entry : mMapHistAmp1D) {
     entry.second->Reset();
   }
@@ -490,12 +344,6 @@ void DigitQcTaskLaser::reset()
     entry.second->Reset();
   }
   for (auto& entry : mMapHistAmpVsTime) {
-    entry.second->Reset();
-  }
-  for (auto& entry : mMapTrgBcOrbit) {
-    entry.second->Reset();
-  }
-  for (auto& entry : mMapPmModuleBcOrbit) {
     entry.second->Reset();
   }
 }


### PR DESCRIPTION
Aligned formatting between DigitQcTask and -Laser task, and between FT0 and FV0 to facilitate code maintenance in the future. Otherwise, specific changelog is as follows:

DigitQcTask revision:
- All: Exclusion of laser data, requirement of dataValid bit to process TCM data
- FT0: Defining magic numbers
- FDD: Minor formatting alignment with FT0

DigitQcTaskLaser revision:
- All: Exclusion of all physics data from processing

@afurs @arvindkhuntia 