### PR TITLE
MCH: use MCHConstants lib from O2

### DIFF
--- a/Modules/MUON/MCH/CMakeLists.txt
+++ b/Modules/MUON/MCH/CMakeLists.txt
@@ -54,7 +54,7 @@ target_include_directories(
 )
 
 target_link_libraries(${MODULE_NAME} PUBLIC O2QualityControl O2QcMUONCommon O2::CommonDataFormat O2::GPUCommon
-        $<TARGET_NAME_IF_EXISTS:O2::MCHMappingFactory> O2::MCHMappingImpl4 O2::MCHMappingSegContour O2::MCHBase O2::DataFormatsMCH O2::MCHRawDecoder O2::MCHCalibration O2::MCHDigitFiltering O2::MCHPreClustering O2::MCHTracking)
+        $<TARGET_NAME_IF_EXISTS:O2::MCHMappingFactory> O2::MCHMappingImpl4 O2::MCHMappingSegContour O2::MCHBase O2::DataFormatsMCH O2::MCHRawDecoder O2::MCHCalibration O2::MCHDigitFiltering O2::MCHPreClustering O2::MCHTracking O2::MCHConstants)
 
 target_compile_definitions(${MODULE_NAME} PRIVATE $<$<TARGET_EXISTS:O2::MCHMappingFactory>:MCH_HAS_MAPPING_FACTORY>)
 

--- a/Modules/MUON/MCH/include/MCH/MergeableTH1MPVPerDECycle.h
+++ b/Modules/MUON/MCH/include/MCH/MergeableTH1MPVPerDECycle.h
@@ -32,6 +32,7 @@
 #else
 #include "MCHBase/Digit.h"
 #endif
+#include "MCHConstants/DetectionElements.h"
 
 using namespace std;
 namespace o2::quality_control_modules::muonchambers
@@ -56,8 +57,8 @@ class MergeableTH1MPVPerDECycle : public TH1F, public o2::mergers::MergeInterfac
   ~MergeableTH1MPVPerDECycle() override = default;
 
   void merge(MergeInterface* const other) override
-  { //FIXME
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  { // FIXME
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
       auto hnumMap = dynamic_cast<const MergeableTH1MPVPerDECycle* const>(other)->getNum();
       auto hnum = hnumMap.find(de);
       if ((hnum != dynamic_cast<const MergeableTH1MPVPerDECycle* const>(other)->getNum().end()) && (hnum->second != NULL)) {
@@ -78,15 +79,15 @@ class MergeableTH1MPVPerDECycle : public TH1F, public o2::mergers::MergeInterfac
   }
 
   void update()
-  { //FIXME
+  { // FIXME
     const char* name = this->GetName();
     const char* title = this->GetTitle();
     Reset();
     SetNameTitle(name, title);
 
-    TF1* f1 = new TF1("f1", "landau", 200, 5000); //1650V [200,5k]    1700V [400,10k]
+    TF1* f1 = new TF1("f1", "landau", 200, 5000); // 1650V [200,5k]    1700V [400,10k]
 
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
       auto hLandauCycle = mhistosCharge.find(de);
       if ((hLandauCycle != mhistosCharge.end()) && (hLandauCycle->second != NULL)) {
 
@@ -124,4 +125,4 @@ class MergeableTH1MPVPerDECycle : public TH1F, public o2::mergers::MergeInterfac
 
 } // namespace o2::quality_control_modules::muonchambers
 
-#endif //O2_MERGEABLETH1MPVPERDECYCLE_H
+#endif // O2_MERGEABLETH1MPVPERDECYCLE_H

--- a/Modules/MUON/MCH/include/MCH/MergeableTH1PseudoEfficiencyPerDE.h
+++ b/Modules/MUON/MCH/include/MCH/MergeableTH1PseudoEfficiencyPerDE.h
@@ -32,6 +32,7 @@
 #include "MCHBase/Digit.h"
 #endif
 #include "MCH/GlobalHistogram.h"
+#include "MCHConstants/DetectionElements.h"
 
 using namespace std;
 namespace o2::quality_control_modules::muonchambers
@@ -111,7 +112,7 @@ class MergeableTH1PseudoEfficiencyPerDE : public TH1F, public o2::mergers::Merge
     double numDE[1100] = { 0 };
     double denDE[1100] = { 0 };
 
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
       auto hnum = histosNum.find(de);
       auto hden = histosDen.find(de);
       if ((hden != histosDen.end()) && (hden->second != NULL) && (hnum != histosNum.end()) && (hnum->second != NULL)) {
@@ -130,7 +131,7 @@ class MergeableTH1PseudoEfficiencyPerDE : public TH1F, public o2::mergers::Merge
       }
     }
 
-    for (auto i : o2::mch::raw::deIdsForAllMCH) {
+    for (auto i : o2::mch::constants::deIdsForAllMCH) {
       mHistoNum->SetBinContent(i + 1, numDE[i]);
       mHistoDen->SetBinContent(i + 1, denDE[i]);
     }
@@ -148,4 +149,4 @@ class MergeableTH1PseudoEfficiencyPerDE : public TH1F, public o2::mergers::Merge
 
 } // namespace o2::quality_control_modules::muonchambers
 
-#endif //O2_MERGEABLETH1PSEUDOEFFICIENCYPERDE_H
+#endif // O2_MERGEABLETH1PSEUDOEFFICIENCYPERDE_H

--- a/Modules/MUON/MCH/include/MCH/MergeableTH1PseudoEfficiencyPerDECycle.h
+++ b/Modules/MUON/MCH/include/MCH/MergeableTH1PseudoEfficiencyPerDECycle.h
@@ -49,7 +49,7 @@ class MergeableTH1PseudoEfficiencyPerDECycle : public TH1F, public o2::mergers::
   MergeableTH1PseudoEfficiencyPerDECycle(const char* name, const char* title, std::map<int, TH2F*> histosnum, std::map<int, TH2F*> histosden)
     : TH1F(name, title, 1100, -0.5, 1099.5), o2::mergers::MergeInterface(), mhistosNum(histosnum), mhistosDen(histosden)
   {
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
       LastMeanNumDE[de] = 0;
       LastMeanDenDE[de] = 0;
     }
@@ -59,8 +59,8 @@ class MergeableTH1PseudoEfficiencyPerDECycle : public TH1F, public o2::mergers::
   ~MergeableTH1PseudoEfficiencyPerDECycle() override = default;
 
   void merge(MergeInterface* const other) override
-  { //FIXME
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  { // FIXME
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
       auto hnumMap = dynamic_cast<const MergeableTH1PseudoEfficiencyPerDECycle* const>(other)->getNum();
       auto hnum = hnumMap.find(de);
       auto hdenMap = dynamic_cast<const MergeableTH1PseudoEfficiencyPerDECycle* const>(other)->getDen();
@@ -79,7 +79,7 @@ class MergeableTH1PseudoEfficiencyPerDECycle : public TH1F, public o2::mergers::
     const double* ptrotherLastMeanNumDE = dynamic_cast<const MergeableTH1PseudoEfficiencyPerDECycle* const>(other)->getLastMeanNumDE();
     const double* ptrotherLastMeanDenDE = dynamic_cast<const MergeableTH1PseudoEfficiencyPerDECycle* const>(other)->getLastMeanDenDE();
 
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
       LastMeanNumDE[de] += ptrotherLastMeanNumDE[de];
       LastMeanDenDE[de] += ptrotherLastMeanDenDE[de];
     }
@@ -87,7 +87,7 @@ class MergeableTH1PseudoEfficiencyPerDECycle : public TH1F, public o2::mergers::
     const double* ptrotherNewMeanNumDE = dynamic_cast<const MergeableTH1PseudoEfficiencyPerDECycle* const>(other)->getNewMeanNumDE();
     const double* ptrotherNewMeanDenDE = dynamic_cast<const MergeableTH1PseudoEfficiencyPerDECycle* const>(other)->getNewMeanDenDE();
 
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
       NewMeanNumDE[de] += ptrotherNewMeanNumDE[de];
       NewMeanDenDE[de] += ptrotherNewMeanDenDE[de];
     }
@@ -136,7 +136,7 @@ class MergeableTH1PseudoEfficiencyPerDECycle : public TH1F, public o2::mergers::
     Reset();
     SetNameTitle(name, title);
 
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
 
       LastMeanNumDE[de] = NewMeanNumDE[de];
       LastMeanDenDE[de] = NewMeanDenDE[de];
@@ -159,7 +159,7 @@ class MergeableTH1PseudoEfficiencyPerDECycle : public TH1F, public o2::mergers::
       }
     }
 
-    for (auto de : o2::mch::raw::deIdsForAllMCH) {
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
       double MeanPseudoeffDECycle = 0;
       if ((NewMeanNumDE[de] - LastMeanNumDE[de]) > 0) {
         MeanPseudoeffDECycle = (NewMeanNumDE[de] - LastMeanNumDE[de]) / (NewMeanDenDE[de] - LastMeanDenDE[de]);
@@ -177,7 +177,7 @@ class MergeableTH1PseudoEfficiencyPerDECycle : public TH1F, public o2::mergers::
 
     // Using NHitsElec and Norbits to get the mean occupancy per DE on last cycle
     // Similarly, by looking at NHits and NOrbits Elec histogram, for each bin incrementing the corresponding DE total hits and total orbits, and from the values obtained at the end of a cycle compared to the beginning of the cycle, computing the occupancy during the cycle.
-    for (auto i : o2::mch::raw::deIdsForAllMCH) {
+    for (auto i : o2::mch::constants::deIdsForAllMCH) {
       auto hnum = mhistosNum.find(i);
       auto hden = mhistosDen.find(i);
       if ((hden != mhistosDen.end()) && (hden->second != NULL) && (hnum != mhistosNum.end()) && (hnum->second != NULL)) {
@@ -204,4 +204,4 @@ class MergeableTH1PseudoEfficiencyPerDECycle : public TH1F, public o2::mergers::
 
 } // namespace o2::quality_control_modules::muonchambers
 
-#endif //O2_MERGEABLETH1PSEUDOEFFICIENCYPERDECYCLE_H
+#endif // O2_MERGEABLETH1PSEUDOEFFICIENCYPERDECYCLE_H

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -34,6 +34,7 @@
 #ifdef MCH_HAS_MAPPING_FACTORY
 #include "MCHMappingFactory/CreateSegmentation.h"
 #endif
+#include "MCHConstants/DetectionElements.h"
 
 using namespace std;
 using namespace o2::framework;
@@ -87,7 +88,7 @@ void PedestalsTask::initialize(o2::framework::InitContext& /*ctx*/)
     publishObject(mHistogramNoiseDistribution[si].get(), "hist", false);
   }
 
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
     auto hPedDE = std::make_shared<TH2F>(TString::Format("%sPedestals_Elec_DE%03d", getHistoPath(de).c_str(), de),
                                          TString::Format("Pedestals (DE%03d)", de), 2000, 0, 2000, 64, 0, 64);
     mHistogramPedestalsDE.insert(make_pair(de, hPedDE));

--- a/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskDigits.cxx
@@ -36,6 +36,7 @@
 #include <Framework/InputRecord.h>
 #include <CommonConstants/LHCConstants.h>
 #include <DetectorsRaw/HBFUtils.h>
+#include "MCHConstants/DetectionElements.h"
 
 using namespace std;
 using namespace o2::mch::raw;
@@ -155,7 +156,7 @@ void PhysicsTaskDigits::initialize(o2::framework::InitContext& /*ctx*/)
   publishObject(mHistogramAmplitudeVsSamples, "colz", false, true);
 
   // Histograms in detector coordinates
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
     auto h = std::make_shared<TH1F>(TString::Format("Expert/%sADCamplitude_DE%03d", getHistoPath(de).c_str(), de),
                                     TString::Format("ADC amplitude (DE%03d)", de), 5000, 0, 5000);
     mHistogramADCamplitudeDE.insert(make_pair(de, h));
@@ -454,7 +455,7 @@ void PhysicsTaskDigits::endOfCycle()
   // update mergeable ratios
   mHistogramOccupancyElec->update();
 
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
     for (int i = 0; i < 2; i++) {
       auto h = mHistogramOccupancyDE[i].find(de);
       if ((h != mHistogramOccupancyDE[i].end()) && (h->second != NULL)) {

--- a/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
+++ b/Modules/MUON/MCH/src/PhysicsTaskPreclusters.cxx
@@ -105,7 +105,7 @@ void PhysicsTaskPreclusters::initialize(o2::framework::InitContext& /*ctx*/)
   mHistogramDenST345->init();
   mAllHistograms.push_back(mHistogramDenST345->getHist());
 
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
 
     auto h = std::make_shared<TH1F>(TString::Format("Expert/%sCluster_Charge_%03d", getHistoPath(de).c_str(), de),
                                     TString::Format("Cluster charge (DE%03d)", de), 1000, 0, 50000);
@@ -536,7 +536,7 @@ void PhysicsTaskPreclusters::computePseudoEfficiency()
   // update mergeable ratios
   mHistogramPseudoeffElec->update();
 
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
     for (int i = 0; i < 2; i++) {
       auto h = mHistogramPseudoeffXY[i].find(de);
       if ((h != mHistogramPseudoeffXY[i].end()) && (h->second != nullptr)) {

--- a/Modules/MUON/MCH/src/TrendingFECHistRatio.cxx
+++ b/Modules/MUON/MCH/src/TrendingFECHistRatio.cxx
@@ -36,6 +36,7 @@
 #include <TGraphErrors.h>
 #include <TProfile.h>
 #include <TPoint.h>
+#include "MCHConstants/DetectionElements.h"
 
 using namespace o2::quality_control;
 using namespace o2::quality_control::core;
@@ -52,7 +53,7 @@ void TrendingFECHistRatio::configure(std::string name, const boost::property_tre
                               fmt::format("CH{}:time", chamber + 1),
                               "", "*L", "" });
   }
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
     mConfig.plots.push_back({ fmt::format("{}{}_{}", getHistoPath(de), mConfig.mConfigTrendingFECHistRatio.namePrefix, de),
                               fmt::format("{} DE{}", mConfig.mConfigTrendingFECHistRatio.namePrefix, de),
                               fmt::format("DE{}:time", de),
@@ -103,7 +104,7 @@ void TrendingFECHistRatio::computeMCHFECHistRatios(TH2F* hNum, TH2F* hDen)
   for (int chamber = 0; chamber < 10; chamber++) {
     mTrendCH[chamber] = 0;
   }
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
     mTrendDE[de] = 0;
   }
 
@@ -178,7 +179,7 @@ void TrendingFECHistRatio::computeMCHFECHistRatios(TH2F* hNum, TH2F* hDen)
   }
 
   // compute and store average rate for each detection element
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
     double ratio = (deDen[de] > 0) ? (deNum[de] / deDen[de]) : 0;
     mTrendDE[de] = ratio;
   }
@@ -214,7 +215,7 @@ void TrendingFECHistRatio::initialize(Trigger, framework::ServiceRegistryRef)
   for (int chamber = 0; chamber < 10; chamber++) {
     mTrend->Branch(fmt::format("CH{}", chamber + 1).c_str(), &mTrendCH[chamber]);
   }
-  for (auto de : o2::mch::raw::deIdsForAllMCH) {
+  for (auto de : o2::mch::constants::deIdsForAllMCH) {
     mTrend->Branch(fmt::format("DE{}", de).c_str(), &mTrendDE[de]);
   }
 


### PR DESCRIPTION
@aferrero2707 a small modification to be able to remove `deIdsForAllMCH` from the `elecmap Mapper` in O2 (was moved to `MCHConstants` lib)