### PR TITLE
[WIP] TPC: add independently configurable data source for each PP-QC task

### DIFF
--- a/Modules/TPC/include/TPC/CalDetPublisher.h
+++ b/Modules/TPC/include/TPC/CalDetPublisher.h
@@ -71,16 +71,14 @@ class CalDetPublisher final : public quality_control::postprocessing::PostProces
   std::vector<std::map<std::string, std::string>> mLookupMaps{};         ///< meta data to look for data in the CCDB
   std::vector<std::map<std::string, std::string>> mStoreMaps{};          ///< meta data to be stored with the output in the QCDB
   bool mCheckZSCalib;                                                    ///< shall the calib data used for ZS be compared to the latest pedestal and noise files
-  bool mCheckZSPrereq = true;                                            ///< is pedestal and noise in the outputList in the config file
+  bool mCheckZSPrereq = false;                                           ///< is pedestal and noise in the outputList in the config file
   std::unique_ptr<o2::tpc::CalDet<float>> mRefPedestal;                  ///< reference pedestal file used for ZS at the moment
   std::unique_ptr<o2::tpc::CalDet<float>> mRefNoise;                     ///< reference noise file used for ZS at the moment
-                                                                         //  long mInitRefCalibTimestamp;                                           ///< timestamp of the pedestal/noise map used at init of the task
-  long mInitRefPedestalTimestamp;                                        ///< timestamp of the pedestal data used at init of the task
-  long mInitRefNoiseTimestamp;                                           ///< timestamp of the noise data used at init of the task
+  long mInitRefCalibTimestamp;                                           ///< timestamp of the pedestal/noise map used at init of the task
   TPaveText* mNewZSCalibMsg = nullptr;                                   ///< badge to indicate the necessity to upload new calibration data for ZS
   std::unordered_map<std::string, std::vector<float>> mRanges;           ///< histogram ranges configurable via config file
 };
 
 } // namespace o2::quality_control_modules::tpc
 
-#endif //QUALITYCONTROL_CALDETPUBLISHER_H
+#endif // QUALITYCONTROL_CALDETPUBLISHER_H

--- a/Modules/TPC/include/TPC/ClusterVisualizer.h
+++ b/Modules/TPC/include/TPC/ClusterVisualizer.h
@@ -17,7 +17,7 @@
 #ifndef QUALITYCONTROL_CLUSTERVISUALIZER_H
 #define QUALITYCONTROL_CLUSTERVISUALIZER_H
 
-//O2 includes
+// O2 includes
 #include "CCDB/CcdbApi.h"
 
 // QC includes
@@ -81,4 +81,4 @@ class ClusterVisualizer final : public quality_control::postprocessing::PostProc
 
 } // namespace o2::quality_control_modules::tpc
 
-#endif //QUALITYCONTROL_CLUSTERVISUALIZER_H
+#endif // QUALITYCONTROL_CLUSTERVISUALIZER_H

--- a/Modules/TPC/include/TPC/LaserTracks.h
+++ b/Modules/TPC/include/TPC/LaserTracks.h
@@ -74,4 +74,4 @@ class LaserTracks final : public quality_control::postprocessing::PostProcessing
 
 } // namespace o2::quality_control_modules::tpc
 
-#endif //QUALITYCONTROL_LASERTRACKS_H
+#endif // QUALITYCONTROL_LASERTRACKS_H

--- a/Modules/TPC/run/tpcQCCalDetPublisher.json
+++ b/Modules/TPC/run/tpcQCCalDetPublisher.json
@@ -28,17 +28,16 @@
         "className": "o2::quality_control_modules::tpc::CalDetPublisher",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
+        "dataSourceURL": "ccdb-test.cern.ch:8080",
         "outputCalPadMaps_comment" : [ "CalDet objects that are stored in std::unordered_map<std::string, o2::tpc::CalDet<float>> need to go here.",
                                        "This needs to be the last part of the CCDB path, e.g. Pulser or CE." ],
         "outputCalPadMaps": [
           "CE",
-          "Pulser"
+          "PedestalNoise"
         ],
         "outputCalPads_comment" : [ "CalDet objects that are stored as plain o2::tpc::CalDet<float> objects need to go here.",
                                     "This needs to be the last part of the CCDB path, e.g. Pedestal or Noise." ],
         "outputCalPads": [
-          "Pedestal",
-          "Noise"
         ],
         "timestamps_comment": [ "Put the timestamp of the corresponding file you want to look for in the timestamps array.",
                                 "You can either put a timestamp for every object or leave the array empty to take the latest file from the CCDB.",
@@ -78,18 +77,13 @@
         "histogramRanges": [
           { "Pedestals" :   [ "240", "0",   "120" ] },
           { "Noise" :       [ "200", "0",   "2"   ] },
-          { "PulserQtot" :  [ "600", "0",   "300" ] },
-          { "PulserT0" :    [ "100", "239", "240" ] },
-          { "PulserWidth" : [ "100", "0",   "1"   ] },
-          { "CEQtot" :      [ "600", "0",   "300" ] },
-          { "CET0" :        [ "200", "400", "500" ] },
-          { "CEWidth" :     [ "100", "0",   "1"   ] }
+          { "Qtot" :  [ "600", "0",   "300" ] },
+          { "T0" :    [ "100", "239", "240" ] },
+          { "Width" : [ "100", "0",   "1"   ] }
         ],
         "checkZSCalibration": {
           "check": "false",
-          "initRefCalibTimestamp": "-1",
-          "initRefPedestalTimestamp": "-1",
-          "initRefNoiseTimestamp": "-1"
+          "initRefCalibTimestamp": "-1"
         },
         "initTrigger": [
           "once"

--- a/Modules/TPC/run/tpcQCClusterVisualizer.json
+++ b/Modules/TPC/run/tpcQCClusterVisualizer.json
@@ -28,6 +28,7 @@
         "className": "o2::quality_control_modules::tpc::ClusterVisualizer",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
+        "dataSourceURL": "ccdb-test.cern.ch:8080",
         "timestamps_comment": [ "Put the timestamp of the corresponding file you want to look for in the timestamps array.",
                                 "You can either put a timestamp for every object or leave the array empty to take the latest file from the CCDB.",
                                 "An empty array to get the the latest version will be the main use case.",

--- a/Modules/TPC/run/tpcQCDCSPTemperature.json
+++ b/Modules/TPC/run/tpcQCDCSPTemperature.json
@@ -26,6 +26,7 @@
         "className": "o2::quality_control_modules::tpc::DCSPTemperature",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
+        "dataSourceURL": "ccdb-test.cern.ch:8080",
         "timestamps_comment": [
           "Use the 'Valid from' timestamp",
           "The timestamp is used as a limit of how recent the files may be for visualization.",

--- a/Modules/TPC/run/tpcQCIDCs.json
+++ b/Modules/TPC/run/tpcQCIDCs.json
@@ -26,6 +26,7 @@
         "className": "o2::quality_control_modules::tpc::IDCs",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
+        "dataSourceURL": "ccdb-test.cern.ch:8080",
         "timestamps_comment": [ "Put the timestamp of the corresponding file you want to look for in the timestamps array.",
                                 "You can either put a timestamp for every object or leave the array empty to take the latest file from the CCDB.",
                                 "An empty array to get the the latest version will be the main use case.",

--- a/Modules/TPC/run/tpcQCLaserTracks.json
+++ b/Modules/TPC/run/tpcQCLaserTracks.json
@@ -28,6 +28,7 @@
         "className": "o2::quality_control_modules::tpc::LaserTracks",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
+        "dataSourceURL": "ccdb-test.cern.ch:8080",
         "timestamps_comment": [ "Select specific timestamp, -1 is default."
         ],
         "timestamp": [

--- a/Modules/TPC/run/tpcQCRawDigitVisualizer.json
+++ b/Modules/TPC/run/tpcQCRawDigitVisualizer.json
@@ -28,6 +28,7 @@
         "className": "o2::quality_control_modules::tpc::ClusterVisualizer",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
+        "dataSourceURL": "ccdb-test.cern.ch:8080",
         "timestamps_comment": [ "Put the timestamp of the corresponding file you want to look for in the timestamps array.",
                                 "You can either put a timestamp for every object or leave the array empty to take the latest file from the CCDB.",
                                 "An empty array to get the the latest version will be the main use case.",

--- a/Modules/TPC/src/ClusterVisualizer.cxx
+++ b/Modules/TPC/src/ClusterVisualizer.cxx
@@ -25,7 +25,7 @@
 #include "TPC/Utility.h"
 #include "TPC/ClustersData.h"
 
-//root includes
+// root includes
 #include "TCanvas.h"
 #include "TPaveText.h"
 
@@ -66,7 +66,7 @@ void ClusterVisualizer::configure(std::string name, const boost::property_tree::
       }
     }
     if (keyVec.size() != valueVec.size()) {
-      throw std::runtime_error("Number of keys and values for lookupMetaData are not matching");
+      ILOG(Error, Support) << "Number of keys and values for lookupMetaData are not matching" << ENDM;
     }
     keyVec.clear();
     valueVec.clear();
@@ -92,7 +92,7 @@ void ClusterVisualizer::configure(std::string name, const boost::property_tree::
       }
     }
     if (keyVec.size() != valueVec.size()) {
-      throw std::runtime_error("Number of keys and values for storeMetaData are not matching");
+      ILOG(Error, Support) << "Number of keys and values for storeMetaData are not matching" << ENDM;
     }
     keyVec.clear();
     valueVec.clear();
@@ -107,7 +107,7 @@ void ClusterVisualizer::configure(std::string name, const boost::property_tree::
   }
 
   mPath = config.get<std::string>("qc.postprocessing." + name + ".path");
-  mHost = config.get<std::string>("qc.config.conditionDB.url");
+  mHost = config.get<std::string>("qc.postprocessing." + name + ".dataSourceURL");
 
   const auto type = config.get<std::string>("qc.postprocessing." + name + ".dataType");
   if (type == "clusters") {
@@ -128,7 +128,7 @@ void ClusterVisualizer::configure(std::string name, const boost::property_tree::
       "Time_Bin"
     };
   } else {
-    throw std::runtime_error("No valid data type given. 'dataType' has to be either 'clusters' or 'raw'.");
+    ILOG(Error, Support) << "No valid data type given. 'dataType' has to be either 'clusters' or 'raw'." << ENDM;
   }
 }
 

--- a/Modules/TPC/src/DCSPTemperature.cxx
+++ b/Modules/TPC/src/DCSPTemperature.cxx
@@ -53,7 +53,7 @@ void DCSPTemperature::configure(std::string name, const boost::property_tree::pt
   }
 
   if (keyVec.size() != valueVec.size()) {
-    throw std::runtime_error("Number of keys and values for lookupMetaData are not matching");
+    ILOG(Error, Support) << "Number of keys and values for lookupMetaData are not matching" << ENDM;
   }
 
   keyVec.clear();
@@ -76,7 +76,7 @@ void DCSPTemperature::configure(std::string name, const boost::property_tree::pt
 
   mTimestamp = std::stol(config.get<std::string>("qc.postprocessing." + name + ".timestamp"));
   mNFiles = std::stoi(config.get<std::string>("qc.postprocessing." + name + ".nFiles"));
-  mHost = config.get<std::string>("qc.config.conditionDB.url");
+  mHost = config.get<std::string>("qc.postprocessing." + name + ".dataSourceURL");
 }
 
 void DCSPTemperature::initialize(Trigger, framework::ServiceRegistry&)
@@ -133,6 +133,9 @@ long DCSPTemperature::getTimestamp(const std::string metaInfo)
   std::string result_str;
   long result;
   std::string token = "Validity: ";
+  if (metaInfo.find(token) == std::string::npos) {
+    return -1;
+  }
   int start = metaInfo.find(token) + token.size();
   int end = metaInfo.find(" -", start);
   result_str = metaInfo.substr(start, end - start);
@@ -147,8 +150,11 @@ std::vector<long> DCSPTemperature::getDataTimestamps(const std::string_view path
   std::vector<std::string> fileList = splitString(mCdbApi.list(path.data()), "\n");
 
   if (limit == -1) {
-    for (unsigned int i = 0; i < nFiles; i++) {
-      outVec.emplace_back(getTimestamp(fileList.at(i)));
+    for (unsigned int i = 1; i <= nFiles; i++) {
+      long timeStamp = getTimestamp(fileList.at(i));
+      if (timeStamp != -1) {
+        outVec.emplace_back(timeStamp);
+      }
     }
   } else {
     std::vector<std::string> tmpFiles;
@@ -157,8 +163,11 @@ std::vector<long> DCSPTemperature::getDataTimestamps(const std::string_view path
         tmpFiles.emplace_back(file);
       }
     }
-    for (unsigned int i = 0; i < nFiles; i++) {
-      outVec.emplace_back(getTimestamp(tmpFiles.at(i)));
+    for (unsigned int i = 1; i <= nFiles; i++) {
+      long timeStamp = getTimestamp(tmpFiles.at(i));
+      if (timeStamp != -1) {
+        outVec.emplace_back(timeStamp);
+      }
     }
   }
   std::sort(outVec.begin(), outVec.end());

--- a/Modules/TPC/src/IDCs.cxx
+++ b/Modules/TPC/src/IDCs.cxx
@@ -56,7 +56,7 @@ void IDCs::configure(std::string name, const boost::property_tree::ptree& config
       }
     }
     if (keyVec.size() != valueVec.size()) {
-      throw std::runtime_error("Number of keys and values for lookupMetaData are not matching");
+      ILOG(Error, Support) << "Number of keys and values for lookupMetaData are not matching" << ENDM;
     }
     keyVec.clear();
     valueVec.clear();
@@ -82,7 +82,7 @@ void IDCs::configure(std::string name, const boost::property_tree::ptree& config
       }
     }
     if (keyVec.size() != valueVec.size()) {
-      throw std::runtime_error("Number of keys and values for storeMetaData are not matching");
+      ILOG(Error, Support) << "Number of keys and values for storeMetaData are not matching" << ENDM;
     }
     keyVec.clear();
     valueVec.clear();
@@ -102,7 +102,7 @@ void IDCs::configure(std::string name, const boost::property_tree::ptree& config
     }
   }
 
-  mHost = config.get<std::string>("qc.config.conditionDB.url");
+  mHost = config.get<std::string>("qc.postprocessing." + name + ".dataSourceURL");
 }
 
 void IDCs::initialize(Trigger, framework::ServiceRegistry&)

--- a/Modules/TPC/src/LaserTracks.cxx
+++ b/Modules/TPC/src/LaserTracks.cxx
@@ -23,7 +23,7 @@
 #include "TPC/LaserTracks.h"
 #include "TPC/Utility.h"
 
-//root includes
+// root includes
 #include "TCanvas.h"
 
 using namespace o2::quality_control::postprocessing;
@@ -33,7 +33,7 @@ namespace o2::quality_control_modules::tpc
 
 void LaserTracks::configure(std::string name, const boost::property_tree::ptree& config)
 {
-  o2::tpc::CDBInterface::instance().setURL(config.get<std::string>("qc.config.conditionDB.url"));
+  o2::tpc::CDBInterface::instance().setURL(config.get<std::string>("qc.postprocessing." + name + ".dataSourceURL"));
 }
 
 void LaserTracks::initialize(Trigger, framework::ServiceRegistry&)


### PR DESCRIPTION
Added the config option `dataSourceURL` to the PP-QC tasks so that multiple tasks running in one workflow can have individual data sources instead of all being fixed to `conditionDB`.

Caveat: When the task is updated on `newObject`, this does not look at `dataSourceURL`. Here you need to choose either ccdb or qcdb ([see docu](https://github.com/AliceO2Group/QualityControl/blob/master/doc/PostProcessing.md#triggers-configuration)). `ccdb` looks at `qc.config.conditioDB.url` and `qcdb` looks at `qc.config.database.host`.

In addition, there are some minor adjustments.