### PR TITLE
[EMCAL-792] Fix reset of all errors and histo for unknown type

### DIFF
--- a/Modules/EMCAL/include/EMCAL/RawErrorTask.h
+++ b/Modules/EMCAL/include/EMCAL/RawErrorTask.h
@@ -64,6 +64,7 @@ class RawErrorTask final : public TaskInterface
   TH2* mErrorTypeFit = nullptr;         ///< Raw fit errors
   TH2* mErrorTypeGeometry = nullptr;    ///< Geometry errors
   TH2* mErrorTypeGain = nullptr;        ///< Gain type errors
+  TH1* mErrorTypeUnknown = nullptr;     ///< Counter of defined error codes
   TH2* mErrorGainLow = nullptr;         ///< FEC with LGnoHG error
   TH2* mErrorGainHigh = nullptr;        ///< FEC with HGnoLG error
   TH2* mChannelGainLow = nullptr;       ///< Tower with LGnoHG error


### PR DESCRIPTION
- Missing reset fixed for counter of any error type, leading
  to same errors merged multiple times
- Add histograms to monitor unkown (errorous) error codes