### PR TITLE
Add missing headers

### DIFF
--- a/Framework/include/QualityControl/ValidityInterval.h
+++ b/Framework/include/QualityControl/ValidityInterval.h
@@ -17,6 +17,7 @@
 #ifndef QUALITYCONTROL_VALIDITYINTERVAL_H
 #define QUALITYCONTROL_VALIDITYINTERVAL_H
 
+#include <limits>
 #include <MathUtils/detail/Bracket.h>
 
 namespace o2::quality_control::core


### PR DESCRIPTION
Before this came parasitically via `fmt` headers, but will no longer when we bump libfmt.