### PR TITLE
FIT: new checker + timestamp usage in PP + adjustments

### DIFF
--- a/Modules/FDD/CMakeLists.txt
+++ b/Modules/FDD/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(O2QcFDD)
 target_sources(O2QcFDD PRIVATE
                                src/DigitQcTaskLaser.cxx
                                src/DigitQcTask.cxx
+                               src/GenericCheck.cxx
                                src/RecPointsQcTask.cxx
                                src/PostProcTask.cxx
                                src/CFDEffCheck.cxx
@@ -28,6 +29,7 @@ add_root_dictionary(O2QcFDD
   HEADERS
           include/FDD/DigitQcTaskLaser.h
           include/FDD/DigitQcTask.h
+          include/FDD/GenericCheck.h
           include/FDD/RecPointsQcTask.h
           include/FDD/Helper.h
           include/FDD/PostProcTask.h

--- a/Modules/FDD/include/FDD/DigitQcTask.h
+++ b/Modules/FDD/include/FDD/DigitQcTask.h
@@ -32,6 +32,8 @@
 #include "FDD/Helper.h"
 #include "Rtypes.h"
 
+#include "CommonConstants/LHCConstants.h"
+
 #include <Framework/InputRecord.h>
 #include "QualityControl/QcInfoLogger.h"
 #include "DataFormatsFDD/Digit.h"
@@ -67,7 +69,7 @@ class DigitQcTask final : public TaskInterface
   constexpr static std::size_t sNCHANNELS_A = 8;
   constexpr static std::size_t sNCHANNELS_C = 8;
   constexpr static std::size_t sOrbitsPerTF = 256;
-  constexpr static std::size_t sBCperOrbit = 3564;
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
   constexpr static float sCFDChannel2NS = o2::fdd::timePerTDC; // CFD channel width in ns
 

--- a/Modules/FDD/include/FDD/DigitQcTask.h
+++ b/Modules/FDD/include/FDD/DigitQcTask.h
@@ -85,6 +85,8 @@ class DigitQcTask final : public TaskInterface
   int mTfCounter = 0;
   double mTimeSum = 0.;
 
+  long mTFcreationTime = 0;
+
   template <typename Param_t,
             typename = typename std::enable_if<std::is_floating_point<Param_t>::value ||
                                                std::is_same<std::string, Param_t>::value || (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>

--- a/Modules/FDD/include/FDD/DigitQcTask.h
+++ b/Modules/FDD/include/FDD/DigitQcTask.h
@@ -109,6 +109,7 @@ class DigitQcTask final : public TaskInterface
 
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
+  std::set<unsigned int> mSetAllowedChIDsAmpVsTime;
   std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
   std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
   uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist

--- a/Modules/FDD/include/FDD/DigitQcTaskLaser.h
+++ b/Modules/FDD/include/FDD/DigitQcTaskLaser.h
@@ -17,6 +17,8 @@
 #ifndef QC_MODULE_FDD_FDDDIGITQCTASKLASER_H
 #define QC_MODULE_FDD_FDDDIGITQCTASKLASER_H
 
+#include "CommonConstants/LHCConstants.h"
+
 #include <Framework/InputRecord.h>
 
 #include "QualityControl/QcInfoLogger.h"
@@ -55,7 +57,7 @@ class DigitQcTaskLaser final : public TaskInterface
   void reset() override;
   constexpr static std::size_t sNCHANNELS_PM = 19;
   constexpr static std::size_t sOrbitsPerTF = 256;
-  constexpr static std::size_t sBCperOrbit = 3564;
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
  private:
   // three ways of computing cycle duration:

--- a/Modules/FDD/include/FDD/GenericCheck.h
+++ b/Modules/FDD/include/FDD/GenericCheck.h
@@ -1,0 +1,130 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   GenericCheck.h
+/// \author Sebastian Bysiak
+///
+
+#ifndef QC_MODULE_FDD_FDDGENERICCHECK_H
+#define QC_MODULE_FDD_FDDGENERICCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+#include <DataFormatsQualityControl/FlagReasons.h>
+
+namespace o2::quality_control_modules::fdd
+{
+
+/// \brief  helper class to store acceptable limits for given quantity
+/// \author Sebastian Bysiak
+class SingleCheck
+{
+ public:
+  SingleCheck() = default;
+  ~SingleCheck() = default;
+
+  SingleCheck(std::string name, float thresholdWarning, float thresholdError, bool shouldBeLower, bool isActive)
+  {
+    mCheckName = name;
+    mThresholdWarning = thresholdWarning;
+    mThresholdError = thresholdError;
+    mShouldBeLower = shouldBeLower;
+    mIsActive = isActive;
+  };
+  bool isActive() { return mIsActive; };
+
+  void doCheck(Quality& result, float checkedValue)
+  {
+    if (!mIsActive)
+      return;
+
+    std::string log = Form("%s : comparing  value = %f with thresholds = %f, %f", mCheckName.c_str(), checkedValue, mThresholdWarning, mThresholdError);
+    if (mShouldBeLower) {
+      if (checkedValue > mThresholdError) {
+        if (result.isBetterThan(Quality::Bad))
+          result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f > %.3f (%s error limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Bad";
+      } else if (checkedValue > mThresholdWarning) {
+        if (result.isBetterThan(Quality::Medium))
+          result.set(Quality::Medium);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f > %.3f (%s warning limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Medium";
+      } else {
+        log += "-> OK";
+      }
+    } else {
+      if (checkedValue < mThresholdError) {
+        if (result.isBetterThan(Quality::Bad))
+          result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f < %.3f (%s error limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Bad";
+      } else if (checkedValue < mThresholdWarning) {
+        if (result.isBetterThan(Quality::Medium))
+          result.set(Quality::Medium);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f < %.3f (%s warning limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Medium";
+      } else {
+        log += "-> OK";
+      }
+    }
+    ILOG(Debug, Support) << log << ENDM;
+  }
+
+ private:
+  std::string mCheckName;
+  float mThresholdWarning;
+  float mThresholdError;
+  bool mShouldBeLower;
+  bool mIsActive;
+};
+
+/// \brief  checks multiple basic hist statistics
+/// \author Sebastian Bysiak
+class GenericCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  GenericCheck() = default;
+  /// Destructor
+  ~GenericCheck() override = default;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+  ClassDefOverride(GenericCheck, 2);
+
+ private:
+  SingleCheck getCheckFromConfig(std::string);
+
+  SingleCheck mCheckMaxOverflowIntegralRatio;
+
+  SingleCheck mCheckMinMeanX;
+  SingleCheck mCheckMaxMeanX;
+  SingleCheck mCheckMaxStddevX;
+
+  SingleCheck mCheckMinMeanY;
+  SingleCheck mCheckMaxMeanY;
+  SingleCheck mCheckMaxStddevY;
+
+  SingleCheck mCheckMinGraphLastPoint;
+  SingleCheck mCheckMaxGraphLastPoint;
+
+  std::array<double, 4> mPositionMsgBox;
+  std::string mNameObjOnCanvas;
+};
+
+} // namespace o2::quality_control_modules::fdd
+
+#endif // QC_MODULE_FDD_FDDGENERICCHECK_H

--- a/Modules/FDD/include/FDD/LinkDef.h
+++ b/Modules/FDD/include/FDD/LinkDef.h
@@ -5,6 +5,7 @@
 
 #pragma link C++ class o2::quality_control_modules::fdd::DigitQcTask+;
 #pragma link C++ class o2::quality_control_modules::fdd::DigitQcTaskLaser + ;
+#pragma link C++ class o2::quality_control_modules::fdd::GenericCheck + ;
 #pragma link C++ class o2::quality_control_modules::fdd::RecPointsQcTask + ;
 #pragma link C++ class o2::quality_control_modules::fdd::PostProcTask + ;
 #pragma link C++ class o2::quality_control_modules::fdd::CFDEffCheck + ;

--- a/Modules/FDD/include/FDD/OutOfBunchCollCheck.h
+++ b/Modules/FDD/include/FDD/OutOfBunchCollCheck.h
@@ -18,6 +18,7 @@
 #define QC_MODULE_FDD_FDDOUTOFBUNCHCOLLCHECK_H
 
 #include "QualityControl/CheckInterface.h"
+#include "CommonConstants/LHCConstants.h"
 
 namespace o2::quality_control_modules::fdd
 {
@@ -37,6 +38,8 @@ class OutOfBunchCollCheck : public o2::quality_control::checker::CheckInterface
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
+
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
   ClassDefOverride(OutOfBunchCollCheck, 2);
 

--- a/Modules/FDD/include/FDD/PostProcTask.h
+++ b/Modules/FDD/include/FDD/PostProcTask.h
@@ -58,6 +58,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   std::string mPathDigitQcTask;
   std::string mCycleDurationMoName;
   std::string mCcdbUrl;
+  std::string mTimestampSourceLhcIf;
   int mNumOrbitsInTF;
 
   std::map<o2::fdd::ChannelData::EEventDataBit, std::string> mMapChTrgNames;

--- a/Modules/FDD/include/FDD/PostProcTask.h
+++ b/Modules/FDD/include/FDD/PostProcTask.h
@@ -20,6 +20,7 @@
 #include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/DatabaseInterface.h"
 #include "CCDB/CcdbApi.h"
+#include "CommonConstants/LHCConstants.h"
 
 #include "FDDBase/Constants.h"
 #include "DataFormatsFDD/ChannelData.h"
@@ -49,6 +50,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   void update(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
 
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
   constexpr static std::size_t sNCHANNELS_PM = 20;
 
  private:

--- a/Modules/FDD/include/FDD/RecPointsQcTask.h
+++ b/Modules/FDD/include/FDD/RecPointsQcTask.h
@@ -17,6 +17,8 @@
 #ifndef QC_MODULE_FDD_FDDRECOQCTASK_H
 #define QC_MODULE_FDD_FDDRECOQCTASK_H
 
+#include "CommonConstants/LHCConstants.h"
+
 #include <Framework/InputRecord.h>
 
 #include "QualityControl/QcInfoLogger.h"
@@ -58,6 +60,7 @@ class RecPointsQcTask final : public TaskInterface
   constexpr static std::size_t sOrbitsPerTF = 256;
   constexpr static uint8_t sDataIsValidBitPos = 7;
   constexpr static std::size_t sNCHANNELS_PM = 19;
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
  private:
   // three ways of computing cycle duration:

--- a/Modules/FDD/src/DigitQcTask.cxx
+++ b/Modules/FDD/src/DigitQcTask.cxx
@@ -47,6 +47,10 @@ void DigitQcTask::rebinFromConfig()
      "binning_Amp_channel2": "5,-10,90" ...
   */
   auto rebinHisto = [](std::string hName, std::string binning) {
+    if (!gROOT->FindObject(hName.data())) {
+      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
+      return;
+    }
     std::vector<std::string> tokenizedBinning;
     boost::split(tokenizedBinning, binning, boost::is_any_of(","));
     if (tokenizedBinning.size() == 3) { // TH1
@@ -75,9 +79,6 @@ void DigitQcTask::rebinFromConfig()
         std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
         rebinHisto(hNameCur, binning);
       }
-    } else if (!gROOT->FindObject(hName.data())) {
-      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
-      continue;
     } else {
       rebinHisto(hName, binning);
     }

--- a/Modules/FDD/src/DigitQcTaskLaser.cxx
+++ b/Modules/FDD/src/DigitQcTaskLaser.cxx
@@ -116,9 +116,9 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
   mHistTime2Ch->SetOption("colz");
   mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4200, -100, 4100);
   mHistAmp2Ch->SetOption("colz");
-  mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", 256, 0, 256, 3564, 0, 3564);
+  mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", 256, 0, 256, sBCperOrbit, 0, sBCperOrbit);
   mHistOrbit2BC->SetOption("colz");
-  mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", 3564, 0, 3564);
+  mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
 
   mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
   mHistChDataBits->SetOption("colz");
@@ -155,7 +155,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
   }
 
   for (const auto& entry : mMapPmModuleChannels) {
-    auto pairModuleBcOrbit = mMapPmModuleBcOrbit.insert({ entry.first, new TH2F(Form("BcOrbitMap_%s", entry.first.c_str()), Form("BC-orbit map for %s;Orbit;BC", entry.first.c_str()), 256, 0, 256, 3564, 0, 3564) });
+    auto pairModuleBcOrbit = mMapPmModuleBcOrbit.insert({ entry.first, new TH2F(Form("BcOrbitMap_%s", entry.first.c_str()), Form("BC-orbit map for %s;Orbit;BC", entry.first.c_str()), 256, 0, 256, sBCperOrbit, 0, sBCperOrbit) });
   }
 
   mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_PM, 0, sNCHANNELS_PM);

--- a/Modules/FDD/src/DigitQcTaskLaser.cxx
+++ b/Modules/FDD/src/DigitQcTaskLaser.cxx
@@ -49,6 +49,10 @@ void DigitQcTaskLaser::rebinFromConfig()
      "binning_Amp_channel2": "5,-10,90" ...
   */
   auto rebinHisto = [](std::string hName, std::string binning) {
+    if (!gROOT->FindObject(hName.data())) {
+      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
+      return;
+    }
     std::vector<std::string> tokenizedBinning;
     boost::split(tokenizedBinning, binning, boost::is_any_of(","));
     if (tokenizedBinning.size() == 3) { // TH1
@@ -81,9 +85,6 @@ void DigitQcTaskLaser::rebinFromConfig()
         std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
         rebinHisto(hNameCur, binning);
       }
-    } else if (!gROOT->FindObject(hName.data())) {
-      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
-      continue;
     } else {
       rebinHisto(hName, binning);
     }

--- a/Modules/FDD/src/GenericCheck.cxx
+++ b/Modules/FDD/src/GenericCheck.cxx
@@ -1,0 +1,252 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   GenericCheck.cxx
+/// \author Sebastian Bysiak
+///
+
+#include "FDD/GenericCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
+// ROOT
+#include <TH1.h>
+#include <TH2.h>
+#include <TGraph.h>
+#include <TCanvas.h>
+#include <TPaveText.h>
+#include <TMath.h>
+// #include <TLine.h>
+#include <TList.h>
+
+#include <DataFormatsQualityControl/FlagReasons.h>
+
+using namespace std;
+using namespace o2::quality_control;
+
+namespace o2::quality_control_modules::fdd
+{
+
+SingleCheck GenericCheck::getCheckFromConfig(std::string paramName)
+{
+  bool isActive = false;
+  float thresholdWarning = TMath::SignalingNaN(), thresholdError = TMath::SignalingNaN();
+  bool shouldBeLower = true;
+  if (paramName.find("Max") != string::npos || paramName.find("max") != string::npos) {
+    shouldBeLower = true;
+  } else if (paramName.find("Min") != string::npos || paramName.find("min") != string::npos) {
+    shouldBeLower = false;
+  }
+
+  if (auto paramWarning = mCustomParameters.find(string("thresholdWarning") + paramName), paramError = mCustomParameters.find(string("thresholdError") + paramName); paramWarning != mCustomParameters.end() || paramError != mCustomParameters.end()) {
+    if (paramWarning != mCustomParameters.end() && paramError != mCustomParameters.end()) {
+      thresholdWarning = stof(paramWarning->second);
+      thresholdError = stof(paramError->second);
+      isActive = true;
+      if ((shouldBeLower && thresholdWarning > thresholdError) || (!shouldBeLower && thresholdWarning < thresholdError)) {
+        ILOG(Warning, Support) << "configure(): warning more strict than error -> swapping values!" << ENDM;
+        std::swap(thresholdWarning, thresholdError);
+      }
+      ILOG(Info, Support) << "configure() : using thresholdWarning" << paramName.c_str() << " = " << thresholdWarning << " , thresholdError" << paramName << " = " << thresholdError << ENDM;
+    } else {
+      ILOG(Warning, Support) << "configure() : only one threshold (warning/error) was provided for  " << paramName.c_str() << " -> this parameter will not be used!" << ENDM;
+    }
+  }
+  return SingleCheck(paramName, thresholdWarning, thresholdError, shouldBeLower, isActive);
+}
+
+void GenericCheck::configure()
+{
+
+  mCheckMaxOverflowIntegralRatio = getCheckFromConfig("MaxOverflowIntegralRatio");
+
+  mCheckMinMeanX = getCheckFromConfig("MinMeanX");
+  mCheckMaxMeanX = getCheckFromConfig("MaxMeanX");
+  mCheckMaxStddevX = getCheckFromConfig("MaxStddevX");
+
+  mCheckMinMeanY = getCheckFromConfig("MinMeanY");
+  mCheckMaxMeanY = getCheckFromConfig("MaxMeanY");
+  mCheckMaxStddevY = getCheckFromConfig("MaxStddevY");
+
+  mCheckMinGraphLastPoint = getCheckFromConfig("MinGraphLastPoint");
+  mCheckMaxGraphLastPoint = getCheckFromConfig("MaxGraphLastPoint");
+
+  mPositionMsgBox = { 0.15, 0.75, 0.85, 0.9 };
+  if (auto param = mCustomParameters.find("positionMsgBox"); param != mCustomParameters.end()) {
+    stringstream ss(param->second);
+    int i = 0;
+    while (ss.good()) {
+      if (i > 4) {
+        ILOG(Info, Support) << "Skipping next values provided for positionMsgBox" << ENDM;
+        break;
+      }
+      string substr;
+      getline(ss, substr, ',');
+      mPositionMsgBox[i] = std::stod(substr);
+      i++;
+    }
+    float minHeight = 0.09, minWidth = 0.19;
+    if (mPositionMsgBox[2] - mPositionMsgBox[0] < minWidth || mPositionMsgBox[3] - mPositionMsgBox[1] < minHeight) {
+      mPositionMsgBox = { 0.15, 0.75, 0.85, 0.9 };
+      ILOG(Info, Support) << "MsgBox too small: returning to default" << ENDM;
+    }
+  }
+
+  if (auto param = mCustomParameters.find("nameObjOnCanvas"); param != mCustomParameters.end()) {
+    mNameObjOnCanvas = param->second;
+    ILOG(Info, Support) << "nameObjOnCanvas set to " << mNameObjOnCanvas << ENDM;
+  } else {
+    mNameObjOnCanvas = "unspecified";
+  }
+}
+
+Quality GenericCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Good;
+  for (auto& [moName, mo] : *moMap) {
+    if (!mo) {
+      result.set(Quality::Null);
+      ILOG(Error, Support) << "MO " << moName << " not found" << ENDM;
+      continue;
+    }
+    if (std::strcmp(mo->getObject()->ClassName(), "TCanvas") == 0) {
+      auto g = (TGraph*)((TCanvas*)mo->getObject())->GetListOfPrimitives()->FindObject(mNameObjOnCanvas.c_str());
+
+      if (!g) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object " << mNameObjOnCanvas << " inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinGraphLastPoint.isActive())
+        mCheckMinGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+      if (mCheckMaxGraphLastPoint.isActive())
+        mCheckMaxGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+    }
+    if (std::strcmp(mo->getObject()->ClassName(), "TGraph") == 0) {
+      auto g = (TGraph*)mo->getObject();
+
+      if (!g) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinGraphLastPoint.isActive())
+        mCheckMinGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+      if (mCheckMaxGraphLastPoint.isActive())
+        mCheckMaxGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+
+    } else {
+      auto h = (TH1*)mo->getObject();
+      if (!h) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinMeanX.isActive())
+        mCheckMinMeanX.doCheck(result, h->GetMean());
+      if (mCheckMaxMeanX.isActive())
+        mCheckMaxMeanX.doCheck(result, h->GetMean());
+      if (mCheckMaxStddevX.isActive())
+        mCheckMaxStddevX.doCheck(result, h->GetStdDev());
+
+      if (mCheckMinMeanY.isActive())
+        mCheckMinMeanY.doCheck(result, h->GetMean(2));
+      if (mCheckMaxMeanY.isActive())
+        mCheckMaxMeanY.doCheck(result, h->GetMean(2));
+      if (mCheckMaxStddevY.isActive())
+        mCheckMaxStddevY.doCheck(result, h->GetStdDev(2));
+
+      if (mCheckMaxOverflowIntegralRatio.isActive()) {
+        float integralWithoutOverflow = 0., overflow = 0.;
+        if (h->GetDimension() == 1) {
+          integralWithoutOverflow = h->Integral();
+          overflow = h->GetBinContent(h->GetNbinsX() + 1);
+        } else if (h->GetDimension() == 2) {
+          // for 2D include these overflows: (over,over), (over,in-range), (in-range, over)
+          TH2* h2 = (TH2*)h->Clone(); // TH2 needed for Integral() with both axis specified
+          integralWithoutOverflow = h2->Integral();
+          float integralWithOverflow = h2->Integral(1, h2->GetNbinsX() + 1, 1, h2->GetNbinsY() + 1);
+          overflow = integralWithOverflow - integralWithoutOverflow;
+        }
+        mCheckMaxOverflowIntegralRatio.doCheck(result, overflow / integralWithoutOverflow);
+      }
+    }
+  }
+  return result;
+}
+
+std::string GenericCheck::getAcceptedType() { return "TObject"; }
+
+void GenericCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (!mo) {
+    ILOG(Error, Support) << "beautify(): MO not found" << ENDM;
+    return;
+  }
+
+  TPaveText* msg = new TPaveText(mPositionMsgBox[0], mPositionMsgBox[1], mPositionMsgBox[2], mPositionMsgBox[3], "NDC");
+  if (std::strcmp(mo->getObject()->ClassName(), "TCanvas") == 0) {
+    auto g = (TGraph*)((TCanvas*)mo->getObject())->GetListOfPrimitives()->FindObject(mNameObjOnCanvas.c_str());
+    if (!g) {
+      ILOG(Error, Support) << "beautify(): Object " << mNameObjOnCanvas << " inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    g->GetListOfFunctions()->Add(msg);
+  } else if (std::strcmp(mo->getObject()->ClassName(), "TGraph") == 0) {
+    auto g = (TGraph*)mo->getObject();
+    if (!g) {
+      ILOG(Error, Support) << "beautify(): Object inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    g->GetListOfFunctions()->Add(msg);
+  } else {
+    auto h = (TH1*)mo->getObject();
+    if (!h) {
+      ILOG(Error, Support) << "beautify(): Object inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    h->GetListOfFunctions()->Add(msg);
+  }
+
+  msg->SetName(Form("%s_msg", mo->GetName()));
+  msg->Clear();
+  auto reasons = checkResult.getReasons();
+  for (int i = 0; i < int(reasons.size()); i++) {
+    msg->AddText(reasons[i].second.c_str());
+    if (i > 4) {
+      msg->AddText("et al ... ");
+      break;
+    }
+  }
+  int color = kBlack;
+  if (checkResult == Quality::Good) {
+    color = kGreen + 1;
+    msg->AddText(">> Quality::Good <<");
+  } else if (checkResult == Quality::Medium) {
+    color = kOrange - 1;
+    msg->AddText(">> Quality::Medium <<");
+  } else if (checkResult == Quality::Bad) {
+    color = kRed;
+    msg->AddText(">> Quality::Bad <<");
+  }
+  msg->SetFillStyle(1);
+  msg->SetLineWidth(3);
+  msg->SetLineColor(color);
+  msg->SetShadowColor(color);
+  msg->SetTextColor(color);
+  msg->SetMargin(0.0);
+}
+
+} // namespace o2::quality_control_modules::fdd

--- a/Modules/FDD/src/OutOfBunchCollCheck.cxx
+++ b/Modules/FDD/src/OutOfBunchCollCheck.cxx
@@ -98,7 +98,7 @@ Quality OutOfBunchCollCheck::check(std::map<std::string, std::shared_ptr<Monitor
   mFractionOutOfBunchColl = 0;
   mNumNonEmptyBins = 0;
 
-  integralOutOfBunchColl = hOutOfBunchColl->Integral(1, 3564, mBinPos, mBinPos);
+  integralOutOfBunchColl = hOutOfBunchColl->Integral(1, sBCperOrbit, mBinPos, mBinPos);
   mFractionOutOfBunchColl = integralOutOfBunchColl / integralBcOrbitMap;
 
   ILOG(Debug, Support) << "in checker: integralBcOrbitMap:" << integralBcOrbitMap << " integralOutOfBunchColl: " << integralOutOfBunchColl << " -> fraction: " << mFractionOutOfBunchColl << ENDM;

--- a/Modules/FDD/src/PostProcTask.cxx
+++ b/Modules/FDD/src/PostProcTask.cxx
@@ -79,6 +79,23 @@ void PostProcTask::configure(std::string, const boost::property_tree::ptree& con
     mPathDigitQcTask = "FDD/MO/DigitQcTask/";
     ILOG(Info, Support) << "configure() : using default pathDigitQcTask = \"" << mPathDigitQcTask << "\"" << ENDM;
   }
+
+  node = config.get_child_optional(Form("%s.custom.timestampSourceLhcIf", configPath));
+  if (node) {
+    mTimestampSourceLhcIf = node.get_ptr()->get_child("").get_value<std::string>();
+    if (mTimestampSourceLhcIf == "last" || mTimestampSourceLhcIf == "trigger" || mTimestampSourceLhcIf == "metadata") {
+      ILOG(Info, Support) << "configure() : using timestampSourceLhcIf = \"" << mTimestampSourceLhcIf << "\"" << ENDM;
+    } else {
+      auto prev = mTimestampSourceLhcIf;
+      mTimestampSourceLhcIf = "trigger";
+      ILOG(Warning, Support) << "configure() : invalid value for timestampSourceLhcIf = \"" << prev
+                             << "\"\n available options are \"last\", \"trigger\" or \"metadata\""
+                             << "\n fallback to default: \"" << mTimestampSourceLhcIf << "\"" << ENDM;
+    }
+  } else {
+    mTimestampSourceLhcIf = "trigger";
+    ILOG(Info, Support) << "configure() : using default timestampSourceLhcIf = \"" << mTimestampSourceLhcIf << "\"" << ENDM;
+  }
 }
 
 void PostProcTask::initialize(Trigger, framework::ServiceRegistry& services)
@@ -318,17 +335,45 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistry&)
     mTime->GetYaxis()->SetTitleOffset(1);
   }
 
+  auto moBCvsTriggers = mDatabase->retrieveMO(mPathDigitQcTask, "BCvsTriggers", t.timestamp, t.activity);
+  auto hBcVsTrg = moBCvsTriggers ? (TH2F*)moBCvsTriggers->getObject() : nullptr;
+  if (!hBcVsTrg) {
+    ILOG(Error, Support) << "MO \"BCvsTriggers\" NOT retrieved!!!" << ENDM;
+    return;
+  }
+
+  long ts = 999;
+  if (mTimestampSourceLhcIf == "last") {
+    ts = -1;
+  } else if (mTimestampSourceLhcIf == "trigger") {
+    ts = t.timestamp;
+  } else if (mTimestampSourceLhcIf == "metadata") {
+    for (auto metainfo : moBCvsTriggers->getMetadataMap()) {
+      if (metainfo.first == "TFcreationTime")
+        ts = std::stol(metainfo.second);
+    }
+    if (ts > 1651500000000 && ts < 1651700000000)
+      ILOG(Warning, Support) << "timestamp (read from TF via metadata) points to 02-04 May 2022"
+                                " - make sure this is the data we are processing and not the default timestamp "
+                                "(it may appear when running on digits w/o providing \"--hbfutils-config o2_tfidinfo.root\")"
+                             << ENDM;
+    if (ts == 999) {
+      ILOG(Error) << "\"TFcreationTime\" not found in metadata, fallback to ts from trigger " << ENDM;
+      ts = t.timestamp;
+    }
+  }
+
   std::map<std::string, std::string> metadata;
   std::map<std::string, std::string> headers;
-  auto* lhcIf = mCcdbApi.retrieveFromTFileAny<o2::parameters::GRPLHCIFData>(mPathGrpLhcIf, metadata, -1, &headers);
+  auto* lhcIf = mCcdbApi.retrieveFromTFileAny<o2::parameters::GRPLHCIFData>(mPathGrpLhcIf, metadata, ts, &headers);
   if (!lhcIf) {
-    ILOG(Error, Support) << "object \"" << mPathGrpLhcIf << "\" NOT retrieved!!!" << ENDM;
+    ILOG(Error, Support) << "object \"" << mPathGrpLhcIf << "\" NOT retrieved. OutOfBunchColTask will not produce valid QC plots." << ENDM;
     return;
   }
   const std::string bcName = lhcIf->getInjectionScheme();
   if (bcName.size() == 8) {
     if (bcName.compare("no_value")) {
-      ILOG(Warning) << "Filling scheme not set. OutOfBunchColTask will not produce valid QC plots." << ENDM;
+      ILOG(Error, Support) << "Filling scheme not set. OutOfBunchColTask will not produce valid QC plots." << ENDM;
     }
   } else {
     ILOG(Info, Support) << "Filling scheme: " << bcName.c_str() << ENDM;
@@ -340,12 +385,6 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistry&)
     for (int j = 0; j < mMapDigitTrgNames.size() + 1; j++) {
       mHistBcPattern->SetBinContent(i + 1, j + 1, bcPattern.testBC(i));
     }
-  }
-  auto moBCvsTriggers = mDatabase->retrieveMO(mPathDigitQcTask, "BCvsTriggers", t.timestamp, t.activity);
-  auto hBcVsTrg = moBCvsTriggers ? (TH2F*)moBCvsTriggers->getObject() : nullptr;
-  if (!hBcVsTrg) {
-    ILOG(Error, Support) << "MO \"BCvsTriggers\" NOT retrieved!!!" << ENDM;
-    return;
   }
 
   mHistBcTrgOutOfBunchColl->Reset();

--- a/Modules/FDD/src/RecPointsQcTask.cxx
+++ b/Modules/FDD/src/RecPointsQcTask.cxx
@@ -94,10 +94,10 @@ void RecPointsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mHistAmp2Ch->SetOption("colz");
   mHistCollTimeA = std::make_unique<TH1F>("CollTimeA", "T0A;Time [ns]", 4100, -20.5, 20.5);
   mHistCollTimeC = std::make_unique<TH1F>("CollTimeC", "T0C;Time [ns]", 4100, -20.5, 20.5);
-  mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", 3564, 0, 3564);
-  mHistBCTCM = std::make_unique<TH1F>("BCTCM", "BC TCM;BC;counts;", 3564, 0, 3564);
-  mHistBCorA = std::make_unique<TH1F>("BCorA", "BC orA;BC;counts;", 3564, 0, 3564);
-  mHistBCorC = std::make_unique<TH1F>("BCorC", "BC orC;BC;counts;", 3564, 0, 3564);
+  mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
+  mHistBCTCM = std::make_unique<TH1F>("BCTCM", "BC TCM;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
+  mHistBCorA = std::make_unique<TH1F>("BCorA", "BC orA;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
+  mHistBCorC = std::make_unique<TH1F>("BCorC", "BC orC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
   mListHistGarbage = new TList();
   mListHistGarbage->SetOwner(kTRUE);
 

--- a/Modules/FT0/CMakeLists.txt
+++ b/Modules/FT0/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(O2QcFT0)
 target_sources(O2QcFT0 PRIVATE src/TH1ReductorLaser.cxx
                                src/DigitQcTaskLaser.cxx
                                src/DigitQcTask.cxx
+                               src/GenericCheck.cxx
                                src/CFDEffCheck.cxx
                                src/PostProcTask.cxx
                                src/OutOfBunchCollCheck.cxx
@@ -38,6 +39,7 @@ add_root_dictionary(O2QcFT0
           include/FT0/PostProcTask.h
           include/FT0/CFDEffCheck.h
           include/FT0/OutOfBunchCollCheck.h
+          include/FT0/GenericCheck.h
           include/FT0/BasicDigitQcTask.h
           include/FT0/ChannelsCheck.h
           include/FT0/DigitsCheck.h

--- a/Modules/FT0/include/FT0/DigitQcTask.h
+++ b/Modules/FT0/include/FT0/DigitQcTask.h
@@ -80,6 +80,8 @@ class DigitQcTask final : public TaskInterface
   int mTfCounter = 0;
   double mTimeSum = 0.;
 
+  long mTFcreationTime = 0;
+
   template <typename Param_t,
             typename = typename std::enable_if<std::is_floating_point<Param_t>::value ||
                                                std::is_same<std::string, Param_t>::value || (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>

--- a/Modules/FT0/include/FT0/DigitQcTask.h
+++ b/Modules/FT0/include/FT0/DigitQcTask.h
@@ -104,6 +104,7 @@ class DigitQcTask final : public TaskInterface
 
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
+  std::set<unsigned int> mSetAllowedChIDsAmpVsTime;
   std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
   std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
   uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist

--- a/Modules/FT0/include/FT0/DigitQcTask.h
+++ b/Modules/FT0/include/FT0/DigitQcTask.h
@@ -31,6 +31,8 @@
 #include "TList.h"
 #include "Rtypes.h"
 
+#include "CommonConstants/LHCConstants.h"
+
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/QcInfoLogger.h"
 
@@ -62,7 +64,7 @@ class DigitQcTask final : public TaskInterface
   constexpr static std::size_t sNCHANNELS_A = o2::ft0::Geometry::NCellsA * 4;
   constexpr static std::size_t sNCHANNELS_C = o2::ft0::Geometry::NCellsC * 4;
   constexpr static std::size_t sOrbitsPerTF = 256;
-  constexpr static std::size_t sBCperOrbit = 3564;
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
   constexpr static float sCFDChannel2NS = 0.01302; // CFD channel width in ns
 

--- a/Modules/FT0/include/FT0/DigitQcTaskLaser.h
+++ b/Modules/FT0/include/FT0/DigitQcTaskLaser.h
@@ -94,6 +94,7 @@ class DigitQcTaskLaser final : public TaskInterface
 
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
+  std::set<unsigned int> mSetAllowedChIDsAmpVsTime;
   std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
   std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
   uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist

--- a/Modules/FT0/include/FT0/DigitQcTaskLaser.h
+++ b/Modules/FT0/include/FT0/DigitQcTaskLaser.h
@@ -31,6 +31,8 @@
 #include "TList.h"
 #include "Rtypes.h"
 
+#include "CommonConstants/LHCConstants.h"
+
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/QcInfoLogger.h"
 
@@ -62,7 +64,7 @@ class DigitQcTaskLaser final : public TaskInterface
   constexpr static std::size_t sNCHANNELS_A = o2::ft0::Geometry::NCellsA * 4;
   constexpr static std::size_t sNCHANNELS_C = o2::ft0::Geometry::NCellsC * 4;
   constexpr static std::size_t sOrbitsPerTF = 256;
-  constexpr static std::size_t sBCperOrbit = 3564;
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
   constexpr static float sCFDChannel2NS = 0.01302; // CFD channel width in ns
 

--- a/Modules/FT0/include/FT0/GenericCheck.h
+++ b/Modules/FT0/include/FT0/GenericCheck.h
@@ -1,0 +1,130 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   GenericCheck.h
+/// \author Sebastian Bysiak
+///
+
+#ifndef QC_MODULE_FT0_FT0GENERICCHECK_H
+#define QC_MODULE_FT0_FT0GENERICCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+#include <DataFormatsQualityControl/FlagReasons.h>
+
+namespace o2::quality_control_modules::ft0
+{
+
+/// \brief  helper class to store acceptable limits for given quantity
+/// \author Sebastian Bysiak
+class SingleCheck
+{
+ public:
+  SingleCheck() = default;
+  ~SingleCheck() = default;
+
+  SingleCheck(std::string name, float thresholdWarning, float thresholdError, bool shouldBeLower, bool isActive)
+  {
+    mCheckName = name;
+    mThresholdWarning = thresholdWarning;
+    mThresholdError = thresholdError;
+    mShouldBeLower = shouldBeLower;
+    mIsActive = isActive;
+  };
+  bool isActive() { return mIsActive; };
+
+  void doCheck(Quality& result, float checkedValue)
+  {
+    if (!mIsActive)
+      return;
+
+    std::string log = Form("%s : comparing  value = %f with thresholds = %f, %f", mCheckName.c_str(), checkedValue, mThresholdWarning, mThresholdError);
+    if (mShouldBeLower) {
+      if (checkedValue > mThresholdError) {
+        if (result.isBetterThan(Quality::Bad))
+          result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f > %.3f (%s error limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Bad";
+      } else if (checkedValue > mThresholdWarning) {
+        if (result.isBetterThan(Quality::Medium))
+          result.set(Quality::Medium);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f > %.3f (%s warning limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Medium";
+      } else {
+        log += "-> OK";
+      }
+    } else {
+      if (checkedValue < mThresholdError) {
+        if (result.isBetterThan(Quality::Bad))
+          result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f < %.3f (%s error limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Bad";
+      } else if (checkedValue < mThresholdWarning) {
+        if (result.isBetterThan(Quality::Medium))
+          result.set(Quality::Medium);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f < %.3f (%s warning limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Medium";
+      } else {
+        log += "-> OK";
+      }
+    }
+    ILOG(Debug, Support) << log << ENDM;
+  }
+
+ private:
+  std::string mCheckName;
+  float mThresholdWarning;
+  float mThresholdError;
+  bool mShouldBeLower;
+  bool mIsActive;
+};
+
+/// \brief  checks multiple basic hist statistics
+/// \author Sebastian Bysiak
+class GenericCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  GenericCheck() = default;
+  /// Destructor
+  ~GenericCheck() override = default;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+  ClassDefOverride(GenericCheck, 2);
+
+ private:
+  SingleCheck getCheckFromConfig(std::string);
+
+  SingleCheck mCheckMaxOverflowIntegralRatio;
+
+  SingleCheck mCheckMinMeanX;
+  SingleCheck mCheckMaxMeanX;
+  SingleCheck mCheckMaxStddevX;
+
+  SingleCheck mCheckMinMeanY;
+  SingleCheck mCheckMaxMeanY;
+  SingleCheck mCheckMaxStddevY;
+
+  SingleCheck mCheckMinGraphLastPoint;
+  SingleCheck mCheckMaxGraphLastPoint;
+
+  std::array<double, 4> mPositionMsgBox;
+  std::string mNameObjOnCanvas;
+};
+
+} // namespace o2::quality_control_modules::ft0
+
+#endif // QC_MODULE_FT0_FT0GENERICCHECK_H

--- a/Modules/FT0/include/FT0/LinkDef.h
+++ b/Modules/FT0/include/FT0/LinkDef.h
@@ -14,6 +14,7 @@
 //#pragma link C++ class o2::quality_control_modules::ft0::CalibrationTask + ;
 //#pragma link C++ class o2::quality_control_modules::ft0::ChannelTimeCalibrationCheck + ;
 #pragma link C++ class o2::quality_control_modules::ft0::PostProcTask + ;
+#pragma link C++ class o2::quality_control_modules::ft0::GenericCheck+;
 #pragma link C++ class o2::quality_control_modules::ft0::CFDEffCheck + ;
 #pragma link C++ class o2::quality_control_modules::ft0::OutOfBunchCollCheck + ;
 #pragma link C++ class o2::quality_control_modules::ft0::RecPointsQcTask + ;

--- a/Modules/FT0/include/FT0/OutOfBunchCollCheck.h
+++ b/Modules/FT0/include/FT0/OutOfBunchCollCheck.h
@@ -18,6 +18,7 @@
 #define QC_MODULE_FT0_FT0OUTOFBUNCHCOLLCHECK_H
 
 #include "QualityControl/CheckInterface.h"
+#include "CommonConstants/LHCConstants.h"
 
 namespace o2::quality_control_modules::ft0
 {
@@ -37,6 +38,8 @@ class OutOfBunchCollCheck : public o2::quality_control::checker::CheckInterface
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
+
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
   ClassDefOverride(OutOfBunchCollCheck, 2);
 

--- a/Modules/FT0/include/FT0/PostProcTask.h
+++ b/Modules/FT0/include/FT0/PostProcTask.h
@@ -20,6 +20,7 @@
 #include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/DatabaseInterface.h"
 #include "CCDB/CcdbApi.h"
+#include "CommonConstants/LHCConstants.h"
 
 #include "FT0Base/Constants.h"
 #include "DataFormatsFT0/ChannelData.h"
@@ -48,6 +49,8 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   void initialize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
   void update(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
+
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
  private:
   std::string mPathGrpLhcIf;

--- a/Modules/FT0/include/FT0/PostProcTask.h
+++ b/Modules/FT0/include/FT0/PostProcTask.h
@@ -57,6 +57,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   std::string mPathDigitQcTask;
   std::string mCycleDurationMoName;
   std::string mCcdbUrl;
+  std::string mTimestampSourceLhcIf;
   int mNumOrbitsInTF;
 
   std::map<o2::ft0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;

--- a/Modules/FT0/src/DigitQcTask.cxx
+++ b/Modules/FT0/src/DigitQcTask.cxx
@@ -270,12 +270,20 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   for (const auto& entry : vecChannelIDs) {
     mSetAllowedChIDs.insert(entry);
   }
+  std::vector<unsigned int> vecChannelIDsAmpVsTime;
+  if (auto param = mCustomParameters.find("ChannelIDsAmpVsTime"); param != mCustomParameters.end()) {
+    const auto chIDs = param->second;
+    const std::string del = ",";
+    vecChannelIDsAmpVsTime = parseParameters<unsigned int>(chIDs, del);
+  }
+  for (const auto& entry : vecChannelIDsAmpVsTime) {
+    mSetAllowedChIDsAmpVsTime.insert(entry);
+  }
 
   for (const auto& chID : mSetAllowedChIDs) {
     auto pairHistAmp = mMapHistAmp1D.insert({ chID, new TH1F(Form("Amp_channel%i", chID), Form("Amplitude, channel %i", chID), 4200, -100, 4100) });
     auto pairHistTime = mMapHistTime1D.insert({ chID, new TH1F(Form("Time_channel%i", chID), Form("Time, channel %i", chID), 4100, -2050, 2050) });
     auto pairHistBits = mMapHistPMbits.insert({ chID, new TH1F(Form("Bits_channel%i", chID), Form("Bits, channel %i", chID), mMapChTrgNames.size(), 0, mMapChTrgNames.size()) });
-    auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
     for (const auto& entry : mMapChTrgNames) {
       pairHistBits.first->second->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     }
@@ -291,6 +299,9 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
       mListHistGarbage->Add(pairHistBits.first->second);
       getObjectsManager()->startPublishing(pairHistBits.first->second);
     }
+  }
+  for (const auto& chID : mSetAllowedChIDsAmpVsTime) {
+    auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
     if (pairHistAmpVsTime.second) {
       mListHistGarbage->Add(pairHistAmpVsTime.first->second);
       getObjectsManager()->startPublishing(pairHistAmpVsTime.first->second);
@@ -470,12 +481,14 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (mSetAllowedChIDs.size() != 0 && mSetAllowedChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDs.end()) {
         mMapHistAmp1D[chData.ChId]->Fill(chData.QTCAmpl);
         mMapHistTime1D[chData.ChId]->Fill(chData.CFDTime);
-        mMapHistAmpVsTime[chData.ChId]->Fill(chData.QTCAmpl, chData.CFDTime);
         for (const auto& entry : mMapChTrgNames) {
           if ((chData.ChainQTC & (1 << entry.first))) {
             mMapHistPMbits[chData.ChId]->Fill(entry.first);
           }
         }
+      }
+      if (mSetAllowedChIDsAmpVsTime.size() != 0 && mSetAllowedChIDsAmpVsTime.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDsAmpVsTime.end()) {
+        mMapHistAmpVsTime[chData.ChId]->Fill(chData.QTCAmpl, chData.CFDTime);
       }
       for (const auto& binPos : mHashedBitBinPos[chData.ChainQTC]) {
         mHistChDataBits->Fill(chData.ChId, binPos);

--- a/Modules/FT0/src/DigitQcTask.cxx
+++ b/Modules/FT0/src/DigitQcTask.cxx
@@ -44,6 +44,10 @@ void DigitQcTask::rebinFromConfig()
      "binning_Amp_channel2": "5,-10,90" ...
   */
   auto rebinHisto = [](std::string hName, std::string binning) {
+    if (!gROOT->FindObject(hName.data())) {
+      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
+      return;
+    }
     std::vector<std::string> tokenizedBinning;
     boost::split(tokenizedBinning, binning, boost::is_any_of(","));
     if (tokenizedBinning.size() == 3) { // TH1
@@ -72,9 +76,6 @@ void DigitQcTask::rebinFromConfig()
         std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
         rebinHisto(hNameCur, binning);
       }
-    } else if (!gROOT->FindObject(hName.data())) {
-      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
-      continue;
     } else {
       rebinHisto(hName, binning);
     }

--- a/Modules/FT0/src/DigitQcTask.cxx
+++ b/Modules/FT0/src/DigitQcTask.cxx
@@ -21,6 +21,7 @@
 #include "QualityControl/QcInfoLogger.h"
 #include "DataFormatsFIT/Triggers.h"
 #include "Framework/InputRecord.h"
+#include "Framework/TimingInfo.h"
 #include "DataFormatsFT0/LookUpTable.h"
 
 namespace o2::quality_control_modules::ft0
@@ -412,6 +413,8 @@ void DigitQcTask::startOfCycle()
 
 void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
+  mTFcreationTime = ctx.services().get<o2::framework::TimingInfo>().creation;
+
   mTfCounter++;
   auto channels = ctx.inputs().get<gsl::span<o2::ft0::ChannelData>>("channels");
   auto digits = ctx.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
@@ -630,6 +633,10 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 void DigitQcTask::endOfCycle()
 {
   ILOG(Info) << "endOfCycle" << ENDM;
+  // add TF creation time for further match with filling scheme in PP in case of offline running
+  ILOG(Debug, Support) << "adding last TF creation time: " << mTFcreationTime << ENDM;
+  getObjectsManager()->getMonitorObject(mHistBCvsTrg->GetName())->addOrUpdateMetadata("TFcreationTime", std::to_string(mTFcreationTime));
+
   // one has to set num. of entries manually because
   // default TH1Reductor gets only mean,stddev and entries (no integral)
   mHistCFDEff->Divide(mHistNumADC.get(), mHistNumCFD.get());

--- a/Modules/FT0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FT0/src/DigitQcTaskLaser.cxx
@@ -45,6 +45,10 @@ void DigitQcTaskLaser::rebinFromConfig()
      "binning_Amp_channel2": "5,-10,90" ...
   */
   auto rebinHisto = [](std::string hName, std::string binning) {
+    if (!gROOT->FindObject(hName.data())) {
+      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
+      return;
+    }
     std::vector<std::string> tokenizedBinning;
     boost::split(tokenizedBinning, binning, boost::is_any_of(","));
     if (tokenizedBinning.size() == 3) { // TH1
@@ -73,9 +77,6 @@ void DigitQcTaskLaser::rebinFromConfig()
         std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
         rebinHisto(hNameCur, binning);
       }
-    } else if (!gROOT->FindObject(hName.data())) {
-      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
-      continue;
     } else {
       rebinHisto(hName, binning);
     }

--- a/Modules/FT0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FT0/src/DigitQcTaskLaser.cxx
@@ -250,12 +250,20 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
   for (const auto& entry : vecChannelIDs) {
     mSetAllowedChIDs.insert(entry);
   }
+  std::vector<unsigned int> vecChannelIDsAmpVsTime;
+  if (auto param = mCustomParameters.find("ChannelIDsAmpVsTime"); param != mCustomParameters.end()) {
+    const auto chIDs = param->second;
+    const std::string del = ",";
+    vecChannelIDsAmpVsTime = parseParameters<unsigned int>(chIDs, del);
+  }
+  for (const auto& entry : vecChannelIDsAmpVsTime) {
+    mSetAllowedChIDsAmpVsTime.insert(entry);
+  }
 
   for (const auto& chID : mSetAllowedChIDs) {
     auto pairHistAmp = mMapHistAmp1D.insert({ chID, new TH1F(Form("Amp_channel%i", chID), Form("Amplitude, channel %i", chID), 4200, -100, 4100) });
     auto pairHistTime = mMapHistTime1D.insert({ chID, new TH1F(Form("Time_channel%i", chID), Form("Time, channel %i", chID), 4100, -2050, 2050) });
     auto pairHistBits = mMapHistPMbits.insert({ chID, new TH1F(Form("Bits_channel%i", chID), Form("Bits, channel %i", chID), mMapChTrgNames.size(), 0, mMapChTrgNames.size()) });
-    auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
     for (const auto& entry : mMapChTrgNames) {
       pairHistBits.first->second->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     }
@@ -271,6 +279,9 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
       mListHistGarbage->Add(pairHistBits.first->second);
       getObjectsManager()->startPublishing(pairHistBits.first->second);
     }
+  }
+  for (const auto& chID : mSetAllowedChIDsAmpVsTime) {
+    auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
     if (pairHistAmpVsTime.second) {
       mListHistGarbage->Add(pairHistAmpVsTime.first->second);
       getObjectsManager()->startPublishing(pairHistAmpVsTime.first->second);
@@ -385,12 +396,14 @@ void DigitQcTaskLaser::monitorData(o2::framework::ProcessingContext& ctx)
       if (mSetAllowedChIDs.size() != 0 && mSetAllowedChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDs.end()) {
         mMapHistAmp1D[chData.ChId]->Fill(chData.QTCAmpl);
         mMapHistTime1D[chData.ChId]->Fill(chData.CFDTime);
-        mMapHistAmpVsTime[chData.ChId]->Fill(chData.QTCAmpl, chData.CFDTime);
         for (const auto& entry : mMapChTrgNames) {
           if ((chData.ChainQTC & (1 << entry.first))) {
             mMapHistPMbits[chData.ChId]->Fill(entry.first);
           }
         }
+      }
+      if (mSetAllowedChIDsAmpVsTime.size() != 0 && mSetAllowedChIDsAmpVsTime.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDsAmpVsTime.end()) {
+        mMapHistAmpVsTime[chData.ChId]->Fill(chData.QTCAmpl, chData.CFDTime);
       }
       for (const auto& binPos : mHashedBitBinPos[chData.ChainQTC]) {
         mHistChDataBits->Fill(chData.ChId, binPos);

--- a/Modules/FT0/src/GenericCheck.cxx
+++ b/Modules/FT0/src/GenericCheck.cxx
@@ -1,0 +1,252 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   GenericCheck.cxx
+/// \author Sebastian Bysiak
+///
+
+#include "FT0/GenericCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
+// ROOT
+#include <TH1.h>
+#include <TH2.h>
+#include <TGraph.h>
+#include <TCanvas.h>
+#include <TPaveText.h>
+#include <TMath.h>
+// #include <TLine.h>
+#include <TList.h>
+
+#include <DataFormatsQualityControl/FlagReasons.h>
+
+using namespace std;
+using namespace o2::quality_control;
+
+namespace o2::quality_control_modules::ft0
+{
+
+SingleCheck GenericCheck::getCheckFromConfig(std::string paramName)
+{
+  bool isActive = false;
+  float thresholdWarning = TMath::SignalingNaN(), thresholdError = TMath::SignalingNaN();
+  bool shouldBeLower = true;
+  if (paramName.find("Max") != string::npos || paramName.find("max") != string::npos) {
+    shouldBeLower = true;
+  } else if (paramName.find("Min") != string::npos || paramName.find("min") != string::npos) {
+    shouldBeLower = false;
+  }
+
+  if (auto paramWarning = mCustomParameters.find(string("thresholdWarning") + paramName), paramError = mCustomParameters.find(string("thresholdError") + paramName); paramWarning != mCustomParameters.end() || paramError != mCustomParameters.end()) {
+    if (paramWarning != mCustomParameters.end() && paramError != mCustomParameters.end()) {
+      thresholdWarning = stof(paramWarning->second);
+      thresholdError = stof(paramError->second);
+      isActive = true;
+      if ((shouldBeLower && thresholdWarning > thresholdError) || (!shouldBeLower && thresholdWarning < thresholdError)) {
+        ILOG(Warning, Support) << "configure(): warning more strict than error -> swapping values!" << ENDM;
+        std::swap(thresholdWarning, thresholdError);
+      }
+      ILOG(Info, Support) << "configure() : using thresholdWarning" << paramName.c_str() << " = " << thresholdWarning << " , thresholdError" << paramName << " = " << thresholdError << ENDM;
+    } else {
+      ILOG(Warning, Support) << "configure() : only one threshold (warning/error) was provided for  " << paramName.c_str() << " -> this parameter will not be used!" << ENDM;
+    }
+  }
+  return SingleCheck(paramName, thresholdWarning, thresholdError, shouldBeLower, isActive);
+}
+
+void GenericCheck::configure()
+{
+
+  mCheckMaxOverflowIntegralRatio = getCheckFromConfig("MaxOverflowIntegralRatio");
+
+  mCheckMinMeanX = getCheckFromConfig("MinMeanX");
+  mCheckMaxMeanX = getCheckFromConfig("MaxMeanX");
+  mCheckMaxStddevX = getCheckFromConfig("MaxStddevX");
+
+  mCheckMinMeanY = getCheckFromConfig("MinMeanY");
+  mCheckMaxMeanY = getCheckFromConfig("MaxMeanY");
+  mCheckMaxStddevY = getCheckFromConfig("MaxStddevY");
+
+  mCheckMinGraphLastPoint = getCheckFromConfig("MinGraphLastPoint");
+  mCheckMaxGraphLastPoint = getCheckFromConfig("MaxGraphLastPoint");
+
+  mPositionMsgBox = { 0.15, 0.75, 0.85, 0.9 };
+  if (auto param = mCustomParameters.find("positionMsgBox"); param != mCustomParameters.end()) {
+    stringstream ss(param->second);
+    int i = 0;
+    while (ss.good()) {
+      if (i > 4) {
+        ILOG(Info, Support) << "Skipping next values provided for positionMsgBox" << ENDM;
+        break;
+      }
+      string substr;
+      getline(ss, substr, ',');
+      mPositionMsgBox[i] = std::stod(substr);
+      i++;
+    }
+    float minHeight = 0.09, minWidth = 0.19;
+    if (mPositionMsgBox[2] - mPositionMsgBox[0] < minWidth || mPositionMsgBox[3] - mPositionMsgBox[1] < minHeight) {
+      mPositionMsgBox = { 0.15, 0.75, 0.85, 0.9 };
+      ILOG(Info, Support) << "MsgBox too small: returning to default" << ENDM;
+    }
+  }
+
+  if (auto param = mCustomParameters.find("nameObjOnCanvas"); param != mCustomParameters.end()) {
+    mNameObjOnCanvas = param->second;
+    ILOG(Info, Support) << "nameObjOnCanvas set to " << mNameObjOnCanvas << ENDM;
+  } else {
+    mNameObjOnCanvas = "unspecified";
+  }
+}
+
+Quality GenericCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Good;
+  for (auto& [moName, mo] : *moMap) {
+    if (!mo) {
+      result.set(Quality::Null);
+      ILOG(Error, Support) << "MO " << moName << " not found" << ENDM;
+      continue;
+    }
+    if (std::strcmp(mo->getObject()->ClassName(), "TCanvas") == 0) {
+      auto g = (TGraph*)((TCanvas*)mo->getObject())->GetListOfPrimitives()->FindObject(mNameObjOnCanvas.c_str());
+
+      if (!g) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object " << mNameObjOnCanvas << " inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinGraphLastPoint.isActive())
+        mCheckMinGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+      if (mCheckMaxGraphLastPoint.isActive())
+        mCheckMaxGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+    }
+    if (std::strcmp(mo->getObject()->ClassName(), "TGraph") == 0) {
+      auto g = (TGraph*)mo->getObject();
+
+      if (!g) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinGraphLastPoint.isActive())
+        mCheckMinGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+      if (mCheckMaxGraphLastPoint.isActive())
+        mCheckMaxGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+
+    } else {
+      auto h = (TH1*)mo->getObject();
+      if (!h) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinMeanX.isActive())
+        mCheckMinMeanX.doCheck(result, h->GetMean());
+      if (mCheckMaxMeanX.isActive())
+        mCheckMaxMeanX.doCheck(result, h->GetMean());
+      if (mCheckMaxStddevX.isActive())
+        mCheckMaxStddevX.doCheck(result, h->GetStdDev());
+
+      if (mCheckMinMeanY.isActive())
+        mCheckMinMeanY.doCheck(result, h->GetMean(2));
+      if (mCheckMaxMeanY.isActive())
+        mCheckMaxMeanY.doCheck(result, h->GetMean(2));
+      if (mCheckMaxStddevY.isActive())
+        mCheckMaxStddevY.doCheck(result, h->GetStdDev(2));
+
+      if (mCheckMaxOverflowIntegralRatio.isActive()) {
+        float integralWithoutOverflow = 0., overflow = 0.;
+        if (h->GetDimension() == 1) {
+          integralWithoutOverflow = h->Integral();
+          overflow = h->GetBinContent(h->GetNbinsX() + 1);
+        } else if (h->GetDimension() == 2) {
+          // for 2D include these overflows: (over,over), (over,in-range), (in-range, over)
+          TH2* h2 = (TH2*)h->Clone(); // TH2 needed for Integral() with both axis specified
+          integralWithoutOverflow = h2->Integral();
+          float integralWithOverflow = h2->Integral(1, h2->GetNbinsX() + 1, 1, h2->GetNbinsY() + 1);
+          overflow = integralWithOverflow - integralWithoutOverflow;
+        }
+        mCheckMaxOverflowIntegralRatio.doCheck(result, overflow / integralWithoutOverflow);
+      }
+    }
+  }
+  return result;
+}
+
+std::string GenericCheck::getAcceptedType() { return "TObject"; }
+
+void GenericCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (!mo) {
+    ILOG(Error, Support) << "beautify(): MO not found" << ENDM;
+    return;
+  }
+
+  TPaveText* msg = new TPaveText(mPositionMsgBox[0], mPositionMsgBox[1], mPositionMsgBox[2], mPositionMsgBox[3], "NDC");
+  if (std::strcmp(mo->getObject()->ClassName(), "TCanvas") == 0) {
+    auto g = (TGraph*)((TCanvas*)mo->getObject())->GetListOfPrimitives()->FindObject(mNameObjOnCanvas.c_str());
+    if (!g) {
+      ILOG(Error, Support) << "beautify(): Object " << mNameObjOnCanvas << " inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    g->GetListOfFunctions()->Add(msg);
+  } else if (std::strcmp(mo->getObject()->ClassName(), "TGraph") == 0) {
+    auto g = (TGraph*)mo->getObject();
+    if (!g) {
+      ILOG(Error, Support) << "beautify(): Object inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    g->GetListOfFunctions()->Add(msg);
+  } else {
+    auto h = (TH1*)mo->getObject();
+    if (!h) {
+      ILOG(Error, Support) << "beautify(): Object inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    h->GetListOfFunctions()->Add(msg);
+  }
+
+  msg->SetName(Form("%s_msg", mo->GetName()));
+  msg->Clear();
+  auto reasons = checkResult.getReasons();
+  for (int i = 0; i < int(reasons.size()); i++) {
+    msg->AddText(reasons[i].second.c_str());
+    if (i > 4) {
+      msg->AddText("et al ... ");
+      break;
+    }
+  }
+  int color = kBlack;
+  if (checkResult == Quality::Good) {
+    color = kGreen + 1;
+    msg->AddText(">> Quality::Good <<");
+  } else if (checkResult == Quality::Medium) {
+    color = kOrange - 1;
+    msg->AddText(">> Quality::Medium <<");
+  } else if (checkResult == Quality::Bad) {
+    color = kRed;
+    msg->AddText(">> Quality::Bad <<");
+  }
+  msg->SetFillStyle(1);
+  msg->SetLineWidth(3);
+  msg->SetLineColor(color);
+  msg->SetShadowColor(color);
+  msg->SetTextColor(color);
+  msg->SetMargin(0.0);
+}
+
+} // namespace o2::quality_control_modules::ft0

--- a/Modules/FT0/src/OutOfBunchCollCheck.cxx
+++ b/Modules/FT0/src/OutOfBunchCollCheck.cxx
@@ -98,7 +98,7 @@ Quality OutOfBunchCollCheck::check(std::map<std::string, std::shared_ptr<Monitor
   mFractionOutOfBunchColl = 0;
   mNumNonEmptyBins = 0;
 
-  integralOutOfBunchColl = hOutOfBunchColl->Integral(1, 3564, mBinPos, mBinPos);
+  integralOutOfBunchColl = hOutOfBunchColl->Integral(1, sBCperOrbit, mBinPos, mBinPos);
   mFractionOutOfBunchColl = integralOutOfBunchColl / integralBcOrbitMap;
 
   ILOG(Debug, Support) << "in checker: integralBcOrbitMap:" << integralBcOrbitMap << " integralOutOfBunchColl: " << integralOutOfBunchColl << " -> fraction: " << mFractionOutOfBunchColl << ENDM;

--- a/Modules/FT0/src/PostProcTask.cxx
+++ b/Modules/FT0/src/PostProcTask.cxx
@@ -79,6 +79,23 @@ void PostProcTask::configure(std::string, const boost::property_tree::ptree& con
     mPathDigitQcTask = "FT0/MO/DigitQcTask/";
     ILOG(Info, Support) << "configure() : using default pathDigitQcTask = \"" << mPathDigitQcTask << "\"" << ENDM;
   }
+
+  node = config.get_child_optional(Form("%s.custom.timestampSourceLhcIf", configPath));
+  if (node) {
+    mTimestampSourceLhcIf = node.get_ptr()->get_child("").get_value<std::string>();
+    if (mTimestampSourceLhcIf == "last" || mTimestampSourceLhcIf == "trigger" || mTimestampSourceLhcIf == "metadata") {
+      ILOG(Info, Support) << "configure() : using timestampSourceLhcIf = \"" << mTimestampSourceLhcIf << "\"" << ENDM;
+    } else {
+      auto prev = mTimestampSourceLhcIf;
+      mTimestampSourceLhcIf = "trigger";
+      ILOG(Warning, Support) << "configure() : invalid value for timestampSourceLhcIf = \"" << prev
+                             << "\"\n available options are \"last\", \"trigger\" or \"metadata\""
+                             << "\n fallback to default: \"" << mTimestampSourceLhcIf << "\"" << ENDM;
+    }
+  } else {
+    mTimestampSourceLhcIf = "trigger";
+    ILOG(Info, Support) << "configure() : using default timestampSourceLhcIf = \"" << mTimestampSourceLhcIf << "\"" << ENDM;
+  }
 }
 
 void PostProcTask::initialize(Trigger, framework::ServiceRegistry& services)
@@ -318,17 +335,45 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistry&)
     mTime->GetYaxis()->SetTitleOffset(1);
   }
 
+  auto moBCvsTriggers = mDatabase->retrieveMO(mPathDigitQcTask, "BCvsTriggers", t.timestamp, t.activity);
+  auto hBcVsTrg = moBCvsTriggers ? (TH2F*)moBCvsTriggers->getObject() : nullptr;
+  if (!hBcVsTrg) {
+    ILOG(Error, Support) << "MO \"BCvsTriggers\" NOT retrieved!!!" << ENDM;
+    return;
+  }
+
+  long ts = 999;
+  if (mTimestampSourceLhcIf == "last") {
+    ts = -1;
+  } else if (mTimestampSourceLhcIf == "trigger") {
+    ts = t.timestamp;
+  } else if (mTimestampSourceLhcIf == "metadata") {
+    for (auto metainfo : moBCvsTriggers->getMetadataMap()) {
+      if (metainfo.first == "TFcreationTime")
+        ts = std::stol(metainfo.second);
+    }
+    if (ts > 1651500000000 && ts < 1651700000000)
+      ILOG(Warning, Support) << "timestamp (read from TF via metadata) points to 02-04 May 2022"
+                                " - make sure this is the data we are processing and not the default timestamp "
+                                "(it may appear when running on digits w/o providing \"--hbfutils-config o2_tfidinfo.root\")"
+                             << ENDM;
+    if (ts == 999) {
+      ILOG(Error) << "\"TFcreationTime\" not found in metadata, fallback to ts from trigger " << ENDM;
+      ts = t.timestamp;
+    }
+  }
+
   std::map<std::string, std::string> metadata;
   std::map<std::string, std::string> headers;
-  auto* lhcIf = mCcdbApi.retrieveFromTFileAny<o2::parameters::GRPLHCIFData>(mPathGrpLhcIf, metadata, -1, &headers);
+  auto* lhcIf = mCcdbApi.retrieveFromTFileAny<o2::parameters::GRPLHCIFData>(mPathGrpLhcIf, metadata, ts, &headers);
   if (!lhcIf) {
-    ILOG(Error, Support) << "object \"" << mPathGrpLhcIf << "\" NOT retrieved!!!" << ENDM;
+    ILOG(Error, Support) << "object \"" << mPathGrpLhcIf << "\" NOT retrieved. OutOfBunchColTask will not produce valid QC plots." << ENDM;
     return;
   }
   const std::string bcName = lhcIf->getInjectionScheme();
   if (bcName.size() == 8) {
     if (bcName.compare("no_value")) {
-      ILOG(Warning) << "Filling scheme not set. OutOfBunchColTask will not produce valid QC plots." << ENDM;
+      ILOG(Error, Support) << "Filling scheme not set. OutOfBunchColTask will not produce valid QC plots." << ENDM;
     }
   } else {
     ILOG(Info, Support) << "Filling scheme: " << bcName.c_str() << ENDM;
@@ -340,12 +385,6 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistry&)
     for (int j = 0; j < mMapDigitTrgNames.size() + 1; j++) {
       mHistBcPattern->SetBinContent(i + 1, j + 1, bcPattern.testBC(i));
     }
-  }
-  auto moBCvsTriggers = mDatabase->retrieveMO(mPathDigitQcTask, "BCvsTriggers", t.timestamp, t.activity);
-  auto hBcVsTrg = moBCvsTriggers ? (TH2F*)moBCvsTriggers->getObject() : nullptr;
-  if (!hBcVsTrg) {
-    ILOG(Error, Support) << "MO \"BCvsTriggers\" NOT retrieved!!!" << ENDM;
-    return;
   }
 
   mHistBcTrgOutOfBunchColl->Reset();

--- a/Modules/FT0/src/PostProcTask.cxx
+++ b/Modules/FT0/src/PostProcTask.cxx
@@ -143,8 +143,8 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistry& services)
   mMapDigitTrgNames.insert({ o2::ft0::Triggers::bitOutputsAreBlocked, "OutputsAreBlocked" });
   mMapDigitTrgNames.insert({ o2::ft0::Triggers::bitDataIsValid, "DataIsValid" });
   mHistTriggers = std::make_unique<TH1F>("Triggers", "Triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-  mHistBcPattern = std::make_unique<TH2F>("bcPattern", "BC pattern", 3564, 0, 3564, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-  mHistBcTrgOutOfBunchColl = std::make_unique<TH2F>("OutOfBunchColl_BCvsTrg", "BC vs Triggers for out-of-bunch collisions;BC;Triggers", 3564, 0, 3564, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistBcPattern = std::make_unique<TH2F>("bcPattern", "BC pattern", sBCperOrbit, 0, sBCperOrbit, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistBcTrgOutOfBunchColl = std::make_unique<TH2F>("OutOfBunchColl_BCvsTrg", "BC vs Triggers for out-of-bunch collisions;BC;Triggers", sBCperOrbit, 0, sBCperOrbit, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
   for (const auto& entry : mMapDigitTrgNames) {
     mHistTriggers->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     mHistBcPattern->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
@@ -335,9 +335,8 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistry&)
   }
   auto bcPattern = lhcIf->getBunchFilling();
 
-  const int nBc = 3564;
   mHistBcPattern->Reset();
-  for (int i = 0; i < nBc + 1; i++) {
+  for (int i = 0; i < sBCperOrbit + 1; i++) {
     for (int j = 0; j < mMapDigitTrgNames.size() + 1; j++) {
       mHistBcPattern->SetBinContent(i + 1, j + 1, bcPattern.testBC(i));
     }
@@ -352,17 +351,17 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistry&)
   mHistBcTrgOutOfBunchColl->Reset();
   float vmax = hBcVsTrg->GetBinContent(hBcVsTrg->GetMaximumBin());
   mHistBcTrgOutOfBunchColl->Add(hBcVsTrg, mHistBcPattern.get(), 1, -1 * vmax);
-  for (int i = 0; i < nBc + 1; i++) {
+  for (int i = 0; i < sBCperOrbit + 1; i++) {
     for (int j = 0; j < mMapDigitTrgNames.size() + 1; j++) {
       if (mHistBcTrgOutOfBunchColl->GetBinContent(i + 1, j + 1) < 0) {
         mHistBcTrgOutOfBunchColl->SetBinContent(i + 1, j + 1, 0); // is it too slow?
       }
     }
   }
-  mHistBcTrgOutOfBunchColl->SetEntries(mHistBcTrgOutOfBunchColl->Integral(1, nBc, 1, mMapDigitTrgNames.size()));
+  mHistBcTrgOutOfBunchColl->SetEntries(mHistBcTrgOutOfBunchColl->Integral(1, sBCperOrbit, 1, mMapDigitTrgNames.size()));
   for (int iBin = 1; iBin < mMapDigitTrgNames.size() + 1; iBin++) {
     const std::string metadataKey = "BcVsTrgIntegralBin" + std::to_string(iBin);
-    const std::string metadataValue = std::to_string(hBcVsTrg->Integral(1, nBc, iBin, iBin));
+    const std::string metadataValue = std::to_string(hBcVsTrg->Integral(1, sBCperOrbit, iBin, iBin));
     getObjectsManager()->getMonitorObject(mHistBcTrgOutOfBunchColl->GetName())->addOrUpdateMetadata(metadataKey, metadataValue);
     ILOG(Info, Support) << metadataKey << ":" << metadataValue << ENDM;
   }

--- a/Modules/FV0/CMakeLists.txt
+++ b/Modules/FV0/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(O2QcFV0)
 target_sources(O2QcFV0 PRIVATE src/TH1ReductorLaser.cxx
                                src/DigitQcTaskLaser.cxx
                                src/DigitQcTask.cxx
+                               src/GenericCheck.cxx
                                src/CFDEffCheck.cxx
                                src/PostProcTask.cxx
                                src/OutOfBunchCollCheck.cxx)
@@ -33,6 +34,7 @@ add_root_dictionary(O2QcFV0
           include/FV0/PostProcTask.h
           include/FV0/CFDEffCheck.h
           include/FV0/OutOfBunchCollCheck.h
+          include/FV0/GenericCheck.h
   LINKDEF include/FV0/LinkDef.h
   BASENAME O2QcFV0)
 

--- a/Modules/FV0/include/FV0/CFDEffCheck.h
+++ b/Modules/FV0/include/FV0/CFDEffCheck.h
@@ -40,6 +40,8 @@ class CFDEffCheck : public o2::quality_control::checker::CheckInterface
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
 
+  constexpr static std::size_t sNCHANNELS_FV0 = o2::fv0::Constants::nFv0Channels;
+
   ClassDefOverride(CFDEffCheck, 2);
 
  private:
@@ -66,7 +68,6 @@ class CFDEffCheck : public o2::quality_control::checker::CheckInterface
     return vecResult;
   }
 
-  constexpr static std::size_t sNCHANNELS = o2::fv0::Constants::nFv0Channels;
   std::vector<unsigned int> mDeadChannelMap;
   std::string mDeadChannelMapStr;
   float mThreshWarning;

--- a/Modules/FV0/include/FV0/DigitQcTask.h
+++ b/Modules/FV0/include/FV0/DigitQcTask.h
@@ -103,6 +103,7 @@ class DigitQcTask final : public TaskInterface
 
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
+  std::set<unsigned int> mSetAllowedChIDsAmpVsTime;
   std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
   std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
   uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist

--- a/Modules/FV0/include/FV0/DigitQcTask.h
+++ b/Modules/FV0/include/FV0/DigitQcTask.h
@@ -79,6 +79,8 @@ class DigitQcTask final : public TaskInterface
   int mTfCounter = 0;
   double mTimeSum = 0.;
 
+  long mTFcreationTime = 0;
+
   template <typename Param_t,
             typename = typename std::enable_if<std::is_floating_point<Param_t>::value ||
                                                std::is_same<std::string, Param_t>::value || (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>

--- a/Modules/FV0/include/FV0/DigitQcTask.h
+++ b/Modules/FV0/include/FV0/DigitQcTask.h
@@ -31,6 +31,8 @@
 #include "TList.h"
 #include "Rtypes.h"
 
+#include "CommonConstants/LHCConstants.h"
+
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/QcInfoLogger.h"
 
@@ -57,11 +59,11 @@ class DigitQcTask final : public TaskInterface
   void endOfCycle() override;
   void endOfActivity(Activity& activity) override;
   void reset() override;
-  constexpr static std::size_t sNCHANNELS_PM = o2::fv0::Constants::nPms * o2::fv0::Constants::nChannelsPerPm;
   constexpr static std::size_t sNCHANNELS_FV0 = o2::fv0::Constants::nFv0Channels;
+  constexpr static std::size_t sNCHANNELS_FV0_PLUSREF = o2::fv0::Constants::nFv0ChannelsPlusRef;
   constexpr static std::size_t sNCHANNELS_FV0_INNER = 24; // "Inner" = 3 inner rings  = first 24 channels
   constexpr static std::size_t sOrbitsPerTF = 256;
-  constexpr static std::size_t sBCperOrbit = 3564;
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
   constexpr static float sCFDChannel2NS = 0.01302; // CFD channel width in ns
 
@@ -104,9 +106,9 @@ class DigitQcTask final : public TaskInterface
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
   std::set<unsigned int> mSetAllowedChIDsAmpVsTime;
-  std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
-  std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
-  uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist
+  std::array<o2::InteractionRecord, sNCHANNELS_FV0_PLUSREF> mStateLastIR2Ch;
+  std::array<uint8_t, sNCHANNELS_FV0_PLUSREF> mChID2PMhash; // map chID->hashed PM value
+  uint8_t mTCMhash;                                         // hash value for TCM, and bin position in hist
   std::map<int, std::string> mMapDigitTrgNames;
   std::map<o2::fv0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
   std::unique_ptr<TH1F> mHistNumADC;

--- a/Modules/FV0/include/FV0/DigitQcTaskLaser.h
+++ b/Modules/FV0/include/FV0/DigitQcTaskLaser.h
@@ -93,6 +93,7 @@ class DigitQcTaskLaser final : public TaskInterface
 
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
+  std::set<unsigned int> mSetAllowedChIDsAmpVsTime;
   std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
   std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
   uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist

--- a/Modules/FV0/include/FV0/DigitQcTaskLaser.h
+++ b/Modules/FV0/include/FV0/DigitQcTaskLaser.h
@@ -31,6 +31,8 @@
 #include "TList.h"
 #include "Rtypes.h"
 
+#include "CommonConstants/LHCConstants.h"
+
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/QcInfoLogger.h"
 
@@ -57,11 +59,11 @@ class DigitQcTaskLaser final : public TaskInterface
   void endOfCycle() override;
   void endOfActivity(Activity& activity) override;
   void reset() override;
-  constexpr static std::size_t sNCHANNELS_PM = o2::fv0::Constants::nPms * o2::fv0::Constants::nChannelsPerPm;
   constexpr static std::size_t sNCHANNELS_FV0 = o2::fv0::Constants::nFv0Channels;
+  constexpr static std::size_t sNCHANNELS_FV0_PLUSREF = o2::fv0::Constants::nFv0ChannelsPlusRef;
   constexpr static std::size_t sNCHANNELS_FV0_INNER = 24; // "Inner" = 3 inner rings  = first 24 channels
   constexpr static std::size_t sOrbitsPerTF = 256;
-  constexpr static std::size_t sBCperOrbit = 3564;
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
   constexpr static float sCFDChannel2NS = 0.01302; // CFD channel width in ns
 
@@ -94,9 +96,9 @@ class DigitQcTaskLaser final : public TaskInterface
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
   std::set<unsigned int> mSetAllowedChIDsAmpVsTime;
-  std::array<o2::InteractionRecord, sNCHANNELS_PM> mStateLastIR2Ch;
-  std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
-  uint8_t mTCMhash;                                // hash value for TCM, and bin position in hist
+  std::array<o2::InteractionRecord, sNCHANNELS_FV0_PLUSREF> mStateLastIR2Ch;
+  std::array<uint8_t, sNCHANNELS_FV0_PLUSREF> mChID2PMhash; // map chID->hashed PM value
+  uint8_t mTCMhash;                                         // hash value for TCM, and bin position in hist
   std::map<int, std::string> mMapDigitTrgNames;
   std::map<o2::fv0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
   std::unique_ptr<TH1F> mHistNumADC;

--- a/Modules/FV0/include/FV0/GenericCheck.h
+++ b/Modules/FV0/include/FV0/GenericCheck.h
@@ -1,0 +1,130 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   GenericCheck.h
+/// \author Sebastian Bysiak
+///
+
+#ifndef QC_MODULE_FV0_FV0GENERICCHECK_H
+#define QC_MODULE_FV0_FV0GENERICCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+#include <DataFormatsQualityControl/FlagReasons.h>
+
+namespace o2::quality_control_modules::fv0
+{
+
+/// \brief  helper class to store acceptable limits for given quantity
+/// \author Sebastian Bysiak
+class SingleCheck
+{
+ public:
+  SingleCheck() = default;
+  ~SingleCheck() = default;
+
+  SingleCheck(std::string name, float thresholdWarning, float thresholdError, bool shouldBeLower, bool isActive)
+  {
+    mCheckName = name;
+    mThresholdWarning = thresholdWarning;
+    mThresholdError = thresholdError;
+    mShouldBeLower = shouldBeLower;
+    mIsActive = isActive;
+  };
+  bool isActive() { return mIsActive; };
+
+  void doCheck(Quality& result, float checkedValue)
+  {
+    if (!mIsActive)
+      return;
+
+    std::string log = Form("%s : comparing  value = %f with thresholds = %f, %f", mCheckName.c_str(), checkedValue, mThresholdWarning, mThresholdError);
+    if (mShouldBeLower) {
+      if (checkedValue > mThresholdError) {
+        if (result.isBetterThan(Quality::Bad))
+          result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f > %.3f (%s error limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Bad";
+      } else if (checkedValue > mThresholdWarning) {
+        if (result.isBetterThan(Quality::Medium))
+          result.set(Quality::Medium);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f > %.3f (%s warning limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Medium";
+      } else {
+        log += "-> OK";
+      }
+    } else {
+      if (checkedValue < mThresholdError) {
+        if (result.isBetterThan(Quality::Bad))
+          result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f < %.3f (%s error limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Bad";
+      } else if (checkedValue < mThresholdWarning) {
+        if (result.isBetterThan(Quality::Medium))
+          result.set(Quality::Medium);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("%.3f < %.3f (%s warning limit)", checkedValue, mThresholdError, mCheckName.c_str()));
+        log += "-> Medium";
+      } else {
+        log += "-> OK";
+      }
+    }
+    ILOG(Debug, Support) << log << ENDM;
+  }
+
+ private:
+  std::string mCheckName;
+  float mThresholdWarning;
+  float mThresholdError;
+  bool mShouldBeLower;
+  bool mIsActive;
+};
+
+/// \brief  checks multiple basic hist statistics
+/// \author Sebastian Bysiak
+class GenericCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  GenericCheck() = default;
+  /// Destructor
+  ~GenericCheck() override = default;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+  ClassDefOverride(GenericCheck, 2);
+
+ private:
+  SingleCheck getCheckFromConfig(std::string);
+
+  SingleCheck mCheckMaxOverflowIntegralRatio;
+
+  SingleCheck mCheckMinMeanX;
+  SingleCheck mCheckMaxMeanX;
+  SingleCheck mCheckMaxStddevX;
+
+  SingleCheck mCheckMinMeanY;
+  SingleCheck mCheckMaxMeanY;
+  SingleCheck mCheckMaxStddevY;
+
+  SingleCheck mCheckMinGraphLastPoint;
+  SingleCheck mCheckMaxGraphLastPoint;
+
+  std::array<double, 4> mPositionMsgBox;
+  std::string mNameObjOnCanvas;
+};
+
+} // namespace o2::quality_control_modules::fv0
+
+#endif // QC_MODULE_FV0_FV0GENERICCHECK_H

--- a/Modules/FV0/include/FV0/LinkDef.h
+++ b/Modules/FV0/include/FV0/LinkDef.h
@@ -7,6 +7,7 @@
 #pragma link C++ class o2::quality_control_modules::fv0::PostProcTask + ;
 #pragma link C++ class o2::quality_control_modules::fv0::CFDEffCheck + ;
 #pragma link C++ class o2::quality_control_modules::fv0::OutOfBunchCollCheck + ;
+#pragma link C++ class o2::quality_control_modules::fv0::GenericCheck+;
 //#pragma link C++ class o2::quality_control_modules::fv0::CalibrationTask + ;
 //#pragma link C++ class o2::quality_control_modules::fv0::ChannelTimeCalibrationCheck + ;
 

--- a/Modules/FV0/include/FV0/OutOfBunchCollCheck.h
+++ b/Modules/FV0/include/FV0/OutOfBunchCollCheck.h
@@ -18,6 +18,7 @@
 #define QC_MODULE_FV0_FV0OUTOFBUNCHCOLLCHECK_H
 
 #include "QualityControl/CheckInterface.h"
+#include "CommonConstants/LHCConstants.h"
 
 namespace o2::quality_control_modules::fv0
 {
@@ -37,6 +38,8 @@ class OutOfBunchCollCheck : public o2::quality_control::checker::CheckInterface
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
+
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
 
   ClassDefOverride(OutOfBunchCollCheck, 2);
 

--- a/Modules/FV0/include/FV0/PostProcTask.h
+++ b/Modules/FV0/include/FV0/PostProcTask.h
@@ -58,6 +58,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   std::string mPathDigitQcTask;
   std::string mCycleDurationMoName;
   std::string mCcdbUrl;
+  std::string mTimestampSourceLhcIf;
   int mNumOrbitsInTF;
 
   std::map<o2::fv0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;

--- a/Modules/FV0/include/FV0/PostProcTask.h
+++ b/Modules/FV0/include/FV0/PostProcTask.h
@@ -20,6 +20,7 @@
 #include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/DatabaseInterface.h"
 #include "CCDB/CcdbApi.h"
+#include "CommonConstants/LHCConstants.h"
 
 #include "FV0Base/Constants.h"
 #include "DataFormatsFV0/ChannelData.h"
@@ -49,7 +50,8 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   void update(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistry&) override;
 
-  constexpr static std::size_t sNCHANNELS_PM = o2::fv0::Constants::nPms * o2::fv0::Constants::nChannelsPerPm;
+  constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
+  constexpr static std::size_t sNCHANNELS_FV0_PLUSREF = o2::fv0::Constants::nFv0ChannelsPlusRef;
 
  private:
   std::string mPathGrpLhcIf;

--- a/Modules/FV0/src/CFDEffCheck.cxx
+++ b/Modules/FV0/src/CFDEffCheck.cxx
@@ -84,7 +84,7 @@ Quality CFDEffCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
       mNumWarnings = 0;
       for (unsigned int iBin = 1; iBin < h->GetNbinsX() + 1; iBin++) {
         unsigned int chId = iBin - 1;
-        if (chId >= sNCHANNELS)
+        if (chId >= sNCHANNELS_FV0)
           continue;
         if (std::find(mDeadChannelMap.begin(), mDeadChannelMap.end(), chId) != mDeadChannelMap.end()) {
           continue;

--- a/Modules/FV0/src/DigitQcTask.cxx
+++ b/Modules/FV0/src/DigitQcTask.cxx
@@ -45,6 +45,10 @@ void DigitQcTask::rebinFromConfig()
      "binning_Amp_channel2": "5,-10,90" ...
   */
   auto rebinHisto = [](std::string hName, std::string binning) {
+    if (!gROOT->FindObject(hName.data())) {
+      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
+      return;
+    }
     std::vector<std::string> tokenizedBinning;
     boost::split(tokenizedBinning, binning, boost::is_any_of(","));
     if (tokenizedBinning.size() == 3) { // TH1
@@ -73,9 +77,6 @@ void DigitQcTask::rebinFromConfig()
         std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
         rebinHisto(hNameCur, binning);
       }
-    } else if (!gROOT->FindObject(hName.data())) {
-      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
-      continue;
     } else {
       rebinHisto(hName, binning);
     }

--- a/Modules/FV0/src/DigitQcTask.cxx
+++ b/Modules/FV0/src/DigitQcTask.cxx
@@ -158,12 +158,12 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
     mTrgThresholdNChannelsOuter = getNumericalParameter("trgThresholdNChannelsOuter", 1);
   }
 
-  mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4100, -2050, 2050);
+  mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, 4100, -2050, 2050);
   mHistTime2Ch->SetOption("colz");
-  mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4200, -100, 4100);
+  mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, 4200, -100, 4100);
   mHistAmp2Ch->SetOption("colz");
   mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
-  mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
+  mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
   mHistChDataBits->SetOption("colz");
   for (const auto& entry : mMapChTrgNames) {
     mHistChDataBits->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
@@ -172,7 +172,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mHistOrbitVsTrg->SetOption("colz");
   mHistOrbit2BC = std::make_unique<TH2F>("OrbitPerBC", "BC-Orbit map;Orbit;BC;", sOrbitsPerTF, 0, sOrbitsPerTF, sBCperOrbit, 0, sBCperOrbit);
   mHistOrbit2BC->SetOption("colz");
-  mHistEventDensity2Ch = std::make_unique<TH2F>("EventDensityPerChannel", "Event density(in BC) per Channel;Channel;BC;", sNCHANNELS_PM, 0, sNCHANNELS_PM, 10000, 0, 1e5);
+  mHistEventDensity2Ch = std::make_unique<TH2F>("EventDensityPerChannel", "Event density(in BC) per Channel;Channel;BC;", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, 10000, 0, 1e5);
   mHistEventDensity2Ch->SetOption("colz");
   mHistTriggersCorrelation = std::make_unique<TH2F>("TriggersCorrelation", "Correlation of triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size(), mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
   mHistTriggersCorrelation->SetOption("colz");
@@ -215,7 +215,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
     }
     if (std::regex_match(strChID, std::regex("[[\\d]{1,3}"))) {
       int chID = std::stoi(strChID);
-      if (chID < sNCHANNELS_PM) {
+      if (chID < sNCHANNELS_FV0_PLUSREF) {
         mChID2PMhash[chID] = mapFEE2hash[moduleName];
       } else {
         LOG(error) << "Incorrect LUT entry: chID " << strChID << " | " << moduleName;
@@ -234,16 +234,16 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   }
 
   // mHistTimeSum2Diff = std::make_unique<TH2F>("timeSumVsDiff", "time A/C side: sum VS diff;(TOC-TOA)/2 [ns];(TOA+TOC)/2 [ns]", 400, -52.08, 52.08, 400, -52.08, 52.08); // range of 52.08 ns = 4000*13.02ps = 4000 channels
-  mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  // mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
+  mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
+  mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
+  mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
+  // mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
   mHistSumAmpA = std::make_unique<TH1F>("SumAmpA", "Sum of amplitudes(TCM), side A;", 1e4, 0, 1e4);
   // mHistSumAmpC = std::make_unique<TH1F>("SumAmpC", "Sum of amplitudes(TCM), side C;", 1e4, 0, 1e4);
   mHistAverageTimeA = std::make_unique<TH1F>("AverageTimeA", "Average time(TCM), side A", 4100, -2050, 2050);
   // mHistAverageTimeC = std::make_unique<TH1F>("AverageTimeC", "Average time(TCM), side C", 4100, -2050, 2050);
-  mHistChannelID = std::make_unique<TH1F>("StatChannelID", "ChannelID statistics;ChannelID", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistChannelID = std::make_unique<TH1F>("StatChannelID", "ChannelID statistics;ChannelID", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
   mHistCycleDuration = std::make_unique<TH1D>("CycleDuration", "Cycle Duration;;time [ns]", 1, 0, 2);
   mHistCycleDurationNTF = std::make_unique<TH1D>("CycleDurationNTF", "Cycle Duration;;time [TimeFrames]", 1, 0, 2);
   mHistCycleDurationRange = std::make_unique<TH1D>("CycleDurationRange", "Cycle Duration (total cycle range);;time [ns]", 1, 0, 2);

--- a/Modules/FV0/src/DigitQcTask.cxx
+++ b/Modules/FV0/src/DigitQcTask.cxx
@@ -257,12 +257,20 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   for (const auto& entry : vecChannelIDs) {
     mSetAllowedChIDs.insert(entry);
   }
+  std::vector<unsigned int> vecChannelIDsAmpVsTime;
+  if (auto param = mCustomParameters.find("ChannelIDsAmpVsTime"); param != mCustomParameters.end()) {
+    const auto chIDs = param->second;
+    const std::string del = ",";
+    vecChannelIDsAmpVsTime = parseParameters<unsigned int>(chIDs, del);
+  }
+  for (const auto& entry : vecChannelIDsAmpVsTime) {
+    mSetAllowedChIDsAmpVsTime.insert(entry);
+  }
 
   for (const auto& chID : mSetAllowedChIDs) {
     auto pairHistAmp = mMapHistAmp1D.insert({ chID, new TH1F(Form("Amp_channel%i", chID), Form("Amplitude, channel %i", chID), 4200, -100, 4100) });
     auto pairHistTime = mMapHistTime1D.insert({ chID, new TH1F(Form("Time_channel%i", chID), Form("Time, channel %i", chID), 4100, -2050, 2050) });
     auto pairHistBits = mMapHistPMbits.insert({ chID, new TH1F(Form("Bits_channel%i", chID), Form("Bits, channel %i", chID), mMapChTrgNames.size(), 0, mMapChTrgNames.size()) });
-    auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
     for (const auto& entry : mMapChTrgNames) {
       pairHistBits.first->second->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     }
@@ -278,6 +286,9 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
       mListHistGarbage->Add(pairHistBits.first->second);
       getObjectsManager()->startPublishing(pairHistBits.first->second);
     }
+  }
+  for (const auto& chID : mSetAllowedChIDsAmpVsTime) {
+    auto pairHistAmpVsTime = mMapHistAmpVsTime.insert({ chID, new TH2F(Form("Amp_vs_time_channel%i", chID), Form("Amplitude vs time, channel %i;Amp;Time", chID), 420, -100, 4100, 410, -2050, 2050) });
     if (pairHistAmpVsTime.second) {
       mListHistGarbage->Add(pairHistAmpVsTime.first->second);
       getObjectsManager()->startPublishing(pairHistAmpVsTime.first->second);
@@ -449,12 +460,14 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (mSetAllowedChIDs.size() != 0 && mSetAllowedChIDs.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDs.end()) {
         mMapHistAmp1D[chData.ChId]->Fill(chData.QTCAmpl);
         mMapHistTime1D[chData.ChId]->Fill(chData.CFDTime);
-        mMapHistAmpVsTime[chData.ChId]->Fill(chData.QTCAmpl, chData.CFDTime);
         for (const auto& entry : mMapChTrgNames) {
           if ((chData.ChainQTC & (1 << entry.first))) {
             mMapHistPMbits[chData.ChId]->Fill(entry.first);
           }
         }
+      }
+      if (mSetAllowedChIDsAmpVsTime.size() != 0 && mSetAllowedChIDsAmpVsTime.find(static_cast<unsigned int>(chData.ChId)) != mSetAllowedChIDsAmpVsTime.end()) {
+        mMapHistAmpVsTime[chData.ChId]->Fill(chData.QTCAmpl, chData.CFDTime);
       }
       for (const auto& binPos : mHashedBitBinPos[chData.ChainQTC]) {
         mHistChDataBits->Fill(chData.ChId, binPos);

--- a/Modules/FV0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FV0/src/DigitQcTaskLaser.cxx
@@ -158,12 +158,12 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
     mTrgThresholdNChannelsOuter = getNumericalParameter("trgThresholdNChannelsOuter", 1);
   }
 
-  mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4100, -2050, 2050);
+  mHistTime2Ch = std::make_unique<TH2F>("TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, 4100, -2050, 2050);
   mHistTime2Ch->SetOption("colz");
-  mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4200, -100, 4100);
+  mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, 4200, -100, 4100);
   mHistAmp2Ch->SetOption("colz");
   mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
-  mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
+  mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
   mHistChDataBits->SetOption("colz");
   for (const auto& entry : mMapChTrgNames) {
     mHistChDataBits->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
@@ -204,7 +204,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
     }
     if (std::regex_match(strChID, std::regex("[[\\d]{1,3}"))) {
       int chID = std::stoi(strChID);
-      if (chID < sNCHANNELS_PM) {
+      if (chID < sNCHANNELS_FV0_PLUSREF) {
         mChID2PMhash[chID] = mapFEE2hash[moduleName];
       } else {
         LOG(error) << "Incorrect LUT entry: chID " << strChID << " | " << moduleName;
@@ -223,9 +223,9 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
   }
 
   // mHistTimeSum2Diff = std::make_unique<TH2F>("timeSumVsDiff", "time A/C side: sum VS diff;(TOC-TOA)/2 [ns];(TOA+TOC)/2 [ns]", 400, -52.08, 52.08, 400, -52.08, 52.08); // range of 52.08 ns = 4000*13.02ps = 4000 channels
-  mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistNumADC = std::make_unique<TH1F>("HistNumADC", "HistNumADC", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
+  mHistNumCFD = std::make_unique<TH1F>("HistNumCFD", "HistNumCFD", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
+  mHistCFDEff = std::make_unique<TH1F>("CFD_efficiency", "CFD efficiency;ChannelID;efficiency", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
 
   std::vector<unsigned int> vecChannelIDs;
   if (auto param = mCustomParameters.find("ChannelIDs"); param != mCustomParameters.end()) {

--- a/Modules/FV0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FV0/src/DigitQcTaskLaser.cxx
@@ -45,6 +45,10 @@ void DigitQcTaskLaser::rebinFromConfig()
      "binning_Amp_channel2": "5,-10,90" ...
   */
   auto rebinHisto = [](std::string hName, std::string binning) {
+    if (!gROOT->FindObject(hName.data())) {
+      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
+      return;
+    }
     std::vector<std::string> tokenizedBinning;
     boost::split(tokenizedBinning, binning, boost::is_any_of(","));
     if (tokenizedBinning.size() == 3) { // TH1
@@ -73,9 +77,6 @@ void DigitQcTaskLaser::rebinFromConfig()
         std::string hNameCur = hName.substr(0, hName.find(channelIdPlaceholder)) + std::to_string(chID) + hName.substr(hName.find(channelIdPlaceholder) + 1);
         rebinHisto(hNameCur, binning);
       }
-    } else if (!gROOT->FindObject(hName.data())) {
-      ILOG(Warning) << "config: histogram named \"" << hName << "\" not found" << ENDM;
-      continue;
     } else {
       rebinHisto(hName, binning);
     }

--- a/Modules/FV0/src/GenericCheck.cxx
+++ b/Modules/FV0/src/GenericCheck.cxx
@@ -1,0 +1,252 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   GenericCheck.cxx
+/// \author Sebastian Bysiak
+///
+
+#include "FV0/GenericCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
+// ROOT
+#include <TH1.h>
+#include <TH2.h>
+#include <TGraph.h>
+#include <TCanvas.h>
+#include <TPaveText.h>
+#include <TMath.h>
+// #include <TLine.h>
+#include <TList.h>
+
+#include <DataFormatsQualityControl/FlagReasons.h>
+
+using namespace std;
+using namespace o2::quality_control;
+
+namespace o2::quality_control_modules::fv0
+{
+
+SingleCheck GenericCheck::getCheckFromConfig(std::string paramName)
+{
+  bool isActive = false;
+  float thresholdWarning = TMath::SignalingNaN(), thresholdError = TMath::SignalingNaN();
+  bool shouldBeLower = true;
+  if (paramName.find("Max") != string::npos || paramName.find("max") != string::npos) {
+    shouldBeLower = true;
+  } else if (paramName.find("Min") != string::npos || paramName.find("min") != string::npos) {
+    shouldBeLower = false;
+  }
+
+  if (auto paramWarning = mCustomParameters.find(string("thresholdWarning") + paramName), paramError = mCustomParameters.find(string("thresholdError") + paramName); paramWarning != mCustomParameters.end() || paramError != mCustomParameters.end()) {
+    if (paramWarning != mCustomParameters.end() && paramError != mCustomParameters.end()) {
+      thresholdWarning = stof(paramWarning->second);
+      thresholdError = stof(paramError->second);
+      isActive = true;
+      if ((shouldBeLower && thresholdWarning > thresholdError) || (!shouldBeLower && thresholdWarning < thresholdError)) {
+        ILOG(Warning, Support) << "configure(): warning more strict than error -> swapping values!" << ENDM;
+        std::swap(thresholdWarning, thresholdError);
+      }
+      ILOG(Info, Support) << "configure() : using thresholdWarning" << paramName.c_str() << " = " << thresholdWarning << " , thresholdError" << paramName << " = " << thresholdError << ENDM;
+    } else {
+      ILOG(Warning, Support) << "configure() : only one threshold (warning/error) was provided for  " << paramName.c_str() << " -> this parameter will not be used!" << ENDM;
+    }
+  }
+  return SingleCheck(paramName, thresholdWarning, thresholdError, shouldBeLower, isActive);
+}
+
+void GenericCheck::configure()
+{
+
+  mCheckMaxOverflowIntegralRatio = getCheckFromConfig("MaxOverflowIntegralRatio");
+
+  mCheckMinMeanX = getCheckFromConfig("MinMeanX");
+  mCheckMaxMeanX = getCheckFromConfig("MaxMeanX");
+  mCheckMaxStddevX = getCheckFromConfig("MaxStddevX");
+
+  mCheckMinMeanY = getCheckFromConfig("MinMeanY");
+  mCheckMaxMeanY = getCheckFromConfig("MaxMeanY");
+  mCheckMaxStddevY = getCheckFromConfig("MaxStddevY");
+
+  mCheckMinGraphLastPoint = getCheckFromConfig("MinGraphLastPoint");
+  mCheckMaxGraphLastPoint = getCheckFromConfig("MaxGraphLastPoint");
+
+  mPositionMsgBox = { 0.15, 0.75, 0.85, 0.9 };
+  if (auto param = mCustomParameters.find("positionMsgBox"); param != mCustomParameters.end()) {
+    stringstream ss(param->second);
+    int i = 0;
+    while (ss.good()) {
+      if (i > 4) {
+        ILOG(Info, Support) << "Skipping next values provided for positionMsgBox" << ENDM;
+        break;
+      }
+      string substr;
+      getline(ss, substr, ',');
+      mPositionMsgBox[i] = std::stod(substr);
+      i++;
+    }
+    float minHeight = 0.09, minWidth = 0.19;
+    if (mPositionMsgBox[2] - mPositionMsgBox[0] < minWidth || mPositionMsgBox[3] - mPositionMsgBox[1] < minHeight) {
+      mPositionMsgBox = { 0.15, 0.75, 0.85, 0.9 };
+      ILOG(Info, Support) << "MsgBox too small: returning to default" << ENDM;
+    }
+  }
+
+  if (auto param = mCustomParameters.find("nameObjOnCanvas"); param != mCustomParameters.end()) {
+    mNameObjOnCanvas = param->second;
+    ILOG(Info, Support) << "nameObjOnCanvas set to " << mNameObjOnCanvas << ENDM;
+  } else {
+    mNameObjOnCanvas = "unspecified";
+  }
+}
+
+Quality GenericCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Good;
+  for (auto& [moName, mo] : *moMap) {
+    if (!mo) {
+      result.set(Quality::Null);
+      ILOG(Error, Support) << "MO " << moName << " not found" << ENDM;
+      continue;
+    }
+    if (std::strcmp(mo->getObject()->ClassName(), "TCanvas") == 0) {
+      auto g = (TGraph*)((TCanvas*)mo->getObject())->GetListOfPrimitives()->FindObject(mNameObjOnCanvas.c_str());
+
+      if (!g) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object " << mNameObjOnCanvas << " inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinGraphLastPoint.isActive())
+        mCheckMinGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+      if (mCheckMaxGraphLastPoint.isActive())
+        mCheckMaxGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+    }
+    if (std::strcmp(mo->getObject()->ClassName(), "TGraph") == 0) {
+      auto g = (TGraph*)mo->getObject();
+
+      if (!g) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinGraphLastPoint.isActive())
+        mCheckMinGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+      if (mCheckMaxGraphLastPoint.isActive())
+        mCheckMaxGraphLastPoint.doCheck(result, g->GetPointY(g->GetN() - 1));
+
+    } else {
+      auto h = (TH1*)mo->getObject();
+      if (!h) {
+        result.set(Quality::Null);
+        ILOG(Error, Support) << "Object inside MO " << moName << " not found" << ENDM;
+        continue;
+      }
+
+      if (mCheckMinMeanX.isActive())
+        mCheckMinMeanX.doCheck(result, h->GetMean());
+      if (mCheckMaxMeanX.isActive())
+        mCheckMaxMeanX.doCheck(result, h->GetMean());
+      if (mCheckMaxStddevX.isActive())
+        mCheckMaxStddevX.doCheck(result, h->GetStdDev());
+
+      if (mCheckMinMeanY.isActive())
+        mCheckMinMeanY.doCheck(result, h->GetMean(2));
+      if (mCheckMaxMeanY.isActive())
+        mCheckMaxMeanY.doCheck(result, h->GetMean(2));
+      if (mCheckMaxStddevY.isActive())
+        mCheckMaxStddevY.doCheck(result, h->GetStdDev(2));
+
+      if (mCheckMaxOverflowIntegralRatio.isActive()) {
+        float integralWithoutOverflow = 0., overflow = 0.;
+        if (h->GetDimension() == 1) {
+          integralWithoutOverflow = h->Integral();
+          overflow = h->GetBinContent(h->GetNbinsX() + 1);
+        } else if (h->GetDimension() == 2) {
+          // for 2D include these overflows: (over,over), (over,in-range), (in-range, over)
+          TH2* h2 = (TH2*)h->Clone(); // TH2 needed for Integral() with both axis specified
+          integralWithoutOverflow = h2->Integral();
+          float integralWithOverflow = h2->Integral(1, h2->GetNbinsX() + 1, 1, h2->GetNbinsY() + 1);
+          overflow = integralWithOverflow - integralWithoutOverflow;
+        }
+        mCheckMaxOverflowIntegralRatio.doCheck(result, overflow / integralWithoutOverflow);
+      }
+    }
+  }
+  return result;
+}
+
+std::string GenericCheck::getAcceptedType() { return "TObject"; }
+
+void GenericCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (!mo) {
+    ILOG(Error, Support) << "beautify(): MO not found" << ENDM;
+    return;
+  }
+
+  TPaveText* msg = new TPaveText(mPositionMsgBox[0], mPositionMsgBox[1], mPositionMsgBox[2], mPositionMsgBox[3], "NDC");
+  if (std::strcmp(mo->getObject()->ClassName(), "TCanvas") == 0) {
+    auto g = (TGraph*)((TCanvas*)mo->getObject())->GetListOfPrimitives()->FindObject(mNameObjOnCanvas.c_str());
+    if (!g) {
+      ILOG(Error, Support) << "beautify(): Object " << mNameObjOnCanvas << " inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    g->GetListOfFunctions()->Add(msg);
+  } else if (std::strcmp(mo->getObject()->ClassName(), "TGraph") == 0) {
+    auto g = (TGraph*)mo->getObject();
+    if (!g) {
+      ILOG(Error, Support) << "beautify(): Object inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    g->GetListOfFunctions()->Add(msg);
+  } else {
+    auto h = (TH1*)mo->getObject();
+    if (!h) {
+      ILOG(Error, Support) << "beautify(): Object inside MO " << mo->GetName() << " not found" << ENDM;
+      return;
+    }
+    h->GetListOfFunctions()->Add(msg);
+  }
+
+  msg->SetName(Form("%s_msg", mo->GetName()));
+  msg->Clear();
+  auto reasons = checkResult.getReasons();
+  for (int i = 0; i < int(reasons.size()); i++) {
+    msg->AddText(reasons[i].second.c_str());
+    if (i > 4) {
+      msg->AddText("et al ... ");
+      break;
+    }
+  }
+  int color = kBlack;
+  if (checkResult == Quality::Good) {
+    color = kGreen + 1;
+    msg->AddText(">> Quality::Good <<");
+  } else if (checkResult == Quality::Medium) {
+    color = kOrange - 1;
+    msg->AddText(">> Quality::Medium <<");
+  } else if (checkResult == Quality::Bad) {
+    color = kRed;
+    msg->AddText(">> Quality::Bad <<");
+  }
+  msg->SetFillStyle(1);
+  msg->SetLineWidth(3);
+  msg->SetLineColor(color);
+  msg->SetShadowColor(color);
+  msg->SetTextColor(color);
+  msg->SetMargin(0.0);
+}
+
+} // namespace o2::quality_control_modules::fv0

--- a/Modules/FV0/src/OutOfBunchCollCheck.cxx
+++ b/Modules/FV0/src/OutOfBunchCollCheck.cxx
@@ -100,7 +100,7 @@ Quality OutOfBunchCollCheck::check(std::map<std::string, std::shared_ptr<Monitor
   mFractionOutOfBunchColl = 0;
   mNumNonEmptyBins = 0;
 
-  integralOutOfBunchColl = hOutOfBunchColl->Integral(1, 3564, mBinPos, mBinPos);
+  integralOutOfBunchColl = hOutOfBunchColl->Integral(1, sBCperOrbit, mBinPos, mBinPos);
   mFractionOutOfBunchColl = integralOutOfBunchColl / integralBcOrbitMap;
 
   ILOG(Debug, Support) << "in checker: integralBcOrbitMap:" << integralBcOrbitMap << " integralOutOfBunchColl: " << integralOutOfBunchColl << " -> fraction: " << mFractionOutOfBunchColl << ENDM;

--- a/Modules/FV0/src/PostProcTask.cxx
+++ b/Modules/FV0/src/PostProcTask.cxx
@@ -92,8 +92,8 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistry& services)
   mRateTrgCharge = std::make_unique<TGraph>(0);
   mRateTrgNchan = std::make_unique<TGraph>(0);
   mRatesCanv = std::make_unique<TCanvas>("cRates", "trigger rates");
-  mAmpl = new TProfile("MeanAmplPerChannel", "mean ampl per channel;Channel;Ampl #mu #pm #sigma", sNCHANNELS_PM, 0, sNCHANNELS_PM);
-  mTime = new TProfile("MeanTimePerChannel", "mean time per channel;Channel;Time #mu #pm #sigma", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mAmpl = new TProfile("MeanAmplPerChannel", "mean ampl per channel;Channel;Ampl #mu #pm #sigma", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
+  mTime = new TProfile("MeanTimePerChannel", "mean time per channel;Channel;Time #mu #pm #sigma", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
 
   mRateOrA->SetNameTitle("rateOrA", "trg rate: OrA;cycle;rate [kHz]");
   mRateOrAout->SetNameTitle("rateOrAout", "trg rate: OrAout;cycle;rate [kHz]");
@@ -126,7 +126,7 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistry& services)
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kIsEventInTVDC, "IsEventInTVDC" });
   mMapChTrgNames.insert({ o2::fv0::ChannelData::kIsTimeInfoLost, "IsTimeInfoLost" });
 
-  mHistChDataNegBits = std::make_unique<TH2F>("ChannelDataNegBits", "ChannelData negative bits per ChannelID;Channel;Negative bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
+  mHistChDataNegBits = std::make_unique<TH2F>("ChannelDataNegBits", "ChannelData negative bits per ChannelID;Channel;Negative bit", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, mMapChTrgNames.size(), 0, mMapChTrgNames.size());
   for (const auto& entry : mMapChTrgNames) {
     std::string stBitName = "! " + entry.second;
     mHistChDataNegBits->GetYaxis()->SetBinLabel(entry.first + 1, stBitName.c_str());
@@ -143,8 +143,8 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistry& services)
   mMapDigitTrgNames.insert({ o2::fit::Triggers::bitOutputsAreBlocked, "OutputsAreBlocked" });
   mMapDigitTrgNames.insert({ o2::fit::Triggers::bitDataIsValid, "DataIsValid" });
   mHistTriggers = std::make_unique<TH1F>("Triggers", "Triggers from TCM", mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-  mHistBcPattern = std::make_unique<TH2F>("bcPattern", "BC pattern", 3564, 0, 3564, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
-  mHistBcTrgOutOfBunchColl = std::make_unique<TH2F>("OutOfBunchColl_BCvsTrg", "BC vs Triggers for out-of-bunch collisions;BC;Triggers", 3564, 0, 3564, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistBcPattern = std::make_unique<TH2F>("bcPattern", "BC pattern", sBCperOrbit, 0, sBCperOrbit, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
+  mHistBcTrgOutOfBunchColl = std::make_unique<TH2F>("OutOfBunchColl_BCvsTrg", "BC vs Triggers for out-of-bunch collisions;BC;Triggers", sBCperOrbit, 0, sBCperOrbit, mMapDigitTrgNames.size(), 0, mMapDigitTrgNames.size());
   for (const auto& entry : mMapDigitTrgNames) {
     mHistTriggers->GetXaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
     mHistBcPattern->GetYaxis()->SetBinLabel(entry.first + 1, entry.second.c_str());
@@ -156,13 +156,13 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistry& services)
   getObjectsManager()->startPublishing(mHistBcTrgOutOfBunchColl.get());
   getObjectsManager()->setDefaultDrawOptions(mHistBcTrgOutOfBunchColl.get(), "COLZ");
 
-  mHistTimeUpperFraction = std::make_unique<TH1F>("TimeUpperFraction", "Fraction of events under time window(-+190 channels);ChID;Fraction", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistTimeUpperFraction = std::make_unique<TH1F>("TimeUpperFraction", "Fraction of events under time window(-+190 channels);ChID;Fraction", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
   getObjectsManager()->startPublishing(mHistTimeUpperFraction.get());
 
-  mHistTimeLowerFraction = std::make_unique<TH1F>("TimeLowerFraction", "Fraction of events below time window(-+190 channels);ChID;Fraction", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistTimeLowerFraction = std::make_unique<TH1F>("TimeLowerFraction", "Fraction of events below time window(-+190 channels);ChID;Fraction", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
   getObjectsManager()->startPublishing(mHistTimeLowerFraction.get());
 
-  mHistTimeInWindow = std::make_unique<TH1F>("TimeInWindowFraction", "Fraction of events within time window(-+190 channels);ChID;Fraction", sNCHANNELS_PM, 0, sNCHANNELS_PM);
+  mHistTimeInWindow = std::make_unique<TH1F>("TimeInWindowFraction", "Fraction of events within time window(-+190 channels);ChID;Fraction", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
   getObjectsManager()->startPublishing(mHistTimeInWindow.get());
 
   getObjectsManager()->startPublishing(mRateOrA.get());
@@ -335,9 +335,8 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistry&)
   }
   auto bcPattern = lhcIf->getBunchFilling();
 
-  const int nBc = 3564;
   mHistBcPattern->Reset();
-  for (int i = 0; i < nBc + 1; i++) {
+  for (int i = 0; i < sBCperOrbit + 1; i++) {
     for (int j = 0; j < mMapDigitTrgNames.size() + 1; j++) {
       mHistBcPattern->SetBinContent(i + 1, j + 1, bcPattern.testBC(i));
     }
@@ -352,17 +351,17 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistry&)
   mHistBcTrgOutOfBunchColl->Reset();
   float vmax = hBcVsTrg->GetBinContent(hBcVsTrg->GetMaximumBin());
   mHistBcTrgOutOfBunchColl->Add(hBcVsTrg, mHistBcPattern.get(), 1, -1 * vmax);
-  for (int i = 0; i < nBc + 1; i++) {
+  for (int i = 0; i < sBCperOrbit + 1; i++) {
     for (int j = 0; j < mMapDigitTrgNames.size() + 1; j++) {
       if (mHistBcTrgOutOfBunchColl->GetBinContent(i + 1, j + 1) < 0) {
         mHistBcTrgOutOfBunchColl->SetBinContent(i + 1, j + 1, 0); // is it too slow?
       }
     }
   }
-  mHistBcTrgOutOfBunchColl->SetEntries(mHistBcTrgOutOfBunchColl->Integral(1, nBc, 1, mMapDigitTrgNames.size()));
+  mHistBcTrgOutOfBunchColl->SetEntries(mHistBcTrgOutOfBunchColl->Integral(1, sBCperOrbit, 1, mMapDigitTrgNames.size()));
   for (int iBin = 1; iBin < mMapDigitTrgNames.size() + 1; iBin++) {
     const std::string metadataKey = "BcVsTrgIntegralBin" + std::to_string(iBin);
-    const std::string metadataValue = std::to_string(hBcVsTrg->Integral(1, nBc, iBin, iBin));
+    const std::string metadataValue = std::to_string(hBcVsTrg->Integral(1, sBCperOrbit, iBin, iBin));
     getObjectsManager()->getMonitorObject(mHistBcTrgOutOfBunchColl->GetName())->addOrUpdateMetadata(metadataKey, metadataValue);
     ILOG(Info, Support) << metadataKey << ":" << metadataValue << ENDM;
   }


### PR DESCRIPTION
Major changes:
- Add new checker `GenericCheck` for FT0/FV0/FDD
- use timestamps when retrieving filling scheme in PP (options for running online and offline)

Other minor changes:
- `AmpVsTime` histos can be preserved separately from other per channel histos as this correlation cannot be retrieved based on 2D histos like `AmpPerChannel`
- use common constants and proper number of channels for FV0
- fix missing obj handling in rebinHisto()