### PR TITLE
Do not build empty tests

### DIFF
--- a/Modules/CPV/CMakeLists.txt
+++ b/Modules/CPV/CMakeLists.txt
@@ -30,7 +30,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CPV
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcCPV.cxx)
+#set(TEST_SRCS test/testQcCPV.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/CTP/CMakeLists.txt
+++ b/Modules/CTP/CMakeLists.txt
@@ -29,7 +29,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CTP
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcCTP.cxx)
+#set(TEST_SRCS test/testQcCTP.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/FDD/CMakeLists.txt
+++ b/Modules/FDD/CMakeLists.txt
@@ -35,7 +35,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/FDD
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcFDD.cxx)
+#set(TEST_SRCS test/testQcFDD.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/FT0/CMakeLists.txt
+++ b/Modules/FT0/CMakeLists.txt
@@ -80,7 +80,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/FT0
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcFT0.cxx)
+#set(TEST_SRCS test/testQcFT0.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/FV0/CMakeLists.txt
+++ b/Modules/FV0/CMakeLists.txt
@@ -45,7 +45,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/FV0
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcFV0.cxx)
+#set(TEST_SRCS test/testQcFV0.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/GLO/CMakeLists.txt
+++ b/Modules/GLO/CMakeLists.txt
@@ -49,7 +49,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/GLO
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcGLO.cxx)
+#set(TEST_SRCS test/testQcGLO.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/HMPID/CMakeLists.txt
+++ b/Modules/HMPID/CMakeLists.txt
@@ -39,7 +39,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/HMPID
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcHMPID.cxx)
+#set(TEST_SRCS test/testQcHMPID.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/ITS/CMakeLists.txt
+++ b/Modules/ITS/CMakeLists.txt
@@ -73,14 +73,19 @@ add_root_dictionary(O2QcITS
 
 # ---- Test(s) ----
 
-add_executable(testQcITS test/testITS.cxx)
-target_link_libraries(testQcITS PRIVATE O2QcITS Boost::unit_test_framework O2::ITSMFTReconstruction O2::ITSBase O2::DetectorsBase O2QualityControl)
-add_test(NAME testQcITS COMMAND testQcITS)
-set_tests_properties(testQcITS PROPERTIES TIMEOUT 60)
-install(
-  TARGETS testQcITS
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+#add_executable(testQcITS test/testITS.cxx) # uncomment to reenable the test which was empty
+foreach(test ${TEST_SRCS})
+  get_filename_component(test_name ${test} NAME)
+  string(REGEX REPLACE ".cxx" "" test_name ${test_name})
+
+  add_executable(${test_name} ${test})
+  target_link_libraries(${test_name}
+    PRIVATE O2QcCPV Boost::unit_test_framework)
+  add_test(NAME ${test_name} COMMAND ${test_name})
+  set_property(TARGET ${test_name}
+    PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
+endforeach()
 
 # ---- Executables ----
 

--- a/Modules/MFT/CMakeLists.txt
+++ b/Modules/MFT/CMakeLists.txt
@@ -80,7 +80,7 @@ install(
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcMFT.cxx)
+#set(TEST_SRCS test/testQcMFT.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/MUON/MID/CMakeLists.txt
+++ b/Modules/MUON/MID/CMakeLists.txt
@@ -48,7 +48,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/MID DESTINATION "${CMAKE_I
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcMID.cxx)
+#set(TEST_SRCS test/testQcMID.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -83,7 +83,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/TPC
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcTPC.cxx)
+#set(TEST_SRCS test/testQcTPC.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)

--- a/Modules/TRD/CMakeLists.txt
+++ b/Modules/TRD/CMakeLists.txt
@@ -32,7 +32,7 @@ add_root_dictionary(O2QcTRD
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcTRD.cxx)
+#set(TEST_SRCS test/testQcTRD.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
 

--- a/Modules/ZDC/CMakeLists.txt
+++ b/Modules/ZDC/CMakeLists.txt
@@ -29,7 +29,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ZDC
 
 # ---- Test(s) ----
 
-set(TEST_SRCS test/testQcZDC.cxx)
+#set(TEST_SRCS test/testQcZDC.cxx) # uncomment to reenable the test which was empty
 
 foreach(test ${TEST_SRCS})
   get_filename_component(test_name ${test} NAME)


### PR DESCRIPTION
I hoped to save time. It is marginal but I don't see a reason for compiling these tests any ways.