### PR TITLE
TRD remove spectra causing problems, and configure checks from json

### DIFF
--- a/Modules/TRD/include/TRD/DigitsTask.h
+++ b/Modules/TRD/include/TRD/DigitsTask.h
@@ -60,10 +60,13 @@ class DigitsTask final : public TaskInterface
   void drawLinesOnPulseHeight(TH1F* h);
   void fillLinesOnHistsPerLayer(int iLayer);
   void drawHashOnLayers(int layer, int hcid, int col, int rowstart, int rowend);
+  void buildChamberIgnoreBP();
+  bool isChamberToBeIgnored(unsigned int sm, unsigned int stack, unsigned int layer);
 
  private:
   // limits
   bool mSkipSharedDigits;
+  unsigned int mPulseHeightThreshold;
   std::pair<float, float> mDriftRegion;
   std::pair<float, float> mPulseHeightPeakRegion;
   long int mTimestamp;
@@ -93,7 +96,6 @@ class DigitsTask final : public TaskInterface
   std::array<std::shared_ptr<TH2F>, 18> mClsDetAmp;
   std::shared_ptr<TH2F> mClsSector;
   std::shared_ptr<TH2F> mClsStack;
-  std::array<std::shared_ptr<TH2F>, 18> mClsDetTime;
   std::shared_ptr<TH1F> mClsChargeTbTigg;
   std::shared_ptr<TH2F> mClsChargeTbTrigHM;
   std::shared_ptr<TH2F> mClsChargeTbTrigMinBias;
@@ -106,11 +108,13 @@ class DigitsTask final : public TaskInterface
   std::shared_ptr<TH1F> mPulseHeightn = nullptr;
   std::shared_ptr<TProfile> mPulseHeightpro = nullptr;
   std::shared_ptr<TProfile2D> mPulseHeightperchamber = nullptr;
-  std::array<std::shared_ptr<TH1F>, 540> mPulseHeightPerChamber_1D; // ph2DSM;
+  //  std::array<std::shared_ptr<TH1F>, 540> mPulseHeightPerChamber_1D; // ph2DSM;
   std::vector<TH2F*> mLayers;
   // information pulled from ccdb
   o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
   o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
+  std::string mChambersToIgnore;
+  std::bitset<o2::trd::constants::MAXCHAMBER> mChambersToIgnoreBP;
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/include/TRD/PulseHeightCheck.h
+++ b/Modules/TRD/include/TRD/PulseHeightCheck.h
@@ -18,6 +18,7 @@
 #define QC_MODULE_TRD_TRDPULSEHEIGHTCHECK_H
 
 #include "QualityControl/CheckInterface.h"
+#include "DataFormatsTRD/Constants.h"
 
 namespace o2::quality_control_modules::trd
 {
@@ -37,10 +38,12 @@ class PulseHeightCheck : public o2::quality_control::checker::CheckInterface
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
+  void buildChamberIgnoreBP();
   long int mTimeStamp;
   std::pair<float, float> mDriftRegion;
   std::pair<float, float> mPulseHeightPeakRegion;
-
+  unsigned int mPulseHeightMinSum;
+  float mPulseHeightRatio;
   ClassDefOverride(PulseHeightCheck, 1);
 };
 

--- a/Modules/TRD/src/PulseHeight.cxx
+++ b/Modules/TRD/src/PulseHeight.cxx
@@ -72,10 +72,10 @@ void PulseHeight::buildHistograms()
   mPulseHeightScaled2.reset(new TH1F("mPulseHeightScaled2", "Scaled Pulse height plot", 30, -0.5, 29.5));
   getObjectsManager()->startPublishing(mPulseHeightScaled2.get());
 
-  mTotalPulseHeight2D.reset(new TH2F("TotalPulseHeight", "Total Pulse Height", 30, 0., 30., 200, 0., 200.));
+  mTotalPulseHeight2D.reset(new TH2F("TotalPulseHeight", "Total Pulse Height", 30, 0., 30., 300, 0., 200.));
   getObjectsManager()->startPublishing(mTotalPulseHeight2D.get());
   getObjectsManager()->setDefaultDrawOptions(mTotalPulseHeight2D->GetName(), "COLZ");
-  mTotalPulseHeight2D2.reset(new TH2F("TotalPulseHeight2", "Total Pulse Height", 30, 0., 30., 200, 0., 200.));
+  mTotalPulseHeight2D2.reset(new TH2F("TotalPulseHeight2", "Total Pulse Height", 30, 0., 30., 300, 0., 200.));
   getObjectsManager()->startPublishing(mTotalPulseHeight2D2.get());
   getObjectsManager()->setDefaultDrawOptions(mTotalPulseHeight2D2->GetName(), "COLZ");
 


### PR DESCRIPTION
- TRD QC is crashing in 2 spectra pulseheight per chamber (both places) on the fill and ClsDetTime also on fill. These are presumed to follow the "Invalid signature" message from ROOT.
- Allow the checks to be configured from json.

DigitsTask:
driftregionstart : 0 red line on pulseheight plot
driftregionend: 5  red line on pulseheight plot.
pulseheightthreshold : 400 min sum of all 3 adjacent adc to enter the pulseheight, displayed in title
chamberstoignore": "16_3_0 06_1_0" applies to pulseheight generation

PulseHeightCheck:
driftregionstart": "7.0",
driftregionend": "20.0",
pulseheightpeaklower": "0.0",
pulseheightpeakupper": "5.0",

pulseheightminsum": "1500", min counts before starting the check.
pulseheightratio": "1.1", min ratio of peak to average of drift region as defined by the paramters above.

TrackletsCheck: applies to tracklets per timeframe
integralthreshold 10000.0
ratiothreshold": "0.9 - 90% of counts must be above the integralthreshold
zerobinratiothrehold 0.9  90% of counts that must be outside bin 0  

