### PR TITLE
[QC-580] Optionally pick up the last TTree in trending task

### DIFF
--- a/Framework/include/QualityControl/TrendingTask.h
+++ b/Framework/include/QualityControl/TrendingTask.h
@@ -53,15 +53,18 @@ class TrendingTask : public PostProcessingInterface
   void finalize(Trigger, framework::ServiceRegistry&) override;
 
  private:
-  struct MetaData {
-    Int_t runNumber = 0;
-  };
+  struct {
+    Long64_t runNumber = 0;
+    static const char* getBranchLeafList()
+    {
+      return "runNumber/L";
+    }
+  } mMetaData;
 
   void trendValues(const Trigger& t, repository::DatabaseInterface&);
   void generatePlots();
 
   TrendingTaskConfig mConfig;
-  MetaData mMetaData;
   UInt_t mTime;
   std::unique_ptr<TTree> mTrend;
   std::map<std::string, TObject*> mPlots;

--- a/Framework/include/QualityControl/TrendingTaskConfig.h
+++ b/Framework/include/QualityControl/TrendingTaskConfig.h
@@ -49,6 +49,7 @@ struct TrendingTaskConfig : PostProcessingConfig {
   };
 
   bool producePlotsOnUpdate;
+  bool resumeTrend;
   std::vector<Plot> plots;
   std::vector<DataSource> dataSources;
 };

--- a/Framework/src/TrendingTaskConfig.cxx
+++ b/Framework/src/TrendingTaskConfig.cxx
@@ -24,6 +24,7 @@ TrendingTaskConfig::TrendingTaskConfig(std::string name, const boost::property_t
   : PostProcessingConfig(name, config)
 {
   producePlotsOnUpdate = config.get<bool>("qc.postprocessing." + name + ".producePlotsOnUpdate", true);
+  resumeTrend = config.get<bool>("qc.postprocessing." + name + ".resumeTrend", false);
   for (const auto& plotConfig : config.get_child("qc.postprocessing." + name + ".plots")) {
     plots.push_back({ plotConfig.second.get<std::string>("name"),
                       plotConfig.second.get<std::string>("title", ""),

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -229,7 +229,8 @@ The TTree is stored back to the **QC database** each time it is updated. In addi
 
 #### Configuration
 
-As this class is a post-processing task, it inherits also its configuration JSON template. It extends it, though, with two additional lists - `"dataSources"` and `"plots"`:
+As this class is a post-processing task, it inherits also its configuration JSON template. It extends it, though, 
+some additional parameters.
 
 ``` json
 {
@@ -241,6 +242,8 @@ As this class is a post-processing task, it inherits also its configuration JSON
         "className": "o2::quality_control::postprocessing::TrendingTask",
         "moduleName": "QualityControl",
         "detectorName": "TST",
+        "resumeTrend": "false",
+        "producePlotsOnUpdate": "true",
         "dataSources": [],
         "plots": [],
         "initTrigger": [ "once" ],
@@ -311,6 +314,12 @@ The `"name"` and `"varexp"` are the only compulsory arguments, others can be omi
         ...
 }
 ```
+
+To decide whether plots should be generated during each update or just during finalization, 
+use the boolean flag `"producePlotsOnUpdate"`.
+
+To pick up the last existing trend which matches the specified Activity, set `"resumeTrend"` to `"true"`.
+
 ### The SliceTrendingTask class
 The `SliceTrendingTask` is a complementary task to the standard `TrendingTask`. This task allows the trending of canvas objects that hold multiple histograms (which have to be of the same dimension, e.g. TH1) and the slicing of histograms. The latter option allows the user to divide a histogram into multiple subsections along one or two dimensions which are trended in parallel to each other. The task has specific reductors for `TH1` and `TH2` objects which are `o2::quality_control_modules::common::TH1SliceReductor` and `o2::quality_control_modules::common::TH2SliceReductor`.
 


### PR DESCRIPTION
For some reason, ROOT can only pick up anonymous structs, this is why MetaData became anonymous