### PR TITLE
Header cleanups & compilation time speedups

### DIFF
--- a/Framework/include/QualityControl/DataProducer.h
+++ b/Framework/include/QualityControl/DataProducer.h
@@ -17,6 +17,7 @@
 #ifndef QUALITYCONTROL_DATAPRODUCER_H
 #define QUALITYCONTROL_DATAPRODUCER_H
 
+#include <string>
 #include <Framework/DataProcessorSpec.h>
 
 namespace o2::quality_control::core

--- a/Framework/include/QualityControl/DataSourceSpec.h
+++ b/Framework/include/QualityControl/DataSourceSpec.h
@@ -17,7 +17,7 @@
 ///
 
 #include <string>
-#include <unordered_map>
+#include <vector>
 #include <Framework/InputSpec.h>
 #include <type_traits>
 
@@ -38,7 +38,6 @@ enum class DataSourceType {
 // this should allow us to represent all data sources which come from DPL (and maybe CCDB).
 struct DataSourceSpec {
   explicit DataSourceSpec(DataSourceType type = DataSourceType::Invalid);
-
   // todo: use c++20 concepts when available
   template <class... Args, class Enable = std::enable_if_t<(... && std::is_convertible_v<Args, DataSourceType>)>>
   bool isOneOf(Args... dataSourceType) const

--- a/Framework/include/QualityControl/InfrastructureGenerator.h
+++ b/Framework/include/QualityControl/InfrastructureGenerator.h
@@ -26,7 +26,6 @@ namespace o2::framework
 class CompletionPolicy;
 }
 #include <Framework/WorkflowSpec.h>
-#include <Framework/DataProcessorSpec.h>
 
 namespace o2::quality_control
 {

--- a/Framework/include/QualityControl/InfrastructureSpec.h
+++ b/Framework/include/QualityControl/InfrastructureSpec.h
@@ -35,7 +35,6 @@ struct InfrastructureSpec {
   std::vector<checker::AggregatorSpec> aggregators;
   std::vector<postprocessing::PostProcessingTaskSpec> postProcessingTasks;
   std::vector<ExternalTaskSpec> externalTasks;
-  // todo: add other actors
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/InfrastructureSpecReader.h
+++ b/Framework/include/QualityControl/InfrastructureSpecReader.h
@@ -27,7 +27,7 @@
 namespace o2::quality_control::core
 {
 
-// If have to increase the performance of reading,
+// If we have to increase the performance of reading,
 // we can probably improve it by writing a proper parser like for WorkflowSerializationHelpers in O2
 // Also, move operators could be implemented.
 

--- a/Framework/include/QualityControl/InputUtils.h
+++ b/Framework/include/QualityControl/InputUtils.h
@@ -13,17 +13,16 @@
 #define QC_INPUT_UTILS_H
 
 // std
-#include <utility>
 #include <vector>
 #include <string>
-//o2
+// o2
 #include <Framework/DataProcessorSpec.h>
 #include <Framework/DataSpecUtils.h>
 
-inline std::vector<std::string> stringifyInput(o2::framework::Inputs& inputs)
+inline std::vector<std::string> stringifyInput(const o2::framework::Inputs& inputs)
 {
   std::vector<std::string> vec;
-  for (auto& input : inputs) {
+  for (const auto& input : inputs) {
     vec.push_back(o2::framework::DataSpecUtils::describe(input));
   }
   return vec;

--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -18,6 +18,7 @@
 #define QC_CORE_OBJECTMANAGER_H
 
 // QC
+#include "QualityControl/Activity.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/MonitorObjectCollection.h"
 // stl

--- a/Framework/include/QualityControl/PostProcessingFactory.h
+++ b/Framework/include/QualityControl/PostProcessingFactory.h
@@ -17,12 +17,11 @@
 #ifndef QUALITYCONTROL_POSTPROCESSINGFACTORY_H
 #define QUALITYCONTROL_POSTPROCESSINGFACTORY_H
 
-#include "QualityControl/PostProcessingConfig.h"
-
 namespace o2::quality_control::postprocessing
 {
 
 class PostProcessingInterface;
+class PostProcessingConfig;
 
 /// \brief Factory in charge of creating post-processing tasks
 ///

--- a/Framework/include/QualityControl/PostProcessingInterface.h
+++ b/Framework/include/QualityControl/PostProcessingInterface.h
@@ -18,10 +18,14 @@
 #define QUALITYCONTROL_POSTPROCESSINTERFACE_H
 
 #include <string>
-#include <Framework/ServiceRegistry.h>
 #include <boost/property_tree/ptree_fwd.hpp>
 #include "QualityControl/Triggers.h"
 #include "QualityControl/ObjectsManager.h"
+
+namespace o2::framework
+{
+class ServiceRegistry;
+}
 
 namespace o2::quality_control::postprocessing
 {

--- a/Framework/include/QualityControl/PostProcessingRunner.h
+++ b/Framework/include/QualityControl/PostProcessingRunner.h
@@ -21,14 +21,11 @@
 #include <functional>
 #include <Framework/ServiceRegistry.h>
 #include <boost/property_tree/ptree_fwd.hpp>
-#include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/PostProcessingConfig.h"
+#include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/PostProcessingRunnerConfig.h"
-#include "QualityControl/PostProcessingTaskSpec.h"
 #include "QualityControl/Triggers.h"
 #include "QualityControl/DatabaseInterface.h"
-#include "QualityControl/ObjectsManager.h"
-#include "QualityControl/MonitorObjectCollection.h"
 
 namespace o2::framework
 {
@@ -39,11 +36,19 @@ namespace o2::quality_control::core
 {
 struct CommonSpec;
 class Activity;
+class ObjectsManager;
+class MonitorObjectCollection;
+} // namespace o2::quality_control::core
+
+namespace o2::quality_control::repository
+{
+class DatabaseInterface;
 }
 
 namespace o2::quality_control::postprocessing
 {
 
+class PostProcessingTaskSpec;
 using MOCPublicationCallback = std::function<void(const o2::quality_control::core::MonitorObjectCollection*, long from, long to)>;
 
 /// \brief A class driving the execution of a post-processing task
@@ -55,7 +60,7 @@ using MOCPublicationCallback = std::function<void(const o2::quality_control::cor
 class PostProcessingRunner
 {
  public:
-  PostProcessingRunner(std::string name);
+  explicit PostProcessingRunner(std::string name);
   ~PostProcessingRunner() = default;
 
   /// \brief Initialization. Creates configuration structures out of the ptree. Throws on errors.

--- a/Framework/include/QualityControl/QualitiesToTRFCollectionConverter.h
+++ b/Framework/include/QualityControl/QualitiesToTRFCollectionConverter.h
@@ -19,7 +19,6 @@
 
 #include <DataFormatsQualityControl/TimeRangeFlag.h>
 #include <memory>
-#include <utility>
 #include <vector>
 
 namespace o2::quality_control

--- a/Framework/include/QualityControl/Quality.h
+++ b/Framework/include/QualityControl/Quality.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <utility>
 #include <DataFormatsQualityControl/FlagReasons.h>
 
 namespace o2::quality_control::core

--- a/Framework/include/QualityControl/QualityObject.h
+++ b/Framework/include/QualityControl/QualityObject.h
@@ -14,6 +14,8 @@
 
 // std
 #include <map>
+#include <string>
+#include <vector>
 // ROOT
 #include <TObject.h>
 // O2

--- a/Framework/include/QualityControl/RootClassFactory.h
+++ b/Framework/include/QualityControl/RootClassFactory.h
@@ -22,14 +22,8 @@
 #include <Common/Exceptions.h>
 // ROOT
 #include <TClass.h>
-#include <TROOT.h>
-#include <TSystem.h>
-// Boost
-#include <boost/filesystem/path.hpp>
 // QC
 #include "QualityControl/QcInfoLogger.h"
-
-namespace bfs = boost::filesystem;
 
 namespace o2::quality_control::core
 {

--- a/Framework/include/QualityControl/ServiceDiscovery.h
+++ b/Framework/include/QualityControl/ServiceDiscovery.h
@@ -17,15 +17,11 @@
 #define QC_SERVICEDISCOVERY_H
 
 #include <atomic>
-#include <curl/curl.h>
 #include <memory>
 #include <string>
 #include <thread>
-#include <boost/asio/ip/host_name.hpp>
-#include <random>
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/io_service.hpp>
-#include "QualityControl/QcInfoLogger.h"
+
+typedef void CURL;
 
 namespace o2::quality_control::core
 {
@@ -55,20 +51,7 @@ class ServiceDiscovery
   /// Deregisters service
   void deregister();
 
-  // https://stackoverflow.com/questions/33358321/using-c-and-boost-or-not-to-check-if-a-specific-port-is-being-used
-  static inline bool PortInUse(unsigned short port)
-  {
-    using namespace boost::asio;
-    using ip::tcp;
-
-    boost::asio::io_service svc;
-    tcp::acceptor a(svc);
-
-    boost::system::error_code ec;
-    a.open(tcp::v4(), ec) || a.bind({ tcp::v4(), port }, ec);
-
-    return ec == error::address_in_use;
-  }
+  static bool PortInUse(unsigned short port);
 
   static inline std::string GetDefaultUrl() ///< Provides default health check URL
   {
@@ -76,36 +59,8 @@ class ServiceDiscovery
   }
 
   /// Find a free port in the range [HealthPortRangeEnd;HealthPortRangeStart] if any available.
-  static inline size_t GetHealthPort()
-  {
-    // inspired by https://stackoverflow.com/questions/7560114/random-number-c-in-some-range/7560151
-    size_t port;
-    std::random_device rd;  // obtain a random number from hardware
-    std::mt19937 gen(rd()); // seed the generator
-    size_t rangeLength = HealthPortRangeEnd - HealthPortRangeStart + 1;
-    std::uniform_int_distribution<> distr(0, rangeLength - 1); // define the inclusive range
-
-    size_t index = distr(gen); // get a random index in the range
-    port = HealthPortRangeStart + index;
-    size_t cycle = 1;                                // count how many ports we tried
-    while (cycle < rangeLength && PortInUse(port)) { // if the port is in use and we did not go through the whole range
-      index = (index + 1) % rangeLength;             // pick the next index
-      port = HealthPortRangeStart + index;
-      cycle++;
-    }
-    if (cycle == rangeLength) {
-      ILOG(Error, Support) << "Could not find a free port for the ServiceDiscovery" << ENDM;
-      // we keep the last port but all calls will fail.
-    } else {
-      ILOG(Debug, Devel) << "ServiceDiscovery selected port: " << port << ENDM;
-    }
-    return port;
-  }
-
-  static inline std::string GetDefaultUrl(size_t port) ///< Provides default health check URL
-  {
-    return boost::asio::ip::host_name() + ":" + std::to_string(port);
-  }
+  static size_t GetHealthPort();
+  static std::string GetDefaultUrl(size_t port); ///< Provides default health check URL
 
   static constexpr size_t HealthPortRangeStart = 47800; ///< Health check port range start
   static constexpr size_t HealthPortRangeEnd = 47899;   ///< Health check port range end

--- a/Framework/include/QualityControl/SliceTrendingTaskConfig.h
+++ b/Framework/include/QualityControl/SliceTrendingTaskConfig.h
@@ -21,6 +21,8 @@
 
 #include "QualityControl/PostProcessingConfig.h"
 
+#include <boost/property_tree/ptree.hpp>
+
 namespace o2::quality_control::postprocessing
 {
 /// \brief  SliceTrendingTask configuration structure

--- a/Framework/include/QualityControl/TaskInterface.h
+++ b/Framework/include/QualityControl/TaskInterface.h
@@ -18,26 +18,19 @@
 #ifndef QC_CORE_TASKINTERFACE_H
 #define QC_CORE_TASKINTERFACE_H
 
-#include <map>
 #include <memory>
-#include <string>
-#include <unordered_map>
 // O2
 #include <Framework/InitContext.h>
 #include <Framework/ProcessingContext.h>
-#include <Monitoring/Monitoring.h>
 // QC
 #include "QualityControl/Activity.h"
 #include "QualityControl/ObjectsManager.h"
-#include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/UserCodeInterface.h"
 
-namespace o2::ccdb
+namespace o2::monitoring
 {
-class CcdbApi;
+class Monitoring;
 }
-
-class TObject;
 
 namespace o2::quality_control::core
 {

--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -23,13 +23,9 @@
 #include <Framework/Task.h>
 #include <Framework/DataProcessorSpec.h>
 #include <Framework/CompletionPolicy.h>
-#include <Framework/EndOfStreamContext.h>
-#include <Framework/InputSpan.h>
 #include <Headers/DataHeader.h>
-#include <Framework/InitContext.h>
 // QC
 #include "QualityControl/TaskRunnerConfig.h"
-#include "QualityControl/TaskInterface.h"
 
 namespace o2::configuration
 {
@@ -41,8 +37,19 @@ namespace o2::monitoring
 class Monitoring;
 }
 
+namespace o2::framework
+{
+class EndOfStreamContext;
+class InputSpan;
+class InitContext;
+class ProcessingContext;
+} // namespace o2::framework
+
 namespace o2::quality_control::core
 {
+
+class TaskInterface;
+class ObjectsManager;
 
 /// \brief A class driving the execution of a QC task inside DPL.
 ///

--- a/Framework/include/QualityControl/TaskRunnerConfig.h
+++ b/Framework/include/QualityControl/TaskRunnerConfig.h
@@ -19,7 +19,6 @@
 
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 #include <Framework/DataProcessorSpec.h>
 

--- a/Framework/include/QualityControl/TaskRunnerFactory.h
+++ b/Framework/include/QualityControl/TaskRunnerFactory.h
@@ -17,12 +17,10 @@
 #ifndef QC_CORE_TASKRUNNERFACTORY_H
 #define QC_CORE_TASKRUNNERFACTORY_H
 
-#include <string>
 #include <vector>
+#include <optional>
 
 #include <Framework/DataProcessorSpec.h>
-#include "QualityControl/CommonSpec.h"
-#include "QualityControl/TaskSpec.h"
 
 namespace o2::framework
 {
@@ -32,7 +30,9 @@ class CompletionPolicy;
 namespace o2::quality_control::core
 {
 
+struct TaskSpec;
 struct TaskRunnerConfig;
+struct CommonSpec;
 
 /// \brief Factory in charge of creating DataProcessorSpec of QC task
 class TaskRunnerFactory

--- a/Framework/include/QualityControl/TaskSpec.h
+++ b/Framework/include/QualityControl/TaskSpec.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "QualityControl/DataSourceSpec.h"
 

--- a/Framework/include/QualityControl/TrendingTask.h
+++ b/Framework/include/QualityControl/TrendingTask.h
@@ -18,8 +18,8 @@
 #define QUALITYCONTROL_TRENDINGTASK_H
 
 #include "QualityControl/PostProcessingInterface.h"
-#include "QualityControl/TrendingTaskConfig.h"
 #include "QualityControl/Reductor.h"
+#include "QualityControl/TrendingTaskConfig.h"
 
 #include <memory>
 #include <unordered_map>

--- a/Framework/include/QualityControl/TrendingTaskConfig.h
+++ b/Framework/include/QualityControl/TrendingTaskConfig.h
@@ -48,8 +48,8 @@ struct TrendingTaskConfig : PostProcessingConfig {
     std::string moduleName;
   };
 
-  bool producePlotsOnUpdate;
-  bool resumeTrend;
+  bool producePlotsOnUpdate{};
+  bool resumeTrend{};
   std::vector<Plot> plots;
   std::vector<DataSource> dataSources;
 };

--- a/Framework/include/QualityControl/TriggerHelpers.h
+++ b/Framework/include/QualityControl/TriggerHelpers.h
@@ -17,8 +17,13 @@
 #define QUALITYCONTROL_TRIGGERHELPERS_H
 
 #include "QualityControl/Triggers.h"
-#include "QualityControl/PostProcessingConfig.h"
+#include <vector>
+#include <string>
 
+namespace o2::quality_control::postprocessing
+{
+class PostProcessingConfig;
+}
 namespace o2::quality_control::postprocessing::trigger_helpers
 {
 

--- a/Framework/src/AggregatorRunner.cxx
+++ b/Framework/src/AggregatorRunner.cxx
@@ -27,6 +27,7 @@
 #include <Framework/ConfigParamRegistry.h>
 
 #include <utility>
+#include <TSystem.h>
 
 // QC
 #include "QualityControl/DatabaseFactory.h"

--- a/Framework/src/DataProducerExample.cxx
+++ b/Framework/src/DataProducerExample.cxx
@@ -15,13 +15,9 @@
 ///
 #include "QualityControl/DataProducerExample.h"
 
-#include <random>
-#include <Common/Timer.h>
-
 using namespace o2::framework;
 
 using SubSpec = o2::header::DataHeader::SubSpecificationType;
-using namespace AliceO2::Common;
 
 namespace o2::quality_control::core
 {

--- a/Framework/src/DataSourceSpec.cxx
+++ b/Framework/src/DataSourceSpec.cxx
@@ -14,12 +14,9 @@
 ///
 
 #include "QualityControl/DataSourceSpec.h"
-#include <utility>
 
 namespace o2::quality_control::core
 {
-
-// todo make DataSourceUtils
 
 DataSourceSpec::DataSourceSpec(DataSourceType type)
   : type(type)

--- a/Framework/src/DatabaseFactory.cxx
+++ b/Framework/src/DatabaseFactory.cxx
@@ -14,13 +14,13 @@
 /// \author Barthelemy von Haller
 ///
 
-// ROOT
-#include <QualityControl/CcdbDatabase.h>
+#include "QualityControl/DatabaseFactory.h"
+
 // O2
 #include <Common/Exceptions.h>
 // QC
+#include "QualityControl/CcdbDatabase.h"
 #include "QualityControl/DummyDatabase.h"
-#include "QualityControl/DatabaseFactory.h"
 #include "QualityControl/QcInfoLogger.h"
 #ifdef _WITH_MYSQL
 #include "QualityControl/MySqlDatabase.h"

--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -19,8 +19,6 @@
 #include "QualityControl/TaskRunner.h"
 #include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/AggregatorRunnerFactory.h"
-#include "QualityControl/Aggregator.h"
-#include "QualityControl/CheckRunner.h"
 #include "QualityControl/Check.h"
 #include "QualityControl/CheckRunnerFactory.h"
 #include "QualityControl/PostProcessingDevice.h"
@@ -32,7 +30,6 @@
 #include "QualityControl/RootFileSink.h"
 #include "QualityControl/RootFileSource.h"
 
-#include <Configuration/ConfigurationFactory.h>
 #include <Framework/DataSpecUtils.h>
 #include <Framework/ExternalFairMQDeviceProxy.h>
 #include <Framework/DataDescriptorQueryBuilder.h>

--- a/Framework/src/PostProcessingDevice.cxx
+++ b/Framework/src/PostProcessingDevice.cxx
@@ -18,6 +18,7 @@
 
 #include "QualityControl/PostProcessingRunner.h"
 #include "QualityControl/PostProcessingConfig.h"
+#include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/PostProcessingRunnerConfig.h"
 #include "QualityControl/QcInfoLogger.h"
 

--- a/Framework/src/PostProcessingFactory.cxx
+++ b/Framework/src/PostProcessingFactory.cxx
@@ -15,6 +15,8 @@
 ///
 
 #include "QualityControl/PostProcessingFactory.h"
+#include "QualityControl/PostProcessingInterface.h"
+#include "QualityControl/PostProcessingConfig.h"
 #include "QualityControl/RootClassFactory.h"
 
 using namespace o2::quality_control::core;

--- a/Framework/src/PostProcessingInterface.cxx
+++ b/Framework/src/PostProcessingInterface.cxx
@@ -15,6 +15,7 @@
 ///
 
 #include "QualityControl/PostProcessingInterface.h"
+#include "QualityControl/ObjectsManager.h"
 
 namespace o2::quality_control::postprocessing
 {
@@ -33,7 +34,7 @@ void PostProcessingInterface::configure(std::string name, const boost::property_
 
 void PostProcessingInterface::setObjectsManager(std::shared_ptr<core::ObjectsManager> objectsManager)
 {
-  mObjectsManager = objectsManager;
+  mObjectsManager = std::move(objectsManager);
 }
 
 std::shared_ptr<core::ObjectsManager> PostProcessingInterface::getObjectsManager()

--- a/Framework/src/PostProcessingRunner.cxx
+++ b/Framework/src/PostProcessingRunner.cxx
@@ -11,8 +11,10 @@
 
 #include "QualityControl/PostProcessingRunner.h"
 
+#include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/PostProcessingFactory.h"
 #include "QualityControl/PostProcessingConfig.h"
+#include "QualityControl/PostProcessingTaskSpec.h"
 #include "QualityControl/TriggerHelpers.h"
 #include "QualityControl/DatabaseFactory.h"
 #include "QualityControl/QcInfoLogger.h"
@@ -22,6 +24,7 @@
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/runnerUtils.h"
 #include "QualityControl/ConfigParamGlo.h"
+#include "QualityControl/MonitorObjectCollection.h"
 
 #include <utility>
 #include <Framework/DataAllocator.h>

--- a/Framework/src/RootClassFactory.cxx
+++ b/Framework/src/RootClassFactory.cxx
@@ -16,6 +16,11 @@
 
 #include "QualityControl/RootClassFactory.h"
 
+#include <TSystem.h>
+#include <boost/filesystem/path.hpp>
+
+namespace bfs = boost::filesystem;
+
 namespace o2::quality_control::core::root_class_factory
 {
 

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -16,10 +16,15 @@
 #include "QualityControl/ServiceDiscovery.h"
 #include "QualityControl/QcInfoLogger.h"
 #include <string>
+#include <random>
+#include <curl/curl.h>
+#include <boost/asio/ip/host_name.hpp>
 #include <boost/asio.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/io_service.hpp>
 
 namespace o2::quality_control::core
 {
@@ -176,4 +181,51 @@ void ServiceDiscovery::send(const std::string& path, std::string&& post)
     ILOG_INST.log(msgLimit, "%s", s.c_str());
   }
 }
+
+// https://stackoverflow.com/questions/33358321/using-c-and-boost-or-not-to-check-if-a-specific-port-is-being-used
+bool ServiceDiscovery::PortInUse(unsigned short port)
+{
+  using namespace boost::asio;
+  using ip::tcp;
+
+  boost::asio::io_service svc;
+  tcp::acceptor a(svc);
+
+  boost::system::error_code ec;
+  a.open(tcp::v4(), ec) || a.bind({ tcp::v4(), port }, ec);
+
+  return ec == error::address_in_use;
+}
+
+size_t ServiceDiscovery::GetHealthPort()
+{
+  // inspired by https://stackoverflow.com/questions/7560114/random-number-c-in-some-range/7560151
+  size_t port;
+  std::random_device rd;  // obtain a random number from hardware
+  std::mt19937 gen(rd()); // seed the generator
+  size_t rangeLength = HealthPortRangeEnd - HealthPortRangeStart + 1;
+  std::uniform_int_distribution<> distr(0, rangeLength - 1); // define the inclusive range
+
+  size_t index = distr(gen); // get a random index in the range
+  port = HealthPortRangeStart + index;
+  size_t cycle = 1;                                // count how many ports we tried
+  while (cycle < rangeLength && PortInUse(port)) { // if the port is in use and we did not go through the whole range
+    index = (index + 1) % rangeLength;             // pick the next index
+    port = HealthPortRangeStart + index;
+    cycle++;
+  }
+  if (cycle == rangeLength) {
+    ILOG(Error, Support) << "Could not find a free port for the ServiceDiscovery" << ENDM;
+    // we keep the last port but all calls will fail.
+  } else {
+    ILOG(Debug, Devel) << "ServiceDiscovery selected port: " << port << ENDM;
+  }
+  return port;
+}
+
+std::string ServiceDiscovery::GetDefaultUrl(size_t port) ///< Provides default health check URL
+{
+  return boost::asio::ip::host_name() + ":" + std::to_string(port);
+}
+
 } // namespace o2::quality_control::core

--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -16,18 +16,14 @@
 /// \author   Based on the work from Piotr Konopka
 ///
 
+#include "QualityControl/SliceTrendingTask.h"
 #include "QualityControl/DatabaseInterface.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/QcInfoLogger.h"
-#include "QualityControl/SliceTrendingTask.h"
 #include "QualityControl/RepoPathUtils.h"
 
-#include <boost/property_tree/ptree.hpp>
-#include <boost/algorithm/string.hpp>
 #include <string>
-#include <TDatime.h>
-#include <TGraph.h>
 #include <TGraphErrors.h>
 #include <TTreeReader.h>
 #include <TTreeReaderValue.h>

--- a/Framework/src/SliceTrendingTaskConfig.cxx
+++ b/Framework/src/SliceTrendingTaskConfig.cxx
@@ -18,7 +18,6 @@
 
 #include "QualityControl/SliceTrendingTaskConfig.h"
 #include <boost/property_tree/ptree.hpp>
-#include <typeinfo>
 
 namespace o2::quality_control::postprocessing
 {

--- a/Framework/src/TaskFactory.cxx
+++ b/Framework/src/TaskFactory.cxx
@@ -15,7 +15,6 @@
 ///
 
 #include "QualityControl/TaskFactory.h"
-#include "QualityControl/QcInfoLogger.h"
 
 #include "QualityControl/RootClassFactory.h"
 

--- a/Framework/src/TaskInterface.cxx
+++ b/Framework/src/TaskInterface.cxx
@@ -16,8 +16,6 @@
 ///
 
 #include "QualityControl/TaskInterface.h"
-#include "QualityControl/stringUtils.h"
-#include <CCDB/CcdbApi.h>
 
 namespace o2::quality_control::core
 {

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -22,15 +22,14 @@
 // O2
 #include <Common/Exceptions.h>
 #include <Monitoring/MonitoringFactory.h>
-#include <DataSampling/DataSampling.h>
 
 #include <Framework/CallbackService.h>
 #include <Framework/CompletionPolicyHelpers.h>
-#include <Framework/TimesliceIndex.h>
 #include <Framework/DataSpecUtils.h>
 #include <Framework/InputRecordWalker.h>
 #include <Framework/InputSpan.h>
 #include <Framework/DataRefUtils.h>
+#include <Framework/EndOfStreamContext.h>
 #include <CommonUtils/ConfigurableParam.h>
 
 #include "QualityControl/QcInfoLogger.h"
@@ -39,6 +38,7 @@
 #include "QualityControl/InfrastructureSpecReader.h"
 #include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/ConfigParamGlo.h"
+#include "QualityControl/ObjectsManager.h"
 
 #include <string>
 #include <TFile.h>
@@ -56,7 +56,6 @@ using namespace o2::framework;
 using namespace o2::header;
 using namespace o2::configuration;
 using namespace o2::monitoring;
-using namespace o2::utilities;
 using namespace std::chrono;
 using namespace AliceO2::Common;
 

--- a/Framework/src/TaskRunnerFactory.cxx
+++ b/Framework/src/TaskRunnerFactory.cxx
@@ -14,18 +14,17 @@
 /// \author Piotr Konopka
 ///
 
+#include "QualityControl/CommonSpec.h"
 #include "QualityControl/TaskRunnerFactory.h"
 #include "QualityControl/TaskRunner.h"
 #include "QualityControl/TaskRunnerConfig.h"
+#include "QualityControl/TaskSpec.h"
 #include "QualityControl/InfrastructureSpecReader.h"
+#include "QualityControl/QcInfoLogger.h"
 
 #include <Framework/DeviceSpec.h>
 #include <Framework/CompletionPolicy.h>
 #include <Headers/DataHeader.h>
-#include <Framework/ConfigParamSpec.h>
-#include <Framework/TimesliceIndex.h>
-#include <Framework/DataSpecUtils.h>
-#include <Framework/InputSpan.h>
 #include <Framework/O2ControlLabels.h>
 #include <Framework/DataProcessorLabel.h>
 

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -21,11 +21,10 @@
 #include "QualityControl/Reductor.h"
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/RepoPathUtils.h"
-#include <boost/property_tree/ptree.hpp>
+
 #include <TH1.h>
 #include <TCanvas.h>
 #include <TPaveText.h>
-#include <TDatime.h>
 #include <TGraphErrors.h>
 #include <TPoint.h>
 

--- a/Framework/src/TriggerHelpers.cxx
+++ b/Framework/src/TriggerHelpers.cxx
@@ -15,6 +15,7 @@
 ///
 
 #include "QualityControl/TriggerHelpers.h"
+#include "QualityControl/PostProcessingConfig.h"
 #include "QualityControl/QcInfoLogger.h"
 #include <boost/algorithm/string.hpp>
 #include <optional>

--- a/Framework/src/runPostProcessingOCC.cxx
+++ b/Framework/src/runPostProcessingOCC.cxx
@@ -16,6 +16,7 @@
 /// \brief This is an OCC executable to run postprocessing
 
 #include "QualityControl/PostProcessingRunner.h"
+#include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/QcInfoLogger.h"
 
 #include <OccInstance.h>

--- a/Framework/test/testPostProcessingInterface.cxx
+++ b/Framework/test/testPostProcessingInterface.cxx
@@ -18,6 +18,7 @@
 #include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/PostProcessingFactory.h"
 #include <Configuration/ConfigurationFactory.h>
+#include <Framework/ServiceRegistry.h>
 
 #define BOOST_TEST_MODULE PostProcessingRunner test
 #define BOOST_TEST_MAIN

--- a/Framework/test/testTaskRunner.cxx
+++ b/Framework/test/testTaskRunner.cxx
@@ -25,6 +25,7 @@
 #include <Framework/InitContext.h>
 #include <Framework/ConfigParamRegistry.h>
 #include <Framework/ConfigParamStore.h>
+#include <Common/Exceptions.h>
 
 #define BOOST_TEST_MODULE TaskRunner test
 #define BOOST_TEST_MAIN


### PR DESCRIPTION
Again, some brain-unintensive work which saves 70-90 seconds of CPU time.

```
-j 32 before
real    3m2.327s
user    79m0.252s
sys     5m20.847s
real    3m1.998s
user    78m55.200s
sys     5m18.392s

-j 32 after
real    2m56.013s
user    77m33.107s
sys     5m12.258s
real    2m56.239s
user    77m39.839s
sys     5m11.790s
```