### PR TITLE
[EMCAL-711, EMCAL-792] Error type monitor and raw error checker

### DIFF
--- a/Modules/EMCAL/CMakeLists.txt
+++ b/Modules/EMCAL/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(O2QcEMCAL)
 
-target_sources(O2QcEMCAL PRIVATE src/RawTask.cxx src/RawCheck.cxx src/CellTask.cxx src/CellCheck.cxx src/DigitsQcTask.cxx src/DigitCheck.cxx src/DigitOccupancyReductor.cxx src/ClusterTask.cxx src/RawErrorTask.cxx)
+target_sources(O2QcEMCAL PRIVATE src/RawErrorCheck.cxx  src/RawTask.cxx src/RawCheck.cxx src/CellTask.cxx src/CellCheck.cxx src/DigitsQcTask.cxx src/DigitCheck.cxx src/DigitOccupancyReductor.cxx src/ClusterTask.cxx src/RawErrorTask.cxx)
 
 target_include_directories(
   O2QcEMCAL
@@ -22,7 +22,8 @@ add_root_dictionary(O2QcEMCAL
   include/EMCAL/DigitOccupancyReductor.h
   include/EMCAL/ClusterTask.h
   include/EMCAL/RawErrorTask.h
-  LINKDEF include/EMCAL/LinkDef.h
+      include/EMCAL/RawErrorCheck.h
+        LINKDEF include/EMCAL/LinkDef.h
   BASENAME O2QcEMCAL)
 
 install(TARGETS O2QcEMCAL

--- a/Modules/EMCAL/include/EMCAL/LinkDef.h
+++ b/Modules/EMCAL/include/EMCAL/LinkDef.h
@@ -21,4 +21,6 @@
 
 #pragma link C++ class o2::quality_control_modules::emcal::RawErrorTask + ;
 
-#endif
+      #pragma link C++ class o2::quality_control_modules::emcal::RawErrorCheck+;
+      
+      #endif

--- a/Modules/EMCAL/include/EMCAL/RawErrorCheck.h
+++ b/Modules/EMCAL/include/EMCAL/RawErrorCheck.h
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   RawErrorCheck.h
+/// \author Markus Fasel
+///
+
+#ifndef QC_MODULE_EMCAL_EMCALRAWERRORCHECK_H
+#define QC_MODULE_EMCAL_EMCALRAWERRORCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+
+namespace o2::quality_control_modules::emcal
+{
+
+/// \class RawErrorCheck
+/// \brief Checker for histograms with error code published by the RawErrorTask
+/// \author Markus Fasel
+///
+/// Checking for presence of an error code. Any presence of error code (non-0 entry)
+/// will define data as bad.
+class RawErrorCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  RawErrorCheck() = default;
+  /// Destructor
+  ~RawErrorCheck() override = default;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+  ClassDefOverride(RawErrorCheck, 2);
+};
+
+} // namespace o2::quality_control_modules::emcal
+
+#endif // QC_MODULE_EMCAL_EMCALRAWERRORCHECK_H

--- a/Modules/EMCAL/include/EMCAL/RawErrorTask.h
+++ b/Modules/EMCAL/include/EMCAL/RawErrorTask.h
@@ -52,14 +52,15 @@ class RawErrorTask final : public TaskInterface
   void reset() override;
 
  private:
-  TH2* mErrorTypeAltro = nullptr;    ///< Error from
-  TH2* mErrorTypePage = nullptr;     ///< Error from
-  TH2* mErrorTypeMinAltro = nullptr; ///< Error from
-  TH2* mErrorTypeFit = nullptr;      ///< Error from
-  TH2* mErrorTypeGeometry = nullptr; ///< Error from
-  TH2* mErrorTypeGain = nullptr;     ///< Error from
-  TH2* mErrorGainLow = nullptr;      ///< Error per SM
-  TH2* mErrorGainHigh = nullptr;     ///< Error per SM
+  TH2* mErrorTypeAll = nullptr;      ///< Base histogram any raw data error
+  TH2* mErrorTypeAltro = nullptr;    ///< Major ALTRO payload decoding errors
+  TH2* mErrorTypePage = nullptr;     ///< DMA page decoding errors
+  TH2* mErrorTypeMinAltro = nullptr; ///< Minor ALTRO payload decoding errors
+  TH2* mErrorTypeFit = nullptr;      ///< Raw fit errors
+  TH2* mErrorTypeGeometry = nullptr; ///< Geometry errors
+  TH2* mErrorTypeGain = nullptr;     ///< Gain type errors
+  TH2* mErrorGainLow = nullptr;      ///< FEC with LGnoHG error
+  TH2* mErrorGainHigh = nullptr;     ///< FEC with HGnoLG error
 
   o2::emcal::Geometry* mGeometry = nullptr; ///< EMCAL geometry
 };

--- a/Modules/EMCAL/src/RawErrorCheck.cxx
+++ b/Modules/EMCAL/src/RawErrorCheck.cxx
@@ -1,0 +1,112 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   RawErrorCheck.cxx
+/// \author My Name
+///
+
+#include <algorithm>
+#include <array>
+#include <string>
+
+#include "EMCAL/RawErrorCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
+// ROOT
+#include <TH1.h>
+#include <TH2.h>
+#include <TLatex.h>
+#include <TList.h>
+
+#include <DataFormatsQualityControl/FlagReasons.h>
+
+using namespace std;
+using namespace o2::quality_control;
+
+namespace o2::quality_control_modules::emcal
+{
+
+void RawErrorCheck::configure() {}
+
+Quality RawErrorCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  std::array<std::string, 7> errorhists = { { "RawDataErrors", "PageErrors", "MajorAltroErrors", "MinorAltroError", "RawFitError", "GeometryError", "GainTypeError" } };
+  std::array<std::string, 2> gainhists = { { "NoHGPerDDL", "NoLGPerDDL" } };
+  Quality result = Quality::Good;
+
+  for (auto& [moName, mo] : *moMap) {
+    if (std::find(errorhists.begin(), errorhists.end(), mo->getName()) != errorhists.end()) {
+      // Check for presence of error codes
+      auto* errorhist = dynamic_cast<TH2*>(mo->getObject());
+
+      for (int linkID = 0; linkID < errorhist->GetXaxis()->GetNbins(); linkID++) {
+        for (int errorcode = 0; errorcode < errorhist->GetYaxis()->GetNbins(); errorcode++) {
+          if (errorhist->GetBinContent(linkID + 1, errorcode + 1)) {
+            // Found raw data error
+            result = Quality::Bad;
+            result.addReason(FlagReasonFactory::Unknown(), "Raw error " + std::string(errorhist->GetYaxis()->GetBinLabel(errorcode + 1)) + " found in DDL " + std::to_string(linkID));
+          }
+        }
+      }
+    } else if (std::find(gainhists.begin(), gainhists.end(), mo->GetName()) != gainhists.end()) {
+      // Find FEC with gain error
+      auto errorhist = dynamic_cast<TH2*>(mo->getObject());
+      std::string errortype;
+      std::string_view histname = mo->GetName();
+      if (histname == "NoHGPerDDL") {
+        errortype = "LGnoHG";
+      } else {
+        errortype = "HGnoLG";
+      }
+      for (int linkID = 0; linkID < errorhist->GetXaxis()->GetNbins(); linkID++) {
+        for (int fecID = 0; fecID < errorhist->GetYaxis()->GetNbins(); fecID++) {
+          if (errorhist->GetBinContent(linkID + 1, fecID + 1)) {
+            result = Quality::Bad;
+            result.addReason(FlagReasonFactory::Unknown(), "Gain error " + errortype + " in FEC " + std::to_string(fecID) + " of DDL " + std::to_string(linkID));
+          }
+        }
+      }
+    } else {
+      ILOG(Error, Support) << "Unsupported histogram in check: " << mo->GetName() << ENDM;
+      continue;
+    }
+  }
+  return result;
+}
+
+std::string RawErrorCheck::getAcceptedType() { return "TH2"; }
+
+void RawErrorCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  auto* h = dynamic_cast<TH1*>(mo->getObject());
+  if (checkResult == Quality::Good) {
+    TLatex* msg = new TLatex(0.2, 0.8, "#color[418]{No Error: OK}");
+    msg->SetNDC();
+    msg->SetTextSize(16);
+    msg->SetTextFont(43);
+    h->GetListOfFunctions()->Add(msg);
+    msg->Draw();
+  } else if (checkResult == Quality::Bad) {
+    TLatex* msg = new TLatex(0.2, 0.8, "#color[2]{Presence of Error Code: call EMCAL oncall}");
+    msg->SetNDC();
+    msg->SetTextSize(16);
+    msg->SetTextFont(43);
+    h->GetListOfFunctions()->Add(msg);
+    msg->Draw();
+    // Notify about found errors on the infoLogger:
+    for (const auto& reason : checkResult.getReasons())
+      ILOG(Error, Support) << "Raw Error in " << mo->GetName() << " found: " << reason.second << ENDM;
+  }
+}
+
+} // namespace o2::quality_control_modules::emcal


### PR DESCRIPTION
- Add histogram monitoring the error type per DDL
 (for shifter)
- First basic version of the checker for the histograms
  produced by the RawErrorTask