### PR TITLE
Post-processing trending FEE task

### DIFF
--- a/Modules/ITS/CMakeLists.txt
+++ b/Modules/ITS/CMakeLists.txt
@@ -1,13 +1,16 @@
-﻿# ---- Library ----
+﻿
+# ---- Library ----
 
 add_library(O2QcITS
             src/ITSRawTask.cxx
             src/TrendingTaskITSThr.cxx
             src/TrendingTaskITSFhr.cxx
+	    src/TrendingTaskITSFEE.cxx
             src/TrendingTaskITSCluster.cxx
             src/TrendingTaskITSTracks.cxx
             src/TrendingTaskConfigITS.cxx
             src/TH2XlineReductor.cxx
+	    src/ReductorBinContent.cxx
             src/ITSFhrTask.cxx
             src/ITSFeeTask.cxx
             src/ITSClusterTask.cxx
@@ -22,7 +25,9 @@ add_library(O2QcITS
             src/ITSThresholdCalibrationCheck.cxx 
             )
 
-target_sources(O2QcITS PRIVATE src/TH2XlineReductor.cxx)
+target_sources(O2QcITS PRIVATE
+               src/TH2XlineReductor.cxx
+               src/ReductorBinContent.cxx)
 
 target_include_directories(
   O2QcITS
@@ -53,9 +58,11 @@ add_root_dictionary(O2QcITS
                     HEADERS include/ITS/ITSRawTask.h
                             include/ITS/TrendingTaskITSThr.h
                             include/ITS/TrendingTaskITSFhr.h
+			    include/ITS/TrendingTaskITSFEE.h
                             include/ITS/TrendingTaskITSCluster.h
                             include/ITS/TrendingTaskITSTracks.h
                             include/ITS/TH2XlineReductor.h
+			    include/ITS/ReductorBinContent.h
                             include/ITS/ITSFhrTask.h
                             include/ITS/ITSFeeTask.h
                             include/ITS/ITSClusterTask.h
@@ -119,6 +126,7 @@ install(FILES
         its.json
         itsQCTrendingThr.json
         itsQCTrendingFhr.json
+	itsQCTrendingFEE.json
         itsQCTrendingCluster.json
         itsQCTrendingTracks.json
         itsFhr.json

--- a/Modules/ITS/include/ITS/LinkDef.h
+++ b/Modules/ITS/include/ITS/LinkDef.h
@@ -6,9 +6,11 @@
 #pragma link C++ class o2::quality_control_modules::its::ITSRawTask + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSThr + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSFhr + ;
+#pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSFEE + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSCluster + ;
 #pragma link C++ class o2::quality_control::postprocessing::TrendingTaskITSTracks + ;
 #pragma link C++ class o2::quality_control_modules::its::TH2XlineReductor + ;
+#pragma link C++ class o2::quality_control_modules::its::ReductorBinContent + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSFhrTask + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSFeeTask + ;
 #pragma link C++ class o2::quality_control_modules::its::ITSClusterTask + ;

--- a/Modules/ITS/include/ITS/ReductorBinContent.h
+++ b/Modules/ITS/include/ITS/ReductorBinContent.h
@@ -1,0 +1,48 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ReductorBinContent.h
+/// \author Artem Kotliarov
+///
+#ifndef QUALITYCONTROL_REDUCTORBINCONTENT_H
+#define QUALITYCONTROL_REDUCTORBINCONTENT_H
+
+#include "QualityControl/Reductor.h"
+#include <vector>
+
+namespace o2::quality_control_modules::its
+{
+
+class ReductorBinContent : public quality_control::postprocessing::Reductor
+{
+ public:
+  ReductorBinContent() = default;
+  virtual ~ReductorBinContent() = default;
+
+  void* getBranchAddress() override;
+  const char* getBranchLeafList() override;
+  void update(TObject* obj) override;
+
+ private:
+  static constexpr int nFlags = 3;
+  static constexpr int nTriggers = 13;
+
+  struct mystat {
+    Double_t binContent[nFlags];  // Bin content in a specified slice
+    Double_t integral[nTriggers]; // Integral over all Fee ID
+  };
+
+  mystat mStats;
+};
+} // namespace o2::quality_control_modules::its
+
+#endif // QUALITYCONTROL_REDUCTORBINCONTENT_H

--- a/Modules/ITS/include/ITS/TrendingTaskITSFEE.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSFEE.h
@@ -67,13 +67,13 @@ class TrendingTaskITSFEE : public PostProcessingInterface
 
  private:
   // other functions; mainly style of plots
-  void SetLegendStyle(TLegend* legend, const std::string& name);
+  void SetLegendStyle(TLegend* legend, const std::string& name, bool isRun);
   void SetCanvasSettings(TCanvas* canvas);
-  void SetGraphStyle(TGraph* graph, int col, int mkr);
-  void SetGraphName(TMultiGraph* graph, std::string name, std::string title);
-  void SetGraphAxes(TMultiGraph* graph, std::string xtitle,
-                    std::string ytitle, bool isTime);
-  void SetHistoAxes(TH1* hist, std::vector<std::string> runlist,
+  void SetGraphStyle(TGraph* graph, const std::string& name, const std::string& title, int col, int mkr);
+  void SetGraphName(TMultiGraph* graph, const std::string& name, const std::string& title);
+  void SetGraphAxes(TMultiGraph* graph, const std::string& xtitle,
+                    const std::string& ytitle, bool isTime);
+  void SetHistoAxes(TH1* hist, const std::vector<std::string>& runlist,
                     const double& Ymin, const double& Ymax);
 
   struct MetaData {
@@ -87,6 +87,7 @@ class TrendingTaskITSFEE : public PostProcessingInterface
   TrendingTaskConfigITS mConfig;
   MetaData mMetaData;
   UInt_t mTime;
+  Int_t nEntries = 0;
 
   std::vector<std::string> runlist;
   std::unique_ptr<TTree> mTrend;
@@ -96,12 +97,12 @@ class TrendingTaskITSFEE : public PostProcessingInterface
   const int markers[14] = { 20, 21, 22, 24, 25, 26, 27, 29, 30, 32, 33, 34, 43, 47 };
 
   static constexpr int nFlags = 3;
-  static constexpr int nITSparts = 3;
+  static constexpr int nITSparts = 4;
   static constexpr int nTriggers = 13;
 
   const std::string mTriggerType[nTriggers] = { "ORBIT", "HB", "HBr", "HC", "PHYSICS", "PP", "CAL", "SOT", "EOT", "SOC", "EOC", "TF", "INT" };
   const std::string trend_titles[nFlags] = { "Warnings", "Errors", "Faults" };
-  const std::string itsParts[nITSparts] = { "IB", "ML", "OL" };
+  const std::string itsParts[nITSparts] = { "IB", "ML", "OL", "Global" };
 };
 } // namespace o2::quality_control::postprocessing
 #endif // QUALITYCONTROL_TRENDINGTASKITSFEE_H

--- a/Modules/ITS/include/ITS/TrendingTaskITSFEE.h
+++ b/Modules/ITS/include/ITS/TrendingTaskITSFEE.h
@@ -1,0 +1,107 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    TrendingTaskITSFEE.h
+/// \author  Artem Kotliarov on the structure from Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_TRENDINGTASKITSFEE_H
+#define QUALITYCONTROL_TRENDINGTASKITSFEE_H
+
+#include "ITS/TrendingTaskConfigITS.h"
+#include "QualityControl/PostProcessingInterface.h"
+#include "QualityControl/Reductor.h"
+
+#include <TAxis.h>
+#include <TColor.h>
+#include <TGraph.h>
+#include <TMultiGraph.h>
+#include <TLegend.h>
+#include <TCanvas.h>
+#include <TTree.h>
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace o2::quality_control::repository
+{
+class DatabaseInterface;
+}
+
+namespace o2::quality_control::postprocessing
+{
+
+/// \brief  A post-processing task which trends values, stores them in a TTree
+/// and produces plots.
+///
+/// A post-processing task which trends objects inside QC database (QCDB). It
+/// extracts some values of one or multiple
+/// objects using the Reductor classes, then stores them inside a TTree. One can
+/// generate plots out the TTree - the
+/// class exposes the TTree::Draw interface to the user. The TTree and plots are
+/// stored in the QCDB. The class is
+/// configured with configuration files, see Framework/postprocessing.json as an
+/// example.
+///
+
+class TrendingTaskITSFEE : public PostProcessingInterface
+{
+ public:
+  TrendingTaskITSFEE() = default;
+  ~TrendingTaskITSFEE() override = default;
+
+  void configure(std::string name, const boost::property_tree::ptree& config) override;
+  void initialize(Trigger, framework::ServiceRegistry&) override;
+  void update(Trigger, framework::ServiceRegistry&) override;
+  void finalize(Trigger, framework::ServiceRegistry&) override;
+
+ private:
+  // other functions; mainly style of plots
+  void SetLegendStyle(TLegend* legend, const std::string& name);
+  void SetCanvasSettings(TCanvas* canvas);
+  void SetGraphStyle(TGraph* graph, int col, int mkr);
+  void SetGraphName(TMultiGraph* graph, std::string name, std::string title);
+  void SetGraphAxes(TMultiGraph* graph, std::string xtitle,
+                    std::string ytitle, bool isTime);
+  void SetHistoAxes(TH1* hist, std::vector<std::string> runlist,
+                    const double& Ymin, const double& Ymax);
+
+  struct MetaData {
+    Int_t runNumber = 0;
+  };
+
+  void trendValues(const Trigger& t, repository::DatabaseInterface& qcdb);
+  void storePlots(repository::DatabaseInterface& qcdb);
+  void storeTrend(repository::DatabaseInterface& qcdb);
+
+  TrendingTaskConfigITS mConfig;
+  MetaData mMetaData;
+  UInt_t mTime;
+
+  std::vector<std::string> runlist;
+  std::unique_ptr<TTree> mTrend;
+  std::unordered_map<std::string, std::unique_ptr<Reductor>> mReductors;
+
+  const int colors[14] = { 1, 2, kAzure + 3, 807, 797, 827, 417, 841, 868, 867, 860, 602, 921, 874 };
+  const int markers[14] = { 20, 21, 22, 24, 25, 26, 27, 29, 30, 32, 33, 34, 43, 47 };
+
+  static constexpr int nFlags = 3;
+  static constexpr int nITSparts = 3;
+  static constexpr int nTriggers = 13;
+
+  const std::string mTriggerType[nTriggers] = { "ORBIT", "HB", "HBr", "HC", "PHYSICS", "PP", "CAL", "SOT", "EOT", "SOC", "EOC", "TF", "INT" };
+  const std::string trend_titles[nFlags] = { "Warnings", "Errors", "Faults" };
+  const std::string itsParts[nITSparts] = { "IB", "ML", "OL" };
+};
+} // namespace o2::quality_control::postprocessing
+#endif // QUALITYCONTROL_TRENDINGTASKITSFEE_H

--- a/Modules/ITS/itsQCTrendingFEE.json
+++ b/Modules/ITS/itsQCTrendingFEE.json
@@ -1,0 +1,214 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "postprocessing": {
+      "ITSqcTrendingFEE": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::TrendingTaskITSFEE",
+        "moduleName": "QualityControl",
+        "detectorName": "ITS",
+        "dataSources": [
+          {
+            "type": "repository",
+            "paths": [ "ITS/MO/ITSFEE/LaneStatusSummary",
+                       "ITS/MO/ITSFEE/LaneStatusSummary",
+                       "ITS/MO/ITSFEE/LaneStatusSummary",
+                       "ITS/MO/ITSFEE" ],
+            "names": [ "LaneStatusSummaryIB",
+                       "LaneStatusSummaryML",
+                       "LaneStatusSummaryOL",
+                       "TriggerVsFeeid" ],
+            "reductorName": "o2::quality_control_modules::its::ReductorBinContent",
+            "moduleName": "QcITS"
+          }
+        ],
+        "plots": [
+          {
+            "names": [ "Number of \"Warnings\"" ],
+            "title": [ "Number of WARNINGS trend in IB" ],
+            "varexp": [ "LaneStatusSummaryIB.binContent[0]" ],
+            "selection": "Time",
+            "option": "PL"
+          },
+          {
+             "names": [ "Number of \"Errors\"" ],
+             "title": [ "Number of ERRORS trend in IB" ],
+             "varexp": [ "LaneStatusSummaryIB.binContent[1]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Number of \"Faults\"" ],
+             "title": [ "Number of FAULTS trend in IB" ],
+             "varexp": [ "LaneStatusSummaryIB.binContent[2]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+            "names": [ "Number of \"Warnings\"" ],
+            "title": [ "Number of WARNINGS trend in ML" ],
+            "varexp": [ "LaneStatusSummaryML.binContent[0]" ],
+            "selection": "Time",
+            "option": "PL"
+          },
+          {
+             "names": [ "Number of \"Errors\"" ],
+             "title": [ "Number of ERRORS trend in ML" ],
+             "varexp": [ "LaneStatusSummaryML.binContent[1]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Number of \"Faults\"" ],
+             "title": [ "Number of FAULTS trend in ML" ],
+             "varexp": [ "LaneStatusSummaryML.binContent[2]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Number of \"Warnings\"" ],
+             "title": [ "Number of WARNINGS trend in OL" ],
+             "varexp": [ "LaneStatusSummaryOL.binContent[0]" ],
+             "selection": "Time",
+             "option": "PL"
+          },
+          {
+             "names": [ "Number of \"Errors\"" ],
+             "title": [ "Number of ERRORS trend in OL" ],
+             "varexp": [ "LaneStatusSummaryOL.binContent[1]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Number of \"Faults\"" ],
+             "title": [ "Number of FAULTS trend in OL" ],
+             "varexp": [ "LaneStatusSummaryOL.binContent[2]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. ORBIT" ],
+             "title": [ "Trig. \"ORBIT\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[0]" ],
+             "selection": "Time",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. HB" ],
+             "title": [ "Trig. \"HB\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[1]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. HBr" ],
+             "title": [ "Trig. \"HBr\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[2]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. HC" ],
+             "title": [ "Trig. \"HC\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[3]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. PHYSICS" ],
+             "title": [ "Trig. \"PHYSICS\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[4]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. PP" ],
+             "title": [ "Trig. \"PP\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[5]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. CAL" ],
+             "title": [ "Trig. \"CAL\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[6]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. SOT" ],
+             "title": [ "Trig. \"SOT\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[7]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. EOT" ],
+             "title": [ "Trig. \"EOT\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[8]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. SOC" ],
+             "title": [ "Trig. \"SOC\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[9]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. EOC" ],
+             "title": [ "Trig. \"EOC\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[10]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. TF" ],
+             "title": [ "Trig. \"TF\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[11]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "Trig. INT" ],
+             "title": [ "Trig. \"INT\" count through all FEE" ],
+             "varexp": [ "TriggerVsFeeid.integral[12]" ],
+             "selection": "",
+             "option": "PL"
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "60 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    }
+  }
+}

--- a/Modules/ITS/itsQCTrendingFEE.json
+++ b/Modules/ITS/itsQCTrendingFEE.json
@@ -34,10 +34,12 @@
             "paths": [ "ITS/MO/ITSFEE/LaneStatusSummary",
                        "ITS/MO/ITSFEE/LaneStatusSummary",
                        "ITS/MO/ITSFEE/LaneStatusSummary",
+                       "ITS/MO/ITSFEE/LaneStatusSummary",
                        "ITS/MO/ITSFEE" ],
             "names": [ "LaneStatusSummaryIB",
                        "LaneStatusSummaryML",
                        "LaneStatusSummaryOL",
+                       "LaneStatusSummaryGlobal",
                        "TriggerVsFeeid" ],
             "reductorName": "o2::quality_control_modules::its::ReductorBinContent",
             "moduleName": "QcITS"
@@ -45,65 +47,86 @@
         ],
         "plots": [
           {
-            "names": [ "Number of \"Warnings\"" ],
-            "title": [ "Number of WARNINGS trend in IB" ],
+            "names": [ "# of lanes in WARNING" ],
+            "title": [ "IB - Trend of number of lanes in WARNING" ],
             "varexp": [ "LaneStatusSummaryIB.binContent[0]" ],
             "selection": "Time",
             "option": "PL"
           },
           {
-             "names": [ "Number of \"Errors\"" ],
-             "title": [ "Number of ERRORS trend in IB" ],
+             "names": [ "# of lanes in ERROR" ],
+             "title": [ "IB - Trend of number of lanes in ERROR" ],
              "varexp": [ "LaneStatusSummaryIB.binContent[1]" ],
              "selection": "",
              "option": "PL"
           },
           {
-             "names": [ "Number of \"Faults\"" ],
-             "title": [ "Number of FAULTS trend in IB" ],
+             "names": [ "# of lanes in FAULT" ],
+             "title": [ "IB - Trend of number of lanes in FAULT" ],
              "varexp": [ "LaneStatusSummaryIB.binContent[2]" ],
              "selection": "",
              "option": "PL"
           },
           {
-            "names": [ "Number of \"Warnings\"" ],
-            "title": [ "Number of WARNINGS trend in ML" ],
+            "names": [ "# of lanes in WARNING" ],
+            "title": [ "ML - Trend of number of lanes in WARNING" ],
             "varexp": [ "LaneStatusSummaryML.binContent[0]" ],
             "selection": "Time",
             "option": "PL"
           },
           {
-             "names": [ "Number of \"Errors\"" ],
-             "title": [ "Number of ERRORS trend in ML" ],
+             "names": [ "# of lanes in ERROR" ],
+             "title": [ "ML - Trend of number of lanes in ERROR" ],
              "varexp": [ "LaneStatusSummaryML.binContent[1]" ],
              "selection": "",
              "option": "PL"
           },
           {
-             "names": [ "Number of \"Faults\"" ],
-             "title": [ "Number of FAULTS trend in ML" ],
+             "names": [ "# of lanes in FAULT" ],
+             "title": [ "ML - Trend of number of lanes in FAULT" ],
              "varexp": [ "LaneStatusSummaryML.binContent[2]" ],
              "selection": "",
              "option": "PL"
           },
           {
-             "names": [ "Number of \"Warnings\"" ],
-             "title": [ "Number of WARNINGS trend in OL" ],
+             "names": [ "# of lanes in WARNING" ],
+             "title": [ "OL - Trend of number of lanes in WARNING" ],
              "varexp": [ "LaneStatusSummaryOL.binContent[0]" ],
              "selection": "Time",
              "option": "PL"
           },
           {
-             "names": [ "Number of \"Errors\"" ],
-             "title": [ "Number of ERRORS trend in OL" ],
+             "names": [ "# of lanes in ERROR" ],
+             "title": [ "OL - Trend of number of lanes in ERROR" ],
              "varexp": [ "LaneStatusSummaryOL.binContent[1]" ],
              "selection": "",
              "option": "PL"
           },
           {
-             "names": [ "Number of \"Faults\"" ],
-             "title": [ "Number of FAULTS trend in OL" ],
+             "names": [ "# of lanes in FAULT" ],
+             "title": [ "OL - Trend of number of lanes in FAULT" ],
              "varexp": [ "LaneStatusSummaryOL.binContent[2]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "# of lanes in WARNING" ],
+             "title": [ "Global - Trend of number of lanes in WARNING" ],
+             "varexp": [ "LaneStatusSummaryGlobal.binContent[0]" ],
+             "selection": "Time",
+             "option": "PL"
+          },
+          {
+             "names": [ "# of lanes in ERROR" ],
+             "title": [ "Global - Trend of number of lanes in ERROR" ],
+             "varexp": [ "LaneStatusSummaryGlobal.binContent[1]" ],
+             "selection": "",
+             "option": "PL"
+          },
+          {
+             "names": [ "# of lanes in FAULT" ],
+             "title": [ "Global - Trend of number of lanes in FAULT" ],
+             "varexp": [ "LaneStatusSummaryGlobal.binContent[2]" ],
              "selection": "",
              "option": "PL"
           },

--- a/Modules/ITS/src/ReductorBinContent.cxx
+++ b/Modules/ITS/src/ReductorBinContent.cxx
@@ -1,0 +1,75 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ReductorBinContent.cxx
+/// \author Artem Kotliarov
+///
+
+#include "QualityControl/QcInfoLogger.h"
+#include <TH1.h>
+#include <TH2.h>
+#include <TH2I.h>
+#include <TObject.h>
+#include <TClass.h>
+#include "ITS/ReductorBinContent.h"
+#include <iostream>
+#include <fmt/format.h>
+
+namespace o2::quality_control_modules::its
+{
+void* ReductorBinContent::getBranchAddress()
+{
+  return &mStats;
+}
+
+const char* ReductorBinContent::getBranchLeafList()
+{
+  return Form("binContent[%i]/D:integral[%i]", nFlags, nTriggers);
+}
+
+void ReductorBinContent::update(TObject* obj)
+{
+  // initialize arrays
+  for (int j = 0; j < nFlags; j++) {
+    mStats.binContent[j] = -1.0;
+  }
+
+  for (int j = 0; j < nTriggers; j++) {
+    mStats.integral[j] = -1.0;
+  }
+
+  // Access the histograms embedded in 'obj'.
+  std::string histoClass = obj->IsA()->GetName();
+
+  if (histoClass.find("TH1") != std::string::npos) {
+    TH1* histo = (TH1*)obj->Clone("LaneStatusSummary_Flags");
+    int numberOfBins = histo->GetXaxis()->GetNbins();
+
+    for (int j = 1; j <= numberOfBins; j++) {
+      mStats.binContent[j - 1] = histo->GetBinContent(j);
+    }
+    delete histo;
+  } else if (histoClass.find("TH2") != std::string::npos) {
+
+    TH2* histo = (TH2*)obj->Clone("TriggerCount");
+
+    int numberOfBinsX = histo->GetXaxis()->GetNbins();
+    int numberOfBinsY = histo->GetYaxis()->GetNbins();
+
+    for (int j = 1; j <= numberOfBinsY; j++) {
+      mStats.integral[j - 1] = histo->Integral(1, numberOfBinsX, j, j); // Summation over all Fee IDs for a given trigger
+    }
+    delete histo;
+  } else {
+    ILOG(Error, Support) << "Error: 'histo' not found." << ENDM;
+  }
+}
+} // namespace o2::quality_control_modules::its

--- a/Modules/ITS/src/TrendingTaskITSFEE.cxx
+++ b/Modules/ITS/src/TrendingTaskITSFEE.cxx
@@ -1,0 +1,356 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    TrendingTaskITSFEE.cxx
+/// \author  Artem Kotliarov on the structure from Piotr Konopka
+///
+
+#include "ITS/TrendingTaskITSFEE.h"
+#include "ITS/ReductorBinContent.h"
+
+#include "QualityControl/RootClassFactory.h"
+#include "QualityControl/DatabaseInterface.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/Reductor.h"
+#include "QualityControl/ObjectMetadataKeys.h"
+
+#include <TCanvas.h>
+#include <TH1.h>
+#include <TGraph.h>
+#include <TMultiGraph.h>
+#include <TFile.h>
+#include <TDatime.h>
+#include <map>
+#include <string>
+#include <TTreeReader.h>
+#include <TTreeReaderValue.h>
+#include <TTreeReaderArray.h>
+
+using namespace o2::quality_control;
+using namespace o2::quality_control::core;
+using namespace o2::quality_control::postprocessing;
+using namespace o2::quality_control::repository;
+using namespace o2::quality_control_modules::its;
+
+void TrendingTaskITSFEE::configure(std::string name,
+                                   const boost::property_tree::ptree& config)
+{
+  mConfig = TrendingTaskConfigITS(name, config);
+}
+
+void TrendingTaskITSFEE::initialize(Trigger, framework::ServiceRegistry&)
+{
+  // Preparing data structure of TTree
+  mTrend = std::make_unique<TTree>();
+  mTrend->SetName(PostProcessingInterface::getName().c_str());
+  mTrend->Branch("runNumber", &mMetaData.runNumber);
+  mTrend->Branch("time", &mTime);
+
+  for (const auto& source : mConfig.dataSources) {
+    std::unique_ptr<Reductor> reductor(root_class_factory::create<Reductor>(source.moduleName, source.reductorName));
+    mTrend->Branch(source.name.c_str(), reductor->getBranchAddress(), reductor->getBranchLeafList());
+    mReductors[source.name] = std::move(reductor);
+  }
+}
+
+// todo: see if OptimizeBaskets() indeed helps after some time
+void TrendingTaskITSFEE::update(Trigger t, framework::ServiceRegistry& services)
+{
+  auto& qcdb = services.get<repository::DatabaseInterface>();
+
+  trendValues(t, qcdb);
+  storePlots(qcdb);
+  storeTrend(qcdb);
+}
+
+void TrendingTaskITSFEE::finalize(Trigger t, framework::ServiceRegistry& services)
+{
+  auto& qcdb = services.get<repository::DatabaseInterface>();
+
+  storePlots(qcdb);
+  storeTrend(qcdb);
+}
+
+void TrendingTaskITSFEE::storeTrend(repository::DatabaseInterface& qcdb)
+{
+  auto mo = std::make_shared<core::MonitorObject>(mTrend.get(), getName(), "o2::quality_control_modules::its::TrendingTaskITSFEE",
+                                                  mConfig.detectorName);
+  mo->setIsOwner(false);
+  qcdb.storeMO(mo);
+}
+
+void TrendingTaskITSFEE::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
+{
+  // We use current date and time. This for planned processing (not history). We
+  // still might need to use the objects
+  // timestamps in the end, but this would become ambiguous if there is more
+  // than one data source.
+
+  mTime = TDatime().Convert();
+  mMetaData.runNumber = t.activity.mId;
+  int count = 0;
+
+  for (auto& dataSource : mConfig.dataSources) {
+    // todo: make it agnostic to MOs, QOs or other objects. Let the reductor
+    // cast to whatever it needs.
+    if (dataSource.type == "repository") {
+      auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name, t.timestamp, t.activity);
+      if (!count) {
+        std::map<std::string, std::string> entryMetadata = mo->getMetadataMap();  // full list of metadata as a map
+        mMetaData.runNumber = std::stoi(entryMetadata[metadata_keys::runNumber]); // get and set run number
+        runlist.push_back(std::to_string(mMetaData.runNumber));
+      }
+      TObject* obj = mo ? mo->getObject() : nullptr;
+      if (obj)
+        mReductors[dataSource.name]->update(obj);
+    } else {
+      ILOGE << "Unknown type of data source '" << dataSource.type << "'.";
+    }
+    count++;
+  }
+  mTrend->Fill();
+}
+
+void TrendingTaskITSFEE::storePlots(repository::DatabaseInterface& qcdb)
+{
+  // ILOG(Info, Support) << "Generating and storing " << mConfig.plots.size() << " plots." << ENDM;
+
+  int countplots = 0;
+  int countITSpart = 0;
+  bool isRun = false;
+
+  // Define output canvas and legend
+  TCanvas* canvas;
+  TLegend* legend;
+
+  TMultiGraph* multi_trend;
+  TGraph* trend_plot_Flags[nFlags];
+
+  // Retrieve X-axis for trend plot. Two options: "Time" or "Run"
+  long int numberOfEntries = mTrend->GetEntriesFast();
+  mTrend->Draw("time", "", "goff");
+  std::vector<double> retrieveTime(mTrend->GetV1(), mTrend->GetV1() + mTrend->GetSelectedRows() % mTrend->GetEstimate());
+
+  std::vector<double> retrieveRunNumber;
+  for (int j = 1; j <= numberOfEntries; j++)
+    retrieveRunNumber.push_back((double)j);
+
+  // Lane status summary plots
+  for (const auto& plot : mConfig.plots) {
+
+    if (plot.varexp.find("binContent") == std::string::npos)
+      continue;
+
+    // Checks neeeded to segregate plots from input list
+    if (countplots > nFlags - 1) {
+      countplots = 0;
+      countITSpart++;
+    }
+
+    // Retrieve data for trend plot
+    mTrend->Draw(plot.varexp.c_str(), "", "goff");
+    std::vector<double> dataRetrieve(mTrend->GetV1(), mTrend->GetV1() + mTrend->GetSelectedRows() % mTrend->GetEstimate());
+
+    // Initialize MultiGraph and Legend
+    if (countplots == 0) {
+      multi_trend = new TMultiGraph();
+      SetGraphName(multi_trend, plot.name, Form("Lane status summary trend %s", itsParts[countITSpart].c_str()));
+
+      legend = new TLegend(0.93, 0.55, 1.0, 0.9);
+      SetLegendStyle(legend, Form("LaneStatusSummary_%s_legend", itsParts[countITSpart].c_str()));
+
+      isRun = plot.selection.find("Run") != std::string::npos ? true : false;
+    }
+
+    trend_plot_Flags[countplots] = new TGraph(numberOfEntries, isRun ? &retrieveRunNumber[0] : &retrieveTime[0], &dataRetrieve[0]);
+    trend_plot_Flags[countplots]->SetName(plot.name.c_str());
+    SetGraphStyle(trend_plot_Flags[countplots], colors[countplots], markers[countplots]);
+    multi_trend->Add(trend_plot_Flags[countplots], plot.option.c_str());
+
+    legend->AddEntry(trend_plot_Flags[countplots], Form("%s", trend_titles[countplots].c_str()), "pl");
+
+    // Create and save plots
+    if (countplots == nFlags - 1) {
+
+      SetGraphAxes(multi_trend, Form("%s", isRun ? "Run" : "Time"), "Number of lanes", !isRun);
+
+      // Canvas settings
+      std::string name = "LaneStatusSummary_" + itsParts[countITSpart] + "_Trends";
+      canvas = new TCanvas(Form("%s", name.c_str()), Form("%s", name.c_str()));
+      SetCanvasSettings(canvas);
+
+      // Plot as a function of run number requires a dummy TH1 histogram
+      TH1I* hDummy = nullptr;
+      if (isRun) {
+        hDummy = new TH1I("hDummy", Form("%s; %s; %s", multi_trend->GetTitle(), multi_trend->GetXaxis()->GetTitle(), multi_trend->GetYaxis()->GetTitle()), numberOfEntries, 0.5, numberOfEntries + 0.5);
+        SetHistoAxes(hDummy, runlist, multi_trend->GetYaxis()->GetXmin(), multi_trend->GetYaxis()->GetXmax());
+      }
+
+      // Draw plots
+      if (hDummy)
+        hDummy->Draw();
+      multi_trend->Draw(Form("%s", hDummy ? "" : "a"));
+      legend->Draw("SAME");
+
+      // Upload plots
+      auto mo = std::make_shared<MonitorObject>(canvas, mConfig.taskName, "o2::quality_control_modules::its::TrendingTaskITSFEE", mConfig.detectorName);
+      mo->setIsOwner(false);
+      qcdb.storeMO(mo);
+
+      delete legend;
+      delete canvas;
+      delete multi_trend; // All included plots are deleted automatically
+      delete hDummy;
+    }
+    countplots++;
+    dataRetrieve.clear();
+  } // end loop on plots
+
+  //___________________________________________________________________________
+  // Trigger Count trending plot
+  TGraph* trend_plot_Triggers[nTriggers];
+  countplots = 0;
+
+  for (const auto& plot : mConfig.plots) {
+
+    if (plot.varexp.find("integral") == std::string::npos)
+      continue;
+
+    // Retrieve data for trend plot
+    mTrend->Draw(plot.varexp.c_str(), "", "goff");
+    std::vector<double> dataRetrieve(mTrend->GetV1(), mTrend->GetV1() + mTrend->GetSelectedRows() % mTrend->GetEstimate());
+
+    // Initialize MultiGraph and Legend
+    if (countplots == 0) {
+      multi_trend = new TMultiGraph();
+      SetGraphName(multi_trend, plot.name, "Trigger count trend");
+
+      legend = new TLegend(0.93, 0.15, 1.0, 0.9);
+      SetLegendStyle(legend, "Trigger_count_trend");
+      isRun = plot.selection.find("Run") != std::string::npos ? true : false;
+    }
+
+    trend_plot_Triggers[countplots] = new TGraph(numberOfEntries, isRun ? &retrieveRunNumber[0] : &retrieveTime[0], &dataRetrieve[0]);
+    trend_plot_Triggers[countplots]->SetName(plot.name.c_str());
+    SetGraphStyle(trend_plot_Triggers[countplots], colors[countplots], markers[countplots]);
+    multi_trend->Add(trend_plot_Triggers[countplots], plot.option.c_str());
+
+    legend->AddEntry(trend_plot_Triggers[countplots], Form("%s", mTriggerType[countplots].c_str()), "pl");
+    if (countplots == nTriggers - 1) {
+
+      SetGraphAxes(multi_trend, Form("%s", isRun ? "Run" : "Time"), "Integral over all FEE", !isRun);
+
+      // Canvas settings
+      canvas = new TCanvas("Trigger_count_trend", "Trigger_count_trend");
+      SetCanvasSettings(canvas);
+
+      // Plot as a function of run number requires a dummy TH1 histogram
+      TH1I* hDummy = nullptr;
+      if (isRun) {
+        hDummy = new TH1I("hDummy", Form("%s; %s; %s", multi_trend->GetTitle(), multi_trend->GetXaxis()->GetTitle(), multi_trend->GetYaxis()->GetTitle()), numberOfEntries, 0.5, numberOfEntries + 0.5);
+        SetHistoAxes(hDummy, runlist, multi_trend->GetYaxis()->GetXmin(), multi_trend->GetYaxis()->GetXmax());
+      }
+
+      // Draw plots
+      if (hDummy)
+        hDummy->Draw();
+      multi_trend->Draw(Form("%s", hDummy ? "" : "a"));
+      legend->Draw("SAME");
+
+      // Upload plots
+      auto mo = std::make_shared<MonitorObject>(canvas, mConfig.taskName, "o2::quality_control_modules::its::TrendingTaskITSFEE", mConfig.detectorName);
+      mo->setIsOwner(false);
+      qcdb.storeMO(mo);
+
+      delete legend;
+      delete canvas;
+      delete multi_trend; // All included plots are deleted automatically
+      delete hDummy;
+    }
+    countplots++;
+    dataRetrieve.clear();
+  } // end loop on plots
+  retrieveTime.clear();
+  retrieveRunNumber.clear();
+}
+
+void TrendingTaskITSFEE::SetLegendStyle(TLegend* legend, const std::string& name)
+{
+  legend->SetTextFont(42);
+  legend->SetLineColor(kWhite);
+  legend->SetFillColor(0);
+  legend->SetName(Form("%s_legend", name.c_str()));
+  legend->SetFillStyle(0);
+  legend->SetBorderSize(0);
+}
+
+void TrendingTaskITSFEE::SetCanvasSettings(TCanvas* canvas)
+{
+  canvas->SetTickx();
+  canvas->SetTicky();
+  canvas->SetBottomMargin(0.18);
+  canvas->SetRightMargin(0.07);
+}
+
+void TrendingTaskITSFEE::SetGraphStyle(TGraph* graph, int col, int mkr)
+{
+  graph->SetLineColor(col);
+  graph->SetMarkerStyle(mkr);
+  graph->SetMarkerColor(col);
+  graph->SetMarkerSize(1.0);
+  graph->SetLineWidth(1);
+}
+
+void TrendingTaskITSFEE::SetGraphName(TMultiGraph* graph, std::string name, std::string title)
+{
+  graph->SetTitle(title.c_str());
+  graph->SetName(name.c_str());
+}
+
+void TrendingTaskITSFEE::SetGraphAxes(TMultiGraph* graph, std::string xtitle,
+                                      std::string ytitle, bool isTime)
+{
+  graph->GetXaxis()->SetTitle(xtitle.c_str());
+  graph->GetXaxis()->SetTitleSize(0.045);
+
+  graph->GetYaxis()->SetTitle(ytitle.c_str());
+  graph->GetYaxis()->SetTitleSize(0.045);
+
+  graph->GetXaxis()->SetNdivisions(505);
+  graph->GetXaxis()->SetTimeOffset(0.0);
+  graph->GetXaxis()->SetLabelOffset(0.02);
+  graph->GetXaxis()->SetLabelSize(0.033);
+  graph->GetXaxis()->SetTitleOffset(2.3);
+  if (isTime) {
+    graph->GetXaxis()->SetTimeFormat("#splitline{%d.%m.%y}{%H:%M}");
+    graph->GetXaxis()->SetTimeDisplay(1);
+  }
+}
+
+void TrendingTaskITSFEE::SetHistoAxes(TH1* hist, std::vector<std::string> runlist,
+                                      const double& Ymin, const double& Ymax)
+{
+  hist->SetStats(0);
+  hist->GetXaxis()->SetTitleSize(0.045);
+  hist->GetYaxis()->SetTitleSize(0.045);
+  hist->GetYaxis()->SetRangeUser(Ymin, Ymax);
+
+  hist->GetXaxis()->SetLabelOffset(0.02);
+  hist->GetXaxis()->SetLabelSize(0.033);
+  hist->GetXaxis()->SetTitleOffset(2.3);
+  hist->GetXaxis()->SetNdivisions(-505);
+
+  for (int iX = 0; iX < runlist.size(); iX++) {
+    hist->GetXaxis()->SetBinLabel(iX + 1, runlist[iX].c_str());
+  }
+}


### PR DESCRIPTION
The task works with 2 histograms: 1D "LaneStatusSummary" (IB, ML, OL) and 2D "TriggerVsFeeid". A specially designed reductor "ReductorBinContent" extracts the needed values used to plot graphs. Totally, the task produces 4 plots: "LaneStatusSummary" for all parts of the ITS and 1 plot for Triggers.

There are 2 possibilities for how the graphs can be represented: as a function of "Run number" or "Time". One needs to specify in the itsQCTrendingFEE.json "selection" criterion "Time or Run".