### PR TITLE
[QC-852] Provide config string of triggers to postprocessing tasks

### DIFF
--- a/Framework/include/QualityControl/Triggers.h
+++ b/Framework/include/QualityControl/Triggers.h
@@ -47,9 +47,11 @@ enum TriggerType {
 struct Trigger {
 
   /// \brief Constructor. Timestamp is generated from the time of construction.
-  Trigger(TriggerType triggerType, bool last = false, core::Activity activity = {}) : triggerType(triggerType), last(last), activity(std::move(activity)), timestamp(msSinceEpoch()){};
+  Trigger(TriggerType triggerType, bool last = false, core::Activity activity = {})
+    : triggerType(triggerType), last(last), activity(std::move(activity)), timestamp(msSinceEpoch()){};
   /// \brief Constructor.
-  Trigger(TriggerType triggerType, bool last, core::Activity activity, uint64_t timestamp) : triggerType(triggerType), last(last), activity(std::move(activity)), timestamp(timestamp){};
+  Trigger(TriggerType triggerType, bool last, core::Activity activity, uint64_t timestamp, std::string config = {})
+    : triggerType(triggerType), last(last), activity(std::move(activity)), timestamp(timestamp), config(std::move(config)){};
   /// \brief Constructor.
   Trigger(TriggerType triggerType, bool last, uint64_t timestamp) : triggerType(triggerType), last(last), activity(), timestamp(timestamp){};
 
@@ -66,6 +68,7 @@ struct Trigger {
   bool last;
   core::Activity activity;
   uint64_t timestamp;
+  std::string config{};
 };
 
 using TriggerFcn = std::function<Trigger()>;
@@ -82,13 +85,13 @@ TriggerFcn StartOfFill(const core::Activity& = {});
 /// \brief Triggers when it detects an event dump during its uptime (once per each)
 TriggerFcn EndOfFill(const core::Activity& = {});
 /// \brief Triggers when a period of time passes
-TriggerFcn Periodic(double seconds, const core::Activity& = {});
+TriggerFcn Periodic(double seconds, const core::Activity& = {}, std::string config = {});
 /// \brief Triggers when it detect a new object in QC repository with given name
-TriggerFcn NewObject(std::string databaseUrl, std::string databaseType, std::string objectPath, const core::Activity& = {});
+TriggerFcn NewObject(std::string databaseUrl, std::string databaseType, std::string objectPath, const core::Activity& = {}, std::string config = {});
 /// \brief Triggers for each object version in the path which match the activity. It retrieves the available list only once!
-TriggerFcn ForEachObject(std::string databaseUrl, std::string databaseType, std::string objectPath, const core::Activity& = {});
+TriggerFcn ForEachObject(std::string databaseUrl, std::string databaseType, std::string objectPath, const core::Activity& = {}, std::string config = {});
 /// \brief Triggers for the latest object version for each distinct activity. It retrieves the available list only once!
-TriggerFcn ForEachLatest(std::string databaseUrl, std::string databaseType, std::string objectPath, const core::Activity& = {});
+TriggerFcn ForEachLatest(std::string databaseUrl, std::string databaseType, std::string objectPath, const core::Activity& = {}, std::string config = {});
 /// \brief Triggers only first time it is executed
 TriggerFcn Once(const core::Activity& = {});
 /// \brief Triggers always

--- a/Framework/src/TriggerHelpers.cxx
+++ b/Framework/src/TriggerHelpers.cxx
@@ -104,20 +104,20 @@ TriggerFcn triggerFactory(std::string trigger, const PostProcessingConfig& confi
   } else if (triggerLowerCase.find("newobject") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "newobject");
     const std::string& dbUrl = db == "qcdb" ? config.qcdbUrl : config.ccdbUrl;
-    return triggers::NewObject(dbUrl, db, objectPath, activity);
+    return triggers::NewObject(dbUrl, db, objectPath, activity, trigger);
   } else if (triggerLowerCase.find("foreachobject") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "foreachobject");
     const std::string& dbUrl = db == "qcdb" ? config.qcdbUrl : config.ccdbUrl;
-    return triggers::ForEachObject(dbUrl, db, objectPath, activity);
+    return triggers::ForEachObject(dbUrl, db, objectPath, activity, trigger);
   } else if (triggerLowerCase.find("foreachlatest") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "foreachlatest");
     const std::string& dbUrl = db == "qcdb" ? config.qcdbUrl : config.ccdbUrl;
-    return triggers::ForEachLatest(dbUrl, db, objectPath, activity);
+    return triggers::ForEachLatest(dbUrl, db, objectPath, activity, trigger);
   } else if (auto seconds = string2Seconds(triggerLowerCase); seconds.has_value()) {
     if (seconds.value() < 0) {
       throw std::invalid_argument("negative number of seconds in trigger '" + trigger + "'");
     }
-    return triggers::Periodic(seconds.value(), activity);
+    return triggers::Periodic(seconds.value(), activity, trigger);
   } else if (triggerLowerCase.find("user") != std::string::npos || triggerLowerCase.find("control") != std::string::npos) {
     return triggers::Never(activity);
   } else {

--- a/Framework/src/Triggers.cxx
+++ b/Framework/src/Triggers.cxx
@@ -83,10 +83,10 @@ TriggerFcn Once(const Activity& activity)
 {
   return [hasTriggered = false, activity]() mutable -> Trigger {
     if (hasTriggered) {
-      return { TriggerType::No, true, activity };
+      return { TriggerType::No, true, activity, Trigger::msSinceEpoch(), "once" };
     } else {
       hasTriggered = true;
-      return { TriggerType::Once, true, activity };
+      return { TriggerType::Once, true, activity, Trigger::msSinceEpoch(), "once" };
     }
   };
 }
@@ -94,14 +94,14 @@ TriggerFcn Once(const Activity& activity)
 TriggerFcn Always(const Activity& activity)
 {
   return [activity]() mutable -> Trigger {
-    return { TriggerType::Always, false, activity };
+    return { TriggerType::Always, false, activity, Trigger::msSinceEpoch(), "always" };
   };
 }
 
 TriggerFcn Never(const Activity& activity)
 {
   return [activity]() mutable -> Trigger {
-    return { TriggerType::No, true, activity };
+    return { TriggerType::No, true, activity, Trigger::msSinceEpoch(), "never" };
   };
 }
 
@@ -120,12 +120,12 @@ TriggerFcn EndOfFill(const Activity&)
   return NotImplemented("EndOfFill");
 }
 
-TriggerFcn Periodic(double seconds, const Activity& activity)
+TriggerFcn Periodic(double seconds, const Activity& activity, std::string config)
 {
   AliceO2::Common::Timer timer;
   timer.reset(static_cast<int>(seconds * 1000000));
 
-  return [timer, activity]() mutable -> Trigger {
+  return [timer, activity, config]() mutable -> Trigger {
     if (timer.isTimeout()) {
       // We calculate the exact time when timer has passed
       uint64_t timestamp = Trigger::msSinceEpoch() + static_cast<int>(timer.getRemainingTime() * 1000);
@@ -134,14 +134,14 @@ TriggerFcn Periodic(double seconds, const Activity& activity)
       while (timer.isTimeout()) {
         timer.increment();
       }
-      return { TriggerType::Periodic, false, activity, timestamp };
+      return { TriggerType::Periodic, false, activity, timestamp, config };
     } else {
-      return { TriggerType::No, false };
+      return { TriggerType::No, false, activity, Trigger::msSinceEpoch(), config };
     }
   };
 }
 
-TriggerFcn NewObject(std::string databaseUrl, std::string databaseType, std::string objectPath, const Activity& activity)
+TriggerFcn NewObject(std::string databaseUrl, std::string databaseType, std::string objectPath, const Activity& activity, std::string config)
 {
   // Key names in the header map.
   constexpr auto timestampKey = metadata_keys::validFrom;
@@ -167,12 +167,12 @@ TriggerFcn NewObject(std::string databaseUrl, std::string databaseType, std::str
     ILOG(Warning, Support) << "Could not find the file '" << fullObjectPath << "' in the db '" << databaseUrl << "' for given Activity settings. It is fine at SOR." << ENDM;
   }
 
-  return [db, databaseUrl = std::move(databaseUrl), fullObjectPath = std::move(fullObjectPath), lastMD5, activity, metadata]() mutable -> Trigger {
+  return [db, databaseUrl = std::move(databaseUrl), fullObjectPath = std::move(fullObjectPath), lastMD5, activity, metadata, config]() mutable -> Trigger {
     if (auto headers = db->retrieveHeaders(fullObjectPath, metadata); headers.count(metadata_keys::md5sum)) {
       auto newMD5 = headers[metadata_keys::md5sum];
       if (lastMD5 != newMD5) {
         lastMD5 = newMD5;
-        return { TriggerType::NewObject, false, activity, std::stoull(headers[timestampKey]) };
+        return { TriggerType::NewObject, false, activity, std::stoull(headers[timestampKey]), config };
       }
     } else {
       // We don't make a fuss over it, because we might be just waiting for the first version of such object.
@@ -181,11 +181,11 @@ TriggerFcn NewObject(std::string databaseUrl, std::string databaseType, std::str
                              << databaseUrl << "' for given Activity settings (" << activity << ")" << ENDM;
     }
 
-    return { TriggerType::No, false };
+    return { TriggerType::No, false, activity, Trigger::msSinceEpoch(), config };
   };
 }
 
-TriggerFcn ForEachObject(std::string databaseUrl, std::string databaseType, std::string objectPath, const Activity& activity)
+TriggerFcn ForEachObject(std::string databaseUrl, std::string databaseType, std::string objectPath, const Activity& activity, std::string config)
 {
   // Key names in the header map.
   constexpr auto timestampKey = metadata_keys::validFrom;
@@ -220,7 +220,7 @@ TriggerFcn ForEachObject(std::string databaseUrl, std::string databaseType, std:
               return a.get<int64_t>(timestampKey) < b.get<int64_t>(timestampKey);
             });
 
-  return [filteredObjects, activity, currentObject = filteredObjects->begin()]() mutable -> Trigger {
+  return [filteredObjects, activity, currentObject = filteredObjects->begin(), config]() mutable -> Trigger {
     if (currentObject != filteredObjects->end()) {
       auto currentActivity = repository::database_helpers::asActivity(*currentObject);
       bool last = currentObject + 1 == filteredObjects->end();
@@ -228,12 +228,12 @@ TriggerFcn ForEachObject(std::string databaseUrl, std::string databaseType, std:
       ++currentObject;
       return trigger;
     } else {
-      return { TriggerType::No, true, activity };
+      return { TriggerType::No, true, activity, Trigger::msSinceEpoch(), config };
     }
   };
 }
 
-TriggerFcn ForEachLatest(std::string databaseUrl, std::string databaseType, std::string objectPath, const Activity& activity)
+TriggerFcn ForEachLatest(std::string databaseUrl, std::string databaseType, std::string objectPath, const Activity& activity, std::string config)
 {
   // Key names in the header map.
   constexpr auto timestampKey = metadata_keys::created;
@@ -283,16 +283,16 @@ TriggerFcn ForEachLatest(std::string databaseUrl, std::string databaseType, std:
                                            b.second.get<int64_t>(metadata_keys::runNumber, 0));
             });
 
-  return [filteredObjects, activity, currentObject = filteredObjects->begin()]() mutable -> Trigger {
+  return [filteredObjects, activity, currentObject = filteredObjects->begin(), config]() mutable -> Trigger {
     if (currentObject != filteredObjects->end()) {
       const auto& currentActivity = currentObject->first;
       const auto& currentPtree = currentObject->second;
       bool last = currentObject + 1 == filteredObjects->end();
-      Trigger trigger(TriggerType::ForEachLatest, last, currentActivity, currentPtree.get<int64_t>(timestampKey));
+      Trigger trigger(TriggerType::ForEachLatest, last, currentActivity, currentPtree.get<int64_t>(timestampKey), config);
       ++currentObject;
       return trigger;
     } else {
-      return { TriggerType::No, true, activity };
+      return { TriggerType::No, true, activity, Trigger::msSinceEpoch(), config };
     }
   };
 }

--- a/Framework/test/testTriggerHelpers.cxx
+++ b/Framework/test/testTriggerHelpers.cxx
@@ -106,6 +106,12 @@ BOOST_AUTO_TEST_CASE(test_factory)
   BOOST_CHECK_THROW(trigger_helpers::triggerFactory("foreachlatest:nodb:qc/incorrect/db/speficied", configWithDBs), std::invalid_argument);
   BOOST_CHECK_THROW(trigger_helpers::triggerFactory("foreachlatest:ccdb:qc/too:many tokens", configWithDBs), std::invalid_argument);
 
+  // check if config string is propagated
+  BOOST_CHECK_EQUAL(trigger_helpers::triggerFactory("10sec", dummyConfig)().config, "10sec");
+  BOOST_CHECK_EQUAL(trigger_helpers::triggerFactory("newobject:qcdb:qc/asdf/vcxz", configWithDBs)().config, "newobject:qcdb:qc/asdf/vcxz");
+  BOOST_CHECK_EQUAL(trigger_helpers::triggerFactory("foreachobject:qcdb:qc/asdf/vcxz", configWithDBs)().config, "foreachobject:qcdb:qc/asdf/vcxz");
+  BOOST_CHECK_EQUAL(trigger_helpers::triggerFactory("foreachlatest:qcdb:qc/asdf/vcxz", configWithDBs)().config, "foreachlatest:qcdb:qc/asdf/vcxz");
+
   // fixme: this is treated as "123 seconds", do we want to be so defensive?
   BOOST_CHECK_NO_THROW(trigger_helpers::triggerFactory("123 secure code", dummyConfig));
 }


### PR DESCRIPTION
Some detector module developers need a path of the object which caused their task to be triggered. A cleaner solution could include some inheritance of Trigger struct, so the applicable triggers would contain the object path and could be casted, but this would require more time...