### PR TITLE
ITS - Improved lane status flag tracking

### DIFF
--- a/Modules/ITS/include/ITS/ITSFeeTask.h
+++ b/Modules/ITS/include/ITS/ITSFeeTask.h
@@ -114,7 +114,8 @@ class ITSFeeTask final : public TaskInterface
 
   // parameters taken from the .json
   int mNPayloadSizeBins = 0;
-  bool mEnableAutoreco = false;
+  bool mResetLaneStatus = false;
+  bool mResetPayload = false;
 
   TH1I* mTFInfo; // count vs TF ID
   TH2I* mTriggerVsFeeId;
@@ -125,6 +126,7 @@ class ITSFeeTask final : public TaskInterface
   TH2I* mIdCheck;    // should be 0x : e4
   TH2I* mRDHSummary;
   TH2I* mLaneStatus[NFlags]; // 4 flags for each lane. 3/8/14 lane for each link. 3/2/2 link for each RU. TODO: remove the OK flag in these 4 flag plots, OK flag plot just used to debug.
+  TH2I* mLaneStatusCumulative[NFlags];
   TH2Poly* mLaneStatusOverview[NFlags] = { 0x0 };
   TH1I* mLaneStatusSummary[NLayer];
   TH1I* mLaneStatusSummaryIB;

--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -102,7 +102,6 @@ class ITSFhrTask final : public TaskInterface
   int mHitNumberOfChip[7][48][2][14][14] = { { { { { 0 } } } } }; // layer, stave, substave, hic, chip
   unsigned int mTimeFrameId = 0;
 
-  int mNError = 19;
   int mNTrigger = 13;
   unsigned int mErrors[19] = { 0 };
   static constexpr int NTrigger = 13;

--- a/Modules/ITS/itsFee.json
+++ b/Modules/ITS/itsFee.json
@@ -37,7 +37,8 @@
                 "location": "local",
                 "taskParameters": {
                     "NPayloadSizeBins": "4096",
-                    "EnableAutoreco": "1"
+                    "ResetLaneStatus": "1",
+                    "ResetPayload": "0"
                 }
             }
         },

--- a/Modules/ITS/src/ITSFeeTask.cxx
+++ b/Modules/ITS/src/ITSFeeTask.cxx
@@ -211,7 +211,7 @@ void ITSFeeTask::setPlotsFormat()
 
   for (int i = 0; i < NFlags; i++) {
     TString title = Form("Fraction of lanes into %s", mLaneStatusFlag[i].c_str());
-    title += ";mm;mm";
+    title += ";mm (IB 3x);mm (IB 3x)";
     mLaneStatusOverview[i]->SetTitle(title);
     mLaneStatusOverview[i]->SetStats(0);
     mLaneStatusOverview[i]->SetOption("lcolz");
@@ -223,6 +223,12 @@ void ITSFeeTask::setPlotsFormat()
         double* px = new double[4];
         double* py = new double[4];
         getStavePoint(ilayer, istave, px, py);
+        if (ilayer < 3) {
+          for (int icoo = 0; icoo < 4; icoo++) {
+            px[icoo] *= 3.;
+            py[icoo] *= 3.;
+          }
+        }
         mLaneStatusOverview[i]->AddBin(4, px, py);
       }
     }

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -236,7 +236,7 @@ void ITSFhrTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void ITSFhrTask::createErrorTriggerPlots()
 {
-  mErrorPlots = new TH1D("General/ErrorPlots", "Decoding Errors", mNError, 0.5, mNError + 0.5);
+  mErrorPlots = new TH1D("General/ErrorPlots", "Decoding Errors", o2::itsmft::GBTLinkDecodingStat::NErrorsDefined, 0.5, o2::itsmft::GBTLinkDecodingStat::NErrorsDefined + 0.5);
   mErrorPlots->SetMinimum(0);
   mErrorPlots->SetFillColor(kRed);
   getObjectsManager()->startPublishing(mErrorPlots); // mErrorPlots

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -89,14 +89,14 @@ void ITSFhrTask::initialize(o2::framework::InitContext& /*ctx*/)
   int numOfChips = mGeom->getNumberOfChips();
 
   mGeneralOccupancy = new TH2Poly();
-  mGeneralOccupancy->SetTitle("General Occupancy;mm;mm");
+  mGeneralOccupancy->SetTitle("General Occupancy;mm (IB 3x);mm (IB 3x)");
   mGeneralOccupancy->SetName("General/General_Occupancy");
   mGeneralOccupancy->SetStats(0);
   mGeneralOccupancy->SetMinimum(pow(10, mMinGeneralAxisRange));
   mGeneralOccupancy->SetMaximum(pow(10, mMaxGeneralAxisRange));
 
   mGeneralNoisyPixel = new TH2Poly();
-  mGeneralNoisyPixel->SetTitle("Noisy Pixel Number;mm;mm");
+  mGeneralNoisyPixel->SetTitle("Noisy Pixel Number;mm (IB 3x);mm (IB 3x)");
   mGeneralNoisyPixel->SetName("General/Noisy_Pixel");
   mGeneralNoisyPixel->SetStats(0);
   mGeneralNoisyPixel->SetMinimum(mMinGeneralNoisyAxisRange);
@@ -131,6 +131,12 @@ void ITSFhrTask::initialize(o2::framework::InitContext& /*ctx*/)
         double* px = new double[4];
         double* py = new double[4];
         getStavePoint(ilayer, istave, px, py);
+        if (ilayer < 3) {
+          for (int icoo = 0; icoo < 4; icoo++) {
+            px[icoo] *= 3.;
+            py[icoo] *= 3.;
+          }
+        }
         mGeneralOccupancy->AddBin(4, px, py);
         mGeneralNoisyPixel->AddBin(4, px, py);
       }


### PR DESCRIPTION
- FHR: Small correction of decoding error plot. Added dynamic number of bins to the 1D plot
- FEE: Added lane status flag that are never reset: they count the number of orbits missed by a given lane
- FEE: Added option to reset lane status and payload plot independently