### PR TITLE
MCH: demote extrapolation failure message from error to warning

### DIFF
--- a/Modules/MUON/Common/src/TrackPlotter.cxx
+++ b/Modules/MUON/Common/src/TrackPlotter.cxx
@@ -351,7 +351,7 @@ void TrackPlotter::fill(gsl::span<const o2::mch::ROFRecord> rofs,
   }
 
   if (nok != ntracks) {
-    std::cerr << "Could only extrapolate " << nok << " tracks over " << ntracks << "\n";
+    std::cout << "Could only extrapolate " << nok << " tracks over " << ntracks << "\n";
   }
 
   for (const auto& rof : rofs) {

--- a/Modules/MUON/MCH/src/TracksTask.cxx
+++ b/Modules/MUON/MCH/src/TracksTask.cxx
@@ -242,7 +242,7 @@ void TracksTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
 
   if (nok != tracks.size()) {
-    ILOG(Error, Support) << "Could only extrapolate " << nok << " tracks over " << tracks.size() << ENDM;
+    ILOG(Warning, Support) << "Could only extrapolate " << nok << " tracks over " << tracks.size() << ENDM;
   }
 
   for (const auto& rof : rofs) {


### PR DESCRIPTION
Failure of extrapolation may (rarely) happen. It is not, strictly speaking, an error.