### PR TITLE
ITS FHR online task: filtering of noise pixel vector 

### DIFF
--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -113,7 +113,7 @@ class ITSFhrTask final : public TaskInterface
   int mHitCutForNoisyPixel = 1024;        // Hit number cut for noisy pixel, this number should be define according how many TF will be accumulated before reset(one can reference the cycle time)
   float mOccupancyCutForNoisyPixel = 0.1; // Occupancy cut for noisy pixel. check if the hit/event value over this cut. similar with mHitCutForNoisyPixel
   double mCutTFForSparse = 1;             // cut to stop THnSparse filling after mCutTrgForSparse triggers
-
+  int mDoHitmapFilter; //do filtering of noise pixel vector
   std::unordered_map<unsigned int, int>*** mHitPixelID_InStave /* = new std::unordered_map<unsigned int, int>**[NStaves[lay]]*/;
   int** mHitnumberLane /* = new int*[NStaves[lay]]*/;       // IB : hitnumber[stave][chip]; OB : hitnumber[stave][lane]
   double** mOccupancyLane /* = new double*[NStaves[lay]]*/; // IB : occupancy[stave][chip]; OB : occupancy[stave][Lane]

--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -114,8 +114,8 @@ class ITSFhrTask final : public TaskInterface
   float mOccupancyCutForNoisyPixel = 0.1; // Occupancy cut for noisy pixel. check if the hit/event value over this cut. similar with mHitCutForNoisyPixel
   float mPhysicalOccupancyIB = 1.7e-3;
   float mPhysicalOccupancyOB = 4.3e-5;
-  double mCutTFForSparse = 1;             // cut to stop THnSparse filling after mCutTrgForSparse triggers
-  int mDoHitmapFilter;                    // do filtering of noise pixel vector
+  double mCutTFForSparse = 1; // cut to stop THnSparse filling after mCutTrgForSparse triggers
+  int mDoHitmapFilter;        // do filtering of noise pixel vector
   std::unordered_map<unsigned int, int>*** mHitPixelID_InStave /* = new std::unordered_map<unsigned int, int>**[NStaves[lay]]*/;
   int** mHitnumberLane /* = new int*[NStaves[lay]]*/;       // IB : hitnumber[stave][chip]; OB : hitnumber[stave][lane]
   double** mOccupancyLane /* = new double*[NStaves[lay]]*/; // IB : occupancy[stave][chip]; OB : occupancy[stave][Lane]

--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -112,6 +112,8 @@ class ITSFhrTask final : public TaskInterface
   int mGetTFFromBinding = 0;
   int mHitCutForNoisyPixel = 1024;        // Hit number cut for noisy pixel, this number should be define according how many TF will be accumulated before reset(one can reference the cycle time)
   float mOccupancyCutForNoisyPixel = 0.1; // Occupancy cut for noisy pixel. check if the hit/event value over this cut. similar with mHitCutForNoisyPixel
+  float mPhysicalOccupancyIB = 1.7e-3;
+  float mPhysicalOccupancyOB = 4.3e-5;
   double mCutTFForSparse = 1;             // cut to stop THnSparse filling after mCutTrgForSparse triggers
   int mDoHitmapFilter;                    // do filtering of noise pixel vector
   std::unordered_map<unsigned int, int>*** mHitPixelID_InStave /* = new std::unordered_map<unsigned int, int>**[NStaves[lay]]*/;

--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -113,7 +113,7 @@ class ITSFhrTask final : public TaskInterface
   int mHitCutForNoisyPixel = 1024;        // Hit number cut for noisy pixel, this number should be define according how many TF will be accumulated before reset(one can reference the cycle time)
   float mOccupancyCutForNoisyPixel = 0.1; // Occupancy cut for noisy pixel. check if the hit/event value over this cut. similar with mHitCutForNoisyPixel
   double mCutTFForSparse = 1;             // cut to stop THnSparse filling after mCutTrgForSparse triggers
-  int mDoHitmapFilter; //do filtering of noise pixel vector
+  int mDoHitmapFilter;                    // do filtering of noise pixel vector
   std::unordered_map<unsigned int, int>*** mHitPixelID_InStave /* = new std::unordered_map<unsigned int, int>**[NStaves[lay]]*/;
   int** mHitnumberLane /* = new int*[NStaves[lay]]*/;       // IB : hitnumber[stave][chip]; OB : hitnumber[stave][lane]
   double** mOccupancyLane /* = new double*[NStaves[lay]]*/; // IB : occupancy[stave][chip]; OB : occupancy[stave][Lane]

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -36,7 +36,7 @@
                 },
                 "location": "remote",
                 "taskParameters": {
-                    "Layer": "2",
+                    "Layer": "1",
 		    "HitNumberCut": "0",
                     "GetTFFromBinding": "0",
                     "decoderThreads": "8",
@@ -50,7 +50,9 @@
                     "Phibins": "240",
 		    "geomPath": "./",
 		    "CutSparseTF": "1",
-                    "DoHitmapFilter": "1"
+                    "DoHitmapFilter": "1",
+                    "PhysicalOccupancyIB": "1.7e-3",
+                    "PhysicalOccupancyOB": "4.3e-5"
                 }
             }
         },

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -3,7 +3,7 @@
         "config": {
             "database": {
                 "implementation": "CCDB",
-                "host": "188.184.2.55:8080",
+                "host": "ccdb-test.cern.ch:8080",
                 "username": "not_applicable",
                 "password": "not_applicable",
                 "name": "not_applicable"
@@ -19,7 +19,7 @@
                 "url": ""
             },
             "conditionDB": {
-                "url": "188.184.2.55:8080"
+                "url": "ccdb-test.cern.ch:8080"
             }
         },
         "tasks": {
@@ -49,7 +49,8 @@
 		    "Etabins": "130",
                     "Phibins": "240",
 		    "geomPath": "./",
-		    "CutSparseTF": "1"
+		    "CutSparseTF": "1",
+                    "DoHitmapFilter": "1"
                 }
             }
         },

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -36,7 +36,7 @@
                 },
                 "location": "remote",
                 "taskParameters": {
-                    "Layer": "1",
+                    "Layer": "3",
 		    "HitNumberCut": "0",
                     "GetTFFromBinding": "0",
                     "decoderThreads": "8",

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -567,7 +567,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
         for (int ichip = 0 + (ilink * 3); ichip < (ilink * 3) + 3; ichip++) {
           std::unordered_map<unsigned int, int>::iterator iter;
 
-          if (mDoHitmapFilter == 1 && mTFCount > mCutTFForSparse) {  
+          if (mDoHitmapFilter == 1 && mTFCount > mCutTFForSparse) {
             for (auto iter = mHitPixelID_InStave[istave][0][ichip].begin(); iter != mHitPixelID_InStave[istave][0][ichip].end();) {
               if ((double)iter->second / GBTLinkInfo->statistics.nTriggers < 1.7e-3) { // 40 hits/cm^2 * 5 pixels/hits * 4.5 cm^2 / 1024 / 512 = 1.7e-3/pixel/event for physics
                 mHitPixelID_InStave[istave][0][ichip].erase(iter++);

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -517,9 +517,8 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
         int chip = digit.getChipIndex() % 9;
         mHitPixelID_InStave[istave][0][chip][1000 * digit.getColumn() + digit.getRow()]++;
         if (mTFCount <= mCutTFForSparse) {
-          int pixelPos[2] = { digit.getColumn() + (1024 * chip) + 1, digit.getRow() + 1 };
-          int BinContent = mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos));
-          mStaveHitmap[istave]->SetBinContent(pixelPos, BinContent + 1);
+          Double_t pixelPos[2] = { digit.getColumn() + (1024 * chip) + 1., digit.getRow() + 1. };
+          mStaveHitmap[istave]->Fill(pixelPos);
         }
       }
     } else {
@@ -530,13 +529,11 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
           int ilink = ihic / (nHicPerStave[mLayer] / 2);
           if (mTFCount <= mCutTFForSparse) {
             if (chip < 7) {
-              int pixelPos[2] = { (ihic % (nHicPerStave[mLayer] / NSubStave[mLayer]) * ((nChipsPerHic[mLayer] / 2) * NCols)) + chip * NCols + digit.getColumn() + 1, NRows - digit.getRow() - 1 + (1024 * ilink) + 1 };
-              int BinContent = mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos));
-              mStaveHitmap[istave]->SetBinContent(pixelPos, BinContent + 1);
+              Double_t pixelPos[2] = { (ihic % (nHicPerStave[mLayer] / NSubStave[mLayer]) * ((nChipsPerHic[mLayer] / 2) * NCols)) + chip * NCols + digit.getColumn() + 1., NRows - digit.getRow() - 1 + (1024 * ilink) + 1. };
+              mStaveHitmap[istave]->Fill(pixelPos);
             } else {
-              int pixelPos[2] = { (ihic % (nHicPerStave[mLayer] / NSubStave[mLayer]) * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (chip - 7) * NCols - digit.getColumn(), NRows + digit.getRow() + (1024 * ilink) + 1 };
-              int BinContent = mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos));
-              mStaveHitmap[istave]->SetBinContent(pixelPos, BinContent + 1);
+              Double_t pixelPos[2] = { (ihic % (nHicPerStave[mLayer] / NSubStave[mLayer]) * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (chip - 7) * NCols - digit.getColumn() * 1., NRows + digit.getRow() + (1024 * ilink) + 1. };
+              mStaveHitmap[istave]->Fill(pixelPos);
             }
           }
         }

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -517,10 +517,9 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
         int chip = digit.getChipIndex() % 9;
         mHitPixelID_InStave[istave][0][chip][1000 * digit.getColumn() + digit.getRow()]++;
         if (mTFCount <= mCutTFForSparse) {
-              int pixelPos[2] = { digit.getColumn() + (1024 * chip) + 1, digit.getRow() + 1 };
-              int BinContent;
-              mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos),&BinContent); 
-              mStaveHitmap[istave]->SetBinContent(pixelPos,BinContent+1);
+          int pixelPos[2] = { digit.getColumn() + (1024 * chip) + 1, digit.getRow() + 1 };
+          int BinContent = mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos));
+          mStaveHitmap[istave]->SetBinContent(pixelPos, BinContent + 1);
         }
       }
     } else {
@@ -529,20 +528,17 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
           int chip = ((digit.getChipIndex() - ChipBoundary[mLayer]) % (14 * nHicPerStave[mLayer])) % 14;
           mHitPixelID_InStave[istave][ihic][chip][1000 * digit.getColumn() + digit.getRow()]++;
           int ilink = ihic / (nHicPerStave[mLayer] / 2);
-          if (mTFCount <= mCutTFForSparse){
-          if (chip < 7) {
-                  int pixelPos[2] = { (ihic % (nHicPerStave[mLayer] / NSubStave[mLayer]) * ((nChipsPerHic[mLayer] / 2) * NCols)) + chip * NCols + digit.getColumn() + 1, NRows - digit.getRow() - 1 + (1024 * ilink) + 1 };
-                  int BinContent;
-                  mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos),&BinContent); 
-                  mStaveHitmap[istave]->SetBinContent(pixelPos,BinContent+1);
-          } else {
-                  int pixelPos[2] = { (ihic % (nHicPerStave[mLayer] / NSubStave[mLayer]) * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (chip - 7) * NCols - digit.getColumn(), NRows + digit.getRow() + (1024 * ilink) + 1 };
-              int BinContent;    
-              mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos),&BinContent); 
-              mStaveHitmap[istave]->SetBinContent(pixelPos,BinContent+1);   
-             }
-         }
-
+          if (mTFCount <= mCutTFForSparse) {
+            if (chip < 7) {
+              int pixelPos[2] = { (ihic % (nHicPerStave[mLayer] / NSubStave[mLayer]) * ((nChipsPerHic[mLayer] / 2) * NCols)) + chip * NCols + digit.getColumn() + 1, NRows - digit.getRow() - 1 + (1024 * ilink) + 1 };
+              int BinContent = mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos));
+              mStaveHitmap[istave]->SetBinContent(pixelPos, BinContent + 1);
+            } else {
+              int pixelPos[2] = { (ihic % (nHicPerStave[mLayer] / NSubStave[mLayer]) * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (chip - 7) * NCols - digit.getColumn(), NRows + digit.getRow() + (1024 * ilink) + 1 };
+              int BinContent = mStaveHitmap[istave]->GetBinContent(mStaveHitmap[istave]->GetBin(pixelPos));
+              mStaveHitmap[istave]->SetBinContent(pixelPos, BinContent + 1);
+            }
+          }
         }
       }
     }
@@ -583,7 +579,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
           continue;
         }
 
-        mNoisyPixelNumber[mLayer][istave] = 0;        
+        mNoisyPixelNumber[mLayer][istave] = 0;
         for (int ichip = 0 + (ilink * 3); ichip < (ilink * 3) + 3; ichip++) {
           std::unordered_map<unsigned int, int>::iterator iter;
 
@@ -603,7 +599,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
               occupancyPlotTmp[i]->Fill(log10((double)iter->second / GBTLinkInfo->statistics.nTriggers));
             }
 
-           totalhit += (int)iter->second;
+            totalhit += (int)iter->second;
           }
 
           mOccupancyLane[istave][ichip] = mHitnumberLane[istave][ichip] / (GBTLinkInfo->statistics.nTriggers * 1024. * 512.);
@@ -636,18 +632,15 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
                     ++iter;
                 }
               }
-          //    std::cout<<"new chip: "<<ichip << " ihic " <<ihic<< " istave " << istave << " ilink: "<<ilink<<std::endl;
               for (auto iter = mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].begin(); iter != mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].end(); iter++) {
                 if ((iter->second > mHitCutForNoisyPixel) &&
                     (iter->second / (double)GBTLinkInfo->statistics.nTriggers) > mOccupancyCutForNoisyPixel) {
                   mNoisyPixelNumber[mLayer][istave]++;
                   occupancyPlotTmp[i]->Fill(log10((double)iter->second / GBTLinkInfo->statistics.nTriggers));
                 }
- 
-                }
               }
             }
-          
+          }
 
           if (mLayer == 3 || mLayer == 4) {
             mOccupancyLane[istave][2 * (ihic + (ilink * 4))] = mHitnumberLane[istave][2 * (ihic + (ilink * 4))] / (GBTLinkInfo->statistics.nTriggers * 1024. * 512. * nChipsPerHic[mLayer] / 2);
@@ -768,7 +761,6 @@ void ITSFhrTask::getParameters()
   mDoHitmapFilter = std::stoi(mCustomParameters["DoHitmapFilter"]);
   mPhysicalOccupancyIB = std::stof(mCustomParameters["PhysicalOccupancyIB"]);
   mPhysicalOccupancyOB = std::stof(mCustomParameters["PhysicalOccupancyOB"]);
-
 }
 
 void ITSFhrTask::endOfCycle()

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -567,7 +567,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
         for (int ichip = 0 + (ilink * 3); ichip < (ilink * 3) + 3; ichip++) {
           std::unordered_map<unsigned int, int>::iterator iter;
 
-          if (mDoHitmapFilter == 1) {
+          if (mDoHitmapFilter == 1 && mTFCount > mCutTFForSparse) {  
             for (auto iter = mHitPixelID_InStave[istave][0][ichip].begin(); iter != mHitPixelID_InStave[istave][0][ichip].end();) {
               if ((double)iter->second / GBTLinkInfo->statistics.nTriggers < 1.7e-3) { // 40 hits/cm^2 * 5 pixels/hits * 4.5 cm^2 / 1024 / 512 = 1.7e-3/pixel/event for physics
                 mHitPixelID_InStave[istave][0][ichip].erase(iter++);
@@ -614,7 +614,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
           for (int ichip = 0; ichip < nChipsPerHic[mLayer]; ichip++) {
             if (GBTLinkInfo->statistics.nTriggers > 0) {
 
-              if (mDoHitmapFilter == 1) {
+              if (mDoHitmapFilter == 1 && mTFCount > mCutTFForSparse) {
                 for (auto iter = mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].begin(); iter != mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].end();) {
                   if ((double)iter->second / GBTLinkInfo->statistics.nTriggers < 4.3e-5) { // 1 hits/cm^2 * 5 pixels/hits * 4.5 cm^2 / 1024 / 512 = 4.3e-5/pixel/event`
                     mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].erase(iter++);

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -291,13 +291,13 @@ void ITSFhrTask::createOccupancyPlots() // create general plots like error, trig
     getObjectsManager()->startPublishing(mDeadChipPos);
     getObjectsManager()->startPublishing(mAliveChipPos);
     getObjectsManager()->startPublishing(mChipStaveOccupancy); // mChipStaveOccupancy
-
     mChipStaveEventHitCheck = new TH2I(Form("Occupancy/Layer%d/Layer%dChipStaveEventHit", mLayer, mLayer), Form("ITS Layer%d, Event Hit Check vs Chip and Stave", mLayer), nHicPerStave[mLayer] * nChipsPerHic[mLayer], -0.5, nHicPerStave[mLayer] * nChipsPerHic[mLayer] - 0.5, NStaves[mLayer], -0.5, NStaves[mLayer] - 0.5);
     mChipStaveEventHitCheck->SetStats(0);
     getObjectsManager()->startPublishing(mChipStaveEventHitCheck);
 
-    mOccupancyPlot = new TH1D(Form("Occupancy/Layer%dOccupancy", mLayer), Form("ITS Layer %d Occupancy Distribution", mLayer), 300, -15, 0);
+    mOccupancyPlot = new TH1D(Form("Occupancy/Layer%dOccupancy", mLayer), Form("ITS Layer %d Noise pixels occupancy distribution", mLayer), 300, -15, 0);
     getObjectsManager()->startPublishing(mOccupancyPlot); // mOccupancyPlot
+
   } else {
     // Create OB plots
     int nBinstmp[nDim] = { (nBins[0] * (nChipsPerHic[mLayer] / 2) * (nHicPerStave[mLayer] / 2) / ReduceFraction), (nBins[1] * 2 * NSubStave[mLayer] / ReduceFraction) };
@@ -331,7 +331,7 @@ void ITSFhrTask::createOccupancyPlots() // create general plots like error, trig
     mChipStaveEventHitCheck->SetStats(0);
     getObjectsManager()->startPublishing(mChipStaveEventHitCheck);
 
-    mOccupancyPlot = new TH1D(Form("Occupancy/Layer%dOccupancy", mLayer), Form("ITS Layer %d Occupancy Distribution", mLayer), 300, -15, 0);
+    mOccupancyPlot = new TH1D(Form("Occupancy/Layer%dOccupancy", mLayer), Form("ITS Layer %d Noise pixels occupancy Distribution", mLayer), 300, -15, 0);
     getObjectsManager()->startPublishing(mOccupancyPlot); // mOccupancyPlot
   }
 }
@@ -363,6 +363,7 @@ void ITSFhrTask::setPlotsFormat()
   if (mOccupancyPlot) {
     mOccupancyPlot->GetXaxis()->SetTitle("log(Occupancy)");
   }
+
   if (mDeadChipPos) {
     setAxisTitle(mDeadChipPos, "ChipEta", "ChipPhi");
   }
@@ -455,6 +456,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
       int stave = 0, chip = 0;
       int hic = 0;
       int lane = 0;
+
       const auto& pixels = mChipDataBuffer->getData();
       if (mChipDataBuffer->getChipID() < ChipBoundary[mLayer] || mChipDataBuffer->getChipID() >= ChipBoundary[mLayer + 1]) { // useful for data replay
         continue;
@@ -471,8 +473,8 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
           int chipIdLocal = (mChipDataBuffer->getChipID() - ChipBoundary[mLayer]) % (14 * nHicPerStave[mLayer]);
           chip = chipIdLocal % 14;
           hic = (chipIdLocal % (14 * nHicPerStave[mLayer])) / 14;
-
           lane = (chipIdLocal % (14 * nHicPerStave[mLayer])) / (14 / 2);
+
           mHitnumberLane[stave][lane]++;
           mChipStat[stave][chipIdLocal]++;
         }
@@ -512,7 +514,8 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
     int istave = activeStaves[i];
     if (mLayer < NLayerIB) {
       for (auto& digit : digVec[istave][0]) {
-        mHitPixelID_InStave[istave][0][digit.getChipIndex() % 9][1000 * digit.getColumn() + digit.getRow()]++;
+        int chip = digit.getChipIndex() % 9;
+        mHitPixelID_InStave[istave][0][chip][1000 * digit.getColumn() + digit.getRow()]++;
       }
     } else {
       for (int ihic = 0; ihic < nHicPerStave[mLayer]; ihic++) {
@@ -527,7 +530,6 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
   // Reset Error plots
   mErrorPlots->Reset();
   mErrorVsFeeid->Reset(); // Error is   statistic by decoder so if we didn't reset decoder, then we need reset Error plots, and use TH::SetBinContent function
-  mOccupancyPlot->Reset();
 
   // define tmp occupancy plot, which will use for multiple threads
   TH1D** occupancyPlotTmp = new TH1D*[(int)activeStaves.size()];
@@ -562,24 +564,36 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
         if ((double)GBTLinkInfo->statistics.nTriggers >= 1e6 && (double)GBTLinkInfo->statistics.nTriggers < 1e6 + 10000) {
           mNoisyPixelNumber[mLayer][istave] = 0;
         }
-
         for (int ichip = 0 + (ilink * 3); ichip < (ilink * 3) + 3; ichip++) {
           std::unordered_map<unsigned int, int>::iterator iter;
+
+          if (mDoHitmapFilter == 1) {
+            for (auto iter = mHitPixelID_InStave[istave][0][ichip].begin(); iter != mHitPixelID_InStave[istave][0][ichip].end();) {
+              if ((double)iter->second / GBTLinkInfo->statistics.nTriggers < 1.7e-3) { // 40 hits/cm^2 * 5 pixels/hits * 4.5 cm^2 / 1024 / 512 = 1.7e-3/pixel/event for physics
+                mHitPixelID_InStave[istave][0][ichip].erase(iter++);
+              } else
+                ++iter;
+            }
+          }
+
           for (iter = mHitPixelID_InStave[istave][0][ichip].begin(); iter != mHitPixelID_InStave[istave][0][ichip].end(); iter++) {
             if ((iter->second > mHitCutForNoisyPixel) &&
                 (iter->second / (double)GBTLinkInfo->statistics.nTriggers) > mOccupancyCutForNoisyPixel &&
                 ((double)GBTLinkInfo->statistics.nTriggers >= 1e6 && (double)GBTLinkInfo->statistics.nTriggers < 1e6 + 10000)) {
               mNoisyPixelNumber[mLayer][istave]++; // count only in 10000 events as soon as nTriggers is 1e6
+              occupancyPlotTmp[i]->Fill(log10((double)iter->second / GBTLinkInfo->statistics.nTriggers));
             }
+
             int pixelPos[2] = { (int)(iter->first / 1000) + (1024 * ichip) + 1, (int)(iter->first % 1000) + 1 };
-            if (mTFCount < mCutTFForSparse) {
+            if (mTFCount == mCutTFForSparse) {
               mStaveHitmap[istave]->SetBinContent(pixelPos, (double)iter->second);
             }
             totalhit += (int)iter->second;
-            occupancyPlotTmp[i]->Fill(log10((double)iter->second / GBTLinkInfo->statistics.nTriggers));
           }
+
           mOccupancyLane[istave][ichip] = mHitnumberLane[istave][ichip] / (GBTLinkInfo->statistics.nTriggers * 1024. * 512.);
         }
+
         for (int ierror = 0; ierror < o2::itsmft::GBTLinkDecodingStat::NErrorsDefined; ierror++) {
           if (GBTLinkInfo->statistics.errorCounts[ierror] <= 0) {
             continue;
@@ -599,29 +613,40 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
         for (int ihic = 0; ihic < ((nHicPerStave[mLayer] / NSubStave[mLayer])); ihic++) {
           for (int ichip = 0; ichip < nChipsPerHic[mLayer]; ichip++) {
             if (GBTLinkInfo->statistics.nTriggers > 0) {
+
+              if (mDoHitmapFilter == 1) {
+                for (auto iter = mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].begin(); iter != mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].end();) {
+                  if ((double)iter->second / GBTLinkInfo->statistics.nTriggers < 4.3e-5) { // 1 hits/cm^2 * 5 pixels/hits * 4.5 cm^2 / 1024 / 512 = 4.3e-5/pixel/event`
+                    mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].erase(iter++);
+                  } else
+                    ++iter;
+                }
+              }
+
               std::unordered_map<unsigned int, int>::iterator iter;
               for (iter = mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].begin(); iter != mHitPixelID_InStave[istave][ihic + ilink * ((nHicPerStave[mLayer] / NSubStave[mLayer]))][ichip].end(); iter++) {
                 if ((iter->second > mHitCutForNoisyPixel) &&
                     (iter->second / (double)GBTLinkInfo->statistics.nTriggers) > mOccupancyCutForNoisyPixel &&
                     ((double)GBTLinkInfo->statistics.nTriggers >= 1e6 && (double)GBTLinkInfo->statistics.nTriggers < 1e6 + 10000)) {
                   mNoisyPixelNumber[mLayer][istave]++;
+                  occupancyPlotTmp[i]->Fill(log10((double)iter->second / GBTLinkInfo->statistics.nTriggers));
                 }
                 double pixelOccupancy = (double)iter->second;
-                occupancyPlotTmp[i]->Fill(log10(pixelOccupancy / GBTLinkInfo->statistics.nTriggers));
                 if (ichip < 7) {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + ichip * NCols + (int)(iter->first / 1000) + 1, NRows - ((int)iter->first % 1000) - 1 + (1024 * ilink) + 1 };
-                  if (mTFCount < mCutTFForSparse) {
+                  if (mTFCount == mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 } else {
                   int pixelPos[2] = { (ihic * ((nChipsPerHic[mLayer] / 2) * NCols)) + (nChipsPerHic[mLayer] / 2) * NCols - (ichip - 7) * NCols - ((int)iter->first / 1000), NRows + ((int)iter->first % 1000) + (1024 * ilink) + 1 };
-                  if (mTFCount < mCutTFForSparse) {
+                  if (mTFCount == mCutTFForSparse) {
                     mStaveHitmap[istave]->SetBinContent(pixelPos, pixelOccupancy);
                   }
                 }
               }
             }
           }
+
           if (mLayer == 3 || mLayer == 4) {
             mOccupancyLane[istave][2 * (ihic + (ilink * 4))] = mHitnumberLane[istave][2 * (ihic + (ilink * 4))] / (GBTLinkInfo->statistics.nTriggers * 1024. * 512. * nChipsPerHic[mLayer] / 2);
             mOccupancyLane[istave][2 * (ihic + (ilink * 4)) + 1] = mHitnumberLane[istave][2 * (ihic + (ilink * 4)) + 1] / (GBTLinkInfo->statistics.nTriggers * 1024. * 512. * nChipsPerHic[mLayer] / 2);
@@ -693,6 +718,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
       mGeneralNoisyPixel->SetBinContent(istave + 1 + StaveBoundary[mLayer], mNoisyPixelNumber[mLayer][istave]);
     }
   }
+
   for (int ierror = 0; ierror < o2::itsmft::GBTLinkDecodingStat::NErrorsDefined; ierror++) {
     int feeError = mErrorVsFeeid->Integral(1, mErrorVsFeeid->GetXaxis()->GetNbins(), ierror + 1, ierror + 1);
     mErrorPlots->SetBinContent(ierror + 1, feeError);
@@ -703,16 +729,20 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
     delete[] digVec[istave];
   }
   delete[] digVec;
+
   for (int i = 0; i < (int)activeStaves.size(); i++) {
     delete occupancyPlotTmp[i];
   }
   delete[] occupancyPlotTmp;
+
   // temporarily reverting to get TFId by querying binding
   //   mTimeFrameId = ctx.inputs().get<int>("G");
   // Timer LOG
   mTFInfo->Fill(mTimeFrameId);
+
   end = std::chrono::high_resolution_clock::now();
   difference = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+
   mAverageProcessTime += difference;
   mTFCount++;
 }
@@ -733,6 +763,7 @@ void ITSFhrTask::getParameters()
   mPhibins = std::stoi(mCustomParameters["Phibins"]);
   mEtabins = std::stoi(mCustomParameters["Etabins"]);
   mCutTFForSparse = std::stod(mCustomParameters["CutSparseTF"]);
+  mDoHitmapFilter = std::stoi(mCustomParameters["DoHitmapFilter"]);
 }
 
 void ITSFhrTask::endOfCycle()


### PR DESCRIPTION
Fixed the problem that FHR task used too large RAM/CPU after increased IR

1) Vector of pixels _mHitPixelID_InStave_ now is pruned at each cycle of Monitoring function
2)  _mOccupancyPlot_ now shows 1D distribution of noise pixel occupancy
3) _mStaveHitmap_ now is filled only once