### PR TITLE
TRD fix errorneous massive 2d histogram causing root errors, and other sundry fixes

### DIFF
--- a/Modules/FDD/include/FDD/LinkDef.h
+++ b/Modules/FDD/include/FDD/LinkDef.h
@@ -4,6 +4,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::quality_control_modules::fdd::DigitQcTask+;
-#pragma link C++ class o2::quality_control_modules::fdd::DigitQcTaskLaser+;
+#pragma link C++ class o2::quality_control_modules::fdd::DigitQcTaskLaser + ;
 #pragma link C++ class o2::quality_control_modules::fdd::RecPointsQcTask + ;
 #endif

--- a/Modules/TRD/include/TRD/DigitsTask.h
+++ b/Modules/TRD/include/TRD/DigitsTask.h
@@ -20,6 +20,7 @@
 #include "QualityControl/TaskInterface.h"
 #include <array>
 #include "DataFormatsTRD/NoiseCalibration.h"
+#include "TRDQC/StatusHelper.h"
 
 class TH1F;
 class TH2F;
@@ -57,6 +58,8 @@ class DigitsTask final : public TaskInterface
   void drawTrdLayersGrid(TH2F* hist);
   void retrieveCCDBSettings();
   void drawLinesOnPulseHeight(TH1F* h);
+  void fillLinesOnHistsPerLayer(int iLayer);
+  void drawHashOnLayers(int layer, int hcid, int col, int rowstart, int rowend);
 
  private:
   // limits
@@ -107,6 +110,7 @@ class DigitsTask final : public TaskInterface
   std::vector<TH2F*> mLayers;
   // information pulled from ccdb
   o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
+  o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/include/TRD/TrackletsCheck.h
+++ b/Modules/TRD/include/TRD/TrackletsCheck.h
@@ -41,13 +41,9 @@ class TrackletsCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
   void retrieveCCDBSettings();
-  void fillTrdMaskHistsPerLayer();
-  std::vector<TH2F*> createTrdMaskHistsPerLayer();
 
  private:
   long int mTimestamp;
-  std::vector<TH2F*> mLayersMask;
-  o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
   float mIntegralThreshold;
   float mRatioThreshold;
   float mZeroBinRatioThreshold;

--- a/Modules/TRD/src/PulseHeightCheck.cxx
+++ b/Modules/TRD/src/PulseHeightCheck.cxx
@@ -123,14 +123,17 @@ void PulseHeightCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality check
 
     if (checkResult == Quality::Good) {
       h->SetFillColor(kGreen);
+      h->SetLineColor(kGreen);
     } else if (checkResult == Quality::Bad) {
       ILOG(Info, Support) << "Quality::Bad, something wrong with the pulseheight spectrum" << ENDM;
       h->SetFillColor(kRed);
+      h->SetLineColor(kRed);
     } else if (checkResult == Quality::Medium) {
       ILOG(Info, Support) << "Quality::medium, pusleheight spectrum is a bit suspect" << ENDM;
       h->SetFillColor(kOrange);
+      h->SetLineColor(kOrange);
     }
-    h->SetLineColor(kBlack);
+    //h->SetLineColor(kBlack);
     h->Draw();
   }
 }

--- a/Modules/TRD/src/TrackletsCheck.cxx
+++ b/Modules/TRD/src/TrackletsCheck.cxx
@@ -117,42 +117,7 @@ Quality TrackletsCheck::check(std::map<std::string, std::shared_ptr<MonitorObjec
 
 std::string TrackletsCheck::getAcceptedType() { return "TH1"; }
 
-std::vector<TH2F*> TrackletsCheck::createTrdMaskHistsPerLayer()
-{
-  std::vector<TH2F*> hMask;
-  for (int iLayer = 0; iLayer < 6; ++iLayer) {
-    hMask.push_back(new TH2F(Form("layer%i_mask", iLayer), "", 76, -0.5, 75.5, 144, -0.5, 143.5));
-    hMask.back()->SetMarkerColor(kRed);
-    hMask.back()->SetMarkerSize(0.9);
-  }
-  return hMask;
-}
 
-void TrackletsCheck::fillTrdMaskHistsPerLayer()
-{
-  for (int iSec = 0; iSec < 18; ++iSec) {
-    for (int iStack = 0; iStack < 5; ++iStack) {
-      int rowMax = (iStack == 2) ? 12 : 16;
-      for (int iLayer = 0; iLayer < 6; ++iLayer) {
-        for (int iCol = 0; iCol < 8; ++iCol) {
-          int side = (iCol < 4) ? 0 : 1;
-          int det = iSec * 30 + iStack * 6 + iLayer;
-          int hcid = (side == 0) ? det * 2 : det * 2 + 1;
-          for (int iRow = 0; iRow < rowMax; ++iRow) {
-            int rowGlb = iStack < 3 ? iRow + iStack * 16 : iRow + 44 + (iStack - 3) * 16; // pad row within whole sector
-            int colGlb = iCol + iSec * 8;
-            // bin number 0 is underflow
-            rowGlb += 1;
-            colGlb += 1;
-            if (mChamberStatus->isMasked(hcid)) {
-              mLayersMask[iLayer]->SetBinContent(rowGlb, colGlb, 1);
-            }
-          }
-        }
-      }
-    }
-  }
-}
 
 void TrackletsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
@@ -161,28 +126,32 @@ void TrackletsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
 
     if (checkResult == Quality::Good) {
       h->SetFillColor(kGreen);
+      h->SetLineColor(kGreen);
     } else if (checkResult == Quality::Bad) {
       ILOG(Info, Support) << "Quality::Bad, setting to red" << ENDM;
       h->SetFillColor(kRed);
+      h->SetLineColor(kRed);
     } else if (checkResult == Quality::Medium) {
       ILOG(Info, Support) << "Quality::medium, setting to orange" << ENDM;
       h->SetFillColor(kOrange);
+      h->SetLineColor(kOrange);
     }
-    h->SetLineColor(kBlack);
   }
   if (mo->getName() == "trackletspertimeframecycled") {
     auto* h = dynamic_cast<TH1F*>(mo->getObject());
 
     if (checkResult == Quality::Good) {
       h->SetFillColor(kGreen);
+      h->SetLineColor(kGreen);
     } else if (checkResult == Quality::Bad) {
       ILOG(Info, Support) << "Quality::Bad, call on call" << ENDM;
       h->SetFillColor(kRed);
+      h->SetLineColor(kRed);
     } else if (checkResult == Quality::Medium) {
       ILOG(Info, Support) << "Quality::medium, something might be off" << ENDM;
       h->SetFillColor(kOrange);
+      h->SetLineColor(kOrange);
     }
-    h->SetLineColor(kBlack);
   }
 }
 


### PR DESCRIPTION
- fix an errorneous large spectrum with 25000 x 25000 spectra, finger trouble in the zeros producing very odd root error messages.
- clean up digits per pad per layer and tracklets per mcm per layer
- fix tracklets per timeframe.