### PR TITLE
[EMCAL-530] Fix uninitialized geometry

### DIFF
--- a/Modules/EMCAL/include/EMCAL/ClusterTask.h
+++ b/Modules/EMCAL/include/EMCAL/ClusterTask.h
@@ -62,7 +62,7 @@ class ClusterTask final : public TaskInterface
   void findClustersInternal(const gsl::span<const o2::emcal::Cell>& cells, const gsl::span<const o2::emcal::TriggerRecord>& cellTriggerRecords, std::vector<o2::emcal::Cluster>& clusters, std::vector<o2::emcal::TriggerRecord>& clusterTriggerRecords, std::vector<int>& clusterIndices, std::vector<o2::emcal::TriggerRecord>& clusterIndexTriggerRecords); //svk
 
  private:
-  o2::emcal::Geometry* mGeometry;
+  o2::emcal::Geometry* mGeometry = nullptr;
   std::unique_ptr<o2::emcal::EventHandler<o2::emcal::Cell>> mEventHandler;
   std::unique_ptr<o2::emcal::ClusterFactory<o2::emcal::Cell>> mClusterFactory;
   std::unique_ptr<o2::emcal::Clusterizer<o2::emcal::Cell>> mClusterizer; //svk

--- a/Modules/EMCAL/src/ClusterTask.cxx
+++ b/Modules/EMCAL/src/ClusterTask.cxx
@@ -175,8 +175,6 @@ void ClusterTask::startOfCycle()
     TaskInterface::retrieveConditionAny<TObject>("GLO/Config/Geometry");
     ILOG(Info, Support) << "Geometry loaded" << ENDM;
   }
-
-  resetHistograms();
 }
 
 void ClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
@@ -320,13 +318,12 @@ void ClusterTask::findClustersInternal(const gsl::span<const o2::emcal::Cell>& c
   int currentStartClusters = 0; // clusters->size();  //svk
   int currentStartIndices = 0;  // clusterIndices->size();  //svk
 
-  for (auto iTrgRcrd : cellTriggerRecords) {
+  for (const auto& iTrgRcrd : cellTriggerRecords) {
     LOG(debug) << " findClustersInternal loop over iTrgRcrd  " << ENDM;
 
     mClusterizer->clear();
     if (cells.size() && iTrgRcrd.getNumberOfObjects()) {
       LOG(debug) << " Number of cells put in " << cells.size() << ENDM;
-
       mClusterizer->findClusters(gsl::span<const o2::emcal::Cell>(cells.data() + iTrgRcrd.getFirstEntry(), iTrgRcrd.getNumberOfObjects())); // Find clusters on cells/digits (pass by ref)
     }
 


### PR DESCRIPTION
Geometry pointer was not initialized with 0 in the
constructor leading to teh geometry not being properly
initialized on certain systems particularly under linux,
resulting in a crash in the internal clusterizer.