### PR TITLE
MFT: edit track histograms

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTAsyncTask.h
+++ b/Modules/MFT/include/MFT/QcMFTAsyncTask.h
@@ -75,6 +75,8 @@ class QcMFTAsyncTask /*final*/ : public TaskInterface // todo add back the "fina
   std::array<unique_ptr<TH2F>, 7> mTrackEtaPhiNCls = { nullptr };
   std::unique_ptr<TH1F> mCATrackEta = nullptr;
   std::unique_ptr<TH1F> mLTFTrackEta = nullptr;
+  std::unique_ptr<TH1F> mCATrackPt = nullptr;
+  std::unique_ptr<TH1F> mLTFTrackPt = nullptr;
   std::unique_ptr<TH1F> mTrackTanl = nullptr;
 
   std::unique_ptr<TH1F> mTrackROFNEntries = nullptr;

--- a/Modules/MFT/src/QcMFTAsyncTask.cxx
+++ b/Modules/MFT/src/QcMFTAsyncTask.cxx
@@ -99,7 +99,7 @@ void QcMFTAsyncTask::initialize(o2::framework::InitContext& /*ctx*/)
                                                      "Number Of Clusters Per LTF Track; # clusters; # entries", 10, 0.5, 10.5);
   getObjectsManager()->startPublishing(mLTFTrackNumberOfClusters.get());
 
-  mTrackInvQPt = std::make_unique<TH1F>("tracks/mMFTTrackInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 50, -2, 2);
+  mTrackInvQPt = std::make_unique<TH1F>("tracks/mMFTTrackInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 250, -10, 10);
   getObjectsManager()->startPublishing(mTrackInvQPt.get());
 
   mTrackChi2 = std::make_unique<TH1F>("tracks/mMFTTrackChi2", "Track #chi^{2}; #chi^{2}; # entries", 21, -0.5, 20.5);
@@ -143,6 +143,14 @@ void QcMFTAsyncTask::initialize(o2::framework::InitContext& /*ctx*/)
   mLTFTrackEta = std::make_unique<TH1F>("tracks/LTF/mMFTLTFTrackEta", "LTF Track #eta; #eta; # entries", 50, -4, -2);
   getObjectsManager()->startPublishing(mLTFTrackEta.get());
 
+  mCATrackPt = std::make_unique<TH1F>("tracks/CA/mMFTCATrackPt", "CA Track p_{T}; p_{T} (GeV/c); # entries", 300, 0, 30);
+  getObjectsManager()->startPublishing(mCATrackPt.get());
+  getObjectsManager()->setDisplayHint(mCATrackPt.get(), "logy");
+
+  mLTFTrackPt = std::make_unique<TH1F>("tracks/LTF/mMFTLTFTrackPt", "LTF Track p_{T}; p_{T} (GeV/c); # entries", 300, 0, 30);
+  getObjectsManager()->startPublishing(mLTFTrackPt.get());
+  getObjectsManager()->setDisplayHint(mLTFTrackPt.get(), "logy");
+
   mTrackTanl = std::make_unique<TH1F>("tracks/mMFTTrackTanl", "Track tan #lambda; tan #lambda; # entries", 100, -25, 0);
   getObjectsManager()->startPublishing(mTrackTanl.get());
 
@@ -155,6 +163,7 @@ void QcMFTAsyncTask::initialize(o2::framework::InitContext& /*ctx*/)
   mTracksBC = std::make_unique<TH1F>("tracks/mMFTTracksBC", "Tracks per BC; BCid; # entries", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches);
   mTracksBC->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mTracksBC.get());
+  getObjectsManager()->setDisplayHint(mTracksBC.get(), "hist");
 
   mNOfTracksTime = std::make_unique<TH1F>("tracks/mNOfTracksTime", "Number of tracks per time bin; time (s); # entries", NofTimeBins, 0, MaxDuration);
   mNOfTracksTime->SetMinimum(0.1);
@@ -252,10 +261,12 @@ void QcMFTAsyncTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (oneTrack.isCA()) {
       mCATrackNumberOfClusters->Fill(oneTrack.getNumberOfPoints());
       mCATrackEta->Fill(oneTrack.getEta());
+      mCATrackPt->Fill(oneTrack.getPt());
     }
     if (oneTrack.isLTF()) {
       mLTFTrackNumberOfClusters->Fill(oneTrack.getNumberOfPoints());
       mLTFTrackEta->Fill(oneTrack.getEta());
+      mLTFTrackPt->Fill(oneTrack.getPt());
     }
   }
 }
@@ -296,6 +307,8 @@ void QcMFTAsyncTask::reset()
   }
   mCATrackEta->Reset();
   mLTFTrackEta->Reset();
+  mCATrackPt->Reset();
+  mLTFTrackPt->Reset();
   mTrackTanl->Reset();
 
   mTrackROFNEntries->Reset();

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -202,6 +202,7 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
   mClustersBC = std::make_unique<TH1F>("mClustersBC", "Clusters per BC; BCid; # entries", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches);
   mClustersBC->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mClustersBC.get());
+  getObjectsManager()->setDisplayHint(mClustersBC.get(), "hist");
 
   // define chip occupancy maps
   QcMFTUtilTables MFTTable;

--- a/Modules/MFT/src/QcMFTDigitTask.cxx
+++ b/Modules/MFT/src/QcMFTDigitTask.cxx
@@ -165,6 +165,7 @@ void QcMFTDigitTask::initialize(o2::framework::InitContext& /*ctx*/)
   mDigitsBC = std::make_unique<TH1F>("mDigitsBC", "Digits per BC; BCid; # entries", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches);
   mDigitsBC->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mDigitsBC.get());
+  getObjectsManager()->setDisplayHint(mDigitsBC.get(), "hist");
 
   // --Chip hit maps
   //==============================================


### PR DESCRIPTION
- edited drawing options (added "hist" option for digits per BC, clusters per BC, tracks per BC)
- added pT histogram for CA and LTF tracks separately 
- changed range in q_pT histogram from -2,2 to -10,10