### PR TITLE
MCH: fix histogram reset at each cycle

### DIFF
--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
@@ -60,6 +60,8 @@ class MergeableTH1Ratio : public TH1F, public o2::mergers::MergeInterface
 
   void update();
 
+  void Reset(Option_t*  option = "");
+
  private:
   TH1D* mHistoNum{ nullptr };
   TH1D* mHistoDen{ nullptr };

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
@@ -60,7 +60,7 @@ class MergeableTH1Ratio : public TH1F, public o2::mergers::MergeInterface
 
   void update();
 
-  void Reset(Option_t* option = "");
+  void Reset(Option_t* option = "") override;
 
  private:
   TH1D* mHistoNum{ nullptr };
@@ -68,7 +68,7 @@ class MergeableTH1Ratio : public TH1F, public o2::mergers::MergeInterface
   std::string mTreatMeAs = "TH1F";
   double mScalingFactor = 1.;
 
-  ClassDefOverride(MergeableTH1Ratio, 1);
+  ClassDefOverride(MergeableTH1Ratio, 2);
 };
 
 } // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
@@ -60,7 +60,7 @@ class MergeableTH1Ratio : public TH1F, public o2::mergers::MergeInterface
 
   void update();
 
-  void Reset(Option_t*  option = "");
+  void Reset(Option_t* option = "");
 
  private:
   TH1D* mHistoNum{ nullptr };

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH1Ratio.h
@@ -68,7 +68,7 @@ class MergeableTH1Ratio : public TH1F, public o2::mergers::MergeInterface
   std::string mTreatMeAs = "TH1F";
   double mScalingFactor = 1.;
 
-  ClassDefOverride(MergeableTH1Ratio, 2);
+  ClassDefOverride(MergeableTH1Ratio, 1);
 };
 
 } // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
@@ -62,7 +62,7 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
 
   void beautify();
 
-  void Reset(Option_t* option = "");
+  void Reset(Option_t* option = "") override;
 
  private:
   TH2F* mHistoNum{ nullptr };
@@ -70,7 +70,7 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
   std::string mTreatMeAs{ "TH2F" };
   bool mShowZeroBins{ false };
 
-  ClassDefOverride(MergeableTH2Ratio, 1);
+  ClassDefOverride(MergeableTH2Ratio, 2);
 };
 
 } // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
@@ -62,7 +62,7 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
 
   void beautify();
 
-  void Reset(Option_t*  option = "");
+  void Reset(Option_t* option = "");
 
  private:
   TH2F* mHistoNum{ nullptr };

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
@@ -62,6 +62,8 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
 
   void beautify();
 
+  void Reset(Option_t*  option = "");
+
  private:
   TH2F* mHistoNum{ nullptr };
   TH2F* mHistoDen{ nullptr };

--- a/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
+++ b/Modules/MUON/Common/include/MUONCommon/MergeableTH2Ratio.h
@@ -70,7 +70,7 @@ class MergeableTH2Ratio : public TH2F, public o2::mergers::MergeInterface
   std::string mTreatMeAs{ "TH2F" };
   bool mShowZeroBins{ false };
 
-  ClassDefOverride(MergeableTH2Ratio, 2);
+  ClassDefOverride(MergeableTH2Ratio, 1);
 };
 
 } // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/src/MergeableTH1Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH1Ratio.cxx
@@ -93,7 +93,7 @@ void MergeableTH1Ratio::update()
   const char* name = this->GetName();
   const char* title = this->GetTitle();
 
-  Reset();
+  TH1F::Reset();
   GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
   SetBinsLength();
 
@@ -113,6 +113,13 @@ void MergeableTH1Ratio::update()
   if (mScalingFactor != 1.) {
     Scale(mScalingFactor);
   }
+}
+
+void MergeableTH1Ratio::Reset(Option_t*  option)
+{
+  getNum()->Reset(option);
+  getDen()->Reset(option);
+  TH1F::Reset(option);
 }
 
 } // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/src/MergeableTH1Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH1Ratio.cxx
@@ -115,7 +115,7 @@ void MergeableTH1Ratio::update()
   }
 }
 
-void MergeableTH1Ratio::Reset(Option_t*  option)
+void MergeableTH1Ratio::Reset(Option_t* option)
 {
   getNum()->Reset(option);
   getDen()->Reset(option);

--- a/Modules/MUON/Common/src/MergeableTH1Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH1Ratio.cxx
@@ -32,6 +32,10 @@ MergeableTH1Ratio::MergeableTH1Ratio(MergeableTH1Ratio const& copymerge)
   mHistoDen = (TH1D*)copymerge.getDen()->Clone();
   TH1::AddDirectory(bStatus);
 
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
   mHistoNum->Sumw2();
   mHistoDen->Sumw2();
 }
@@ -46,6 +50,10 @@ MergeableTH1Ratio::MergeableTH1Ratio(const char* name, const char* title, int nb
   mHistoNum = new TH1D("num", "num", nbinsx, xmin, xmax);
   mHistoDen = new TH1D("den", "den", nbinsx, xmin, xmax);
   TH1::AddDirectory(bStatus);
+
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
 
   mHistoNum->Sumw2();
   mHistoDen->Sumw2();
@@ -63,6 +71,10 @@ MergeableTH1Ratio::MergeableTH1Ratio(const char* name, const char* title, double
   mHistoNum = new TH1D("num", "num", 10, 0, 10);
   mHistoDen = new TH1D("den", "den", 10, 0, 10);
   TH1::AddDirectory(bStatus);
+
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
 
   mHistoNum->Sumw2();
   mHistoDen->Sumw2();
@@ -83,6 +95,10 @@ MergeableTH1Ratio::~MergeableTH1Ratio()
 
 void MergeableTH1Ratio::merge(MergeInterface* const other)
 {
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
   mHistoNum->Add(dynamic_cast<const MergeableTH1Ratio* const>(other)->getNum());
   mHistoDen->Add(dynamic_cast<const MergeableTH1Ratio* const>(other)->getDen());
   update();
@@ -90,6 +106,10 @@ void MergeableTH1Ratio::merge(MergeInterface* const other)
 
 void MergeableTH1Ratio::update()
 {
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
   const char* name = this->GetName();
   const char* title = this->GetTitle();
 
@@ -117,8 +137,14 @@ void MergeableTH1Ratio::update()
 
 void MergeableTH1Ratio::Reset(Option_t* option)
 {
-  getNum()->Reset(option);
-  getDen()->Reset(option);
+  if (mHistoNum) {
+    mHistoNum->Reset(option);
+  }
+
+  if (mHistoDen) {
+    mHistoDen->Reset(option);
+  }
+
   TH1F::Reset(option);
 }
 

--- a/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
@@ -73,6 +73,10 @@ MergeableTH2Ratio::~MergeableTH2Ratio()
 
 void MergeableTH2Ratio::merge(MergeInterface* const other)
 {
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
   mHistoNum->Add(dynamic_cast<const MergeableTH2Ratio* const>(other)->getNum());
   mHistoDen->Add(dynamic_cast<const MergeableTH2Ratio* const>(other)->getDen());
   update();
@@ -80,6 +84,10 @@ void MergeableTH2Ratio::merge(MergeInterface* const other)
 
 void MergeableTH2Ratio::update()
 {
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
   const char* name = this->GetName();
   const char* title = this->GetTitle();
 
@@ -113,7 +121,10 @@ void MergeableTH2Ratio::update()
 
 void MergeableTH2Ratio::beautify()
 {
-  SetOption("colz");
+  if (!mHistoNum) {
+    return;
+  }
+
   GetListOfFunctions()->RemoveAll();
 
   TList* functions = (TList*)mHistoNum->GetListOfFunctions()->Clone();
@@ -125,8 +136,14 @@ void MergeableTH2Ratio::beautify()
 
 void MergeableTH2Ratio::Reset(Option_t* option)
 {
-  getNum()->Reset(option);
-  getDen()->Reset(option);
+  if (mHistoNum) {
+    mHistoNum->Reset(option);
+  }
+
+  if (mHistoDen) {
+    mHistoDen->Reset(option);
+  }
+
   TH2F::Reset(option);
 }
 

--- a/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
@@ -83,15 +83,15 @@ void MergeableTH2Ratio::update()
   const char* name = this->GetName();
   const char* title = this->GetTitle();
 
-  Reset();
-  beautify();
+  TH2F::Reset();
 
+  SetNameTitle(name, title);
   GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
   GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXmin(), mHistoNum->GetYaxis()->GetXmax());
   SetBinsLength();
+  beautify();
 
   Divide(mHistoNum, mHistoDen);
-  SetNameTitle(name, title);
 
   if (mShowZeroBins) {
     // bins which have zero numerators are plotted in white when using the "col" and "colz" options, regardless of
@@ -121,6 +121,13 @@ void MergeableTH2Ratio::beautify()
     GetListOfFunctions()->AddAll(functions);
     delete functions;
   }
+}
+
+void MergeableTH2Ratio::Reset(Option_t*  option)
+{
+  getNum()->Reset(option);
+  getDen()->Reset(option);
+  TH2F::Reset(option);
 }
 
 } // namespace o2::quality_control_modules::muon

--- a/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
+++ b/Modules/MUON/Common/src/MergeableTH2Ratio.cxx
@@ -123,7 +123,7 @@ void MergeableTH2Ratio::beautify()
   }
 }
 
-void MergeableTH2Ratio::Reset(Option_t*  option)
+void MergeableTH2Ratio::Reset(Option_t* option)
 {
   getNum()->Reset(option);
   getDen()->Reset(option);

--- a/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
+++ b/Modules/MUON/MCH/include/MCH/PhysicsTaskDigits.h
@@ -67,6 +67,7 @@ class PhysicsTaskDigits /*final*/ : public TaskInterface // todo add back the "f
   void addDefaultOrbitsInTF();
   void plotDigit(const o2::mch::Digit& digit);
   void updateOrbits();
+  void resetOrbits();
 
   template <typename T>
   void publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox, bool isExpert)

--- a/Modules/MUON/MCH/src/DecodingErrorsTask.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsTask.cxx
@@ -315,11 +315,10 @@ void DecodingErrorsTask::endOfActivity(Activity& /*activity*/)
 void DecodingErrorsTask::reset()
 {
   // clean all the monitor objects here
-
   ILOG(Info, Support) << "Resetting the histograms" << ENDM;
 
   for (auto h : mAllHistograms) {
-    h->Reset();
+    h->Reset("ICES");
   }
 }
 

--- a/Modules/MUON/MCH/src/PhysicsCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsCheck.cxx
@@ -181,9 +181,6 @@ Quality PhysicsCheck::processFecOccupancy(MergeableTH2Ratio* hr, std::vector<dou
     // integrated occupancies
     if (deOccupancyDen[de] > 0) {
       deOccupancy[de] = deOccupancyNum[de] / deOccupancyDen[de];
-      if (de == 10) {
-        std::cout << fmt::format("xxxx occupancy: {} = {} / {}", deOccupancy[de], deOccupancyNum[de], deOccupancyDen[de]) << std::endl;
-      }
     } else {
       deOccupancy[de] = 0;
     }
@@ -211,15 +208,11 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
         mHistogramOccupancyFecPrevCycle = std::make_shared<MergeableTH2Ratio>(*hr);
         mHistogramOccupancyFecPrevCycle->SetName("mHistogramOccupancyFecPrevCycle");
         mHistogramOccupancyFecPrevCycle->Reset();
-        mHistogramOccupancyFecPrevCycle->getNum()->Reset();
-        mHistogramOccupancyFecPrevCycle->getDen()->Reset();
       }
 
       MergeableTH2Ratio hdiff(*hr);
       hdiff.SetName("mHistogramOccupancyFecOnCycle");
       hdiff.Reset();
-      hdiff.getNum()->Reset();
-      hdiff.getDen()->Reset();
 
       hdiff.getNum()->Add(hr->getNum());
       hdiff.getNum()->Add(mHistogramOccupancyFecPrevCycle->getNum(), -1);
@@ -231,8 +224,6 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
 
       // update previous cycle plot
       mHistogramOccupancyFecPrevCycle->Reset();
-      mHistogramOccupancyFecPrevCycle->getNum()->Reset();
-      mHistogramOccupancyFecPrevCycle->getDen()->Reset();
       mHistogramOccupancyFecPrevCycle->getNum()->Add(hr->getNum());
       mHistogramOccupancyFecPrevCycle->getDen()->Add(hr->getDen());
     }

--- a/Modules/MUON/MCH/src/PhysicsPreclustersCheck.cxx
+++ b/Modules/MUON/MCH/src/PhysicsPreclustersCheck.cxx
@@ -198,7 +198,6 @@ Quality PhysicsPreclustersCheck::check(std::map<std::string, std::shared_ptr<Mon
       // into the histogram bins in the beutify() method
       for (int i = 0; i < 2; i++) {
         for (size_t de = 0; de < dePseudoeffDen[i].size(); de++) {
-          std::cout << fmt::format("xxxx DE{}  num {}  den {}", de, dePseudoeffNum[i][de], dePseudoeffDen[i][de]) << std::endl;
           if (dePseudoeffDen[i][de] > 0) {
             mDePseudoeff[i][de] = dePseudoeffNum[i][de] / dePseudoeffDen[i][de];
           } else {

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -106,11 +106,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
 
   const uint32_t nElecXbins = PhysicsTaskDigits::sMaxFeeId * PhysicsTaskDigits::sMaxLinkId * PhysicsTaskDigits::sMaxDsId;
 
-  for (int fee = 0; fee < PhysicsTaskDigits::sMaxFeeId; fee++) {
-    for (int link = 0; link < PhysicsTaskDigits::sMaxLinkId; link++) {
-      mNOrbits[fee][link] = mLastOrbitSeen[fee][link] = 0;
-    }
-  }
+  resetOrbits();
 
   // Histograms in electronics coordinates
   mHistogramOccupancyElec = std::make_shared<MergeableTH2Ratio>("Occupancy_Elec", "Occupancy", nElecXbins, 0, nElecXbins, 64, 0, 64);
@@ -401,6 +397,15 @@ void PhysicsTaskDigits::updateOrbits()
   }
 }
 
+void PhysicsTaskDigits::resetOrbits()
+{
+  for (int fee = 0; fee < PhysicsTaskDigits::sMaxFeeId; fee++) {
+    for (int link = 0; link < PhysicsTaskDigits::sMaxLinkId; link++) {
+      mNOrbits[fee][link] = mLastOrbitSeen[fee][link] = 0;
+    }
+  }
+}
+
 void PhysicsTaskDigits::endOfCycle()
 {
   // copy bin contents from src to dst
@@ -486,10 +491,12 @@ void PhysicsTaskDigits::endOfActivity(Activity& /*activity*/)
 void PhysicsTaskDigits::reset()
 {
   // clean all the monitor objects here
-  ILOG(Info, Support) << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
+  ILOG(Info, Support) << "Resetting the histograms" << AliceO2::InfoLogger::InfoLogger::endm;
+
+  resetOrbits();
 
   for (auto h : mAllHistograms) {
-    h->Reset();
+    h->Reset("ICES");
   }
 }
 

--- a/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
@@ -578,7 +578,7 @@ void PhysicsTaskPreclusters::reset()
   ILOG(Info, Support) << "Reseting the histogram" << AliceO2::InfoLogger::InfoLogger::endm;
 
   for (auto h : mAllHistograms) {
-    h->Reset();
+    h->Reset("ICES");
   }
 }
 

--- a/Modules/MUON/MCH/src/PhysicsTaskRofs.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskRofs.cxx
@@ -177,7 +177,7 @@ void PhysicsTaskRofs::reset()
   ILOG(Info, Support) << "Resetting the histograms" << ENDM;
 
   for (auto h : mAllHistograms) {
-    h->Reset();
+    h->Reset("ICES");
   }
 }
 

--- a/Modules/MUON/MCH/src/TrendingFECHistRatio.cxx
+++ b/Modules/MUON/MCH/src/TrendingFECHistRatio.cxx
@@ -148,7 +148,6 @@ void TrendingFECHistRatio::computeMCHFECHistRatios(TH2F* hNum, TH2F* hDen)
 
   int nbinsx = hDiffNum.GetXaxis()->GetNbins();
   int nbinsy = hDiffNum.GetYaxis()->GetNbins();
-  std::cout << fmt::format("xxxx bins {} {}", nbinsx, nbinsy) << std::endl;
   int ngood = 0;
   int npads = 0;
   for (int i = 1; i <= nbinsx; i++) {
@@ -177,19 +176,16 @@ void TrendingFECHistRatio::computeMCHFECHistRatios(TH2F* hNum, TH2F* hDen)
       chamberDen[chamber] += 1;
     }
   }
-  std::cout << "xxxx Processing of FEC plot finished" << std::endl;
 
   // compute and store average rate for each detection element
   for (auto de : o2::mch::raw::deIdsForAllMCH) {
     double ratio = (deDen[de] > 0) ? (deNum[de] / deDen[de]) : 0;
-    std::cout << fmt::format("xxxx DE{}  ratio {} / {} = {}", de, deNum[de], deDen[de], ratio) << std::endl;
     mTrendDE[de] = ratio;
   }
 
   // compute and store average rate for each chamber
   for (int ch = 0; ch < 10; ch++) {
     double ratio = (chamberDen[ch] > 0) ? (chamberNum[ch] / chamberDen[ch]) : 0;
-    std::cout << fmt::format("xxxx CH{}  ratio {} / {} = {}", ch + 1, chamberNum[ch], chamberDen[ch], ratio) << std::endl;
     mTrendCH[ch] = ratio;
   }
 
@@ -277,7 +273,6 @@ void TrendingFECHistRatio::trendValues(const Trigger& t, repository::DatabaseInt
     ILOG(Info, Support) << "Cannot cast histogramRates, can't compute rates";
     return;
   }
-  std::cout << fmt::format("xxxx calling computeMCHFECHistRatios()") << std::endl;
   computeMCHFECHistRatios(hr->getNum(), hr->getDen());
 
   mTrend->Fill();


### PR DESCRIPTION
- added method to properly reset the numerator and denominator in the mergeable histogram ratios
- added option "ICES" to the histogram reset to avoid removing the associated functions
- added reset of orbit counters in digits task
