### PR TITLE
[FOCAL] Add mapping for pixels + geometry histos

### DIFF
--- a/Modules/FOCAL/CMakeLists.txt
+++ b/Modules/FOCAL/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(O2QcFOCAL)
 
-target_sources(O2QcFOCAL PRIVATE src/LaneData.cxx src/PadWord.cxx src/PadData.cxx src/PadDecoder.cxx src/PadMapper.cxx src/PixelHit.cxx src/PixelChip.cxx src/PixelDecoder.cxx src/TestbeamRawTask.cxx)
+target_sources(O2QcFOCAL PRIVATE src/LaneData.cxx src/PadWord.cxx src/PadData.cxx src/PadDecoder.cxx src/PadMapper.cxx src/PixelHit.cxx src/PixelChip.cxx src/PixelDecoder.cxx src/PixelMapper.cxx src/TestbeamRawTask.cxx)
 
 target_include_directories(
   O2QcFOCAL
@@ -20,6 +20,12 @@ install(TARGETS O2QcFOCAL
 add_root_dictionary(O2QcFOCAL
   HEADERS
   include/FOCAL/TestbeamRawTask.h
+  include/FOCAL/PixelMapper.h
+  include/FOCAL/PixelDecoder.h
+  include/FOCAL/PadData.h
+  include/FOCAL/PadMapper.h
+  include/FOCAL/LaneData.h
+  include/FOCAL/PadDecoder.h
   LINKDEF include/FOCAL/LinkDef.h)
 
 install(

--- a/Modules/FOCAL/include/FOCAL/LinkDef.h
+++ b/Modules/FOCAL/include/FOCAL/LinkDef.h
@@ -4,5 +4,15 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::quality_control_modules::focal::TestbeamRawTask + ;
+#pragma link C++ class o2::quality_control_modules::focal::PixelMapper + ;
+#pragma link C++ class o2::quality_control_modules::focal::PixelMapping + ;
+#pragma link C++ class o2::quality_control_modules::focal::PixelDecoder + ;
+#pragma link C++ class o2::quality_control_modules::focal::PadMapper + ;
+#pragma link C++ class o2::quality_control_modules::focal::PadDecoder + ;
+#pragma link C++ class o2::quality_control_modules::focal::LaneHandler + ;
+#pragma link C++ class o2::quality_control_modules::focal::LanePayload + ;
+#pragma link C++ class o2::quality_control_modules::focal::PadData + ;
+#pragma link C++ class o2::quality_control_modules::focal::ASICContainer + ;
+#pragma link C++ class o2::quality_control_modules::focal::ASICData + ;
 
 #endif

--- a/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
+++ b/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
@@ -18,13 +18,16 @@
 #define QC_MODULE_FOCAL_FOCALTESTBEAMRAWTASK_H
 
 #include <array>
+#include <unordered_map>
 
 #include "QualityControl/TaskInterface.h"
+#include "CommonDataFormat/InteractionRecord.h"
 #include "ITSMFTReconstruction/GBTWord.h"
 #include "FOCAL/PadWord.h"
 #include "FOCAL/PadDecoder.h"
 #include "FOCAL/PadMapper.h"
 #include "FOCAL/PixelDecoder.h"
+#include "FOCAL/PixelMapper.h"
 
 class TH1;
 class TH2;
@@ -59,9 +62,12 @@ class TestbeamRawTask final : public TaskInterface
   void processPixelPayload(gsl::span<const o2::itsmft::GBTWord> gbtpayload, uint16_t feeID);
   void processPadEvent(gsl::span<const PadGBTWord> gbtpayload);
 
-  PadDecoder mPadDecoder;     ///< Decoder for pad data
-  PadMapper mPadMapper;       ///< Mapping for Pads
-  PixelDecoder mPixelDecoder; ///< Decoder for pixel data
+  PadDecoder mPadDecoder;                                                         ///< Decoder for pad data
+  PadMapper mPadMapper;                                                           ///< Mapping for Pads
+  PixelDecoder mPixelDecoder;                                                     ///< Decoder for pixel data
+  PixelMapper mPixelMapper;                                                       ///< Testbeam mapping for pixels
+  std::unordered_map<o2::InteractionRecord, int> mPixelNHitsAll;                  ///< Number of hits / event all layers
+  std::array<std::unordered_map<o2::InteractionRecord, int>, 2> mPixelNHitsLayer; ///< Number of hits / event layer
 
   /////////////////////////////////////////////////////////////////////////////////////
   /// Pad histograms
@@ -75,10 +81,15 @@ class TestbeamRawTask final : public TaskInterface
   /////////////////////////////////////////////////////////////////////////////////////
   /// Pixel histograms
   /////////////////////////////////////////////////////////////////////////////////////
-  TH1* mLinksWithPayloadPixel;       ///< HBF with payload per link
-  TH2* mTriggersFeePixel;            ///< Nunber of triggers per HBF and FEE ID
-  TProfile2D* mAverageHitsChipPixel; ///< Average number of hits / chip
-  TH1* mHitsChipPixel;               ///< Number of hits / chip
+  TH1* mLinksWithPayloadPixel;                         ///< HBF with payload per link
+  TH2* mTriggersFeePixel;                              ///< Nunber of triggers per HBF and FEE ID
+  TProfile2D* mAverageHitsChipPixel;                   ///< Average number of hits / chip
+  TH1* mHitsChipPixel;                                 ///< Number of hits / chip
+  std::array<TProfile2D*, 2> mPixelChipHitPofileLayer; ///< Hit profile for pixel chips
+  std::array<TH2*, 2> mPixelChipHitProfileLayer;       ///< Hit map for pixel chips
+  std::array<TH2*, 2> mPixelHitDistribitionLayer;      ///< Hit distribution per chip in layer
+  TH1* mPixelHitsTriggerAll;                           ///< Number of pixel hits / trigger
+  std::array<TH1*, 2> mPixelHitsTriggerLayer;          ///< Number of pixel hits in layer / trigger
 };
 
 } // namespace o2::quality_control_modules::focal

--- a/Modules/FOCAL/src/PixelMapper.cxx
+++ b/Modules/FOCAL/src/PixelMapper.cxx
@@ -1,0 +1,131 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include <FOCAL/PixelMapper.h>
+
+using namespace o2::quality_control_modules::focal;
+
+PixelMapping::PixelMapping(unsigned int version) { init(version); }
+
+void PixelMapping::init(unsigned int version)
+{
+  if (version >= 2) {
+    throw VersionException(version);
+  }
+  switch (version) {
+    case 0:
+      buildVersion0();
+      break;
+
+    case 1:
+      buildVersion0();
+      break;
+
+    default:
+      break;
+  }
+}
+
+PixelMapping::ChipPosition PixelMapping::getPosition(unsigned int laneID, unsigned int chipID) const
+{
+  ChipIdentifier identifier{ laneID, chipID };
+  auto found = mMapping.find(identifier);
+  if (found == mMapping.end()) {
+    throw InvalidChipException(mVersion, identifier);
+  }
+  return found->second;
+}
+
+void PixelMapping::buildVersion0()
+{
+  mMapping.clear();
+  mMapping.insert({ { 7, 6 }, { 0, 0 } });
+  mMapping.insert({ { 7, 5 }, { 1, 0 } });
+  mMapping.insert({ { 7, 4 }, { 2, 0 } });
+  mMapping.insert({ { 7, 3 }, { 3, 0 } });
+  mMapping.insert({ { 7, 2 }, { 4, 0 } });
+  mMapping.insert({ { 7, 1 }, { 5, 0 } });
+  mMapping.insert({ { 7, 0 }, { 6, 0 } });
+  mMapping.insert({ { 6, 8 }, { 0, 1 } });
+  mMapping.insert({ { 6, 9 }, { 1, 1 } });
+  mMapping.insert({ { 6, 10 }, { 2, 1 } });
+  mMapping.insert({ { 6, 11 }, { 3, 1 } });
+  mMapping.insert({ { 6, 12 }, { 4, 1 } });
+  mMapping.insert({ { 6, 13 }, { 5, 1 } });
+  mMapping.insert({ { 7, 14 }, { 6, 1 } });
+  mMapping.insert({ { 21, 6 }, { 0, 4 } });
+  mMapping.insert({ { 21, 5 }, { 1, 4 } });
+  mMapping.insert({ { 21, 4 }, { 2, 4 } });
+  mMapping.insert({ { 21, 3 }, { 3, 4 } });
+  mMapping.insert({ { 21, 2 }, { 4, 4 } });
+  mMapping.insert({ { 21, 1 }, { 5, 4 } });
+  mMapping.insert({ { 21, 0 }, { 6, 4 } });
+  mMapping.insert({ { 20, 8 }, { 0, 5 } });
+  mMapping.insert({ { 20, 9 }, { 1, 5 } });
+  mMapping.insert({ { 20, 10 }, { 2, 5 } });
+  mMapping.insert({ { 20, 11 }, { 3, 5 } });
+  mMapping.insert({ { 20, 12 }, { 4, 5 } });
+  mMapping.insert({ { 20, 13 }, { 5, 5 } });
+  mMapping.insert({ { 20, 14 }, { 6, 5 } });
+}
+
+void PixelMapping::buildVersion1()
+{
+  mMapping.clear();
+  mMapping.insert({ { 6, 8 }, { 0, 2 } });
+  mMapping.insert({ { 6, 9 }, { 1, 2 } });
+  mMapping.insert({ { 6, 10 }, { 2, 2 } });
+  mMapping.insert({ { 6, 11 }, { 3, 2 } });
+  mMapping.insert({ { 6, 12 }, { 4, 2 } });
+  mMapping.insert({ { 6, 13 }, { 5, 2 } });
+  mMapping.insert({ { 6, 14 }, { 6, 2 } });
+  mMapping.insert({ { 7, 6 }, { 0, 3 } });
+  mMapping.insert({ { 7, 5 }, { 1, 3 } });
+  mMapping.insert({ { 7, 4 }, { 2, 3 } });
+  mMapping.insert({ { 7, 3 }, { 3, 3 } });
+  mMapping.insert({ { 7, 2 }, { 4, 3 } });
+  mMapping.insert({ { 7, 1 }, { 5, 3 } });
+  mMapping.insert({ { 7, 0 }, { 6, 3 } });
+}
+
+void PixelMapping::InvalidChipException::print(std::ostream& stream) const
+{
+  stream << mMessage;
+}
+
+void PixelMapping::VersionException::print(std::ostream& stream) const
+{
+  stream << mMessage;
+}
+
+PixelMapper::PixelMapper()
+{
+  mMappings[0].init(0);
+  mMappings[1].init(1);
+}
+
+const PixelMapping& PixelMapper::getMapping(unsigned int feeID) const
+{
+  return mMappings[feeID % 2];
+}
+
+std::ostream& o2::quality_control_modules::focal::operator<<(std::ostream& stream, const PixelMapping::InvalidChipException& error)
+{
+  error.print(stream);
+  return stream;
+}
+
+std::ostream& o2::quality_control_modules::focal::operator<<(std::ostream& stream, const PixelMapping::VersionException& error)
+{
+  error.print(stream);
+  return stream;
+}


### PR DESCRIPTION
- Testbeam setup for FOCAL pixels Nov. 22 (2 layers, 7 cols x 6 rows each)
- Adding histograms for
  + hit profile (average number of hits / chip)
  + hit map (sum number of hits / chip)
  + hit distribution (number of hits / chip)
  + Total number of hits / trigger
  + Number of hits in layer / trigger
- Add FOCAL decoding objects to LinkDef