### PR TITLE
PHS: fix for TH2SBitmask::merge()

### DIFF
--- a/Modules/PHOS/src/TH2SBitmask.cxx
+++ b/Modules/PHOS/src/TH2SBitmask.cxx
@@ -26,7 +26,8 @@ void TH2SBitmask::merge(MergeInterface* const other)
     for (unsigned int ix = 1; ix <= this->GetNbinsX(); ix++) {
       for (unsigned int iz = 1; iz <= this->GetNbinsY(); iz++) {
         int cont = this->GetBinContent(ix, iz);
-        cont |= int(otherHisto->GetBinContent(ix, iz, cont));
+        cont |= int(otherHisto->GetBinContent(ix, iz));
+        this->SetBinContent(ix, iz, cont);
       }
     }
   }


### PR DESCRIPTION
Hello! This is another fix for PHOS's TH2SBitmask::merge() method. Hope it's a final one.