### PR TITLE
[QC-878] Make sure Service Discovery quits immediately

### DIFF
--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -124,7 +124,6 @@ void ServiceDiscovery::runHealthServer(unsigned int port)
     while (mThreadRunning) {
       io_service.reset();
       timer.expires_from_now(boost::posix_time::seconds(1));
-      tcp::socket socket(io_service);
       acceptor.async_accept([this](boost::system::error_code ec, tcp::socket socket) {
       });
       timer.async_wait([&](boost::system::error_code ec) {

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -26,6 +26,8 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/io_service.hpp>
 
+using boost::asio::ip::tcp;
+
 namespace o2::quality_control::core
 {
 
@@ -170,8 +172,6 @@ bool ServiceDiscovery::send(const std::string& path, std::string&& post)
 // https://stackoverflow.com/questions/33358321/using-c-and-boost-or-not-to-check-if-a-specific-port-is-being-used
 bool ServiceDiscovery::PortInUse(unsigned short port)
 {
-  using ip::tcp;
-
   boost::asio::io_service svc;
   tcp::acceptor a(svc);
 

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -120,10 +120,17 @@ void ServiceDiscovery::runHealthServer(unsigned int port)
   try {
     boost::asio::io_service io_service;
     tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), port));
+    boost::asio::deadline_timer timer(io_service);
     while (mThreadRunning) {
+      io_service.reset();
+      timer.expires_from_now(boost::posix_time::seconds(1));
       tcp::socket socket(io_service);
-      acceptor.accept(socket);
-      std::this_thread::sleep_for(std::chrono::seconds(1));
+      acceptor.async_accept([this](boost::system::error_code ec, tcp::socket socket) {
+      });
+      timer.async_wait([&](boost::system::error_code ec) {
+        io_service.stop();
+      });
+      io_service.run();
     }
   } catch (std::exception& e) {
     mThreadRunning = false;

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -171,7 +171,6 @@ bool ServiceDiscovery::send(const std::string& path, std::string&& post)
 // https://stackoverflow.com/questions/33358321/using-c-and-boost-or-not-to-check-if-a-specific-port-is-being-used
 bool ServiceDiscovery::PortInUse(unsigned short port)
 {
-  using namespace boost::asio;
   using ip::tcp;
 
   boost::asio::io_service svc;
@@ -180,7 +179,7 @@ bool ServiceDiscovery::PortInUse(unsigned short port)
   boost::system::error_code ec;
   a.open(tcp::v4(), ec) || a.bind({ tcp::v4(), port }, ec);
 
-  return ec == error::address_in_use;
+  return ec == boost::asio::error::address_in_use;
 }
 
 size_t ServiceDiscovery::GetHealthPort()


### PR DESCRIPTION
This makes sure that Service Discovery health thread quits immediately without waiting for the blocking call to be completed...