### PR TITLE
Add C to allowed languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ include(AddQCWorkflow)
 # ---- Project ----
 
 project(QualityControl
-        VERSION 1.67.0 
+        VERSION 1.67.0
         DESCRIPTION "O2 Data Quality Control Framework"
-        LANGUAGES CXX)
+        LANGUAGES C CXX)
 
 if(ONLYDOC)
   add_subdirectory(doc)


### PR DESCRIPTION
There is a bug in LLVM CMake (for LLVM > 14), which is pulled in since you load the O2 dependencies, which breaks the cmake phase if C is not in the list of allowerd languages.