### PR TITLE
Do not allow to publish in two PP callbacks in one iteration

### DIFF
--- a/Framework/include/QualityControl/PostProcessingRunner.h
+++ b/Framework/include/QualityControl/PostProcessingRunner.h
@@ -86,9 +86,9 @@ class PostProcessingRunner
   static PostProcessingRunnerConfig extractConfig(const core::CommonSpec& commonSpec, const PostProcessingTaskSpec& ppTaskSpec);
 
  private:
-  void doInitialize(Trigger trigger);
-  void doUpdate(Trigger trigger);
-  void doFinalize(Trigger trigger);
+  void doInitialize(const Trigger& trigger);
+  void doUpdate(const Trigger& trigger);
+  void doFinalize(const Trigger& trigger);
 
   enum class TaskState {
     INVALID,
@@ -105,7 +105,7 @@ class PostProcessingRunner
   framework::ServiceRegistry mServices;
   std::shared_ptr<o2::quality_control::core::ObjectsManager> mObjectManager;
   // TODO in a longer run, we should store from/to in the MonitorObject itself and use them.
-  std::function<void(const o2::quality_control::core::MonitorObjectCollection*, long /*from*/, long /*to*/)> mPublicationCallback = nullptr;
+  std::function<void(const o2::quality_control::core::MonitorObjectCollection*, uint64_t /*from*/, uint64_t /*to*/)> mPublicationCallback = nullptr;
 
   std::string mName{};
   PostProcessingConfig mTaskConfig;

--- a/Framework/src/PostProcessingRunner.cxx
+++ b/Framework/src/PostProcessingRunner.cxx
@@ -111,16 +111,20 @@ bool PostProcessingRunner::run()
   if (mTaskState == TaskState::Created) {
     if (Trigger trigger = trigger_helpers::tryTrigger(mInitTriggers)) {
       doInitialize(trigger);
+      return true;
     }
   }
   if (mTaskState == TaskState::Running) {
     if (Trigger trigger = trigger_helpers::tryTrigger(mUpdateTriggers)) {
       doUpdate(trigger);
+      return true;
     }
     if (mUpdateTriggers.empty()) {
       doFinalize({ TriggerType::UserOrControl, true, mTaskConfig.activity });
+      return false;
     } else if (Trigger trigger = trigger_helpers::tryTrigger(mStopTriggers)) {
       doFinalize(trigger);
+      return false;
     }
   }
   if (mTaskState == TaskState::Finished) {
@@ -205,7 +209,7 @@ void PostProcessingRunner::reset()
   mStopTriggers.clear();
 }
 
-void PostProcessingRunner::doInitialize(Trigger trigger)
+void PostProcessingRunner::doInitialize(const Trigger& trigger)
 {
   ILOG(Info, Support) << "Initializing the user task due to trigger '" << trigger << "'" << ENDM;
 
@@ -217,14 +221,14 @@ void PostProcessingRunner::doInitialize(Trigger trigger)
   mStopTriggers = trigger_helpers::createTriggers(mTaskConfig.stopTriggers, mTaskConfig);
 }
 
-void PostProcessingRunner::doUpdate(Trigger trigger)
+void PostProcessingRunner::doUpdate(const Trigger& trigger)
 {
   ILOG(Info, Support) << "Updating the user task due to trigger '" << trigger << "'" << ENDM;
   mTask->update(trigger, mServices);
   mPublicationCallback(mObjectManager->getNonOwningArray(), trigger.timestamp, trigger.timestamp + objectValidity);
 }
 
-void PostProcessingRunner::doFinalize(Trigger trigger)
+void PostProcessingRunner::doFinalize(const Trigger& trigger)
 {
   ILOG(Info, Support) << "Finalizing the user task due to trigger '" << trigger << "'" << ENDM;
   mTask->finalize(trigger, mServices);
@@ -253,7 +257,7 @@ PostProcessingRunnerConfig PostProcessingRunner::extractConfig(const CommonSpec&
 
 MOCPublicationCallback publishToDPL(framework::DataAllocator& allocator, std::string outputBinding)
 {
-  return [&allocator = allocator, outputBinding = std::move(outputBinding)](const MonitorObjectCollection* moc, long, long) {
+  return [&allocator = allocator, outputBinding = std::move(outputBinding)](const MonitorObjectCollection* moc, uint64_t, uint64_t) {
     // TODO pass timestamps to objects, so they are later stored correctly.
     allocator.snapshot(framework::OutputRef{ outputBinding }, *moc);
   };
@@ -261,7 +265,7 @@ MOCPublicationCallback publishToDPL(framework::DataAllocator& allocator, std::st
 
 MOCPublicationCallback publishToRepository(o2::quality_control::repository::DatabaseInterface& repository)
 {
-  return [&](const MonitorObjectCollection* collection, long from, long to) {
+  return [&](const MonitorObjectCollection* collection, uint64_t from, uint64_t to) {
     for (const TObject* mo : *collection) {
       // We have to copy the object so we can pass a shared_ptr.
       // This is not ideal, but MySQL interface requires shared ptrs to queue the objects.

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -150,7 +150,7 @@ void TrendingTask::generatePlots()
     // we have to delete the graph errors after the plot is saved, unfortunately the canvas does not take its ownership
     TGraphErrors* graphErrors = nullptr;
 
-    TCanvas* c = new TCanvas();
+    auto* c = new TCanvas();
 
     mTrend->Draw(plot.varexp.c_str(), plot.selection.c_str(), plot.option.c_str());
 


### PR DESCRIPTION
When objects were published during update() and finalize() in one Data Processor's run(),
we would create two sets of MonitorObjects. CheckRunner cannot cope with this, it may accept
just one set at a time, thus we avoid this from happening.

A proper solution would be to let CheckRunner process more than one MOC for a source at the same time,
but this might require some major changes.