### PR TITLE
[TOF] Add TPC-TOF tracks in the computation of TOF event time

### DIFF
--- a/Modules/PID/include/PID/TaskFT0TOF.h
+++ b/Modules/PID/include/PID/TaskFT0TOF.h
@@ -26,8 +26,11 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "DataFormatsTRD/TrackTRD.h"
+#include "TOFBase/Geo.h"
 
 class TH1F;
+class TH1I;
 class TH2F;
 
 namespace o2::quality_control_modules::pid
@@ -96,13 +99,20 @@ class TaskFT0TOF final : public TaskInterface
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
   o2::globaltracking::RecoContainer mRecoCont;
   GID::mask_t mSrc = GID::getSourcesMask("ITS-TPC");
-  GID::mask_t mAllowedSources = GID::getSourcesMask("TPC,ITS-TPC,TPC-TOF,ITS-TPC-TOF");
+  GID::mask_t mAllowedSources = GID::getSourcesMask("TPC,TPC-TOF,ITS-TPC,ITS-TPC-TOF,TPC-TRD,TPC-TRD-TOF,ITS-TPC-TRD,ITS-TPC-TRD-TOF");
   // TPC-TOF
   gsl::span<const o2::tpc::TrackTPC> mTPCTracks;
   gsl::span<const o2::dataformats::MatchInfoTOF> mTPCTOFMatches;
   // ITS-TPC-TOF
   gsl::span<const o2::dataformats::TrackTPCITS> mITSTPCTracks;
   gsl::span<const o2::dataformats::MatchInfoTOF> mITSTPCTOFMatches;
+  // TPC-TRD-TOF
+  gsl::span<const o2::trd::TrackTRD> mTPCTRDTracks;
+  gsl::span<const o2::dataformats::MatchInfoTOF> mTPCTRDTOFMatches;
+  // TPC-TRD-TOF
+  gsl::span<const o2::trd::TrackTRD> mITSTPCTRDTracks;
+  gsl::span<const o2::dataformats::MatchInfoTOF> mITSTPCTRDTOFMatches;
+  //
   std::vector<MyTrack> mMyTracks;
 
   // for track selection
@@ -125,9 +135,10 @@ class TaskFT0TOF final : public TaskInterface
   TH2F* mHistDeltatPrPt;
   TH1F* mHistMass;
   TH2F* mHistBetavsP;
-  TH2F* mHistDeltatPiEvtimeRes;
+  TH2F* mHistDeltatPiEvTimeRes;
   TH2F* mHistDeltatPiEvTimeMult;
-  TH2F* mHistT0ResEvTimeMult;
+  TH2F* mHistEvTimeResEvTimeMult;
+  TH1F* mHistEvTimeTOF;
 };
 
 } // namespace o2::quality_control_modules::pid

--- a/Modules/PID/pidft0tof.json
+++ b/Modules/PID/pidft0tof.json
@@ -40,10 +40,10 @@
                 "dataSource": {
                     "type": "direct",
                     "query_comment": "checking every matched track",
-                    "query": "matchITSTPCTOF:TOF/MTC_ITSTPC/0;trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;tofcluster:TOF/CLUSTERS/0;trackTPC:TPC/TRACKS/0;trackTPCClRefs:TPC/CLUSREFS/0;recpoints:FT0/RECPOINTS/0"
+                    "query": "matchITSTPCTOF:TOF/MTC_ITSTPC/0;matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0;trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS/0;trackTPCClRefs:TPC/CLUSREFS/0;tofcluster:TOF/CLUSTERS/0;recpoints:FT0/RECPOINTS/0"
                 },
                 "taskParameters": {
-                    "GID": "ITS-TPC,TPC,ITS-TPC-TOF",
+                    "GID": "ITS-TPC,ITS-TPC-TOF,TPC,TPC-TOF",
                     "verbose": "false",
                     "minPtCut": "0.3f",
                     "etaCut": "0.8f",

--- a/Modules/PID/pidtof.json
+++ b/Modules/PID/pidtof.json
@@ -40,10 +40,10 @@
                 "dataSource": {
                     "type": "direct",
                     "query_comment": "checking every matched track",
-                    "query": "matchITSTPCTOF:TOF/MTC_ITSTPC/0;trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;tofcluster:TOF/CLUSTERS/0;trackTPC:TPC/TRACKS/0;trackTPCClRefs:TPC/CLUSREFS/0"
+                    "query": "matchITSTPCTOF:TOF/MTC_ITSTPC/0;matchTPCTOF:TOF/MTC_TPC/0;trackTPCTOF:TOF/TOFTRACKS_TPC/0;trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS/0;trackTPCClRefs:TPC/CLUSREFS/0;tofcluster:TOF/CLUSTERS/0"
                 },
                 "taskParameters": {
-                    "GID": "ITS-TPC,TPC,ITS-TPC-TOF",
+                    "GID": "ITS-TPC,ITS-TPC-TOF,TPC,TPC-TOF",
                     "verbose": "false",
                     "minPtCut": "0.3f",
                     "etaCut": "0.8f",


### PR DESCRIPTION
@noferini @njacazio 
Added new histogram with the distribution of TOF event time and included TPC tracks in the computation of TOF event time (before it was only ITS-TPC).
In principle, when it will be possible to use also tracks matched to TRD, everything is already in place, we will only need to change the json.
