### PR TITLE
TRD Fix parsing error graph labels, data acceptance graph

### DIFF
--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -281,7 +281,7 @@ void TrackletsTask::drawHashedOnHistsPerLayer(int iLayer)
     for (int iSec = 0; iSec < 18; ++iSec) {
       for (int iStack = 0; iStack < 5; ++iStack) {
         int rowMax = (iStack == 2) ? 12 : 16;
-        for (int side = 0; side < 8; ++side) {
+        for (int side = 0; side < 2; ++side) {
           int det = iSec * 30 + iStack * 6 + iLayer;
           int hcid = (side == 0) ? det * 2 : det * 2 + 1;
           int rowstart = iStack < 3 ? iStack * 16 : 44 + (iStack - 3) * 16;                 // pad row within whole sector


### PR DESCRIPTION
- fix the labels on the parsing errors graph to reflect what they are
- fix the data acceptance graph.

Some other sundry fixes.