### PR TITLE
[EMCAL-846] Add reductor for bad channel and time calib params

### DIFF
--- a/Modules/EMCAL/CMakeLists.txt
+++ b/Modules/EMCAL/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 add_library(O2QcEMCAL)
 
-target_sources(O2QcEMCAL PRIVATE src/RawErrorCheck.cxx  src/RawTask.cxx src/RawCheck.cxx src/CellTask.cxx src/CellCheck.cxx src/DigitsQcTask.cxx src/DigitCheck.cxx src/DigitOccupancyReductor.cxx src/ClusterTask.cxx src/RawErrorTask.cxx src/CalibMonitoringTask.cxx src/SupermoduleProjectorTask.cxx)
+target_sources(O2QcEMCAL PRIVATE src/RawErrorCheck.cxx src/RawTask.cxx src/RawCheck.cxx src/CellTask.cxx src/CellCheck.cxx src/DigitsQcTask.cxx src/DigitCheck.cxx src/DigitOccupancyReductor.cxx src/ClusterTask.cxx src/RawErrorTask.cxx src/CalibMonitoringTask.cxx src/SupermoduleProjectorTask.cxx src/BadChannelMapReductor.cxx src/TimeCalibParamReductor.cxx
+)
 
 target_include_directories(
   O2QcEMCAL
@@ -25,7 +26,9 @@ add_root_dictionary(O2QcEMCAL
   include/EMCAL/RawErrorCheck.h
   include/EMCAL/CalibMonitoringTask.h
   include/EMCAL/SupermoduleProjectorTask.h
-        LINKDEF include/EMCAL/LinkDef.h)
+  include/EMCAL/BadChannelMapReductor.h
+  include/EMCAL/TimeCalibParamReductor.h
+  LINKDEF include/EMCAL/LinkDef.h)
 
 install(TARGETS O2QcEMCAL
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/EMCAL/include/EMCAL/BadChannelMapReductor.h
+++ b/Modules/EMCAL/include/EMCAL/BadChannelMapReductor.h
@@ -1,0 +1,71 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QUALITYCONTROL_EMCAL_BADCHANNELMAPREDUCTOR_H
+#define QUALITYCONTROL_EMCAL_BADCHANNELMAPREDUCTOR_H
+
+#include "QualityControl/Reductor.h"
+
+namespace o2
+{
+namespace emcal
+{
+class Geometry;
+}
+} // namespace o2
+
+namespace o2::quality_control_modules::emcal
+{
+
+/// \brief Dedicated reductor for EMCAL bad channel map
+///
+/// Produces entries:
+/// - Bad/Dead channels for Full acceptance/Subdetector/Supermodule
+/// - Fraction Bad/Dead channels for Full acceptance/Subdetector/Supermodule
+class BadChannelMapReductor : public quality_control::postprocessing::Reductor
+{
+ public:
+  BadChannelMapReductor();
+  virtual ~BadChannelMapReductor() = default;
+
+  void* getBranchAddress() override;
+  const char* getBranchLeafList() override;
+  void update(TObject* obj) override;
+
+ private:
+  bool isPHOSRegion(int column, int row) const;
+
+  o2::emcal::Geometry* mGeometry;
+  struct {
+    Int_t mBadChannelsTotal;
+    Int_t mDeadChannelsTotal;
+    Int_t mBadChannelsEMCAL;
+    Int_t mBadChannelsDCAL;
+    Int_t mDeadChannelsEMCAL;
+    Int_t mDeadChannelsDCAL;
+    Int_t mBadChannelsSM[20];
+    Int_t mDeadChannelsSM[20];
+    Int_t mSupermoduleMaxBad;
+    Int_t mSupermoduleMaxDead;
+    Double_t mFractionBadTotal;
+    Double_t mFractionDeadTotal;
+    Double_t mFractionBadEMCAL;
+    Double_t mFractionBadDCAL;
+    Double_t mFractionDeadEMCAL;
+    Double_t mFractionDeadDCAL;
+    Double_t mFractionBadSM[20];
+    Double_t mFractionDeadSM[20];
+  } mStats;
+};
+
+} // namespace o2::quality_control_modules::emcal
+
+#endif // QUALITYCONTROL_TH2REDUCTOR_

--- a/Modules/EMCAL/include/EMCAL/LinkDef.h
+++ b/Modules/EMCAL/include/EMCAL/LinkDef.h
@@ -27,4 +27,7 @@
 
 #pragma link C++ class o2::quality_control_modules::emcal::SupermoduleProjectorTask + ;
 
-      #endif
+#pragma link C++ class o2::quality_control_modules::emcal::BadChannelMapReductor + ;
+
+#pragma link C++ class o2::quality_control_modules::emcal::TimeCalibParamReductor + ;
+#endif

--- a/Modules/EMCAL/include/EMCAL/TimeCalibParamReductor.h
+++ b/Modules/EMCAL/include/EMCAL/TimeCalibParamReductor.h
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef QUALITYCONTROL_EMCAL_TIMECALIBPARAMREDUCTOR_H
+#define QUALITYCONTROL_EMCAL_TIMECALIBPARAMREDUCTOR_H
+
+#include "QualityControl/Reductor.h"
+
+namespace o2
+{
+namespace emcal
+{
+class Geometry;
+}
+} // namespace o2
+
+namespace o2::quality_control_modules::emcal
+{
+
+/// \brief Dedicated reductor for EMCAL time calibration param
+///
+/// Produces entries:
+/// - Channels with failed fit for Full acceptance/Subdetector/Supermodule
+/// - Fraction channels with failed fit for Full acceptance/Subdetector/Supermodule
+/// - Mean time shift
+/// - Sigma time shift
+class TimeCalibParamReductor : public quality_control::postprocessing::Reductor
+{
+ public:
+  TimeCalibParamReductor();
+  virtual ~TimeCalibParamReductor() = default;
+
+  void* getBranchAddress() override;
+  const char* getBranchLeafList() override;
+  void update(TObject* obj) override;
+
+ private:
+  bool isPHOSRegion(int column, int row) const;
+
+  o2::emcal::Geometry* mGeometry;
+  struct {
+    Int_t mFailedParams;
+    Int_t mFailedParamsEMCAL;
+    Int_t mFailedParamsDCAL;
+    Int_t mFailedParamSM[20];
+    Int_t mSupermoduleMaxFailed;
+    Double_t mFractionFailed;
+    Double_t mFractionFailedEMCAL;
+    Double_t mFractionFailedDCAL;
+    Double_t mFractionFailedSM[20];
+    Double_t mMeanShiftGood;
+    Double_t mSigmaShiftGood;
+  } mStats;
+};
+
+} // namespace o2::quality_control_modules::emcal
+
+#endif // QUALITYCONTROL_TH2REDUCTOR_

--- a/Modules/EMCAL/src/BadChannelMapReductor.cxx
+++ b/Modules/EMCAL/src/BadChannelMapReductor.cxx
@@ -1,0 +1,96 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <map>
+#include <TH2.h>
+#include <QualityControl/QcInfoLogger.h>
+#include <EMCALBase/Geometry.h>
+#include <EMCAL/BadChannelMapReductor.h>
+
+using namespace o2::quality_control_modules::emcal;
+
+BadChannelMapReductor::BadChannelMapReductor() : Reductor(), mGeometry(nullptr), mStats()
+{
+  mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
+}
+
+void* BadChannelMapReductor::getBranchAddress()
+{
+  return &mStats;
+}
+
+const char* BadChannelMapReductor::getBranchLeafList()
+{
+  return "BadChannelsTotal/I:DeadChannelsTotal:BadChannelsEMCAL:BadChannelsDCAL:DeadChannelsEMCAL:DeadChannelsDCAL:BadChannelsSM[20]:DeadChannelsSM[20]:SupermoduleMaxBad:SupermoduleMaxDead:FractionBadTotal/D:FractionDeadTotal:FractionBadEMCAL:FractionBadDCAL:FractionDeadEMCAL:FractionDeadDCAL:FractionBadSupermodule[20]:FractionDeadSupermodule[20]";
+}
+
+void BadChannelMapReductor::update(TObject* obj)
+{
+  const std::map<o2::emcal::EMCALSMType, int> channelsSMTYPE = { { o2::emcal::EMCAL_STANDARD, 1152 }, { o2::emcal::EMCAL_THIRD, 384 }, { o2::emcal::DCAL_STANDARD, 768 }, { o2::emcal::DCAL_EXT, 384 } };
+  constexpr int CHANNELS_TOTAL = 17664, CHANNELS_EMC = 12288, CHANNELS_DCAL = CHANNELS_TOTAL - CHANNELS_EMC;
+  memset(&mStats, 0, sizeof(mStats));
+  auto badChannelMap = static_cast<TH2*>(obj);
+  for (int icolumn = 0; icolumn < badChannelMap->GetXaxis()->GetNbins(); icolumn++) {
+    for (int irow = 0; irow < badChannelMap->GetYaxis()->GetNbins(); irow++) {
+      if (isPHOSRegion(icolumn, irow)) {
+        continue;
+      }
+      auto status = badChannelMap->GetBinContent(icolumn + 1, irow + 1);
+      auto [sm, mod, modrow, modcol] = mGeometry->GetCellIndexFromGlobalRowCol(irow, icolumn);
+      if (status == 1) { // bad channel
+        mStats.mBadChannelsTotal++;
+        mStats.mBadChannelsSM[sm]++;
+        if (sm < 12) {
+          mStats.mBadChannelsEMCAL++;
+        } else {
+          mStats.mBadChannelsDCAL++;
+        }
+      } else if (status == 2) {
+        mStats.mDeadChannelsTotal++;
+        mStats.mDeadChannelsSM[sm]++;
+        if (sm < 12) {
+          mStats.mDeadChannelsEMCAL++;
+        } else {
+          mStats.mDeadChannelsDCAL++;
+        }
+      }
+    }
+  }
+  mStats.mFractionBadTotal = static_cast<double>(mStats.mBadChannelsTotal) / static_cast<double>(CHANNELS_TOTAL);
+  mStats.mFractionDeadTotal = static_cast<double>(mStats.mDeadChannelsTotal) / static_cast<double>(CHANNELS_TOTAL);
+  mStats.mFractionBadEMCAL = static_cast<double>(mStats.mBadChannelsEMCAL) / static_cast<double>(CHANNELS_EMC);
+  mStats.mFractionDeadEMCAL = static_cast<double>(mStats.mDeadChannelsEMCAL) / static_cast<double>(CHANNELS_EMC);
+  mStats.mFractionBadDCAL = static_cast<double>(mStats.mBadChannelsDCAL) / static_cast<double>(CHANNELS_DCAL);
+  mStats.mFractionDeadDCAL = mStats.mDeadChannelsDCAL / CHANNELS_DCAL;
+  int currentbad = -1, currentdead = -1;
+  for (int ism = 0; ism < 20; ism++) {
+    auto smtype = mGeometry->GetSMType(ism);
+    auto nchannels = channelsSMTYPE.find(smtype);
+    if (nchannels == channelsSMTYPE.end()) {
+      ILOG(Error, Support) << "Unhandled Supermodule type" << ENDM;
+      continue;
+    }
+    mStats.mFractionDeadSM[ism] = static_cast<double>(mStats.mDeadChannelsSM[ism]) / nchannels->second;
+    mStats.mFractionBadSM[ism] = static_cast<double>(mStats.mBadChannelsSM[ism]) / static_cast<double>(nchannels->second);
+    if (mStats.mBadChannelsSM[ism] > currentbad) {
+      currentbad = mStats.mBadChannelsSM[ism];
+      mStats.mSupermoduleMaxBad = ism;
+    }
+    if (mStats.mDeadChannelsSM[ism] > currentdead) {
+      currentdead = mStats.mDeadChannelsSM[ism];
+      mStats.mSupermoduleMaxDead = ism;
+    }
+  }
+}
+
+bool BadChannelMapReductor::isPHOSRegion(int column, int row) const
+{
+  return (column >= 32 && column < 64) && (row >= 128 && row < 200);
+}

--- a/Modules/EMCAL/src/TimeCalibParamReductor.cxx
+++ b/Modules/EMCAL/src/TimeCalibParamReductor.cxx
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <map>
+#include <vector>
+#include <TH2.h>
+#include <TMath.h>
+#include <QualityControl/QcInfoLogger.h>
+#include <EMCALBase/Geometry.h>
+#include <EMCAL/TimeCalibParamReductor.h>
+
+using namespace o2::quality_control_modules::emcal;
+
+TimeCalibParamReductor::TimeCalibParamReductor() : Reductor(), mGeometry(nullptr), mStats()
+{
+  mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
+}
+
+void* TimeCalibParamReductor::getBranchAddress()
+{
+  return &mStats;
+}
+
+const char* TimeCalibParamReductor::getBranchLeafList()
+{
+  return "FailedChannelsTotal/I:FailedChannelsEMCAL:FailedChannelsDCAL:FailedChannelsSM[20]:SupermoduleMaxFailed:FractionFailedTotal/D:FractionFailedEMCAL:FractionFaileDCAL:FractionFailedSupermodule[20]:MeanShift:SigmaShift";
+}
+
+void TimeCalibParamReductor::update(TObject* obj)
+{
+  const std::map<o2::emcal::EMCALSMType, int> channelsSMTYPE = { { o2::emcal::EMCAL_STANDARD, 1152 }, { o2::emcal::EMCAL_THIRD, 384 }, { o2::emcal::DCAL_STANDARD, 768 }, { o2::emcal::DCAL_EXT, 384 } };
+  constexpr int CHANNELS_TOTAL = 17664, CHANNELS_EMC = 12288, CHANNELS_DCAL = CHANNELS_TOTAL - CHANNELS_EMC;
+  memset(&mStats, 0, sizeof(mStats));
+  auto timeCalib = static_cast<TH1*>(obj);
+  std::vector<double> tcpGood;
+  for (auto itower = 0; itower < timeCalib->GetXaxis()->GetNbins(); itower++) {
+    auto param = timeCalib->GetBinContent(itower + 1);
+    if (std::abs(param) > 100) {
+      // Consider fit failed if the time calibration param is larger than 100
+      mStats.mFailedParams++;
+      auto [sm, mod, modphi, modeta] = mGeometry->GetCellIndex(itower);
+      mStats.mFailedParamSM[sm]++;
+      if (sm >= 12) {
+        mStats.mFailedParamsDCAL++;
+      } else {
+        mStats.mFailedParamsEMCAL++;
+      }
+    } else {
+      tcpGood.emplace_back(param);
+    }
+  }
+  mStats.mFractionFailed = static_cast<double>(mStats.mFailedParams) / static_cast<double>(CHANNELS_TOTAL);
+  mStats.mFractionFailedEMCAL = static_cast<double>(mStats.mFractionFailedEMCAL) / static_cast<double>(CHANNELS_EMC);
+  mStats.mFractionFailedDCAL = static_cast<double>(mStats.mFailedParamsDCAL) / static_cast<double>(CHANNELS_DCAL);
+  int currentmax = -1;
+  for (int ism = 0; ism < 20; ism++) {
+    auto smtype = mGeometry->GetSMType(ism);
+    auto nchannels = channelsSMTYPE.find(smtype);
+    if (nchannels == channelsSMTYPE.end()) {
+      ILOG(Error, Support) << "Unhandled Supermodule type" << ENDM;
+      continue;
+    }
+    mStats.mFractionFailedSM[ism] = static_cast<double>(mStats.mFailedParamSM[ism]) / static_cast<double>(nchannels->second);
+    if (mStats.mFailedParamSM[ism] > currentmax) {
+      currentmax = mStats.mFailedParamSM[ism];
+      mStats.mSupermoduleMaxFailed = ism;
+    }
+  }
+  mStats.mMeanShiftGood = TMath::Mean(tcpGood.begin(), tcpGood.end());
+  mStats.mSigmaShiftGood = TMath::Mean(tcpGood.begin(), tcpGood.end());
+}
+
+bool TimeCalibParamReductor::isPHOSRegion(int column, int row) const
+{
+  return (column >= 32 && column < 64) && (row >= 128 && row < 200);
+}


### PR DESCRIPTION
Dedicated reductors for histograms of the bad channel map and time calibration params
- Number and fraction of bad/dead channels in various detecotor segments (full/subdetector/supermodule)
- Number of failures in time calib params
- Supermodule with most bad/dead channels or failed time calib params