### PR TITLE
Propagate start and end of activity from config

### DIFF
--- a/Framework/include/QualityControl/AggregatorRunnerConfig.h
+++ b/Framework/include/QualityControl/AggregatorRunnerConfig.h
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <string>
 #include <Framework/DataProcessorSpec.h>
+#include "QualityControl/Activity.h"
 
 namespace o2::quality_control::checker
 {
@@ -31,11 +32,7 @@ struct AggregatorRunnerConfig {
   bool infologgerFilterDiscardDebug = false;
   int infologgerDiscardLevel = 21;
   std::string infologgerDiscardFile{};
-  int fallbackRunNumber = 0;
-  int fallbackRunType = 0;
-  std::string fallbackPeriodName{};
-  std::string fallbackPassName{};
-  std::string fallbackProvenance{};
+  core::Activity fallbackActivity;
   framework::Options options{};
 };
 

--- a/Framework/include/QualityControl/CheckRunnerConfig.h
+++ b/Framework/include/QualityControl/CheckRunnerConfig.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "QualityControl/Activity.h"
+
 namespace o2::quality_control::checker
 {
 
@@ -29,11 +31,7 @@ struct CheckRunnerConfig {
   bool infologgerFilterDiscardDebug = false;
   int infologgerDiscardLevel = 21;
   std::string infologgerDiscardFile{};
-  int fallbackRunNumber = 0;
-  int fallbackRunType = 0;
-  std::string fallbackPeriodName{};
-  std::string fallbackPassName{};
-  std::string fallbackProvenance{};
+  core::Activity fallbackActivity;
   framework::Options options{};
 };
 

--- a/Framework/include/QualityControl/PostProcessingRunnerConfig.h
+++ b/Framework/include/QualityControl/PostProcessingRunnerConfig.h
@@ -30,7 +30,7 @@ struct PostProcessingRunnerConfig {
   std::string consulUrl{};
   bool infologgerFilterDiscardDebug = false;
   int infologgerDiscardLevel = 21;
-  std::string infologgerDiscardFile = "";
+  std::string infologgerDiscardFile{};
   double periodSeconds = 10.0;
   std::string configKeyValues; // These are for ConfigurableParams, not for override-values!
   boost::property_tree::ptree configTree{};

--- a/Framework/include/QualityControl/TaskRunnerConfig.h
+++ b/Framework/include/QualityControl/TaskRunnerConfig.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 #include <Framework/DataProcessorSpec.h>
+#include "QualityControl/Activity.h"
 
 namespace o2::quality_control::core
 {
@@ -47,11 +48,7 @@ struct TaskRunnerConfig {
   bool infologgerFilterDiscardDebug = false;
   int infologgerDiscardLevel = 21;
   std::string infologgerDiscardFile = "";
-  int activityType = 0;
-  std::string activityPeriodName = "";
-  std::string activityPassName = "";
-  std::string activityProvenance = "qc";
-  int fallbackRunNumber = 0;
+  Activity fallbackActivity;
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/runnerUtils.h
+++ b/Framework/include/QualityControl/runnerUtils.h
@@ -26,6 +26,7 @@
 #include <QualityControl/QcInfoLogger.h>
 #include <boost/property_tree/json_parser.hpp>
 #include <CommonUtils/StringUtils.h>
+#include "QualityControl/Activity.h"
 
 namespace o2::quality_control::core
 {
@@ -125,18 +126,26 @@ inline std::string computePeriodName(const framework::ServiceRegistry& services,
 
 inline std::string computePassName(const std::string& fallbackPassName = "")
 {
-  std::string passName;
-  passName = fallbackPassName;
-  ILOG(Debug, Devel) << "Pass Name returned by computePassName : " << passName << ENDM;
-  return passName;
+  ILOG(Debug, Devel) << "Pass Name returned by computePassName : " << fallbackPassName << ENDM;
+  return fallbackPassName;
 }
 
 inline std::string computeProvenance(const std::string& fallbackProvenance = "")
 {
-  std::string provenance;
-  provenance = fallbackProvenance;
-  ILOG(Debug, Devel) << "Provenance returned by computeProvenance : " << provenance << ENDM;
-  return provenance;
+  ILOG(Debug, Devel) << "Provenance returned by computeProvenance : " << fallbackProvenance << ENDM;
+  return fallbackProvenance;
+}
+
+inline Activity computeActivity(const framework::ServiceRegistry& services, const Activity& fallbackActivity)
+{
+  return {
+    computeRunNumber(services, fallbackActivity.mId),
+    computeRunType(services, fallbackActivity.mType),
+    computePeriodName(services, fallbackActivity.mPeriodName),
+    computePassName(fallbackActivity.mPassName),
+    computeProvenance(fallbackActivity.mProvenance),
+    fallbackActivity.mValidity
+  };
 }
 
 inline std::string indentTree(int level)

--- a/Framework/src/AggregatorRunner.cxx
+++ b/Framework/src/AggregatorRunner.cxx
@@ -398,11 +398,7 @@ void AggregatorRunner::sendPeriodicMonitoring()
 
 void AggregatorRunner::start(const ServiceRegistry& services)
 {
-  mActivity.mId = computeRunNumber(services, mRunnerConfig.fallbackRunNumber);
-  mActivity.mType = computeRunType(services, mRunnerConfig.fallbackRunType);
-  mActivity.mPeriodName = computePeriodName(services, mRunnerConfig.fallbackPeriodName);
-  mActivity.mPassName = computePassName(mRunnerConfig.fallbackPassName);
-  mActivity.mProvenance = computeProvenance(mRunnerConfig.fallbackProvenance);
+  mActivity = computeActivity(services, mRunnerConfig.fallbackActivity);
   mTimerTotalDurationActivity.reset();
   string partitionName = computePartitionName(services);
   QcInfoLogger::setRun(mActivity.mId);

--- a/Framework/src/AggregatorRunnerFactory.cxx
+++ b/Framework/src/AggregatorRunnerFactory.cxx
@@ -71,6 +71,15 @@ AggregatorRunnerConfig AggregatorRunnerFactory::extractRunnerConfig(const core::
     { "qcConfiguration", VariantType::Dict, emptyDict(), { "Some dictionary configuration" } }
   };
 
+  core::Activity fallbackActivity{
+    commonSpec.activityNumber,
+    commonSpec.activityType,
+    commonSpec.activityPeriodName,
+    commonSpec.activityPassName,
+    commonSpec.activityProvenance,
+    { commonSpec.activityStart, commonSpec.activityEnd }
+  };
+
   return {
     commonSpec.database,
     commonSpec.consulUrl,
@@ -78,11 +87,7 @@ AggregatorRunnerConfig AggregatorRunnerFactory::extractRunnerConfig(const core::
     commonSpec.infologgerFilterDiscardDebug,
     commonSpec.infologgerDiscardLevel,
     commonSpec.infologgerDiscardFile,
-    commonSpec.activityNumber,
-    commonSpec.activityType,
-    commonSpec.activityPeriodName,
-    commonSpec.activityPassName,
-    commonSpec.activityProvenance,
+    fallbackActivity,
     options
   };
 }

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -507,11 +507,7 @@ void CheckRunner::initLibraries()
 
 void CheckRunner::start(const ServiceRegistry& services)
 {
-  mActivity.mId = computeRunNumber(services, mConfig.fallbackRunNumber);
-  mActivity.mType = computeRunType(services, mConfig.fallbackRunType);
-  mActivity.mPeriodName = computePeriodName(services, mConfig.fallbackPeriodName);
-  mActivity.mPassName = computePassName(mConfig.fallbackPassName);
-  mActivity.mProvenance = computeProvenance(mConfig.fallbackProvenance);
+  mActivity = computeActivity(services, mConfig.fallbackActivity);
   string partitionName = computePartitionName(services);
   QcInfoLogger::setRun(mActivity.mId);
   QcInfoLogger::setPartition(partitionName);

--- a/Framework/src/CheckRunnerFactory.cxx
+++ b/Framework/src/CheckRunnerFactory.cxx
@@ -82,6 +82,14 @@ CheckRunnerConfig CheckRunnerFactory::extractConfig(const CommonSpec& commonSpec
     { "qcConfiguration", VariantType::Dict, emptyDict(), { "Some dictionary configuration" } }
   };
 
+  core::Activity fallbackActivity{
+    commonSpec.activityNumber,
+    commonSpec.activityType,
+    commonSpec.activityPeriodName,
+    commonSpec.activityPassName,
+    commonSpec.activityProvenance,
+    { commonSpec.activityStart, commonSpec.activityEnd }
+  };
   return {
     commonSpec.database,
     commonSpec.consulUrl,
@@ -89,11 +97,7 @@ CheckRunnerConfig CheckRunnerFactory::extractConfig(const CommonSpec& commonSpec
     commonSpec.infologgerFilterDiscardDebug,
     commonSpec.infologgerDiscardLevel,
     commonSpec.infologgerDiscardFile,
-    commonSpec.activityNumber,
-    commonSpec.activityType,
-    commonSpec.activityPeriodName,
-    commonSpec.activityPassName,
-    commonSpec.activityProvenance,
+    fallbackActivity,
     options
   };
 }

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -301,7 +301,7 @@ void TaskRunner::endOfStream(framework::EndOfStreamContext& eosContext)
 
 void TaskRunner::start(const ServiceRegistry& services)
 {
-  mRunNumber = o2::quality_control::core::computeRunNumber(services, mTaskConfig.fallbackRunNumber);
+  mRunNumber = o2::quality_control::core::computeRunNumber(services, mTaskConfig.fallbackActivity.mId);
   QcInfoLogger::setRun(mRunNumber);
   string partitionName = computePartitionName(services);
   QcInfoLogger::setPartition(partitionName);
@@ -399,7 +399,8 @@ void TaskRunner::startOfActivity()
   mTotalNumberObjectsPublished = 0;
 
   // Start activity in module's stask and update objectsManager
-  Activity activity(mRunNumber, mTaskConfig.activityType, mTaskConfig.activityPeriodName, mTaskConfig.activityPassName, mTaskConfig.activityProvenance);
+  Activity activity = mTaskConfig.fallbackActivity;
+  activity.mId = mRunNumber;
   ILOG(Info, Ops) << "Starting run " << mRunNumber << ENDM;
   mObjectsManager->setActivity(activity);
   mCollector->setRunNumber(mRunNumber);
@@ -409,7 +410,8 @@ void TaskRunner::startOfActivity()
 
 void TaskRunner::endOfActivity()
 {
-  Activity activity(mRunNumber, mTaskConfig.activityType, mTaskConfig.activityPeriodName, mTaskConfig.activityPassName, mTaskConfig.activityProvenance);
+  Activity activity = mTaskConfig.fallbackActivity;
+  activity.mId = mRunNumber;
   ILOG(Info, Ops) << "Stopping run " << mRunNumber << ENDM;
   mTask->endOfActivity(activity);
   mObjectsManager->removeAllFromServiceDiscovery();

--- a/Framework/src/TaskRunnerFactory.cxx
+++ b/Framework/src/TaskRunnerFactory.cxx
@@ -84,6 +84,15 @@ TaskRunnerConfig TaskRunnerFactory::extractConfig(const CommonSpec& globalConfig
     { "qcConfiguration", VariantType::Dict, emptyDict(), { "Some dictionary configuration" } }
   };
 
+  Activity fallbackActivity{
+    globalConfig.activityNumber,
+    globalConfig.activityType,
+    globalConfig.activityPeriodName,
+    globalConfig.activityPassName,
+    globalConfig.activityProvenance,
+    { globalConfig.activityStart, globalConfig.activityEnd }
+  };
+
   return {
     deviceName,
     taskSpec.taskName,
@@ -105,11 +114,7 @@ TaskRunnerConfig TaskRunnerFactory::extractConfig(const CommonSpec& globalConfig
     globalConfig.infologgerFilterDiscardDebug,
     globalConfig.infologgerDiscardLevel,
     globalConfig.infologgerDiscardFile,
-    globalConfig.activityType,
-    globalConfig.activityPeriodName,
-    globalConfig.activityPassName,
-    globalConfig.activityProvenance,
-    globalConfig.activityNumber
+    fallbackActivity
   };
 }
 


### PR DESCRIPTION
This will allow to provide SOR time for asynchronous and MC processing
for CCDB object retrieval