### PR TITLE
[MRRTF-186] QC for mch mid matched tracks

### DIFF
--- a/Modules/MUON/Common/CMakeLists.txt
+++ b/Modules/MUON/Common/CMakeLists.txt
@@ -3,13 +3,20 @@ set(MODULE_NAME "O2QcMUONCommon")
 # ---- Files ----
 
 set(SRCS
+  src/Helpers.cxx
   src/MergeableTH1Ratio.cxx
   src/MergeableTH2Ratio.cxx
+  src/TrackPlotter.cxx
+  src/TracksCheck.cxx
+  src/TracksTask.cxx
 )
 
 set(HEADERS
   include/MUONCommon/MergeableTH1Ratio.h
   include/MUONCommon/MergeableTH2Ratio.h
+  include/MUONCommon/TrackCheck.h
+  include/MUONCommon/TrackPlotter.h
+  include/MUONCommon/TracksTask.h
 )
 
 # ---- Library ----
@@ -22,7 +29,7 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_link_libraries(${MODULE_NAME} PUBLIC O2QualityControl)
+target_link_libraries(${MODULE_NAME} PUBLIC O2QualityControl O2::MCHMappingImpl4 O2::DataFormatsMCH O2::MCHTracking O2::MCHRawElecMap O2::ReconstructionDataFormats O2::MCHGeometryTransformer)
 
 # Digit.h is moving from MCHBase to DataFormatsMCH : let's handle both
 # gracefully for the moment...
@@ -43,6 +50,9 @@ install(
 add_root_dictionary(${MODULE_NAME}
                     HEADERS include/MUONCommon/MergeableTH1Ratio.h
                             include/MUONCommon/MergeableTH2Ratio.h
+                            include/MUONCommon/TrackPlotter.h
+                            include/MUONCommon/TracksCheck.h
+                            include/MUONCommon/TracksTask.h
                     LINKDEF include/MUONCommon/LinkDef.h)
 
 # ---- Tests ----

--- a/Modules/MUON/Common/etc/qc-tracks.json
+++ b/Modules/MUON/Common/etc/qc-tracks.json
@@ -1,0 +1,78 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "localhost:6464",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "conditionDB": {
+        "url": "http://alice-ccdb.cern.ch"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2",
+        "start":"1655682579514"
+      }
+    },
+    "tasks": {
+      "FwdTracks": {
+        "active": "true",
+        "className": "o2::quality_control_modules::muon::TracksTask",
+        "moduleName": "QcMuonCommon",
+        "detectorName": "GLO",
+        "cycleDurationSeconds": "120",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "mchtracks:MCH/TRACKS;mchtrackrofs:MCH/TRACKROFS;mchtrackclusters:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS;muontracks:GLO/MTC_MCHMID"
+        },
+        "taskParameters": {
+          "maxTracksPerTF": "100",
+          "standaloneMCHTracks": true,
+          "matchedMCHMIDTracks": true
+        },
+        "location": "remote"
+      },
+      "MCHStdTracks": {
+        "active": "true",
+        "className": "o2::quality_control_modules::muon::TracksTask",
+        "moduleName": "QcMuonCommon",
+        "detectorName": "GLO",
+        "cycleDurationSeconds": "120",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "mchtracks:MCH/TRACKS;mchtrackrofs:MCH/TRACKROFS;mchtrackclusters:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS"
+        },
+        "taskParameters": {
+          "maxTracksPerTF": "100",
+          "standaloneMCHTracks": true,
+          "matchedMCHMIDTracks": false
+        },
+        "location": "remote"
+      },
+      "MCHTracks": {
+        "active": "true",
+        "className": "o2::quality_control_modules::muonchambers::TracksTask",
+        "moduleName": "QcMuonChambers",
+        "detectorName": "MCH",
+        "cycleDurationSeconds": "120",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "tracks:MCH/TRACKS;trackrofs:MCH/TRACKROFS;trackclusters:MCH/TRACKCLUSTERS;trackdigits:MCH/CLUSTERDIGITS"
+        },
+        "taskParameters": {
+          "maxTracksPerTF": "100"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {}
+  },
+  "dataSamplingPolicies": []
+}
+

--- a/Modules/MUON/Common/include/MUONCommon/Helpers.h
+++ b/Modules/MUON/Common/include/MUONCommon/Helpers.h
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QC_MODULE_MUON_COMMON_HELPERS_H
+#define QC_MODULE_MUON_COMMON_HELPERS_H
+
+#include <gsl/span>
+
+class TH1;
+class TLine;
+
+namespace o2::quality_control_modules::muon
+{
+TLine* addHorizontalLine(TH1& histo, double y,
+                         int lineColor = 1, int lineStyle = 10,
+                         int lineWidth = 1);
+TLine* addVerticalLine(TH1& histo, double x,
+                       int lineColor = 1, int lineStyle = 10,
+                       int lineWidth = 1);
+void cleanup(TH1& histo, const char* classname);
+void markBunchCrossing(TH1& histo,
+                       gsl::span<int> bunchCrossings);
+
+} // namespace o2::quality_control_modules::muon
+
+#endif

--- a/Modules/MUON/Common/include/MUONCommon/LinkDef.h
+++ b/Modules/MUON/Common/include/MUONCommon/LinkDef.h
@@ -5,5 +5,8 @@
 
 #pragma link C++ class o2::quality_control_modules::muon::MergeableTH1Ratio + ;
 #pragma link C++ class o2::quality_control_modules::muon::MergeableTH2Ratio + ;
+#pragma link C++ class o2::quality_control_modules::muon::TrackPlotter + ;
+#pragma link C++ class o2::quality_control_modules::muon::TracksTask + ;
+#pragma link C++ class o2::quality_control_modules::muon::TracksCheck + ;
 
 #endif

--- a/Modules/MUON/Common/include/MUONCommon/TrackPlotter.h
+++ b/Modules/MUON/Common/include/MUONCommon/TrackPlotter.h
@@ -12,14 +12,15 @@
 #ifndef QC_MODULE_MUON_COMMON_TRACK_PLOTTER_H
 #define QC_MODULE_MUON_COMMON_TRACK_PLOTTER_H
 
+#include "MCHGeometryTransformer/Transformations.h"
 #include <MCHRawElecMap/Mapper.h>
 #include <TH1F.h>
 #include <TProfile.h>
+#include <fmt/core.h>
 #include <gsl/span>
 #include <memory>
 #include <string>
-#include <fmt/core.h>
-#include "MCHGeometryTransformer/Transformations.h"
+#include <vector>
 
 namespace o2::mch
 {
@@ -65,6 +66,12 @@ class TrackPlotter
   const std::vector<HistInfo>& histograms() const { return mHistograms; }
 
  private:
+  void fill(gsl::span<const o2::mch::ROFRecord> rofs,
+            gsl::span<const o2::mch::TrackMCH> tracks,
+            gsl::span<const o2::mch::Cluster> clusters,
+            gsl::span<const o2::mch::Digit> digits,
+            const std::vector<bool>& selectedTracks);
+
   /** create one histogram with relevant drawing options / stat box status.*/
   template <typename T>
   std::unique_ptr<T> createHisto(const char* name, const char* title,

--- a/Modules/MUON/Common/include/MUONCommon/TrackPlotter.h
+++ b/Modules/MUON/Common/include/MUONCommon/TrackPlotter.h
@@ -1,0 +1,141 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QC_MODULE_MUON_COMMON_TRACK_PLOTTER_H
+#define QC_MODULE_MUON_COMMON_TRACK_PLOTTER_H
+
+#include <MCHRawElecMap/Mapper.h>
+#include <TH1F.h>
+#include <TProfile.h>
+#include <gsl/span>
+#include <memory>
+#include <string>
+#include <fmt/core.h>
+#include "MCHGeometryTransformer/Transformations.h"
+
+namespace o2::mch
+{
+class Cluster;
+class ROFRecord;
+class TrackMCH;
+class Digit;
+} // namespace o2::mch
+
+namespace o2::dataformats
+{
+class TrackMCHMID;
+}
+class TH1F;
+
+namespace o2::quality_control_modules::muon
+{
+
+class TrackPlotter
+{
+ public:
+  TrackPlotter(o2::mch::geo::TransformationCreator transformation, int maxTracksPerTF);
+  ~TrackPlotter() = default;
+
+ public:
+  void fillHistograms(gsl::span<const o2::mch::ROFRecord> rofs,
+                      gsl::span<const o2::mch::TrackMCH> tracks,
+                      gsl::span<const o2::mch::Cluster> clusters,
+                      gsl::span<const o2::mch::Digit> digits);
+
+  void fillHistograms(gsl::span<const o2::mch::ROFRecord> rofs,
+                      gsl::span<const o2::mch::TrackMCH> tracks,
+                      gsl::span<const o2::mch::Cluster> clusters,
+                      gsl::span<const o2::mch::Digit> digits,
+                      gsl::span<const o2::dataformats::TrackMCHMID> muonTracks);
+
+  struct HistInfo {
+    TH1* histo;
+    std::string drawOptions;
+    std::string displayHints;
+  };
+
+  const std::vector<HistInfo>& histograms() const { return mHistograms; }
+
+ private:
+  /** create one histogram with relevant drawing options / stat box status.*/
+  template <typename T>
+  std::unique_ptr<T> createHisto(const char* name, const char* title,
+                                 int nbins, double xmin, double xmax,
+                                 bool statBox = false,
+                                 const char* drawOptions = "",
+                                 const char* displayHints = "");
+
+  /** create histograms related to clusters (those attached to tracks) */
+  void createClusterHistos();
+  /** create histograms related to tracks */
+  void createTrackHistos(int maxTracksPerTF);
+  /** create histograms related to track pairs */
+  void createTrackPairHistos();
+
+  /** fill histogram related to each cluster */
+  void fillClusterHistos(gsl::span<const o2::mch::Cluster> clusters,
+                         gsl::span<const o2::mch::Digit> digits);
+
+  /** fill histograms related to a single track */
+  bool fillTrackHistos(const o2::mch::TrackMCH& track,
+                       gsl::span<const o2::mch::Cluster> clusters,
+                       gsl::span<const o2::mch::Digit> digits);
+
+  /** fill histograms for track pairs */
+  void fillTrackPairHistos(gsl::span<const o2::mch::TrackMCH> tracks);
+
+  int dsbinx(int deid, int dsid) const;
+
+  std::unique_ptr<TH1F> mNofTracksPerTF;   ///< number of tracks per TF
+  std::unique_ptr<TH1F> mTrackBC;          ///< BC associated to the track
+  std::unique_ptr<TH1F> mTrackBCWidth;     ///< BC width associated to the track
+  std::unique_ptr<TH1F> mTrackChi2OverNDF; ///< chi2/ndf for the track
+  std::unique_ptr<TH1F> mTrackDCA;         ///< DCA (cm) of the track
+  std::unique_ptr<TH1F> mTrackEta;         ///< eta of the track
+  std::unique_ptr<TH1F> mTrackPDCA;        ///< p (GeV/c) x DCA (cm) of the track
+  std::unique_ptr<TH1F> mTrackPhi;         ///< phi (in degrees) of the track
+  std::unique_ptr<TH1F> mTrackPt;          ///< Pt (Gev/c^2) of the track
+  std::unique_ptr<TH1F> mTrackRAbs;        ///< R at absorber end of the track
+
+  std::unique_ptr<TH1F> mNofClustersPerDualSampa;             //< aka cluster map
+  std::unique_ptr<TH1F> mNofClustersPerTrack;                 ///< number of clusters per track
+  std::unique_ptr<TProfile> mClusterBendingSizePerChamber;    ///< mean cluster size in bending direction (y) per chamber
+  std::unique_ptr<TProfile> mClusterNonBendingSizePerChamber; ///< mean cluster size in non-bending direction (x) per chamber
+  std::unique_ptr<TProfile> mClusterSizePerChamber;           ///< mean cluster size per chamber
+  std::unique_ptr<TProfile> mNofClustersPerChamber;           ///< mean number of clusters per chamber
+
+  std::unique_ptr<TH1F> mMinv; ///< invariant mass of unlike-sign track pairs
+
+  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
+  o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
+
+  std::vector<HistInfo> mHistograms;
+  o2::mch::geo::TransformationCreator mTransformation; ///< creator of local to global transformations
+};
+
+template <typename T>
+std::unique_ptr<T> TrackPlotter::createHisto(const char* name, const char* title,
+                                             int nbins, double xmin, double xmax,
+                                             bool statBox,
+                                             const char* drawOptions,
+                                             const char* displayHints)
+{
+  auto h = std::make_unique<T>(name, title, nbins, xmin, xmax);
+  if (!statBox) {
+    h->SetStats(0);
+  }
+  mHistograms.emplace_back(HistInfo{ h.get(), drawOptions, displayHints });
+  return h;
+}
+
+} // namespace o2::quality_control_modules::muon
+
+#endif

--- a/Modules/MUON/Common/include/MUONCommon/TracksCheck.h
+++ b/Modules/MUON/Common/include/MUONCommon/TracksCheck.h
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QC_MODULE_MUON_COMMON_TRACKS_CHECK_H
+#define QC_MODULE_MUON_COMMON_TRACKS_CHECK_H
+
+#include "QualityControl/CheckInterface.h"
+#include <vector>
+
+namespace o2::quality_control_modules::muon
+{
+
+class TracksCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  TracksCheck();
+  ~TracksCheck() override;
+
+  void configure() override;
+
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMa) override;
+
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+ private:
+  std::vector<int> mBunchCrossings;
+
+  ClassDefOverride(TracksCheck, 1);
+};
+} // namespace o2::quality_control_modules::muon
+
+#endif

--- a/Modules/MUON/Common/include/MUONCommon/TracksTask.h
+++ b/Modules/MUON/Common/include/MUONCommon/TracksTask.h
@@ -1,0 +1,53 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QC_MODULE_MUON_COMMON_TRACKS_TASK_H
+#define QC_MODULE_MUON_COMMON_TRACKS_TASK_H
+
+#include "QualityControl/TaskInterface.h"
+#include <memory>
+#include "MUONCommon/TrackPlotter.h"
+#include <vector>
+#include <array>
+
+using namespace o2::quality_control::core;
+
+namespace o2::quality_control_modules::muon
+{
+
+class TracksTask /*final*/ : public TaskInterface
+{
+ public:
+  TracksTask();
+  ~TracksTask() override;
+
+  void initialize(o2::framework::InitContext& ctx) override;
+  void startOfActivity(Activity& activity) override;
+  void startOfCycle() override;
+  void monitorData(o2::framework::ProcessingContext& ctx) override;
+  void endOfCycle() override;
+  void endOfActivity(Activity& activity) override;
+  void reset() override;
+
+ private:
+  /** check whether all the expected inputs are present.*/
+  bool assertInputs(o2::framework::ProcessingContext& ctx);
+  void publish(const TrackPlotter& tp);
+  bool getBooleanParam(const char* paramName) const;
+
+ private:
+  std::unique_ptr<muon::TrackPlotter> mTrackPlotter;
+  bool mUseMatchedMCHMIDTracks{ false };
+};
+
+} // namespace o2::quality_control_modules::muon
+
+#endif

--- a/Modules/MUON/Common/src/Helpers.cxx
+++ b/Modules/MUON/Common/src/Helpers.cxx
@@ -1,0 +1,74 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MUONCommon/Helpers.h"
+#include <TLine.h>
+#include <TAxis.h>
+#include <TH1.h>
+#include <TList.h>
+#include <regex>
+#include "QualityControl/ObjectsManager.h"
+
+namespace o2::quality_control_modules::muon
+{
+TLine* addHorizontalLine(TH1& histo, double y,
+                         int lineColor, int lineStyle,
+                         int lineWidth)
+{
+  auto nbins = histo.GetXaxis()->GetNbins();
+
+  TLine* line = new TLine(histo.GetBinLowEdge(1), y, histo.GetBinLowEdge(nbins) + histo.GetBinWidth(nbins), y);
+  line->SetLineColor(lineColor);
+  line->SetLineStyle(lineStyle);
+  line->SetLineWidth(lineWidth);
+  histo.GetListOfFunctions()->Add(line);
+  return line;
+}
+
+void markBunchCrossing(TH1& histo,
+                       gsl::span<int> bunchCrossings)
+{
+  for (auto b : bunchCrossings) {
+    addVerticalLine(histo, b * 1.0, 1, 10, 1);
+  }
+}
+
+TLine* addVerticalLine(TH1& histo, double x,
+                       int lineColor, int lineStyle,
+                       int lineWidth)
+{
+  TLine* line = new TLine(x, histo.GetMinimum(),
+                          x, histo.GetMaximum());
+  line->SetLineColor(lineColor);
+  line->SetLineStyle(lineStyle);
+  line->SetLineWidth(lineWidth);
+  histo.GetListOfFunctions()->Add(line);
+  return line;
+}
+
+// remove all elements of class c
+// from histo->GetListOfFunctions()
+void cleanup(TH1& histo, const char* classname)
+{
+  TList* elements = histo.GetListOfFunctions();
+  TIter next(elements);
+  TObject* obj;
+  std::vector<TObject*> toBeRemoved;
+  while ((obj = next())) {
+    if (strcmp(obj->ClassName(), classname) == 0) {
+      toBeRemoved.push_back(obj);
+    }
+  }
+  for (auto o : toBeRemoved) {
+    elements->Remove(o);
+  }
+}
+} // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/src/TrackPlotter.cxx
+++ b/Modules/MUON/Common/src/TrackPlotter.cxx
@@ -1,0 +1,344 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MUONCommon/TrackPlotter.h"
+
+#include "CommonConstants/LHCConstants.h"
+#include <DataFormatsMCH/Cluster.h>
+#include <DataFormatsMCH/Digit.h>
+#include <DataFormatsMCH/ROFRecord.h>
+#include <DataFormatsMCH/TrackMCH.h>
+#include <DetectorsBase/GeometryManager.h>
+#include <Framework/DataRefUtils.h>
+#include <Framework/InputRecord.h>
+#include <MCHMappingInterface/Segmentation.h>
+#include <MCHTracking/TrackExtrap.h>
+#include <MCHTracking/TrackParam.h>
+#include <Math/Vector4D.h>
+#include <Math/Vector4Dfwd.h>
+#include <ReconstructionDataFormats/TrackMCHMID.h>
+#include <TH1F.h>
+#include <TMath.h>
+#include <gsl/span>
+#include <set>
+
+namespace
+{
+
+constexpr double muonMass = 0.1056584;
+constexpr double muonMass2 = muonMass * muonMass;
+
+static void setXAxisLabels(TProfile* h)
+{
+  TAxis* axis = h->GetXaxis();
+  for (int i = 1; i <= 10; i++) {
+    auto label = fmt::format("CH{}", i);
+    axis->SetBinLabel(i, label.c_str());
+  }
+}
+
+uint16_t computeDsBinX(int feeId, int linkId, int elinkId)
+{
+  constexpr uint64_t maxLinkId = 12;
+  constexpr uint64_t maxElinkId = 40;
+
+  int v = feeId * maxLinkId * maxElinkId +
+          (linkId % maxLinkId) * maxElinkId + elinkId + 1;
+  return static_cast<uint16_t>(v & 0xFFFF);
+}
+
+std::array<int, 10> getClustersPerChamber(gsl::span<const o2::mch::Cluster> clusters)
+{
+  std::array<int, 10> clustersPerChamber;
+  clustersPerChamber.fill(0);
+  for (const auto& cluster : clusters) {
+    int chamberId = cluster.getChamberId();
+    clustersPerChamber[chamberId]++;
+  }
+  return clustersPerChamber;
+}
+
+} // namespace
+
+namespace o2::quality_control_modules::muon
+{
+
+TrackPlotter::TrackPlotter(o2::mch::geo::TransformationCreator transformation, int maxTracksPerTF) : mTransformation(transformation)
+{
+  createClusterHistos();
+  createTrackHistos(maxTracksPerTF);
+  createTrackPairHistos();
+  mDet2ElecMapper = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
+}
+
+void TrackPlotter::createClusterHistos()
+{
+  mNofClustersPerTrack = createHisto<TH1F>("ClustersPerTrack", "Number of clusters per track;Mean number of clusters per track", 30, 0, 30);
+  mNofClustersPerDualSampa = createHisto<TH1F>("ClustersPerDualSampa", "Number of clusters per dual sampa;Number of clusters per DS", 30720, 0, 30719);
+
+  mNofClustersPerChamber = createHisto<TProfile>("ClustersPerChamber", "Clusters per chamber;;Number of clusters", 10, 1, 11);
+  setXAxisLabels(mNofClustersPerChamber.get());
+  mClusterSizePerChamber = createHisto<TProfile>("ClusterSizePerChamber", "Cluster size per chamber;;Mean number of pads per cluster", 10, 1, 11);
+  mClusterBendingSizePerChamber = createHisto<TProfile>("ClusterBendingSizePerChamber", "Cluster size in bending direction (y) per chamber;;Mean number of pads per cluster", 10, 1, 11);
+  mClusterNonBendingSizePerChamber = createHisto<TProfile>("ClusterNonBendingSizePerChamber", "Cluster size in non-bending direction (x) per chamber;;Mean number of pads per cluster", 10, 1, 11);
+  setXAxisLabels(mClusterSizePerChamber.get());
+  setXAxisLabels(mClusterBendingSizePerChamber.get());
+  setXAxisLabels(mClusterNonBendingSizePerChamber.get());
+}
+
+void TrackPlotter::createTrackHistos(int maxTracksPerTF)
+{
+
+  mNofTracksPerTF = createHisto<TH1F>("TracksPerTF", "Number of tracks per TimeFrame;Number of tracks per TF", maxTracksPerTF, 0, maxTracksPerTF, true, "logy");
+
+  mTrackDCA = createHisto<TH1F>("TrackDCA", "Track DCA;DCA (cm)", 500, 0, 500);
+  mTrackPDCA = createHisto<TH1F>("TrackPDCA", "Track p#timesDCA;p#timesDCA (GeVcm/c)", 5000, 0, 5000);
+  mTrackPt = createHisto<TH1F>("TrackPt", "Track p_{T};p_{T} (GeV/c)", 300, 0, 30, false, "logy");
+  mTrackEta = createHisto<TH1F>("TrackEta", "Track #eta;#eta", 200, -4.5, -2);
+  mTrackPhi = createHisto<TH1F>("TrackPhi", "Track #phi;#phi (deg)", 360, 0, 360);
+  mTrackRAbs = createHisto<TH1F>("TrackRAbs", "Track R_{abs};R_{abs} (cm)", 1000, 0, 100);
+  mTrackBC = createHisto<TH1F>("TrackBC", "Track BC;BC", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches);
+  mTrackBCWidth = createHisto<TH1F>("TrackBCWidth", "Track BCWidth;BC Width", 400, 0, 400);
+  mTrackChi2OverNDF = createHisto<TH1F>("TrackChi2OverNDF", "Track #chi^{2}/ndf;#chi^{2}/ndf", 500, 0, 50);
+}
+
+void TrackPlotter::createTrackPairHistos()
+{
+  mMinv = createHisto<TH1F>("Minv", "#mu^{+}#mu^{-} invariant mass;M_{#mu^{+}#mu^{-}} (GeV/c^{2})", 300, 0, 6);
+}
+
+int TrackPlotter::dsbinx(int deid, int dsid) const
+{
+  o2::mch::raw::DsDetId det{ deid, dsid };
+  auto elec = mDet2ElecMapper(det);
+  if (!elec.has_value()) {
+    std::cerr << "mapping is wrong somewhere...";
+    return -1;
+  }
+  auto eLinkId = elec->elinkId();
+  auto solarId = elec->solarId();
+  auto s2f = mSolar2FeeLinkMapper(solarId);
+  if (!s2f.has_value()) {
+    std::cerr << "mapping is wrong somewhere...";
+    return -1;
+  }
+  auto feeId = s2f->feeId();
+  auto linkId = s2f->linkId();
+
+  return computeDsBinX(feeId, linkId, eLinkId);
+}
+
+ROOT::Math::PxPyPzMVector getMomentum4D(const o2::mch::TrackParam& trackParam)
+{
+  double px = trackParam.px();
+  double py = trackParam.py();
+  double pz = trackParam.pz();
+  return { px, py, pz, muonMass };
+}
+
+ROOT::Math::PxPyPzMVector getMomentum4D(const o2::mch::TrackMCH& track)
+{
+  o2::mch::TrackParam trackParamAtVertex(track.getZ(), track.getParameters());
+  double vz = 0.0;
+  if (!o2::mch::TrackExtrap::extrapToVertex(trackParamAtVertex, 0.0, 0.0, 0.0, 0.0, 0.0)) {
+    std::cerr << "Track extrap failed\n";
+    return { 0, 0, 0, 0 };
+  }
+  return getMomentum4D(trackParamAtVertex);
+}
+
+namespace
+{
+struct PadSize {
+  double dx, dy;
+};
+const bool operator<(const PadSize& s1, const PadSize& s2)
+{
+  if (s1.dx == s2.dx) {
+    return s1.dy < s2.dy;
+  }
+  return s1.dx < s2.dx;
+};
+} // namespace
+
+void TrackPlotter::fillClusterHistos(gsl::span<const o2::mch::Cluster> clusters,
+                                     gsl::span<const o2::mch::Digit> digits)
+{
+
+  auto padPosCompare = [](double a, double b) {
+    constexpr double smallestPadSize = 0.21;
+    if (std::fabs(a - b) < smallestPadSize) {
+      return false;
+    }
+    return a < b;
+  };
+
+  for (const auto& cluster : clusters) {
+    int deId = cluster.getDEId();
+    const auto& seg = o2::mch::mapping::segmentation(deId);
+    int b, nb;
+    o2::math_utils::Point3D<double> global{ cluster.getX(),
+                                            cluster.getY(), cluster.getZ() };
+    auto t = mTransformation(deId).Inverse();
+    auto local = t(global);
+
+    seg.findPadPairByPosition(local.X(), local.Y(), b, nb);
+    if (b >= 0) {
+      int dsId = seg.padDualSampaId(b);
+      mNofClustersPerDualSampa->Fill(dsbinx(deId, dsId));
+    }
+    if (nb >= 0) {
+      int dsId = seg.padDualSampaId(nb);
+      mNofClustersPerDualSampa->Fill(dsbinx(deId, dsId));
+    }
+    int chamberId = cluster.getChamberId();
+    mClusterSizePerChamber->Fill(chamberId + 1, cluster.nDigits);
+    std::set<PadSize> padSizes;
+    std::set<double, decltype(padPosCompare)> xpos(padPosCompare);
+    std::set<double, decltype(padPosCompare)> ypos(padPosCompare);
+    for (int dix = cluster.firstDigit; dix < cluster.firstDigit + cluster.nDigits; ++dix) {
+      const auto& digit = digits[dix];
+      auto padid = digit.getPadID();
+      PadSize padSize{ seg.padSizeX(padid),
+                       seg.padSizeY(padid) };
+      padSizes.emplace(padSize);
+      if (seg.isBendingPad(padid)) {
+        ypos.emplace(seg.padPositionY(padid));
+      } else {
+        xpos.emplace(seg.padPositionX(padid));
+      }
+    }
+    mClusterBendingSizePerChamber->Fill(chamberId + 1, ypos.size());
+    mClusterNonBendingSizePerChamber->Fill(chamberId + 1, xpos.size());
+  }
+}
+
+void TrackPlotter::fillTrackPairHistos(gsl::span<const o2::mch::TrackMCH> tracks)
+{
+  if (tracks.size() > 1) {
+    for (auto i = 0; i < tracks.size(); i++) {
+      auto ti = getMomentum4D(tracks[i]);
+      for (auto j = i + 1; j < tracks.size(); j++) {
+        if (tracks[i].getSign() == tracks[j].getSign()) {
+          continue;
+        }
+        auto tj = getMomentum4D(tracks[j]);
+        auto p = ti + tj;
+        mMinv->Fill(p.M());
+      }
+    }
+  }
+}
+
+bool TrackPlotter::fillTrackHistos(const o2::mch::TrackMCH& track,
+                                   gsl::span<const o2::mch::Cluster> clusters,
+                                   gsl::span<const o2::mch::Digit> digits)
+{
+  mNofClustersPerTrack->Fill(track.getNClusters());
+  mTrackChi2OverNDF->Fill(track.getChi2OverNDF());
+
+  const auto trackClusters = clusters.subspan(track.getFirstClusterIdx(), track.getNClusters());
+  fillClusterHistos(trackClusters, digits);
+
+  auto clustersPerChamber = getClustersPerChamber(trackClusters);
+
+  for (auto i = 0; i < clustersPerChamber.size(); i++) {
+    mNofClustersPerChamber->Fill(i + 1, clustersPerChamber[i]);
+  }
+
+  auto p = track.getP(); // uncorrected p
+
+  o2::mch::TrackParam trackParamAtDCA(track.getZ(), track.getParameters());
+  if (!o2::mch::TrackExtrap::extrapToVertexWithoutBranson(trackParamAtDCA, 0.0)) {
+    return false;
+  }
+
+  o2::mch::TrackParam trackParamAtOrigin(track.getZ(), track.getParameters());
+  if (!o2::mch::TrackExtrap::extrapToVertex(trackParamAtOrigin, 0.0, 0.0, 0.0, 0.0, 0.0)) {
+    return false;
+  }
+  double dcaX = trackParamAtDCA.getBendingCoor();
+  double dcaY = trackParamAtDCA.getNonBendingCoor();
+  double dca = std::sqrt(dcaX * dcaX + dcaY * dcaY);
+  mTrackDCA->Fill(dca);
+  mTrackPDCA->Fill(p * dca);
+
+  auto muon = getMomentum4D(trackParamAtOrigin);
+
+  mTrackEta->Fill(muon.eta());
+  mTrackPhi->Fill(muon.phi() * TMath::RadToDeg() + 180);
+  mTrackPt->Fill(muon.pt());
+
+  o2::mch::TrackExtrap::extrapToZ(trackParamAtOrigin, -505.);
+  double xAbs = trackParamAtOrigin.getNonBendingCoor();
+  double yAbs = trackParamAtOrigin.getBendingCoor();
+  auto rAbs = std::sqrt(xAbs * xAbs + yAbs * yAbs);
+  mTrackRAbs->Fill(rAbs);
+
+  return true;
+}
+void TrackPlotter::fillHistograms(gsl::span<const o2::mch::ROFRecord> rofs,
+                                  gsl::span<const o2::mch::TrackMCH> tracks,
+                                  gsl::span<const o2::mch::Cluster> clusters,
+                                  gsl::span<const o2::mch::Digit> digits,
+                                  gsl::span<const o2::dataformats::TrackMCHMID> muonTracks)
+{
+
+  if (muonTracks.size() == 0) {
+    return;
+  }
+
+  std::vector<o2::mch::TrackMCH> matchedTracks;
+  for (const auto& mt : muonTracks) {
+    auto ix = mt.getMCHRef().getIndex();
+    matchedTracks.emplace_back(tracks[ix]);
+  }
+  fillHistograms(rofs, matchedTracks, clusters, digits);
+}
+
+void TrackPlotter::fillHistograms(gsl::span<const o2::mch::ROFRecord> rofs,
+                                  gsl::span<const o2::mch::TrackMCH> tracks,
+                                  gsl::span<const o2::mch::Cluster> clusters,
+                                  gsl::span<const o2::mch::Digit> digits)
+{
+
+  mNofTracksPerTF->Fill(tracks.size());
+
+  for (const auto& rof : rofs) {
+    if (rof.getNEntries() > 0) {
+      mTrackBC->Fill(rof.getBCData().bc);
+      mTrackBCWidth->Fill(rof.getBCWidth());
+    }
+  }
+
+  decltype(tracks.size()) nok{ 0 };
+
+  for (const auto& track : tracks) {
+    bool ok = fillTrackHistos(track, clusters, digits);
+    if (ok) {
+      ++nok;
+    }
+  }
+
+  if (nok != tracks.size()) {
+    std::cerr << "Could only extrapolate " << nok << " tracks over " << tracks.size() << "\n";
+  }
+
+  for (const auto& rof : rofs) {
+    if (rof.getNEntries() > 0) {
+      auto rtracks = tracks.subspan(rof.getFirstIdx(), rof.getNEntries());
+      fillTrackPairHistos(rtracks);
+    }
+  }
+}
+
+} // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/src/TracksCheck.cxx
+++ b/Modules/MUON/Common/src/TracksCheck.cxx
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MUONCommon/TracksCheck.h"
+#include <regex>
+#include <TH1.h>
+#include <CommonDataFormat/BunchFilling.h>
+#include "QualityControl/QcInfoLogger.h"
+#include "MUONCommon/Helpers.h"
+
+namespace o2::quality_control_modules::muon
+{
+
+TracksCheck::TracksCheck()
+{
+}
+
+TracksCheck::~TracksCheck() = default;
+
+void TracksCheck::configure()
+{
+  //   auto bf = TaskInterface::retrieveConditionAny<o2::BunchFilling>("GLO/GRP/BunchFilling");
+  o2::BunchFilling* bf = nullptr;
+  if (bf == nullptr) {
+    ILOG(Error, Support) << "could not get filling scheme" << ENDM;
+  }
+  auto pattern = bf ? bf->getBCPattern() : o2::BunchFilling::createPattern("3564L");
+
+  for (auto i = 0; i < pattern.size(); i++) {
+    if (pattern.test(i)) {
+      mBunchCrossings.emplace_back(i);
+    }
+  }
+}
+
+Quality TracksCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Null;
+
+  return result;
+}
+
+std::string TracksCheck::getAcceptedType() { return "TH1"; }
+
+void TracksCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  std::regex re("TrackBC$");
+
+  if (std::regex_search(mo->getName(), re)) {
+    TH1* h = dynamic_cast<TH1*>(mo->getObject());
+    if (h == nullptr) {
+      return;
+    }
+    markBunchCrossing(*h, mBunchCrossings);
+  }
+}
+
+} // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/src/TracksTask.cxx
+++ b/Modules/MUON/Common/src/TracksTask.cxx
@@ -1,0 +1,151 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MUONCommon/TracksTask.h"
+
+#include "MUONCommon/Helpers.h"
+#include "QualityControl/ObjectsManager.h"
+#include <DataFormatsMCH/Cluster.h>
+#include <DataFormatsMCH/Digit.h>
+#include <DataFormatsMCH/ROFRecord.h>
+#include <DataFormatsMCH/TrackMCH.h>
+#include <DetectorsBase/GeometryManager.h>
+#include <Framework/DataRefUtils.h>
+#include <Framework/InputRecord.h>
+#include <MCHGeometryTransformer/Transformations.h>
+#include <ReconstructionDataFormats/TrackMCHMID.h>
+#include <gsl/span>
+
+namespace o2::quality_control_modules::muon
+{
+
+TracksTask::TracksTask()
+{
+}
+
+TracksTask::~TracksTask() = default;
+
+bool TracksTask::getBooleanParam(const char* paramName) const
+{
+  if (auto param = mCustomParameters.find(paramName); param != mCustomParameters.end()) {
+    std::string p = param->second;
+    std::transform(p.begin(), p.end(), p.begin(), ::toupper);
+    return p == "TRUE";
+  }
+  return false;
+}
+
+void TracksTask::initialize(o2::framework::InitContext& /*ic*/)
+{
+  ILOG(Info, Support) << "initialize TracksTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+
+  if (!o2::base::GeometryManager::isGeometryLoaded()) {
+    TaskInterface::retrieveConditionAny<TObject>("GLO/Config/Geometry");
+  }
+
+  auto transformation = o2::mch::geo::transformationFromTGeoManager(*gGeoManager);
+
+  double maxTracksPerTF = 400;
+
+  if (auto param = mCustomParameters.find("maxTracksPerTF"); param != mCustomParameters.end()) {
+    maxTracksPerTF = std::stof(param->second);
+  }
+
+  mUseMatchedMCHMIDTracks = getBooleanParam("matchedMCHMIDTracks");
+
+  mTrackPlotter = std::make_unique<muon::TrackPlotter>(transformation, maxTracksPerTF);
+
+  publish(*(mTrackPlotter.get()));
+}
+
+void TracksTask::publish(const TrackPlotter& tp)
+{
+  auto hinfos = tp.histograms();
+
+  for (auto hinfo : hinfos) {
+    getObjectsManager()->startPublishing(hinfo.histo);
+    getObjectsManager()->setDefaultDrawOptions(hinfo.histo, hinfo.drawOptions);
+    getObjectsManager()->setDisplayHint(hinfo.histo, hinfo.displayHints);
+  }
+}
+
+void TracksTask::startOfActivity(Activity& activity)
+{
+  ILOG(Info, Support) << "startOfActivity : " << activity << ENDM;
+}
+
+void TracksTask::startOfCycle()
+{
+  ILOG(Info, Support) << "startOfCycle" << ENDM;
+}
+
+bool TracksTask::assertInputs(o2::framework::ProcessingContext& ctx)
+{
+  if (!ctx.inputs().isValid("mchtracks")) {
+    ILOG(Info, Support) << "no mch tracks available on input" << ENDM;
+    return false;
+  }
+  if (!ctx.inputs().isValid("mchtrackrofs")) {
+    ILOG(Info, Support) << "no mch track rofs available on input" << ENDM;
+    return false;
+  }
+  if (!ctx.inputs().isValid("mchtrackclusters")) {
+    ILOG(Info, Support) << "no mch track clusters available on input" << ENDM;
+    return false;
+  }
+  if (!ctx.inputs().isValid("mchtrackdigits")) {
+    ILOG(Info, Support) << "no mch track digits available on input" << ENDM;
+    return false;
+  }
+  if (mUseMatchedMCHMIDTracks) {
+    if (!ctx.inputs().isValid("muontracks")) {
+      ILOG(Info, Support) << "no muon (mch+mid) track available on input" << ENDM;
+      return false;
+    }
+  }
+  return true;
+}
+
+void TracksTask::monitorData(o2::framework::ProcessingContext& ctx)
+{
+  if (!assertInputs(ctx)) {
+    return;
+  }
+
+  auto tracks = ctx.inputs().get<gsl::span<o2::mch::TrackMCH>>("mchtracks");
+  auto rofs = ctx.inputs().get<gsl::span<o2::mch::ROFRecord>>("mchtrackrofs");
+  auto clusters = ctx.inputs().get<gsl::span<o2::mch::Cluster>>("mchtrackclusters");
+  auto digits = ctx.inputs().get<gsl::span<o2::mch::Digit>>("mchtrackdigits");
+
+  if (mUseMatchedMCHMIDTracks) {
+    auto muonTracks = ctx.inputs().get<gsl::span<o2::dataformats::TrackMCHMID>>("muontracks");
+    mTrackPlotter->fillHistograms(rofs, tracks, clusters, digits, muonTracks);
+  } else {
+    mTrackPlotter->fillHistograms(rofs, tracks, clusters, digits);
+  }
+}
+
+void TracksTask::endOfCycle()
+{
+  ILOG(Info, Support) << "endOfCycle" << ENDM;
+}
+
+void TracksTask::endOfActivity(Activity& /*activity*/)
+{
+  ILOG(Info, Support) << "endOfActivity" << ENDM;
+}
+
+void TracksTask::reset()
+{
+  ILOG(Warning, Support) << "resetting the histograms is not implemented" << ENDM;
+}
+
+} // namespace o2::quality_control_modules::muon


### PR DESCRIPTION
Introduce a new task that can be used to monitor MCH standalone tracks and/or MCH-MID matched tracks.

In order to ensure the current QC (MCH only) tracks won't break at Pt2, this is a new task and not a replacement for the current one. Only once validated will this new one replace the current one.

This PR has also a couple of fix for the current tracks task, please do not squash.
