### PR TITLE
[QC-856] Mark postprocessing task outputs as sporadic

### DIFF
--- a/Framework/src/PostProcessingDevice.cxx
+++ b/Framework/src/PostProcessingDevice.cxx
@@ -123,7 +123,7 @@ framework::Inputs PostProcessingDevice::getInputsSpecs()
 
 framework::Outputs PostProcessingDevice::getOutputSpecs()
 {
-  return { { { outputBinding }, createPostProcessingDataOrigin(), createPostProcessingDataDescription(mRunner->getName()), 0 } };
+  return { { { outputBinding }, createPostProcessingDataOrigin(), createPostProcessingDataDescription(mRunner->getName()), 0, Lifetime::Sporadic } };
 }
 
 framework::Options PostProcessingDevice::getOptions()


### PR DESCRIPTION
Just like QC Tasks, PP tasks publish data rather rarely, which confuses DPL and makes it produce the following:

```
We are trying to send an oldest possible timeslice 1663079429268659 that is older than the last one we sent 1663079429269885
```