### PR TITLE
MFT: timing info edit

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTAsyncTask.h
+++ b/Modules/MFT/include/MFT/QcMFTAsyncTask.h
@@ -87,7 +87,7 @@ class QcMFTAsyncTask /*final*/ : public TaskInterface // todo add back the "fina
   std::unique_ptr<TH1F> mClusterSensorIndex = nullptr;
   std::unique_ptr<TH1F> mClusterPatternIndex = nullptr;
 
-  uint32_t mRefOrbit = 0; // Reference orbit used in relative time calculation
+  uint32_t mRefOrbit = -1; // Reference orbit used in relative time calculation
 
   static constexpr array<short, 7> sMinNClustersList = { 4, 5, 6, 7, 8, 9, 10 };
 };

--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -105,7 +105,7 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   std::string mGeomPath;
 
   // reference orbit used in relative time calculation
-  uint32_t mRefOrbit = 0;
+  uint32_t mRefOrbit = -1;
 };
 
 } // namespace o2::quality_control_modules::mft

--- a/Modules/MFT/include/MFT/QcMFTDigitTask.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitTask.h
@@ -103,7 +103,7 @@ class QcMFTDigitTask final : public TaskInterface
   std::vector<std::unique_ptr<TH2F>> mDigitPixelOccupancyMap;
 
   // reference orbit used in relative time calculation
-  uint32_t mRefOrbit = 0;
+  uint32_t mRefOrbit = -1;
 
   //  functions
   int getVectorIndexChipOccupancyMap(int chipIndex);

--- a/Modules/MFT/src/QcMFTAsyncTask.cxx
+++ b/Modules/MFT/src/QcMFTAsyncTask.cxx
@@ -146,13 +146,13 @@ void QcMFTAsyncTask::initialize(o2::framework::InitContext& /*ctx*/)
   mTrackTanl = std::make_unique<TH1F>("tracks/mMFTTrackTanl", "Track tan #lambda; tan #lambda; # entries", 100, -25, 0);
   getObjectsManager()->startPublishing(mTrackTanl.get());
 
-  mClusterROFNEntries = std::make_unique<TH1F>("clusters/mMFTClustersROFSize", "MFT Cluster ROFs size; ROF Size; # entries", MaxClusterROFSize, 0, MaxClusterROFSize);
+  mClusterROFNEntries = std::make_unique<TH1F>("clusters/mMFTClustersROFSize", "ROF size in #clusters; ROF Size; # entries", MaxClusterROFSize, 0, MaxClusterROFSize);
   getObjectsManager()->startPublishing(mClusterROFNEntries.get());
 
-  mTrackROFNEntries = std::make_unique<TH1F>("tracks/mMFTTrackROFSize", "MFT Track ROFs size; ROF Size; # entries", MaxTrackROFSize, 0, MaxTrackROFSize);
+  mTrackROFNEntries = std::make_unique<TH1F>("tracks/mMFTTrackROFSize", "ROF size in #tracks; ROF Size (# tracks); # entries", MaxTrackROFSize, 0, MaxTrackROFSize);
   getObjectsManager()->startPublishing(mTrackROFNEntries.get());
 
-  mTracksBC = std::make_unique<TH1F>("tracks/mMFTTracksBC", "Tracks per BC (sum over orbits); BCid; # entries", ROFsPerOrbit, 0, o2::constants::lhc::LHCMaxBunches);
+  mTracksBC = std::make_unique<TH1F>("tracks/mMFTTracksBC", "Tracks per BC; BCid; # entries", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches);
   mTracksBC->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mTracksBC.get());
 
@@ -195,7 +195,9 @@ void QcMFTAsyncTask::monitorData(o2::framework::ProcessingContext& ctx)
   const auto clustersrofs = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clustersrofs");
 
   // get correct timing info of the first TF orbit
-  mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
+  if (mRefOrbit == -1) {
+    mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
+  }
 
   // Fill the clusters histograms
   for (const auto& rof : clustersrofs) {

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -186,20 +186,20 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mClusterOccupancySummary.get());
   getObjectsManager()->setDefaultDrawOptions(mClusterOccupancySummary.get(), "colz");
 
-  mClusterZ = std::make_unique<TH1F>("mClusterZ", "Z position of clusters; Z (cm); #Entries", 400, -80, -40);
+  mClusterZ = std::make_unique<TH1F>("mClusterZ", "Z position of clusters; Z (cm); # entries", 400, -80, -40);
   mClusterZ->SetStats(0);
   getObjectsManager()->startPublishing(mClusterZ.get());
 
-  mClustersROFSize = std::make_unique<TH1F>("mClustersROFSize", "Cluster ROFs size; ROF Size (#Clusters); #Entries", maxClusterROFSize, 0, maxClusterROFSize);
+  mClustersROFSize = std::make_unique<TH1F>("mClustersROFSize", "ROF size in # clusters; ROF Size (# clusters); # entries", maxClusterROFSize, 0, maxClusterROFSize);
   mClustersROFSize->SetStats(0);
   getObjectsManager()->startPublishing(mClustersROFSize.get());
   getObjectsManager()->setDisplayHint(mClustersROFSize.get(), "logx logy");
 
-  mNOfClustersTime = std::make_unique<TH1F>("mNOfClustersTime", "Number of clusters per time bin; time (s); #Entries", NofTimeBins, 0, maxDuration);
+  mNOfClustersTime = std::make_unique<TH1F>("mNOfClustersTime", "Number of clusters per time bin; time (s); # entries", NofTimeBins, 0, maxDuration);
   mNOfClustersTime->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mNOfClustersTime.get());
 
-  mClustersBC = std::make_unique<TH1F>("mClustersBC", "Clusters per BC (sum over orbits); BCid; #Entries", ROFsPerOrbit, 0, o2::constants::lhc::LHCMaxBunches);
+  mClustersBC = std::make_unique<TH1F>("mClustersBC", "Clusters per BC; BCid; # entries", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches);
   mClustersBC->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mClustersBC.get());
 
@@ -283,7 +283,9 @@ void QcMFTClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   o2::mft::ioutils::convertCompactClusters(clusters, patternIt, mClustersGlobal, mDict);
 
   // get correct timing info of the first TF orbit
-  mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
+  if (mRefOrbit == -1) {
+    mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
+  }
 
   // reset the cluster pattern iterator which will be used later
   patternIt = clustersPattern.begin();

--- a/Modules/MFT/src/QcMFTDigitTask.cxx
+++ b/Modules/MFT/src/QcMFTDigitTask.cxx
@@ -153,16 +153,16 @@ void QcMFTDigitTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mDigitOccupancySummary.get());
   getObjectsManager()->setDefaultDrawOptions(mDigitOccupancySummary.get(), "colz");
 
-  mDigitsROFSize = std::make_unique<TH1F>("mDigitsROFSize", "Digits ROFs size; ROF Size (#Digits); #Entries", maxDigitROFSize, 0, maxDigitROFSize);
+  mDigitsROFSize = std::make_unique<TH1F>("mDigitsROFSize", "ROF size in # digits; ROF Size (# digits); # entries", maxDigitROFSize, 0, maxDigitROFSize);
   mDigitsROFSize->SetStats(0);
   getObjectsManager()->startPublishing(mDigitsROFSize.get());
   getObjectsManager()->setDisplayHint(mDigitsROFSize.get(), "logx logy");
 
-  mNOfDigitsTime = std::make_unique<TH1F>("mNOfDigitsTime", "Number of Digits per time bin; time (s); #Entries", NofTimeBins, 0, maxDuration);
+  mNOfDigitsTime = std::make_unique<TH1F>("mNOfDigitsTime", "Number of Digits per time bin; time (s); # entries", NofTimeBins, 0, maxDuration);
   mNOfDigitsTime->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mNOfDigitsTime.get());
 
-  mDigitsBC = std::make_unique<TH1F>("mDigitsBC", "Digits per BC (sum over orbits); BCid; #Entries", ROFsPerOrbit, 0, o2::constants::lhc::LHCMaxBunches);
+  mDigitsBC = std::make_unique<TH1F>("mDigitsBC", "Digits per BC; BCid; # entries", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches);
   mDigitsBC->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mDigitsBC.get());
 
@@ -255,7 +255,9 @@ void QcMFTDigitTask::monitorData(o2::framework::ProcessingContext& ctx)
   mDigitOccupancySummary->Fill(-1, -1, nROFs);
 
   // get correct timing info of the first TF orbit
-  mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
+  if (mRefOrbit == -1) {
+    mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
+  }
 
   // fill the digits time histograms
   for (const auto& rof : rofs) {


### PR DESCRIPTION
- set orbit of the first TF for relative time calculation (before, it was updated with every new TF)
- change binning for digits, clusters and tracks per BC to one bin per BC, instead of the number of triggers per orbit