### PR TITLE
Set cycle duration of multinode test to 10

### DIFF
--- a/Framework/multinode-test.json.in
+++ b/Framework/multinode-test.json.in
@@ -28,7 +28,7 @@
         "className": "o2::quality_control_modules::skeleton::SkeletonTask",
         "moduleName": "QcSkeleton",
         "detectorName": "TST",
-        "cycleDurationSeconds": "5",
+        "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
@@ -49,7 +49,7 @@
         "className": "o2::quality_control_modules::skeleton::SkeletonTask",
         "moduleName": "QcSkeleton",
         "detectorName": "TST",
-        "cycleDurationSeconds": "5",
+        "cycleDurationSeconds": "10",
         "maxNumberCycles": "-1",
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {


### PR DESCRIPTION
We get rid of warnings saying that 5s is not allowed and 10s will be used anyway