### PR TITLE
MFT: reduced number of plots, geometry loaded, cluster position plots added

### DIFF
--- a/Modules/MFT/CMakeLists.txt
+++ b/Modules/MFT/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcMFT PUBLIC O2QualityControl O2::DataFormatsITSMFT O2::ITSMFTReconstruction)
+target_link_libraries(O2QcMFT PUBLIC O2QualityControl O2::DataFormatsITSMFT O2::ITSMFTReconstruction O2::MFTTracking)
 
 install(TARGETS O2QcMFT
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/MFT/CMakeLists.txt
+++ b/Modules/MFT/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcMFT PUBLIC O2QualityControl O2::DataFormatsITSMFT O2::ITSMFTReconstruction O2::MFTTracking)
+target_link_libraries(O2QcMFT PUBLIC O2QualityControl O2::DataFormatsITSMFT O2::ITSMFTReconstruction O2::MFTTracking O2::MFTBase O2::ITSMFTBase O2::DetectorsBase)
 
 install(TARGETS O2QcMFT
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -22,6 +22,7 @@
 #include <TH1F.h>
 #include <TH2F.h>
 #include <DataFormatsITSMFT/TopologyDictionary.h>
+#include "ReconstructionDataFormats/BaseCluster.h"
 
 // Quality Control
 #include "QualityControl/TaskInterface.h"
@@ -64,6 +65,10 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   std::unique_ptr<TH2F> mClusterPatternSensorIndices = nullptr;
   std::vector<std::unique_ptr<TH2F>> mClusterChipOccupancyMap;
   std::vector<std::unique_ptr<TH2F>> mClusterLadderPatternSensorMap;
+
+  std::unique_ptr<TH1F> mClusterZ = nullptr;
+  
+  std::vector<o2::BaseCluster<float>> mClustersGlobal;
 
   // needed to construct the name and path of some histograms
   int mHalf[936] = { 0 };

--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -23,6 +23,7 @@
 #include <TH2F.h>
 #include <DataFormatsITSMFT/TopologyDictionary.h>
 #include "ReconstructionDataFormats/BaseCluster.h"
+#include "MFTBase/GeometryTGeo.h"
 
 // Quality Control
 #include "QualityControl/TaskInterface.h"
@@ -38,7 +39,7 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
 {
  public:
   /// \brief Constructor
-  QcMFTClusterTask() = default;
+  QcMFTClusterTask();
   /// Destructor
   ~QcMFTClusterTask() override;
 
@@ -64,10 +65,10 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
 
   std::unique_ptr<TH2F> mClusterPatternSensorIndices = nullptr;
   std::vector<std::unique_ptr<TH2F>> mClusterChipOccupancyMap;
-  std::vector<std::unique_ptr<TH2F>> mClusterLadderPatternSensorMap;
 
   std::unique_ptr<TH1F> mClusterZ = nullptr;
-  
+  std::vector<std::unique_ptr<TH2F>> mClusterXYinLayer;
+
   std::vector<o2::BaseCluster<float>> mClustersGlobal;
 
   // needed to construct the name and path of some histograms
@@ -81,15 +82,6 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   float mX[936] = { 0 };
   float mY[936] = { 0 };
 
-  // ladder vs Pattern ID histrograms
-  int mChipLadder[936] = { 0 };
-  int mChipPositionInLadder[936] = { 0 };
-  int mChipsInLadder[280] = { 0 };
-  int mHalfLadder[280] = { 0 };
-  int mDiskLadder[280] = { 0 };
-  int mFaceLadder[280] = { 0 };
-  int mZoneLadder[280] = { 0 };
-
   // internal functions
   void getChipMapData();
 
@@ -98,6 +90,9 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
 
   // dictionary
   o2::itsmft::TopologyDictionary* mDict;
+
+  // where the geometry file is stored
+  std::string mGeomPath;
 };
 
 } // namespace o2::quality_control_modules::mft

--- a/Modules/MFT/include/MFT/QcMFTDigitTask.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitTask.h
@@ -87,19 +87,10 @@ class QcMFTDigitTask final : public TaskInterface
   std::unique_ptr<TH1F> mDigitChipOccupancy = nullptr;
   std::unique_ptr<TH1F> mDigitChipStdDev = nullptr;
   std::unique_ptr<TH2F> mDigitOccupancySummary = nullptr;
+  std::unique_ptr<TH2F> mDigitDoubleColumnSensorIndices = nullptr;
 
   std::vector<std::unique_ptr<TH2F>> mDigitChipOccupancyMap;
   std::vector<std::unique_ptr<TH2F>> mDigitPixelOccupancyMap;
-
-  // new ladder vs double column histrograms
-  int mChipLadder[936] = { 0 };
-  int mChipPositionInLadder[936] = { 0 };
-  int mChipsInLadder[280] = { 0 };
-  int mHalfLadder[280] = { 0 };
-  int mDiskLadder[280] = { 0 };
-  int mFaceLadder[280] = { 0 };
-  int mZoneLadder[280] = { 0 };
-  std::vector<std::unique_ptr<TH2F>> mDigitLadderDoubleColumnOccupancyMap;
 
   //  functions
   int getVectorIndexChipOccupancyMap(int chipIndex);

--- a/Modules/MFT/qc-mft-cluster.json
+++ b/Modules/MFT/qc-mft-cluster.json
@@ -36,7 +36,8 @@
           "name" : "mft-clusters"
         },
         "taskParameters" : {
-          "myOwnKey" : "myOwnValue"
+          "myOwnKey" : "myOwnValue",
+          "geomFileName" : "o2sim_geometry-aligned.root"
         },
         "location" : "remote"
       }

--- a/Modules/MFT/qc-mft-cluster.json
+++ b/Modules/MFT/qc-mft-cluster.json
@@ -37,7 +37,7 @@
         },
         "taskParameters" : {
           "myOwnKey" : "myOwnValue",
-          "geomFileName" : "o2sim_geometry-aligned.root"
+          "geomFileName" : "/home/epn/odc/files/o2sim_geometry-aligned.root"
         },
         "location" : "remote"
       }

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -32,6 +32,8 @@
 #include "CCDB/BasicCCDBManager.h"
 #include "CCDB/CCDBTimeStampUtils.h"
 #include "MFTTracking/IOUtils.h"
+#include "MFTBase/GeometryTGeo.h"
+#include <DetectorsBase/GeometryManager.h>
 
 // Quality Control
 #include "QualityControl/QcInfoLogger.h"
@@ -45,6 +47,12 @@ using namespace o2::mft;
 
 namespace o2::quality_control_modules::mft
 {
+
+QcMFTClusterTask::QcMFTClusterTask()
+  : TaskInterface()
+{
+  // o2::base::GeometryManager::loadGeometry();
+}
 
 QcMFTClusterTask::~QcMFTClusterTask()
 {
@@ -61,6 +69,13 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
   if (auto param = mCustomParameters.find("myOwnKey"); param != mCustomParameters.end()) {
     ILOG(Info, Support) << "Custom parameter - myOwnKey: " << param->second << ENDM;
   }
+
+  if (auto param = mCustomParameters.find("geomFileName"); param != mCustomParameters.end()) {
+    ILOG(Info, Devel) << "Custom parameter - geometry filename: " << param->second << ENDM;
+    mGeomPath = param->second;
+  }
+
+  o2::base::GeometryManager::loadGeometry(mGeomPath.c_str());
 
   getChipMapData();
 
@@ -97,7 +112,7 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
   mClusterOccupancy->SetStats(0);
   getObjectsManager()->startPublishing(mClusterOccupancy.get());
 
-  mClusterPatternIndex = std::make_unique<TH1F>("mClusterPatternIndex", "Cluster Pattern ID;Pattern ID;#Entries per TF", 300, -0.5, 299.5);
+  mClusterPatternIndex = std::make_unique<TH1F>("mClusterPatternIndex", "Cluster Pattern ID;Pattern ID;#Entries per TF", 500, -0.5, 499.5);
   mClusterPatternIndex->SetStats(0);
   getObjectsManager()->startPublishing(mClusterPatternIndex.get());
   getObjectsManager()->setDisplayHint(mClusterPatternIndex.get(), "logy");
@@ -114,7 +129,7 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   mClusterPatternSensorIndices = std::make_unique<TH2F>("mClusterPatternSensorIndices",
                                                         "Cluster Pattern ID vs Chip ID;Chip ID;Pattern ID",
-                                                        936, -0.5, 935.5, 100, -0.5, 99.5);
+                                                        936, -0.5, 935.5, 500, -0.5, 499.5);
   mClusterPatternSensorIndices->SetStats(0);
   getObjectsManager()->startPublishing(mClusterPatternSensorIndices.get());
   getObjectsManager()->setDefaultDrawOptions(mClusterPatternSensorIndices.get(), "colz");
@@ -155,22 +170,6 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
   mDict = mgr.get<o2::itsmft::TopologyDictionary>("MFT/Calib/ClusterDictionary");
   ILOG(Info, Support) << "Dictionary size: " << mDict->getSize() << ENDM;
 
-  // --Ladder occupancy maps
-  //==============================================
-  for (int i = 0; i < 280; i++) { // there are 280 ladders
-    auto ladderHistogram = std::make_unique<TH2F>(
-      Form("LadderClusterSensorMaps/Ladder%d-h%d-d%d-f%d-z%d", i, mHalfLadder[i], mDiskLadder[i], mFaceLadder[i], mZoneLadder[i]),
-      Form("Cluster sensor map ladder%d-h%d-d%d-f%d-z%d; Pattern ID; Chip", i, mHalfLadder[i], mDiskLadder[i], mFaceLadder[i], mZoneLadder[i]),
-      100, 0, 100, // Pattern ID per chip
-      mChipsInLadder[i], 0, mChipsInLadder[i]);
-    for (int iBin = 0; iBin < mChipsInLadder[i]; iBin++)
-      ladderHistogram->GetYaxis()->SetBinLabel(iBin + 1, Form("%d", iBin));
-    ladderHistogram->SetStats(0);
-    mClusterLadderPatternSensorMap.push_back(std::move(ladderHistogram));
-    getObjectsManager()->startPublishing(mClusterLadderPatternSensorMap[i].get());
-    getObjectsManager()->setDefaultDrawOptions(mClusterLadderPatternSensorMap[i].get(), "colz");
-  }
-
   // define chip occupancy maps
   QcMFTUtilTables MFTTable;
   for (int iHalf = 0; iHalf < 2; iHalf++) {
@@ -193,6 +192,16 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
       } // loop over faces
     }   // loop over disks
   }     // loop over halfs
+
+  for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
+    auto clusterXY = std::make_unique<TH2F>(
+      Form("ClusterXYinLayer/mClusterXYinLayer%d", nMFTLayer),
+      Form("Cluster Position in Layer %d; x (cm); y (cm)", nMFTLayer), 400, -20, 20, 400, -20, 20);
+    clusterXY->SetStats(0);
+    mClusterXYinLayer.push_back(std::move(clusterXY));
+    getObjectsManager()->startPublishing(mClusterXYinLayer[nMFTLayer].get());
+    getObjectsManager()->setDefaultDrawOptions(mClusterXYinLayer[nMFTLayer].get(), "colz");
+  }
 }
 
 void QcMFTClusterTask::startOfActivity(Activity& /*activity*/)
@@ -224,9 +233,9 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   auto clustersPattern = ctx.inputs().get<gsl::span<unsigned char>>("patterns");
   auto patternIt = clustersPattern.begin();
 
-  // get clusters with global xy position 
+  // get clusters with global xy position
   mClustersGlobal.clear();
-  mClustersGlobal.reserve(clusters.size()); 
+  mClustersGlobal.reserve(clusters.size());
   o2::mft::ioutils::convertCompactClusters(clusters, patternIt, mClustersGlobal, mDict);
 
   if (clusters.size() < 1)
@@ -258,14 +267,14 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     int xBin = mDisk[sensorID] * 2 + mFace[sensorID];
     int yBin = mZone[sensorID] + mHalf[sensorID] * 4;
     mClusterOccupancySummary->Fill(xBin, yBin);
-
-    // fill ladder histogram
-    mClusterLadderPatternSensorMap[mChipLadder[sensorID]]->Fill(oneCluster.getPatternID() >> 1, mChipPositionInLadder[sensorID]);
   }
 
-    // fill the histograms that use global position of cluster
+  // fill the histograms that use global position of cluster
   for (auto& oneGlobalCluster : mClustersGlobal) {
     mClusterZ->Fill(oneGlobalCluster.getZ());
+    int sensorID = oneGlobalCluster.getSensorID();
+    int layerID = mDisk[sensorID] * 2 + mFace[sensorID];
+    mClusterXYinLayer[layerID]->Fill(oneGlobalCluster.getX(), oneGlobalCluster.getY());
   }
 }
 
@@ -296,9 +305,9 @@ void QcMFTClusterTask::reset()
   for (int i = 0; i < 20; i++) {
     mClusterChipOccupancyMap[i]->Reset();
   }
-  // ladder histograms
-  for (int i = 0; i < 280; i++) { // there are 280 ladders
-    mClusterLadderPatternSensorMap[i]->Reset();
+  // layer histograms
+  for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) { // there are 10 layers
+    mClusterXYinLayer[nMFTLayer]->Reset();
   }
 }
 
@@ -318,15 +327,6 @@ void QcMFTClusterTask::getChipMapData()
     mLadder[i] = MFTTable.mLadder[i];
     mX[i] = MFTTable.mX[i];
     mY[i] = MFTTable.mY[i];
-    // info needed for ladder histograms
-    mChipLadder[i] = chipMapData[i].module;
-    mChipPositionInLadder[i] = chipMapData[i].chipOnModule;
-    if (mChipsInLadder[mChipLadder[i]] < (mChipPositionInLadder[i] + 1))
-      mChipsInLadder[mChipLadder[i]]++;
-    mHalfLadder[mChipLadder[i]] = mHalf[i];
-    mDiskLadder[mChipLadder[i]] = mDisk[i];
-    mFaceLadder[mChipLadder[i]] = mFace[i];
-    mZoneLadder[mChipLadder[i]] = mZone[i];
   }
 }
 

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -228,6 +228,9 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   // get the clusters
   const auto clusters = ctx.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("randomcluster");
 
+  if (clusters.size() < 1)
+    return;
+
   // get cluster patterns and iterator
   auto clustersPattern = ctx.inputs().get<gsl::span<unsigned char>>("patterns");
   auto patternIt = clustersPattern.begin();
@@ -236,9 +239,6 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   mClustersGlobal.clear();
   mClustersGlobal.reserve(clusters.size());
   o2::mft::ioutils::convertCompactClusters(clusters, patternIt, mClustersGlobal, mDict);
-
-  if (clusters.size() < 1)
-    return;
 
   // fill the histograms
   for (auto& oneCluster : clusters) {

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -51,7 +51,6 @@ namespace o2::quality_control_modules::mft
 QcMFTClusterTask::QcMFTClusterTask()
   : TaskInterface()
 {
-  // o2::base::GeometryManager::loadGeometry();
 }
 
 QcMFTClusterTask::~QcMFTClusterTask()

--- a/Modules/MFT/src/runMFTClustersRootFileReader.cxx
+++ b/Modules/MFT/src/runMFTClustersRootFileReader.cxx
@@ -145,7 +145,7 @@ class MFTClustersRootFileReader : public o2::framework::Task
 
 WorkflowSpec defineDataProcessing(const ConfigContext&)
 {
-  WorkflowSpec specs; // to return the work flow
+  WorkflowSpec specs; // to return the work
 
   // define the outputs
   std::vector<OutputSpec> outputs;

--- a/Modules/MFT/src/runMFTClustersRootFileReader.cxx
+++ b/Modules/MFT/src/runMFTClustersRootFileReader.cxx
@@ -145,7 +145,7 @@ class MFTClustersRootFileReader : public o2::framework::Task
 
 WorkflowSpec defineDataProcessing(const ConfigContext&)
 {
-  WorkflowSpec specs; // to return the work
+  WorkflowSpec specs; // to return the work flow
 
   // define the outputs
   std::vector<OutputSpec> outputs;


### PR DESCRIPTION
- Removed patternID per ladder (280 histos less)
- Replace digit double column occupancy per ladder for a single histogram (per chip) (280 histos less, 1 new histo)
- Loaded MFT geometry 
- Added histograms for clusters z-position and clusters xy-position per layer