### PR TITLE
MFT: fetch cluster dictionary from DPL and pattern iterator edit

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -53,6 +53,8 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   void endOfActivity(Activity& activity) override;
   void reset() override;
 
+  // void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = d; }
+
   double orbitToSeconds(uint32_t orbit, uint32_t refOrbit)
   {
     return (orbit - refOrbit) * o2::constants::lhc::LHCOrbitNS / 1E9;
@@ -99,7 +101,8 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   int mClusterSize = { 0 };
 
   // dictionary
-  o2::itsmft::TopologyDictionary* mDict;
+  //std::unique_ptr<o2::itsmft::TopologyDictionary> mDict = nullptr;
+  const o2::itsmft::TopologyDictionary* mDict = nullptr;
 
   // where the geometry file is stored
   std::string mGeomPath;

--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -101,7 +101,6 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   int mClusterSize = { 0 };
 
   // dictionary
-  //std::unique_ptr<o2::itsmft::TopologyDictionary> mDict = nullptr;
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
 
   // where the geometry file is stored

--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -53,8 +53,6 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   void endOfActivity(Activity& activity) override;
   void reset() override;
 
-  // void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = d; }
-
   double orbitToSeconds(uint32_t orbit, uint32_t refOrbit)
   {
     return (orbit - refOrbit) * o2::constants::lhc::LHCOrbitNS / 1E9;

--- a/Modules/MFT/qc-mft-cluster.json
+++ b/Modules/MFT/qc-mft-cluster.json
@@ -41,7 +41,7 @@
           "maxDuration" : "60000",
           "timeBinSize" : "0.1",
           "ROFLengthInBC" : "198",
-          "geomFileName" : "/home/epn/odc/files/o2sim_geometry-aligned.root"
+          "geomFileName" : "o2sim_geometry-aligned.root"
         },
         "location" : "remote"
       }
@@ -66,7 +66,7 @@
              "id" : "mft-clusters",
              "active" : "true",
              "machines" : [],
-             "query" : "randomcluster:MFT/COMPCLUSTERS/0;clustersrof:MFT/CLUSTERSROF/0;patterns:MFT/PATTERNS/0",
+             "query" : "randomcluster:MFT/COMPCLUSTERS/0;clustersrof:MFT/CLUSTERSROF/0;patterns:MFT/PATTERNS/0;cldict:MFT/CLUSDICT/0?lifetime=condition&ccdb-path=MFT/Calib/ClusterDictionary",
              "samplingConditions" : [
                {
                  "condition" : "random",

--- a/Modules/MFT/qc-mft-cluster.json
+++ b/Modules/MFT/qc-mft-cluster.json
@@ -41,7 +41,7 @@
           "maxDuration" : "60000",
           "timeBinSize" : "0.1",
           "ROFLengthInBC" : "198",
-          "geomFileName" : "o2sim_geometry-aligned.root"
+          "geomFileName" : "/home/epn/odc/files/o2sim_geometry-aligned.root"
         },
         "location" : "remote"
       }

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -261,13 +261,11 @@ void QcMFTClusterTask::startOfCycle()
 
 void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  static bool initOnceDone = false;
-  if (!initOnceDone) { // the dictionary needs to be queried only once
+  if (mDict == nullptr){
     std::cout << "Getting dictionary from CCDB" << std::endl;
     ILOG(Info, Support) << "Getting dictionary from ccdb" << ENDM;
-    initOnceDone = true;
-    auto clusDict = ctx.inputs().get<o2::itsmft::TopologyDictionary*>("cldict");
-    mDict = clusDict;
+    auto mDictPtr = ctx.inputs().get<o2::itsmft::TopologyDictionary*>("cldict");
+    mDict = mDictPtr.get();
     std::cout << "Dictionary loaded with size" << mDict->getSize() << std::endl;
     ILOG(Info, Support) << "Dictionary size: " << mDict->getSize() << ENDM;
   }
@@ -320,7 +318,8 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (oneCluster.getPatternID() != o2::itsmft::CompCluster::InvalidPatternID && !mDict->isGroup(oneCluster.getPatternID())) {
       mClusterSizeSummary->Fill(mDict->getNpixels(oneCluster.getPatternID()));
     } else {
-      o2::itsmft::ClusterPattern patt(patternIt);
+      auto patternIt2 = clustersPattern.begin();
+      o2::itsmft::ClusterPattern patt(patternIt2);
       mGroupedClusterSizeSummary->Fill(patt.getNPixels());
     }
 

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -267,7 +267,7 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     ILOG(Info, Support) << "Getting dictionary from ccdb" << ENDM;
     initOnceDone = true;
     auto clusDict = ctx.inputs().get<o2::itsmft::TopologyDictionary*>("cldict");
-    mDict = clusDict.get();
+    mDict = clusDict;
     std::cout << "Dictionary loaded with size" << mDict->getSize() << std::endl;
     ILOG(Info, Support) << "Dictionary size: " << mDict->getSize() << ENDM;
   }

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -203,15 +203,6 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
   mClustersBC->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mClustersBC.get());
 
-/*
-  // get dict from ccdb
-  long int ts = o2::ccdb::getCurrentTimestamp();
-  ILOG(Info, Support) << "Getting dictionary from ccdb - timestamp: " << ts << ENDM;
-  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setTimestamp(ts);
-  mDict = mgr.get<o2::itsmft::TopologyDictionary>("MFT/Calib/ClusterDictionary");
-  ILOG(Info, Support) << "Dictionary size: " << mDict->getSize() << ENDM;
-*/
   // define chip occupancy maps
   QcMFTUtilTables MFTTable;
   for (int iHalf = 0; iHalf < 2; iHalf++) {
@@ -261,13 +252,11 @@ void QcMFTClusterTask::startOfCycle()
 
 void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  if (mDict == nullptr){
-    std::cout << "Getting dictionary from CCDB" << std::endl;
+  if (mDict == nullptr) {
     ILOG(Info, Support) << "Getting dictionary from ccdb" << ENDM;
     auto mDictPtr = ctx.inputs().get<o2::itsmft::TopologyDictionary*>("cldict");
     mDict = mDictPtr.get();
-    std::cout << "Dictionary loaded with size" << mDict->getSize() << std::endl;
-    ILOG(Info, Support) << "Dictionary size: " << mDict->getSize() << ENDM;
+    ILOG(Info, Support) << "Dictionary loaded with size: " << mDict->getSize() << ENDM;
   }
 
   // normalisation for the summary histogram to TF
@@ -294,7 +283,7 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   o2::mft::ioutils::convertCompactClusters(clusters, patternIt, mClustersGlobal, mDict);
 
   // get correct timing info of the first TF orbit
-   mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
+  mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
 
   // fill the clusters time histograms
   for (const auto& rof : clustersROFs) {

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -285,6 +285,9 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   // get correct timing info of the first TF orbit
   mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
 
+  // reset the cluster pattern iterator which will be used later
+  patternIt = clustersPattern.begin();
+
   // fill the clusters time histograms
   for (const auto& rof : clustersROFs) {
     mClustersROFSize->Fill(rof.getNEntries());
@@ -307,8 +310,7 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (oneCluster.getPatternID() != o2::itsmft::CompCluster::InvalidPatternID && !mDict->isGroup(oneCluster.getPatternID())) {
       mClusterSizeSummary->Fill(mDict->getNpixels(oneCluster.getPatternID()));
     } else {
-      auto patternIt2 = clustersPattern.begin();
-      o2::itsmft::ClusterPattern patt(patternIt2);
+      o2::itsmft::ClusterPattern patt(patternIt);
       mGroupedClusterSizeSummary->Fill(patt.getNPixels());
     }
 


### PR DESCRIPTION
- cluster dictionary is fetched from DPL
- task was crashing with the use of pattern iterator for grouped clusters, because the iterator was already used in convertCompactClusters -> a new iterator was added 