### PR TITLE
MCH: added FEC synchronization diagnostics

### DIFF
--- a/Modules/MUON/MCH/include/MCH/DecodingErrorsTask.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingErrorsTask.h
@@ -18,8 +18,7 @@
 #ifndef QC_MODULE_MCH_DECODINGERRORSTASK_H
 #define QC_MODULE_MCH_DECODINGERRORSTASK_H
 
-#include <TH2.h>
-
+#include "MUONCommon/MergeableTH1Ratio.h"
 #include "MUONCommon/MergeableTH2Ratio.h"
 #include <DPLUtils/DPLRawParser.h>
 #include <MCHRawDecoder/PageDecoder.h>
@@ -54,6 +53,9 @@ class DecodingErrorsTask /*final*/ : public TaskInterface
   void reset() override;
 
  private:
+  /// \brief functions that instatiate and publish the plots
+  void createErrorHistos();
+  void createHeartBeatHistos();
   /// \brief decoding of the TimeFrame data sent from the (sub)TimeFrame builder
   void decodeTF(framework::ProcessingContext& pc);
   /// \brief decoding of the TimeFrame data sent directly from readout
@@ -64,38 +66,66 @@ class DecodingErrorsTask /*final*/ : public TaskInterface
   void decodePage(gsl::span<const std::byte> page);
   /// \brief helper function to process the array of errors sent via DPL
   void processErrors(framework::ProcessingContext& pc);
-
   /// \brief helper function for updating the error histograms
   void plotError(int solarId, int dsAddr, int chip, uint32_t error);
+  /// \brief helper function to process the heart-beat packets sent via DPL
+  void processHBPackets(framework::ProcessingContext& pc);
+  /// \brief helper function for updating the heart-beat packets histograms
+  void plotHBPacket(int solarId, int dsAddr, int chip, uint32_t bc);
+  /// \brief checker function for the heart-beat packets histograms
+  void checkSyncErrors();
+  /// \brief function returning the detection element corresponding to a given FEEID/LINKID/ELINKID triplet
+  int getDeId(uint16_t feeId, uint8_t linkId, uint8_t eLinkId);
 
+  /// \brief helper function for pubishing and formatting a given plot
   template <typename T>
-  void publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox, bool isExpert)
-  {
-    histo->SetOption(drawOption.c_str());
-    if (!statBox) {
-      histo->SetStats(0);
-    }
-    mAllHistograms.push_back(histo.get());
-    getObjectsManager()->startPublishing(histo.get());
-    getObjectsManager()->setDefaultDrawOptions(histo.get(), drawOption);
-  }
+  void publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox, bool isExpert);
 
+  /// \brief functions providing the forward and backward electronics mapping
   mch::raw::Elec2DetMapper mElec2Det{ nullptr };
   mch::raw::FeeLink2SolarMapper mFee2Solar{ nullptr };
   o2::mch::raw::Solar2FeeLinkMapper mSolar2Fee{ nullptr };
+
+  /// \brief raw data decoder
   o2::mch::raw::PageDecoder mDecoder;
 
-  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerChamber; ///< histogram to visualize the decoding errors
-  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerFeeId;   ///< histogram to visualize the decoding errors
-  // histograms up to previously processed cycle
-  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerChamberPrevCycle; ///< histogram to visualize the decoding errors
-  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerFeeIdPrevCycle;   ///< histogram to visualize the decoding errors
-  // histograms from last processed cycle
-  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerChamberOnCycle; ///< histogram to visualize the decoding errors
-  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerFeeIdOnCycle;   ///< histogram to visualize the decoding errors
+  /// \brief expected bunch-crossing value in heart-beat packets
+  int mHBExpectedBc{ 456190 };
+
+  /// \brief number of processed time-frames
+  std::shared_ptr<TH1F> mHistogramTimeFramesCount;
+
+  /// \brief decoding error plots
+  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerChamber; ///< error codes per chamber
+  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerFeeId;   ///< error codes per detection element
+  /// \brief histograms up to previously processed cycle
+  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerChamberPrevCycle; ///< error codes per chamber
+  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerFeeIdPrevCycle;   ///< error codes per detection element
+  /// \brief histograms from last processed cycle
+  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerChamberOnCycle; ///< error codes per chamber
+  std::shared_ptr<MergeableTH2Ratio> mHistogramErrorsPerFeeIdOnCycle;   ///< error codes per detection element
+
+  /// \brief time synchronization diagnostics plots
+  std::shared_ptr<MergeableTH2Ratio> mHistogramHBTimeFEC;             ///< bunch-crossing from HB packets vs. FEC id
+  std::shared_ptr<MergeableTH2Ratio> mHistogramHBCoarseTimeFEC;       ///< bunch-crossing from HB packets vs. FEC id, coarse scale
+  std::shared_ptr<MergeableTH1Ratio> mHistogramSynchErrorsPerDE;      ///< fraction of out-of-sync DS boards per detection element
+  std::shared_ptr<MergeableTH1Ratio> mHistogramSynchErrorsPerChamber; ///< fraction of out-of-sync DS boards per chamber
+  std::shared_ptr<TH2F> mSyncStatusFEC;                               ///< time synchronization status of each DS board (OK, out-of-synch, missing good HB)
 
   std::vector<TH1*> mAllHistograms;
 };
+
+template <typename T>
+void DecodingErrorsTask::publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox, bool isExpert)
+{
+  histo->SetOption(drawOption.c_str());
+  if (!statBox) {
+    histo->SetStats(0);
+  }
+  mAllHistograms.push_back(histo.get());
+  getObjectsManager()->startPublishing(histo.get());
+  getObjectsManager()->setDefaultDrawOptions(histo.get(), drawOption);
+}
 
 } // namespace o2::quality_control_modules::muonchambers
 

--- a/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
@@ -113,7 +113,7 @@ static std::string getCurrentTime()
   tmp = localtime(&t);
 
   char timestr[500];
-  strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);
+  strftime(timestr, sizeof(timestr), "(%d/%m/%Y - %R)", tmp);
 
   std::string result = timestr;
   return result;
@@ -155,6 +155,49 @@ void DecodingErrorsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
       msg->SetFillColor(kYellow);
       h->SetFillColor(kOrange);
     }
+    h->SetLineColor(kBlack);
+  }
+
+
+  if (mo->getName().find("SynchErrorsPerDE") != std::string::npos) {
+    auto* h = dynamic_cast<TH1F*>(mo->getObject());
+
+    // disable ticks on vertical axis
+    h->GetXaxis()->SetTickLength(0.0);
+    h->GetXaxis()->SetLabelSize(0.0);
+    h->GetYaxis()->SetTickLength(0);
+    h->GetYaxis()->SetTitle("out-of-sync fraction");
+    //h->SetMaximum(h->GetMaximum() * 1.5);
+
+    TText* xtitle = new TText();
+    xtitle->SetNDC();
+    xtitle->SetText(0.87, 0.03, "chamber #");
+    xtitle->SetTextSize(15);
+    h->GetListOfFunctions()->Add(xtitle);
+
+    // draw chamber delimiters
+    for (int demin = 200; demin <= 1000; demin += 100) {
+      float xpos = static_cast<float>(getDEindex(demin));
+      TLine* delimiter = new TLine(xpos, 0, xpos, h->GetMaximum() * 1.05);
+      delimiter->SetLineColor(kBlack);
+      delimiter->SetLineStyle(kDashed);
+      h->GetListOfFunctions()->Add(delimiter);
+    }
+
+    // draw x-axis labels
+    for (int ch = 1; ch <= 10; ch += 1) {
+      float x1 = static_cast<float>(getDEindex(ch * 100));
+      float x2 = (ch < 10) ? static_cast<float>(getDEindex(ch * 100 + 100)) : h->GetXaxis()->GetXmax();
+      float x0 = 0.8 * (x1 + x2) / (2 * h->GetXaxis()->GetXmax()) + 0.1;
+      float y0 = 0.05;
+      TText* label = new TText();
+      label->SetNDC();
+      label->SetText(x0, y0, TString::Format("%d", ch));
+      label->SetTextSize(15);
+      label->SetTextAlign(22);
+      h->GetListOfFunctions()->Add(label);
+    }
+
     h->SetLineColor(kBlack);
   }
 }

--- a/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
+++ b/Modules/MUON/MCH/src/DecodingErrorsCheck.cxx
@@ -158,7 +158,6 @@ void DecodingErrorsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     h->SetLineColor(kBlack);
   }
 
-
   if (mo->getName().find("SynchErrorsPerDE") != std::string::npos) {
     auto* h = dynamic_cast<TH1F*>(mo->getObject());
 


### PR DESCRIPTION
This PR adds some diagnostics plots to asses the time synchronization of the individual FEC boards.
The diagnostics is based on the analysis of the heart-beat packet's time stamp.
The following plots are added:
- distribution of heart-beat packet bunch-crossing values for each FEC board (coarse and fine-grained around the expected BC value)
- fraction of out-of-sync FEC boards for each detection element and each chamber, based on the analysis of the HB packet bunch-crossings
- sync status of each FEC board (OK, out-of-synch, missing good HB)