### PR TITLE
[FOCAL] Fixes for pixel mapping and high-granularity hitmaps

### DIFF
--- a/Modules/FOCAL/include/FOCAL/PixelMapper.h
+++ b/Modules/FOCAL/include/FOCAL/PixelMapper.h
@@ -151,8 +151,10 @@ class PixelMapper
   ~PixelMapper() = default;
 
   const PixelMapping& getMapping(unsigned int feeID) const;
+  MappingType_t getMappingType() const { return mMappingType; }
 
  private:
+  MappingType_t mMappingType;
   std::array<std::shared_ptr<PixelMapping>, 2> mMappings;
 };
 

--- a/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
+++ b/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
@@ -86,6 +86,7 @@ class TestbeamRawTask final : public TaskInterface
   TH2* mTriggersFeePixel;                              ///< Nunber of triggers per HBF and FEE ID
   TProfile2D* mAverageHitsChipPixel;                   ///< Average number of hits / chip
   TH1* mHitsChipPixel;                                 ///< Number of hits / chip
+  TH2* mPixelChipsIDsFound;                            ///< Chip IDs vs Pixel IDs
   std::array<TProfile2D*, 2> mPixelChipHitPofileLayer; ///< Hit profile for pixel chips
   std::array<TH2*, 2> mPixelChipHitProfileLayer;       ///< Hit map for pixel chips
   std::array<TH2*, 2> mPixelHitDistribitionLayer;      ///< Hit distribution per chip in layer

--- a/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
+++ b/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
@@ -58,9 +58,19 @@ class TestbeamRawTask final : public TaskInterface
   void reset() override;
 
  private:
+  static constexpr int PIXEL_ROWS_IB = 512,
+                       PIXEL_COLS_IB = 1024,
+                       PIXEL_ROW_SEGMENTSIZE_IB = 8,
+                       PIXEL_COL_SEGMENSIZE_IB = 32,
+                       PIXEL_ROWS_OB = 512,
+                       PIXEL_COLS_OB = 1024,
+                       PIXEL_ROW_SEGMENTSIZE_OB = 8,
+                       PIXEL_COL_SEGMENSIZE_OB = 32;
   void processPadPayload(gsl::span<const PadGBTWord> gbtpayload);
   void processPixelPayload(gsl::span<const o2::itsmft::GBTWord> gbtpayload, uint16_t feeID);
   void processPadEvent(gsl::span<const PadGBTWord> gbtpayload);
+  std::pair<int, int> getNumberOfPixelSegments(PixelMapper::MappingType_t mappingtype) const;
+  std::pair<int, int> getPixelSegment(const PixelHit& hit, PixelMapper::MappingType_t mappingtype) const;
 
   PadDecoder mPadDecoder;                                                         ///< Decoder for pad data
   PadMapper mPadMapper;                                                           ///< Mapping for Pads
@@ -68,6 +78,7 @@ class TestbeamRawTask final : public TaskInterface
   std::unique_ptr<PixelMapper> mPixelMapper;                                      ///< Testbeam mapping for pixels
   std::unordered_map<o2::InteractionRecord, int> mPixelNHitsAll;                  ///< Number of hits / event all layers
   std::array<std::unordered_map<o2::InteractionRecord, int>, 2> mPixelNHitsLayer; ///< Number of hits / event layer
+  std::vector<int> mHitSegmentCounter;                                            ///< Number of hits / segment
   bool mDebugMode = false;                                                        ///< Additional debug verbosity
 
   /////////////////////////////////////////////////////////////////////////////////////
@@ -82,16 +93,19 @@ class TestbeamRawTask final : public TaskInterface
   /////////////////////////////////////////////////////////////////////////////////////
   /// Pixel histograms
   /////////////////////////////////////////////////////////////////////////////////////
-  TH1* mLinksWithPayloadPixel;                         ///< HBF with payload per link
-  TH2* mTriggersFeePixel;                              ///< Nunber of triggers per HBF and FEE ID
-  TProfile2D* mAverageHitsChipPixel;                   ///< Average number of hits / chip
-  TH1* mHitsChipPixel;                                 ///< Number of hits / chip
-  TH2* mPixelChipsIDsFound;                            ///< Chip IDs vs Pixel IDs
-  std::array<TProfile2D*, 2> mPixelChipHitPofileLayer; ///< Hit profile for pixel chips
-  std::array<TH2*, 2> mPixelChipHitProfileLayer;       ///< Hit map for pixel chips
-  std::array<TH2*, 2> mPixelHitDistribitionLayer;      ///< Hit distribution per chip in layer
-  TH1* mPixelHitsTriggerAll;                           ///< Number of pixel hits / trigger
-  std::array<TH1*, 2> mPixelHitsTriggerLayer;          ///< Number of pixel hits in layer / trigger
+  TH1* mLinksWithPayloadPixel;                             ///< HBF with payload per link
+  TH2* mTriggersFeePixel;                                  ///< Nunber of triggers per HBF and FEE ID
+  TProfile2D* mAverageHitsChipPixel;                       ///< Average number of hits / chip
+  TH1* mHitsChipPixel;                                     ///< Number of hits / chip
+  TH2* mPixelChipsIDsFound;                                ///< Chip IDs vs FEE IDs
+  TH2* mPixelChipsIDsHits;                                 ///< Chip IDs with hits vs FEE IDs
+  std::array<TProfile2D*, 2> mPixelChipHitProfileLayer;    ///< Hit profile for pixel chips
+  std::array<TH2*, 2> mPixelChipHitmapLayer;               ///< Hit map for pixel chips
+  std::array<TProfile2D*, 2> mPixelSegmentHitProfileLayer; ///< Hit profile for pixel segments
+  std::array<TH2*, 2> mPixelSegmentHitmapLayer;            ///< Hit map for pixel segments
+  std::array<TH2*, 2> mPixelHitDistribitionLayer;          ///< Hit distribution per chip in layer
+  TH1* mPixelHitsTriggerAll;                               ///< Number of pixel hits / trigger
+  std::array<TH1*, 2> mPixelHitsTriggerLayer;              ///< Number of pixel hits in layer / trigger
 };
 
 } // namespace o2::quality_control_modules::focal

--- a/Modules/FOCAL/src/PixelMapper.cxx
+++ b/Modules/FOCAL/src/PixelMapper.cxx
@@ -50,7 +50,7 @@ void PixelMappingOB::init(unsigned int version)
       break;
 
     case 1:
-      buildVersion0();
+      buildVersion1();
       break;
 
     default:
@@ -125,7 +125,7 @@ void PixelMappingIB::init(unsigned int version)
       break;
 
     case 1:
-      buildVersion0();
+      buildVersion1();
       break;
 
     default:

--- a/Modules/FOCAL/src/PixelMapper.cxx
+++ b/Modules/FOCAL/src/PixelMapper.cxx
@@ -162,7 +162,7 @@ void PixelMappingIB::buildVersion1()
   mMapping.insert({ { 0, 8 }, { 2, 1 } });
 }
 
-PixelMapper::PixelMapper(PixelMapper::MappingType_t mappingtype)
+PixelMapper::PixelMapper(PixelMapper::MappingType_t mappingtype) : mMappingType(mappingtype)
 {
   switch (mappingtype) {
     case MappingType_t::MAPPING_IB:


### PR DESCRIPTION
- Fix incorrect mapping of odd FEEs
  + Mapping for event FEEs loaded by mistake for odd FEEs
- Add pixe plots with high granularity
  + Add hitmap with segmentation of the pixel chip
  + Fix buffer reset leading to double counting
  + Add histograms of chip counts (empty/filled)