### PR TITLE
[EMCAL-792] Fix shadowing of a setting

### DIFF
--- a/Modules/EMCAL/src/RawErrorTask.cxx
+++ b/Modules/EMCAL/src/RawErrorTask.cxx
@@ -71,7 +71,7 @@ void RawErrorTask::initialize(o2::framework::InitContext& /*ctx*/)
   auto get_bool = [](const std::string_view input) -> bool {
     return input == "true";
   };
-  auto mExcludeGainErrorsFromOverview = get_bool(getConfigValueLower("excludeGainErrorFromSummary"));
+  mExcludeGainErrorsFromOverview = get_bool(getConfigValueLower("excludeGainErrorFromSummary"));
 
   mErrorTypeAll = new TH2F("RawDataErrors", "Raw data errors", 40, 0, 40, 6, -0.5, 5.5);
   mErrorTypeAll->GetXaxis()->SetTitle("Link");


### PR DESCRIPTION
Variable shadowing in initialize when parsing the
setting from the taskParameters prevented the
setting to be propagated to the task, therefore
excluding gain errors from the summary plot
was ignored.