### PR TITLE
[QC-823] Provide a method to decode booleans 

### DIFF
--- a/Modules/Common/src/IncreasingEntries.cxx
+++ b/Modules/Common/src/IncreasingEntries.cxx
@@ -33,7 +33,7 @@ namespace o2::quality_control_modules::common
 
 void IncreasingEntries::configure()
 {
-  parseBooleanParam(mCustomParameters, "mustIncrease", mMustIncrease);
+  mMustIncrease = parseBoolParam(mCustomParameters, "mustIncrease");
 
   ILOG(Debug, Support) << "mustIncrease: " << mMustIncrease << ENDM;
 

--- a/Modules/EMCAL/include/EMCAL/RawCheck.h
+++ b/Modules/EMCAL/include/EMCAL/RawCheck.h
@@ -43,25 +43,6 @@ class RawCheck final : public o2::quality_control::checker::CheckInterface
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
 
- private:
-  /// \brief Decode key of a configurable parameter as boolean
-  /// \param value Value to be decoded (true or false, case-insensitive)
-  /// \return Boolean representation of the value
-  /// \throw std::runtime_error in case value is not a boolean value
-  bool decodeBool(std::string value) const;
-
-  /// \brief Decode key of a configurable parameter as integer
-  /// \param value Value to be decoded
-  /// \return Integer representation of the value
-  /// \throw std::runtime_error in case value is not a integer value
-  int decodeInt(std::string value) const;
-
-  /// \brief Decode key of a configurable parameter as double
-  /// \param value Value to be decoded
-  /// \return Double representation of the value
-  /// \throw std::runtime_error in case value is not a double value
-  double decodeDouble(std::string value) const;
-
   /************************************************
    * Switches for InfoLogger Messages             *
    ************************************************/

--- a/Modules/EMCAL/src/RawCheck.cxx
+++ b/Modules/EMCAL/src/RawCheck.cxx
@@ -16,12 +16,10 @@
 
 #include <string>
 #include <exception>
-#include <boost/algorithm/string.hpp>
 
 #include <TCanvas.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TPaveText.h>
 #include <TLatex.h>
 #include <TList.h>
 #include <TLine.h>
@@ -32,6 +30,7 @@
 #include "QualityControl/Quality.h"
 #include <fairlogger/Logger.h>
 #include "EMCAL/RawCheck.h"
+#include "QualityControl/stringUtils.h"
 
 using namespace std;
 
@@ -46,7 +45,7 @@ void RawCheck::configure()
     try {
       mIlMessageBunchMinAmpCheckSM = decodeBool(switchBunchMinSM->second);
     } catch (std::exception& e) {
-      ILOG(Error, Support) << e.what() << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Error, Support) << e.what() << ENDM;
     }
   }
 
@@ -55,7 +54,7 @@ void RawCheck::configure()
     try {
       mIlMessageBunchMinAmpCheckDetector = decodeBool(switchBunchMinDetector->second);
     } catch (std::exception& e) {
-      ILOG(Error, Support) << e.what() << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Error, Support) << e.what() << ENDM;
     }
   }
 
@@ -64,7 +63,7 @@ void RawCheck::configure()
     try {
       mIlMessageBunchMinAmpCheckFull = decodeBool(switchBunchMinFull->second);
     } catch (std::exception& e) {
-      ILOG(Error, Support) << e.what() << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Error, Support) << e.what() << ENDM;
     }
   }
 
@@ -73,7 +72,7 @@ void RawCheck::configure()
     try {
       mILMessageRawErrorCheck = decodeBool(switchErrorCode->second);
     } catch (std::exception& e) {
-      ILOG(Error, Support) << e.what() << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Error, Support) << e.what() << ENDM;
     }
   }
 
@@ -82,7 +81,7 @@ void RawCheck::configure()
     try {
       mILMessageNoisyFECCheck = decodeBool(switchNoisyFEC->second);
     } catch (std::exception& e) {
-      ILOG(Error, Support) << e.what() << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Error, Support) << e.what() << ENDM;
     }
   }
 
@@ -91,7 +90,7 @@ void RawCheck::configure()
     try {
       mILMessagePayloadSizeCheck = decodeBool(switchPayloadSizeCheck->second);
     } catch (std::exception& e) {
-      ILOG(Error, Support) << e.what() << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Error, Support) << e.what() << ENDM;
     }
   }
 
@@ -99,17 +98,17 @@ void RawCheck::configure()
   auto nsigmaFECMaxPayload = mCustomParameters.find("SigmaFECMaxPayload");
   if (nsigmaFECMaxPayload != mCustomParameters.end()) {
     try {
-      mNsigmaFECMaxPayload = decodeDouble(nsigmaFECMaxPayload->second);
+      mNsigmaFECMaxPayload = std::stod(nsigmaFECMaxPayload->second);
     } catch (std::exception& e) {
-      ILOG(Error, Support) << e.what() << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Error, Support) << fmt::format("Value {} not a boolean", nsigmaFECMaxPayload->second.data()) << ENDM;
     }
   }
   auto nsigmaPayloadSize = mCustomParameters.find("SigmaPayloadSize");
   if (nsigmaPayloadSize != mCustomParameters.end()) {
     try {
-      mNsigmaPayloadSize = decodeDouble(nsigmaPayloadSize->second);
+      mNsigmaPayloadSize = std::stod(nsigmaPayloadSize->second);
     } catch (std::exception& e) {
-      ILOG(Error, Support) << e.what() << AliceO2::InfoLogger::InfoLogger::endm;
+      ILOG(Error, Support) << fmt::format("Value {} not a boolean", nsigmaFECMaxPayload->second.data()) << ENDM;
     }
   }
 }
@@ -256,7 +255,7 @@ void RawCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
       msg->Draw();
     } else if (checkResult == Quality::Bad) {
       if (mILMessageRawErrorCheck) {
-        ILOG(Error, Support) << " QualityBad:Presence of Error Code" << AliceO2::InfoLogger::InfoLogger::endm;
+        ILOG(Error, Support) << " QualityBad:Presence of Error Code" << ENDM;
       }
       TLatex* msg = new TLatex(0.2, 0.8, "#color[2]{Presence of Error Code: call EMCAL oncall}");
       msg->SetNDC();
@@ -292,7 +291,7 @@ void RawCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
         showMessage = true;
       }
       if (showMessage) {
-        ILOG(Error, Support) << " QualityBad:Bunch min Amplitude outside limits (" << mo->getName() << ")" << AliceO2::InfoLogger::InfoLogger::endm;
+        ILOG(Error, Support) << " QualityBad:Bunch min Amplitude outside limits (" << mo->getName() << ")" << ENDM;
       }
       TLatex* msg = new TLatex(0.2, 0.8, "#color[2]{Pedestal peak detected}");
       msg->SetNDC();
@@ -335,13 +334,13 @@ void RawCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
       TLatex* msg;
       if (mo->getName() == "FECidMaxChWithInput_perSM") {
         if (mILMessageNoisyFECCheck) {
-          ILOG(Error, Support) << "Noisy FEC detected" << AliceO2::InfoLogger::InfoLogger::endm;
+          ILOG(Error, Support) << "Noisy FEC detected" << ENDM;
         }
         msg = new TLatex(0.2, 0.8, "#color[2]{Noisy FEC detected}");
       }
       if (mo->getName().find("PayloadSize") != std::string::npos) {
         if (mILMessagePayloadSizeCheck) {
-          ILOG(Error, Support) << "Large payload in several DDLs" << AliceO2::InfoLogger::InfoLogger::endm;
+          ILOG(Error, Support) << "Large payload in several DDLs" << ENDM;
         }
         msg = new TLatex(0.2, 0.8, "#color[2]{Large payload in several DDLs}");
       }
@@ -425,36 +424,6 @@ void RawCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
     l13->Draw();
     l14->Draw();
     l15->Draw();
-  }
-}
-
-bool RawCheck::decodeBool(std::string value) const
-{
-  boost::algorithm::to_lower_copy(value);
-  if (value == "true") {
-    return true;
-  }
-  if (value == "false") {
-    return false;
-  }
-  throw std::runtime_error(fmt::format("Value {} not a boolean", value.data()).data());
-}
-
-double RawCheck::decodeDouble(std::string value) const
-{
-  try {
-    return std::stod(value);
-  } catch (std::exception& e) {
-    throw std::runtime_error(fmt::format("Value {} not a double", value.data()).data());
-  }
-}
-
-int RawCheck::decodeInt(std::string value) const
-{
-  try {
-    return std::stoi(value);
-  } catch (std::exception& e) {
-    throw std::runtime_error(fmt::format("Value {} not an integer", value.data()).data());
   }
 }
 


### PR DESCRIPTION
from a string coming from the config.

Use it in EMCal module.
Removed decodeInt and decodeDouble in EMC module because it does not bring value.

@mfasDa As discussed some time ago. 