### PR TITLE
Condition to fill hitmaps changed from nTriggers to nTF

### DIFF
--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -112,7 +112,7 @@ class ITSFhrTask final : public TaskInterface
   int mGetTFFromBinding = 0;
   int mHitCutForNoisyPixel = 1024;        // Hit number cut for noisy pixel, this number should be define according how many TF will be accumulated before reset(one can reference the cycle time)
   float mOccupancyCutForNoisyPixel = 0.1; // Occupancy cut for noisy pixel. check if the hit/event value over this cut. similar with mHitCutForNoisyPixel
-  double mCutTrgForSparse = 1000;         // cut to stop THnSparse filling after mCutTrgForSparse triggers
+  double mCutTFForSparse = 1;         // cut to stop THnSparse filling after mCutTrgForSparse triggers
 
   std::unordered_map<unsigned int, int>*** mHitPixelID_InStave /* = new std::unordered_map<unsigned int, int>**[NStaves[lay]]*/;
   int** mHitnumberLane /* = new int*[NStaves[lay]]*/;       // IB : hitnumber[stave][chip]; OB : hitnumber[stave][lane]

--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -112,7 +112,7 @@ class ITSFhrTask final : public TaskInterface
   int mGetTFFromBinding = 0;
   int mHitCutForNoisyPixel = 1024;        // Hit number cut for noisy pixel, this number should be define according how many TF will be accumulated before reset(one can reference the cycle time)
   float mOccupancyCutForNoisyPixel = 0.1; // Occupancy cut for noisy pixel. check if the hit/event value over this cut. similar with mHitCutForNoisyPixel
-  double mCutTFForSparse = 1;         // cut to stop THnSparse filling after mCutTrgForSparse triggers
+  double mCutTFForSparse = 1;             // cut to stop THnSparse filling after mCutTrgForSparse triggers
 
   std::unordered_map<unsigned int, int>*** mHitPixelID_InStave /* = new std::unordered_map<unsigned int, int>**[NStaves[lay]]*/;
   int** mHitnumberLane /* = new int*[NStaves[lay]]*/;       // IB : hitnumber[stave][chip]; OB : hitnumber[stave][lane]

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -49,7 +49,7 @@
 		    "Etabins": "130",
                     "Phibins": "240",
 		    "geomPath": "./",
-		    "CutSparseTriggers": "1000"
+		    "CutSparseTF": "1"
                 }
             }
         },

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -610,12 +610,12 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
                 occupancyPlotTmp[i]->Fill(log10(pixelOccupancy / GBTLinkInfo->statistics.nTriggers));
                 if (ichip < 7) {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + ichip * NCols + (int)(iter->first / 1000) + 1, NRows - ((int)iter->first % 1000) - 1 + (1024 * ilink) + 1 };
-                  if (mTFCount <= mCutTFForSparse) {
+                  if (mTFCount < mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 } else {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (ichip - 7) * NCols - ((int)iter->first / 1000), NRows + ((int)iter->first % 1000) + (1024 * ilink) + 1 };
-                  if (mTFCount <= mCutTFForSparse) {
+                  if (mTFCount < mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 }

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -572,7 +572,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
               mNoisyPixelNumber[mLayer][istave]++; // count only in 10000 events as soon as nTriggers is 1e6
             }
             int pixelPos[2] = { (int)(iter->first / 1000) + (1024 * ichip) + 1, (int)(iter->first % 1000) + 1 };
-            if ( mTFCount < mCutTFForSparse) {
+            if (mTFCount < mCutTFForSparse) {
               mStaveHitmap[istave]->SetBinContent(pixelPos, (double)iter->second);
             }
             totalhit += (int)iter->second;

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -572,7 +572,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
               mNoisyPixelNumber[mLayer][istave]++; // count only in 10000 events as soon as nTriggers is 1e6
             }
             int pixelPos[2] = { (int)(iter->first / 1000) + (1024 * ichip) + 1, (int)(iter->first % 1000) + 1 };
-            if ((double)GBTLinkInfo->statistics.nTriggers <= mCutTrgForSparse) {
+            if ( (mTimeFrameId+1) <= mCutTFForSparse) {
               mStaveHitmap[istave]->SetBinContent(pixelPos, (double)iter->second);
             }
             totalhit += (int)iter->second;
@@ -610,12 +610,12 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
                 occupancyPlotTmp[i]->Fill(log10(pixelOccupancy / GBTLinkInfo->statistics.nTriggers));
                 if (ichip < 7) {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + ichip * NCols + (int)(iter->first / 1000) + 1, NRows - ((int)iter->first % 1000) - 1 + (1024 * ilink) + 1 };
-                  if ((double)GBTLinkInfo->statistics.nTriggers <= mCutTrgForSparse) {
+                  if ((mTimeFrameId+1) <= mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 } else {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (ichip - 7) * NCols - ((int)iter->first / 1000), NRows + ((int)iter->first % 1000) + (1024 * ilink) + 1 };
-                  if ((double)GBTLinkInfo->statistics.nTriggers <= mCutTrgForSparse) {
+                  if ((mTimeFrameId+1) <= mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 }
@@ -732,7 +732,7 @@ void ITSFhrTask::getParameters()
   mMinGeneralNoisyAxisRange = std::stof(mCustomParameters["MinGeneralNoisyAxisRange"]);
   mPhibins = std::stoi(mCustomParameters["Phibins"]);
   mEtabins = std::stoi(mCustomParameters["Etabins"]);
-  mCutTrgForSparse = std::stod(mCustomParameters["CutSparseTriggers"]);
+  mCutTFForSparse = std::stod(mCustomParameters["CutSparseTF"]);
 }
 
 void ITSFhrTask::endOfCycle()

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -572,7 +572,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
               mNoisyPixelNumber[mLayer][istave]++; // count only in 10000 events as soon as nTriggers is 1e6
             }
             int pixelPos[2] = { (int)(iter->first / 1000) + (1024 * ichip) + 1, (int)(iter->first % 1000) + 1 };
-            if ((mTimeFrameId + 1) <= mCutTFForSparse) {
+            if ( mTFCount < mCutTFForSparse) {
               mStaveHitmap[istave]->SetBinContent(pixelPos, (double)iter->second);
             }
             totalhit += (int)iter->second;
@@ -610,12 +610,12 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
                 occupancyPlotTmp[i]->Fill(log10(pixelOccupancy / GBTLinkInfo->statistics.nTriggers));
                 if (ichip < 7) {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + ichip * NCols + (int)(iter->first / 1000) + 1, NRows - ((int)iter->first % 1000) - 1 + (1024 * ilink) + 1 };
-                  if ((mTimeFrameId + 1) <= mCutTFForSparse) {
+                  if (mTFCount <= mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 } else {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (ichip - 7) * NCols - ((int)iter->first / 1000), NRows + ((int)iter->first % 1000) + (1024 * ilink) + 1 };
-                  if ((mTimeFrameId + 1) <= mCutTFForSparse) {
+                  if (mTFCount <= mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 }

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -572,7 +572,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
               mNoisyPixelNumber[mLayer][istave]++; // count only in 10000 events as soon as nTriggers is 1e6
             }
             int pixelPos[2] = { (int)(iter->first / 1000) + (1024 * ichip) + 1, (int)(iter->first % 1000) + 1 };
-            if ( (mTimeFrameId+1) <= mCutTFForSparse) {
+            if ((mTimeFrameId + 1) <= mCutTFForSparse) {
               mStaveHitmap[istave]->SetBinContent(pixelPos, (double)iter->second);
             }
             totalhit += (int)iter->second;
@@ -610,12 +610,12 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
                 occupancyPlotTmp[i]->Fill(log10(pixelOccupancy / GBTLinkInfo->statistics.nTriggers));
                 if (ichip < 7) {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + ichip * NCols + (int)(iter->first / 1000) + 1, NRows - ((int)iter->first % 1000) - 1 + (1024 * ilink) + 1 };
-                  if ((mTimeFrameId+1) <= mCutTFForSparse) {
+                  if ((mTimeFrameId + 1) <= mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 } else {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (ichip - 7) * NCols - ((int)iter->first / 1000), NRows + ((int)iter->first % 1000) + (1024 * ilink) + 1 };
-                  if ((mTimeFrameId+1) <= mCutTFForSparse) {
+                  if ((mTimeFrameId + 1) <= mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 }


### PR DESCRIPTION
Condition for filling THnSparse hitmaps were changed from the first 1000 triggers to the first 1 TF. 
Previous criteria required to adjust the threshold based on current IR, while the new one should be more generalized