### PR TITLE
[EMCAL-711] Fix faulty bin range

### DIFF
--- a/Modules/EMCAL/src/RawErrorTask.cxx
+++ b/Modules/EMCAL/src/RawErrorTask.cxx
@@ -159,13 +159,13 @@ void RawErrorTask::initialize(o2::framework::InitContext& /*ctx*/)
   mErrorGainHigh->SetStats(0);
   getObjectsManager()->startPublishing(mErrorGainHigh);
 
-  mChannelGainLow = new TH2F("ChannelLGnoHG", "Channel with HG bunch missing", 96, -0.5, 96.5, 208, -0.5, 207.5);
+  mChannelGainLow = new TH2F("ChannelLGnoHG", "Channel with HG bunch missing", 96, -0.5, 95.5, 208, -0.5, 207.5);
   mChannelGainLow->GetXaxis()->SetTitle("Column");
   mChannelGainLow->GetYaxis()->SetTitle("Row");
   mChannelGainLow->SetStats(0);
   getObjectsManager()->startPublishing(mChannelGainLow);
 
-  mChannelGainHigh = new TH2F("ChannelHGnoLG", "Channel with LG bunch missing", 96, -0.5, 96.5, 208, -0.5, 207.5);
+  mChannelGainHigh = new TH2F("ChannelHGnoLG", "Channel with LG bunch missing", 96, -0.5, 95.5, 208, -0.5, 207.5);
   mChannelGainHigh->GetXaxis()->SetTitle("Column");
   mChannelGainHigh->GetYaxis()->SetTitle("Row");
   mChannelGainHigh->SetStats(0);


### PR DESCRIPTION
Overvlow bin added by mistake in position of gain type
error channels. This will make the checker fail in case the
fault channel is close to the PHOS hole which make the
checker interpret the channel being in the PHOS hole.