### PR TITLE
[FOCAL] Several fixes for SPS Testbeam Nov 2022

### DIFF
--- a/Modules/FOCAL/include/FOCAL/PixelMapper.h
+++ b/Modules/FOCAL/include/FOCAL/PixelMapper.h
@@ -35,6 +35,8 @@ class PixelMapping
   struct ChipPosition {
     unsigned int mColumn;
     unsigned int mRow;
+    bool mInvertColumn;
+    bool mInvertRow;
 
     bool operator==(const ChipPosition& other) const { return mColumn == other.mColumn && mRow == other.mRow; }
   };

--- a/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
+++ b/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
@@ -58,7 +58,8 @@ class TestbeamRawTask final : public TaskInterface
   void reset() override;
 
  private:
-  static constexpr int PIXEL_ROWS_IB = 512,
+  static constexpr int PAD_ASICS = 18,
+                       PIXEL_ROWS_IB = 512,
                        PIXEL_COLS_IB = 1024,
                        PIXEL_ROW_SEGMENTSIZE_IB = 8,
                        PIXEL_COL_SEGMENSIZE_IB = 32,
@@ -66,11 +67,20 @@ class TestbeamRawTask final : public TaskInterface
                        PIXEL_COLS_OB = 1024,
                        PIXEL_ROW_SEGMENTSIZE_OB = 8,
                        PIXEL_COL_SEGMENSIZE_OB = 32;
+  struct PadChannelProjections {
+    PadChannelProjections() = default;
+    ~PadChannelProjections();
+    std::unordered_map<int, TH1*> mHistos;
+    void init(const std::vector<int> channels, int ASICid);
+    void startPublishing(o2::quality_control::core::ObjectsManager& manager);
+    void reset();
+  };
+  void default_init();
   void processPadPayload(gsl::span<const PadGBTWord> gbtpayload);
   void processPixelPayload(gsl::span<const o2::itsmft::GBTWord> gbtpayload, uint16_t feeID);
   void processPadEvent(gsl::span<const PadGBTWord> gbtpayload);
   std::pair<int, int> getNumberOfPixelSegments(PixelMapper::MappingType_t mappingtype) const;
-  std::pair<int, int> getPixelSegment(const PixelHit& hit, PixelMapper::MappingType_t mappingtype) const;
+  std::pair<int, int> getPixelSegment(const PixelHit& hit, PixelMapper::MappingType_t mappingtype, const PixelMapping::ChipPosition& chipMapping) const;
 
   PadDecoder mPadDecoder;                                                         ///< Decoder for pad data
   PadMapper mPadMapper;                                                           ///< Mapping for Pads
@@ -79,32 +89,38 @@ class TestbeamRawTask final : public TaskInterface
   std::unordered_map<o2::InteractionRecord, int> mPixelNHitsAll;                  ///< Number of hits / event all layers
   std::array<std::unordered_map<o2::InteractionRecord, int>, 2> mPixelNHitsLayer; ///< Number of hits / event layer
   std::vector<int> mHitSegmentCounter;                                            ///< Number of hits / segment
+  std::vector<int> mChannelsPadProjections;                                       ///< Channels selected for pad projections
+  int mPadTOTCutADC = 1;                                                          ///< Max TOT for ADC plot
   bool mDebugMode = false;                                                        ///< Additional debug verbosity
+  bool mDisablePads = false;                                                      ///< Disable pads
+  bool mDisablePixels = false;                                                    ///< Disable pixels
 
   /////////////////////////////////////////////////////////////////////////////////////
   /// Pad histograms
   /////////////////////////////////////////////////////////////////////////////////////
-  TH1* mPayloadSizePadsGBT;                             ///< Payload size GBT words of pad data
-  std::array<TH2*, PadData::NASICS> mPadASICChannelADC; ///< ADC per channel for each ASIC
-  std::array<TH2*, PadData::NASICS> mPadASICChannelTOA; ///< TOA per channel for each ASIC
-  std::array<TH2*, PadData::NASICS> mPadASICChannelTOT; ///< TOT per channel for each ASIC
-  std::array<TH2*, PadData::NASICS> mHitMapPadASIC;     ///< Hitmap per ASIC
+  TH1* mPayloadSizePadsGBT;                                                             ///< Payload size GBT words of pad data
+  std::array<TH2*, PAD_ASICS> mPadASICChannelADC;                                       ///< ADC per channel for each ASIC
+  std::array<TH2*, PAD_ASICS> mPadASICChannelTOA;                                       ///< TOA per channel for each ASIC
+  std::array<TH2*, PAD_ASICS> mPadASICChannelTOT;                                       ///< TOT per channel for each ASIC
+  std::array<TH2*, PAD_ASICS> mHitMapPadASIC;                                           ///< Hitmap per ASIC
+  std::array<std::unique_ptr<PadChannelProjections>, PAD_ASICS> mPadChannelProjections; ///< ADC projections per ASIC channel
 
   /////////////////////////////////////////////////////////////////////////////////////
   /// Pixel histograms
   /////////////////////////////////////////////////////////////////////////////////////
-  TH1* mLinksWithPayloadPixel;                             ///< HBF with payload per link
-  TH2* mTriggersFeePixel;                                  ///< Nunber of triggers per HBF and FEE ID
-  TProfile2D* mAverageHitsChipPixel;                       ///< Average number of hits / chip
-  TH1* mHitsChipPixel;                                     ///< Number of hits / chip
-  TH2* mPixelChipsIDsFound;                                ///< Chip IDs vs FEE IDs
-  TH2* mPixelChipsIDsHits;                                 ///< Chip IDs with hits vs FEE IDs
+  TH1* mLinksWithPayloadPixel = nullptr;                   ///< HBF with payload per link
+  TH2* mTriggersFeePixel = nullptr;                        ///< Nunber of triggers per HBF and FEE ID
+  TProfile2D* mAverageHitsChipPixel = nullptr;             ///< Average number of hits / chip
+  TH1* mHitsChipPixel = nullptr;                           ///< Number of hits / chip
+  TH2* mPixelChipsIDsFound = nullptr;                      ///< Chip IDs vs FEE IDs
+  TH2* mPixelChipsIDsHits = nullptr;                       ///< Chip IDs with hits vs FEE IDs
+  std::array<TH1*, 4> mPixelLaneIDChipIDFEE;               ///< Lane ID vs. chip ID for each FEE
   std::array<TProfile2D*, 2> mPixelChipHitProfileLayer;    ///< Hit profile for pixel chips
   std::array<TH2*, 2> mPixelChipHitmapLayer;               ///< Hit map for pixel chips
   std::array<TProfile2D*, 2> mPixelSegmentHitProfileLayer; ///< Hit profile for pixel segments
   std::array<TH2*, 2> mPixelSegmentHitmapLayer;            ///< Hit map for pixel segments
   std::array<TH2*, 2> mPixelHitDistribitionLayer;          ///< Hit distribution per chip in layer
-  TH1* mPixelHitsTriggerAll;                               ///< Number of pixel hits / trigger
+  TH1* mPixelHitsTriggerAll = nullptr;                     ///< Number of pixel hits / trigger
   std::array<TH1*, 2> mPixelHitsTriggerLayer;              ///< Number of pixel hits in layer / trigger
 };
 

--- a/Modules/FOCAL/src/PixelDecoder.cxx
+++ b/Modules/FOCAL/src/PixelDecoder.cxx
@@ -61,7 +61,13 @@ void PixelDecoder::decodeEvent(gsl::span<const o2::itsmft::GBTWord> payload)
       if (word.isDataIB()) {
         lane = dataword->getLaneIB();
       } else if (word.isDataOB()) {
-        lane = dataword->getLaneOB();
+        // lane = dataword->getLaneOB();
+        // MF treat as if they would be IB lanes
+        lane = dataword->getLaneIB();
+      }
+      if (lane >= LaneHandler::NLANES) {
+        // Discarding lanes
+        continue;
       }
       currenttrigger->getLane(lane).append(payload);
     }

--- a/Modules/FOCAL/src/PixelMapper.cxx
+++ b/Modules/FOCAL/src/PixelMapper.cxx
@@ -62,53 +62,55 @@ void PixelMappingOB::init(unsigned int version)
 void PixelMappingOB::buildVersion0()
 {
   mMapping.clear();
-  mMapping.insert({ { 7, 6 }, { 0, 5 } });
-  mMapping.insert({ { 7, 5 }, { 1, 5 } });
-  mMapping.insert({ { 7, 4 }, { 2, 5 } });
-  mMapping.insert({ { 7, 3 }, { 3, 5 } });
-  mMapping.insert({ { 7, 2 }, { 4, 5 } });
-  mMapping.insert({ { 7, 1 }, { 5, 5 } });
-  mMapping.insert({ { 7, 0 }, { 6, 5 } });
-  mMapping.insert({ { 6, 8 }, { 0, 4 } });
-  mMapping.insert({ { 6, 9 }, { 1, 4 } });
-  mMapping.insert({ { 6, 10 }, { 2, 4 } });
-  mMapping.insert({ { 6, 11 }, { 3, 4 } });
-  mMapping.insert({ { 6, 12 }, { 4, 4 } });
-  mMapping.insert({ { 6, 13 }, { 5, 4 } });
-  mMapping.insert({ { 7, 14 }, { 6, 4 } });
-  mMapping.insert({ { 21, 6 }, { 0, 1 } });
-  mMapping.insert({ { 21, 5 }, { 1, 1 } });
-  mMapping.insert({ { 21, 4 }, { 2, 1 } });
-  mMapping.insert({ { 21, 3 }, { 3, 1 } });
-  mMapping.insert({ { 21, 2 }, { 4, 1 } });
-  mMapping.insert({ { 21, 1 }, { 5, 1 } });
-  mMapping.insert({ { 21, 0 }, { 6, 1 } });
-  mMapping.insert({ { 20, 8 }, { 0, 0 } });
-  mMapping.insert({ { 20, 9 }, { 1, 0 } });
-  mMapping.insert({ { 20, 10 }, { 2, 0 } });
-  mMapping.insert({ { 20, 11 }, { 3, 0 } });
-  mMapping.insert({ { 20, 12 }, { 4, 0 } });
-  mMapping.insert({ { 20, 13 }, { 5, 0 } });
-  mMapping.insert({ { 20, 14 }, { 6, 0 } });
+  /**                Lane, Chip, Col, Row, Inv Col, Inv Row **/
+  mMapping.insert({ { 8, 6 }, { 0, 5, true, false } });
+  mMapping.insert({ { 8, 5 }, { 1, 5, true, false } });
+  mMapping.insert({ { 8, 4 }, { 2, 5, true, false } });
+  mMapping.insert({ { 8, 3 }, { 3, 5, true, false } });
+  mMapping.insert({ { 8, 2 }, { 4, 5, true, false } });
+  mMapping.insert({ { 8, 1 }, { 5, 5, true, false } });
+  mMapping.insert({ { 8, 0 }, { 6, 5, true, false } });
+  mMapping.insert({ { 6, 8 }, { 0, 4, false, true } });
+  mMapping.insert({ { 6, 9 }, { 1, 4, false, true } });
+  mMapping.insert({ { 6, 10 }, { 2, 4, false, true } });
+  mMapping.insert({ { 6, 11 }, { 3, 4, false, true } });
+  mMapping.insert({ { 6, 12 }, { 4, 4, false, true } });
+  mMapping.insert({ { 6, 13 }, { 5, 4, false, true } });
+  mMapping.insert({ { 6, 14 }, { 6, 4, false, true } });
+  mMapping.insert({ { 24, 6 }, { 0, 1, true, false } });
+  mMapping.insert({ { 24, 5 }, { 1, 1, true, false } });
+  mMapping.insert({ { 24, 4 }, { 2, 1, true, false } });
+  mMapping.insert({ { 24, 3 }, { 3, 1, true, false } });
+  mMapping.insert({ { 24, 2 }, { 4, 1, true, false } });
+  mMapping.insert({ { 24, 1 }, { 5, 1, true, false } });
+  mMapping.insert({ { 24, 0 }, { 6, 1, true, false } });
+  mMapping.insert({ { 22, 8 }, { 0, 0, false, true } });
+  mMapping.insert({ { 22, 9 }, { 1, 0, false, true } });
+  mMapping.insert({ { 22, 10 }, { 2, 0, false, true } });
+  mMapping.insert({ { 22, 11 }, { 3, 0, false, true } });
+  mMapping.insert({ { 22, 12 }, { 4, 0, false, true } });
+  mMapping.insert({ { 22, 13 }, { 5, 0, false, true } });
+  mMapping.insert({ { 22, 14 }, { 6, 0, false, true } });
 }
 
 void PixelMappingOB::buildVersion1()
 {
   mMapping.clear();
-  mMapping.insert({ { 6, 8 }, { 0, 3 } });
-  mMapping.insert({ { 6, 9 }, { 1, 3 } });
-  mMapping.insert({ { 6, 10 }, { 2, 3 } });
-  mMapping.insert({ { 6, 11 }, { 3, 3 } });
-  mMapping.insert({ { 6, 12 }, { 4, 3 } });
-  mMapping.insert({ { 6, 13 }, { 5, 3 } });
-  mMapping.insert({ { 6, 14 }, { 6, 3 } });
-  mMapping.insert({ { 7, 6 }, { 0, 2 } });
-  mMapping.insert({ { 7, 5 }, { 1, 2 } });
-  mMapping.insert({ { 7, 4 }, { 2, 2 } });
-  mMapping.insert({ { 7, 3 }, { 3, 2 } });
-  mMapping.insert({ { 7, 2 }, { 4, 2 } });
-  mMapping.insert({ { 7, 1 }, { 5, 2 } });
-  mMapping.insert({ { 7, 0 }, { 6, 2 } });
+  /**                Lane, Chip, Col, Row, Inv Col, Inv Row **/
+  mMapping.insert({ { 6, 8 }, { 0, 3, false, false } });
+  mMapping.insert({ { 6, 9 }, { 1, 3, false, false } });
+  mMapping.insert({ { 6, 10 }, { 2, 3, false, false } });
+  mMapping.insert({ { 6, 11 }, { 3, 3, false, false } });
+  mMapping.insert({ { 6, 12 }, { 4, 3, false, false } });
+  mMapping.insert({ { 6, 13 }, { 5, 3, false, false } });
+  mMapping.insert({ { 6, 14 }, { 6, 3, false, false } });
+  mMapping.insert({ { 8, 6 }, { 0, 2, true, true } });
+  mMapping.insert({ { 8, 5 }, { 1, 2, true, true } });
+  mMapping.insert({ { 8, 4 }, { 2, 2, true, true } });
+  mMapping.insert({ { 8, 3 }, { 3, 2, true, true } });
+  mMapping.insert({ { 8, 2 }, { 4, 2, true, true } });
+  mMapping.insert({ { 8, 1 }, { 5, 2, true, true } });
+  mMapping.insert({ { 8, 0 }, { 6, 2, true, true } });
 }
 
 PixelMappingIB::PixelMappingIB(unsigned int version) : PixelMapping(version) { init(version); }
@@ -137,29 +139,29 @@ void PixelMappingIB::init(unsigned int version)
 void PixelMappingIB::buildVersion0()
 {
   mMapping.clear();
-  mMapping.insert({ { 0, 0 }, { 0, 4 } });
-  mMapping.insert({ { 0, 1 }, { 1, 4 } });
-  mMapping.insert({ { 0, 2 }, { 2, 4 } });
-  mMapping.insert({ { 0, 3 }, { 0, 2 } });
-  mMapping.insert({ { 0, 4 }, { 1, 2 } });
-  mMapping.insert({ { 0, 5 }, { 2, 2 } });
-  mMapping.insert({ { 0, 6 }, { 0, 0 } });
-  mMapping.insert({ { 0, 7 }, { 1, 0 } });
-  mMapping.insert({ { 0, 8 }, { 2, 0 } });
+  mMapping.insert({ { 0, 0 }, { 0, 4, false, false } });
+  mMapping.insert({ { 0, 1 }, { 1, 4, false, false } });
+  mMapping.insert({ { 0, 2 }, { 2, 4, false, false } });
+  mMapping.insert({ { 0, 3 }, { 0, 2, false, false } });
+  mMapping.insert({ { 0, 4 }, { 1, 2, false, false } });
+  mMapping.insert({ { 0, 5 }, { 2, 2, false, false } });
+  mMapping.insert({ { 0, 6 }, { 0, 0, false, false } });
+  mMapping.insert({ { 0, 7 }, { 1, 0, false, false } });
+  mMapping.insert({ { 0, 8 }, { 2, 0, false, false } });
 }
 
 void PixelMappingIB::buildVersion1()
 {
   mMapping.clear();
-  mMapping.insert({ { 0, 0 }, { 0, 5 } });
-  mMapping.insert({ { 0, 1 }, { 1, 5 } });
-  mMapping.insert({ { 0, 2 }, { 2, 5 } });
-  mMapping.insert({ { 0, 3 }, { 0, 3 } });
-  mMapping.insert({ { 0, 4 }, { 1, 3 } });
-  mMapping.insert({ { 0, 5 }, { 2, 3 } });
-  mMapping.insert({ { 0, 6 }, { 0, 1 } });
-  mMapping.insert({ { 0, 7 }, { 1, 1 } });
-  mMapping.insert({ { 0, 8 }, { 2, 1 } });
+  mMapping.insert({ { 0, 0 }, { 0, 5, false, false } });
+  mMapping.insert({ { 0, 1 }, { 1, 5, false, false } });
+  mMapping.insert({ { 0, 2 }, { 2, 5, false, false } });
+  mMapping.insert({ { 0, 3 }, { 0, 3, false, false } });
+  mMapping.insert({ { 0, 4 }, { 1, 3, false, false } });
+  mMapping.insert({ { 0, 5 }, { 2, 3, false, false } });
+  mMapping.insert({ { 0, 6 }, { 0, 1, false, false } });
+  mMapping.insert({ { 0, 7 }, { 1, 1, false, false } });
+  mMapping.insert({ { 0, 8 }, { 2, 1, false, false } });
 }
 
 PixelMapper::PixelMapper(PixelMapper::MappingType_t mappingtype) : mMappingType(mappingtype)

--- a/Modules/FOCAL/src/TestbeamRawTask.cxx
+++ b/Modules/FOCAL/src/TestbeamRawTask.cxx
@@ -70,6 +70,9 @@ TestbeamRawTask::~TestbeamRawTask()
   if (mPixelChipsIDsHits) {
     delete mPixelChipsIDsHits;
   }
+  for (auto& hist : mPixelLaneIDChipIDFEE) {
+    delete hist;
+  }
   for (auto& hist : mPixelChipHitProfileLayer) {
     delete hist;
   }
@@ -90,6 +93,22 @@ TestbeamRawTask::~TestbeamRawTask()
   }
 }
 
+void TestbeamRawTask::default_init()
+{
+  std::fill(mPadASICChannelADC.begin(), mPadASICChannelADC.end(), nullptr);
+  std::fill(mPadASICChannelTOA.begin(), mPadASICChannelTOA.end(), nullptr);
+  std::fill(mPadASICChannelTOT.begin(), mPadASICChannelTOT.end(), nullptr);
+  std::fill(mHitMapPadASIC.begin(), mHitMapPadASIC.end(), nullptr);
+
+  std::fill(mPixelLaneIDChipIDFEE.begin(), mPixelLaneIDChipIDFEE.end(), nullptr);
+  std::fill(mPixelChipHitProfileLayer.begin(), mPixelChipHitProfileLayer.end(), nullptr);
+  std::fill(mPixelChipHitmapLayer.begin(), mPixelChipHitmapLayer.end(), nullptr);
+  std::fill(mPixelSegmentHitProfileLayer.begin(), mPixelSegmentHitProfileLayer.end(), nullptr);
+  std::fill(mPixelSegmentHitmapLayer.begin(), mPixelSegmentHitmapLayer.end(), nullptr);
+  std::fill(mPixelHitDistribitionLayer.begin(), mPixelHitDistribitionLayer.end(), nullptr);
+  std::fill(mPixelHitsTriggerLayer.begin(), mPixelHitsTriggerLayer.end(), nullptr);
+}
+
 void TestbeamRawTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   auto get_bool = [](const std::string_view input) -> bool {
@@ -107,113 +126,177 @@ void TestbeamRawTask::initialize(o2::framework::InitContext& /*ctx*/)
     mDebugMode = get_bool(hasDebugParam->second);
   }
 
-  PixelMapper::MappingType_t mappingtype = PixelMapper::MappingType_t::MAPPING_IB;
-  auto pixellayout = mCustomParameters.find("Pixellayout");
-  if (pixellayout != mCustomParameters.end()) {
-    if (pixellayout->second == "IB") {
-      mappingtype = PixelMapper::MappingType_t::MAPPING_IB;
-    } else if (pixellayout->second == "OB") {
-      mappingtype = PixelMapper::MappingType_t::MAPPING_OB;
-    } else {
-      ILOG(Fatal, Support) << "Unknown pixel setup: " << pixellayout->second << ENDM;
+  auto hasDisablePads = mCustomParameters.find("DisablePads");
+  if (hasDisablePads != mCustomParameters.end()) {
+    mDisablePads = get_bool(hasDisablePads->second);
+  }
+  auto hasDisablePixels = mCustomParameters.find("DisablePixels");
+  if (hasDisablePixels != mCustomParameters.end()) {
+    mDisablePixels = get_bool(hasDisablePixels->second);
+  }
+
+  mChannelsPadProjections = { 52, 16, 19, 46, 59, 14, 42 };
+  if (!mDisablePads) {
+    auto hasChannelsPadProjections = mCustomParameters.find("ChannelsPadProjections");
+    if (hasChannelsPadProjections != mCustomParameters.end()) {
+      std::stringstream parser(hasChannelsPadProjections->second);
+      std::string buffer;
+      while (std::getline(parser, buffer, ',')) {
+        mChannelsPadProjections.emplace_back(std::stoi(buffer));
+      }
+    }
+    std::sort(mChannelsPadProjections.begin(), mChannelsPadProjections.end(), std::less<int>());
+
+    auto hasCutTOT = mCustomParameters.find("PadCutTOT");
+    if (hasCutTOT != mCustomParameters.end()) {
+      mPadTOTCutADC = std::stoi(hasCutTOT->second);
     }
   }
-  switch (mappingtype) {
-    case PixelMapper::MappingType_t::MAPPING_IB:
-      ILOG(Info, Support) << "Using pixel layout: IB" << ENDM;
-      break;
 
-    case PixelMapper::MappingType_t::MAPPING_OB:
-      ILOG(Info, Support) << "Using pixel layout: OB" << ENDM;
-      break;
-    default:
-      break;
+  default_init();
+
+  ILOG(Info, Support) << "Pad QC:     " << (mDisablePads ? "disabled" : "enabled") << ENDM;
+  ILOG(Info, Support) << "Pixel QC:   " << (mDisablePixels ? "disabled" : "enabled") << ENDM;
+  if (!mDisablePads) {
+    ILOG(Info, Support) << "Window dur:  " << winDur << ENDM;
+    std::stringstream channelstring;
+    bool firstchannel = true;
+    for (auto chan : mChannelsPadProjections) {
+      if (firstchannel) {
+        firstchannel = false;
+      } else {
+        channelstring << ", ";
+      }
+      channelstring << chan;
+    }
+    ILOG(Info, Support) << "Selected channels for pad ADC projections: " << channelstring.str() << ENDM;
   }
-  mPixelMapper = std::make_unique<PixelMapper>(mappingtype);
+  ILOG(Info, Support) << "Debug mode: " << (mDebugMode ? "yes" : "no") << ENDM;
+
+  if (!mDisablePixels) {
+    PixelMapper::MappingType_t mappingtype = PixelMapper::MappingType_t::MAPPING_IB;
+    auto pixellayout = mCustomParameters.find("Pixellayout");
+    if (pixellayout != mCustomParameters.end()) {
+      if (pixellayout->second == "IB") {
+        mappingtype = PixelMapper::MappingType_t::MAPPING_IB;
+      } else if (pixellayout->second == "OB") {
+        mappingtype = PixelMapper::MappingType_t::MAPPING_OB;
+      } else {
+        ILOG(Fatal, Support) << "Unknown pixel setup: " << pixellayout->second << ENDM;
+      }
+    }
+    switch (mappingtype) {
+      case PixelMapper::MappingType_t::MAPPING_IB:
+        ILOG(Info, Support) << "Using pixel layout: IB" << ENDM;
+        break;
+
+      case PixelMapper::MappingType_t::MAPPING_OB:
+        ILOG(Info, Support) << "Using pixel layout: OB" << ENDM;
+        break;
+      default:
+        break;
+    }
+    mPixelMapper = std::make_unique<PixelMapper>(mappingtype);
+  }
 
   /////////////////////////////////////////////////////////////////
   /// PAD histograms
   /////////////////////////////////////////////////////////////////
 
-  constexpr int PAD_CHANNELS = 76;
-  constexpr int RANGE_ADC = 1024;
-  constexpr int RANGE_TOA = 1024;
-  constexpr int RANGE_TOT = 4096;
+  if (!mDisablePads) {
+    constexpr int PAD_CHANNELS = 76;
+    constexpr int RANGE_ADC = 1024;
+    constexpr int RANGE_TOA = 1024;
+    constexpr int RANGE_TOT = 4096;
 
-  for (int iasic = 0; iasic < PadData::NASICS; iasic++) {
-    mPadASICChannelADC[iasic] = new TH2D(Form("PadADC_ASIC_%d", iasic), Form("ADC vs. channel ID for ASIC %d; channel ID; ADC", iasic), PAD_CHANNELS, -0.5, PAD_CHANNELS - 0.5, RANGE_ADC, 0., RANGE_ADC);
-    mPadASICChannelADC[iasic]->SetStats(false);
-    mPadASICChannelTOA[iasic] = new TH2D(Form("PadTOA_ASIC_%d", iasic), Form("TOA vs. channel ID for ASIC %d; channel ID; TOA", iasic), PAD_CHANNELS, -0.5, PAD_CHANNELS - 0.5, RANGE_TOA, 0., RANGE_TOA);
-    mPadASICChannelTOA[iasic]->SetStats(false);
-    mPadASICChannelTOT[iasic] = new TH2D(Form("PadTOT_ASIC_%d", iasic), Form("TOT vs. channel ID for ASIC %d; channel ID; TOT", iasic), PAD_CHANNELS, -0.5, PAD_CHANNELS - 0.5, RANGE_TOT / 4, 0., RANGE_TOT);
-    mPadASICChannelTOT[iasic]->SetStats(false);
-    mHitMapPadASIC[iasic] = new TProfile2D(Form("HitmapPadASIC_%d", iasic), Form("Hitmap for ASIC %d; col; row", iasic), PadMapper::NCOLUMN, -0.5, PadMapper::NCOLUMN - 0.5, PadMapper::NROW, -0.5, PadMapper::NROW - 0.5);
-    mHitMapPadASIC[iasic]->SetStats(false);
-    getObjectsManager()->startPublishing(mPadASICChannelADC[iasic]);
-    getObjectsManager()->startPublishing(mPadASICChannelTOA[iasic]);
-    getObjectsManager()->startPublishing(mPadASICChannelTOT[iasic]);
-    getObjectsManager()->startPublishing(mHitMapPadASIC[iasic]);
+    for (int iasic = 0; iasic < PAD_ASICS; iasic++) {
+      mPadASICChannelADC[iasic] = new TH2D(Form("PadADC_ASIC_%d", iasic), Form("ADC vs. channel ID for ASIC %d; channel ID; ADC", iasic), PAD_CHANNELS, -0.5, PAD_CHANNELS - 0.5, RANGE_ADC, 0., RANGE_ADC);
+      mPadASICChannelADC[iasic]->SetStats(false);
+      mPadASICChannelTOA[iasic] = new TH2D(Form("PadTOA_ASIC_%d", iasic), Form("TOA vs. channel ID for ASIC %d; channel ID; TOA", iasic), PAD_CHANNELS, -0.5, PAD_CHANNELS - 0.5, RANGE_TOA, 0., RANGE_TOA);
+      mPadASICChannelTOA[iasic]->SetStats(false);
+      mPadASICChannelTOT[iasic] = new TH2D(Form("PadTOT_ASIC_%d", iasic), Form("TOT vs. channel ID for ASIC %d; channel ID; TOT", iasic), PAD_CHANNELS, -0.5, PAD_CHANNELS - 0.5, RANGE_TOT / 4, 0., RANGE_TOT);
+      mPadASICChannelTOT[iasic]->SetStats(false);
+      mHitMapPadASIC[iasic] = new TProfile2D(Form("HitmapPadASIC_%d", iasic), Form("Hitmap for ASIC %d; col; row", iasic), PadMapper::NCOLUMN, -0.5, PadMapper::NCOLUMN - 0.5, PadMapper::NROW, -0.5, PadMapper::NROW - 0.5);
+      mHitMapPadASIC[iasic]->SetStats(false);
+      getObjectsManager()->startPublishing(mPadASICChannelADC[iasic]);
+      getObjectsManager()->startPublishing(mPadASICChannelTOA[iasic]);
+      getObjectsManager()->startPublishing(mPadASICChannelTOT[iasic]);
+      getObjectsManager()->startPublishing(mHitMapPadASIC[iasic]);
+
+      mPadChannelProjections[iasic] = std::make_unique<PadChannelProjections>();
+      mPadChannelProjections[iasic]->init(mChannelsPadProjections, iasic);
+      mPadChannelProjections[iasic]->startPublishing(*getObjectsManager());
+    }
+    mPayloadSizePadsGBT = new TH1D("PayloadSizePadGBT", "Payload size GBT words", 10000, 0., 10000.);
+    getObjectsManager()->startPublishing(mPayloadSizePadsGBT);
   }
-  mPayloadSizePadsGBT = new TH1D("PayloadSizePadGBT", "Payload size GBT words", 10000, 0., 10000.);
-  getObjectsManager()->startPublishing(mPayloadSizePadsGBT);
 
   /////////////////////////////////////////////////////////////////
   /// Pixel histograms
   /////////////////////////////////////////////////////////////////
-  constexpr int FEES = 30;
-  constexpr int MAX_CHIPS = 14;    // For the moment leave completely open
-  constexpr int MAX_TRIGGERS = 10; // Number of triggers / HBF usually sparse
-  mLinksWithPayloadPixel = new TH1D("Pixel_PagesFee", "HBF vs. FEE ID; FEE ID; HBFs", FEES, -0.5, FEES - 0.5);
-  getObjectsManager()->startPublishing(mLinksWithPayloadPixel);
-  mTriggersFeePixel = new TH2D("Pixel_NumTriggerHBF", "Number of triggers per HBF and FEE; FEE ID; Number of triggers / HBF", FEES, -0.5, FEES - 0.5, MAX_TRIGGERS, -0.5, MAX_TRIGGERS - 0.5);
-  mTriggersFeePixel->SetStats(false);
-  getObjectsManager()->startPublishing(mTriggersFeePixel);
-  mAverageHitsChipPixel = new TProfile2D("Pixel_AverageNumberOfHitsChip", "Average number of hits / chip", FEES, -0.5, FEES - 0.5, MAX_CHIPS, -0.5, MAX_CHIPS - 0.5);
-  mAverageHitsChipPixel->SetStats(false);
-  getObjectsManager()->startPublishing(mAverageHitsChipPixel);
-  mHitsChipPixel = new TH1D("Pixel_NumberHits", "Number of hits / chip", 50, 0., 50);
-  mHitsChipPixel->SetStats(false);
-  getObjectsManager()->startPublishing(mHitsChipPixel);
-  mPixelHitsTriggerAll = new TH1D("Pixel_TotalNumberHitsTrigger", "Number of hits per trigger", 1001, -0.5, 1000.5);
-  mPixelHitsTriggerAll->SetStats(false);
-  getObjectsManager()->startPublishing(mPixelHitsTriggerAll);
-  mPixelChipsIDsFound = new TH2D("Pixel_ChipIDsFEE", "Chip ID vs. FEE ID", FEES, -0.5, FEES - 0.5, MAX_CHIPS, -0.5, MAX_CHIPS - 0.5);
-  mPixelChipsIDsFound->SetDirectory(nullptr);
-  getObjectsManager()->startPublishing(mPixelChipsIDsFound);
-  mPixelChipsIDsHits = new TH2D("Pixel_ChipIDsFilledFEE", "Chip ID with hits vs. FEE ID", FEES, -0.5, FEES - 0.5, MAX_CHIPS, -0.5, MAX_CHIPS - 0.5);
-  mPixelChipsIDsHits->SetDirectory(nullptr);
-  getObjectsManager()->startPublishing(mPixelChipsIDsHits);
+  if (!mDisablePixels) {
+    constexpr int FEES = 30;
+    constexpr int MAX_CHIPS = 14;    // For the moment leave completely open
+    constexpr int MAX_TRIGGERS = 10; // Number of triggers / HBF usually sparse
+    mLinksWithPayloadPixel = new TH1D("Pixel_PagesFee", "HBF vs. FEE ID; FEE ID; HBFs", FEES, -0.5, FEES - 0.5);
+    getObjectsManager()->startPublishing(mLinksWithPayloadPixel);
+    mTriggersFeePixel = new TH2D("Pixel_NumTriggerHBF", "Number of triggers per HBF and FEE; FEE ID; Number of triggers / HBF", FEES, -0.5, FEES - 0.5, MAX_TRIGGERS, -0.5, MAX_TRIGGERS - 0.5);
+    mTriggersFeePixel->SetStats(false);
+    getObjectsManager()->startPublishing(mTriggersFeePixel);
+    mAverageHitsChipPixel = new TProfile2D("Pixel_AverageNumberOfHitsChip", "Average number of hits / chip", FEES, -0.5, FEES - 0.5, MAX_CHIPS, -0.5, MAX_CHIPS - 0.5);
+    mAverageHitsChipPixel->SetStats(false);
+    getObjectsManager()->startPublishing(mAverageHitsChipPixel);
+    mHitsChipPixel = new TH1D("Pixel_NumberHits", "Number of hits / chip", 50, 0., 50);
+    mHitsChipPixel->SetStats(false);
+    getObjectsManager()->startPublishing(mHitsChipPixel);
+    mPixelHitsTriggerAll = new TH1D("Pixel_TotalNumberHitsTrigger", "Number of hits per trigger; Number of hits; Number of events", 1500, -0.5, 15000);
+    mPixelHitsTriggerAll->SetStats(false);
+    getObjectsManager()->startPublishing(mPixelHitsTriggerAll);
+    mPixelChipsIDsFound = new TH2D("Pixel_ChipIDsFEE", "Chip ID vs. FEE ID", FEES, -0.5, FEES - 0.5, MAX_CHIPS, -0.5, MAX_CHIPS - 0.5);
+    mPixelChipsIDsFound->SetDirectory(nullptr);
+    getObjectsManager()->startPublishing(mPixelChipsIDsFound);
+    mPixelChipsIDsHits = new TH2D("Pixel_ChipIDsFilledFEE", "Chip ID with hits vs. FEE ID", FEES, -0.5, FEES - 0.5, MAX_CHIPS, -0.5, MAX_CHIPS - 0.5);
+    mPixelChipsIDsHits->SetDirectory(nullptr);
+    getObjectsManager()->startPublishing(mPixelChipsIDsHits);
 
-  constexpr int PIXEL_LAYERS = 2;
-  auto& refmapping = mPixelMapper->getMapping(0);
-  auto pixel_segments = getNumberOfPixelSegments(mPixelMapper->getMappingType());
-  auto pixel_columns = refmapping.getNumberOfColumns(),
-       pixel_rows = refmapping.getNumberOfRows(),
-       pixel_chips = pixel_columns * pixel_rows,
-       segments_colums = pixel_columns * pixel_segments.first,
-       segments_rows = pixel_rows * pixel_segments.second;
-  ILOG(Info, Support) << "Setup acceptance histograms " << pixel_columns << " colums and " << pixel_rows << " rows (" << pixel_chips << " chips)" << ENDM;
-  for (int ilayer = 0; ilayer < PIXEL_LAYERS; ilayer++) {
-    mPixelChipHitProfileLayer[ilayer] = new TProfile2D(Form("Pixel_Hitprofile_%d", ilayer), Form("Pixel hit profile in layer %d", ilayer), pixel_columns, -0.5, pixel_columns - 0.5, pixel_rows, -0.5, pixel_rows - 0.5);
-    mPixelChipHitProfileLayer[ilayer]->SetStats(false);
-    getObjectsManager()->startPublishing(mPixelChipHitProfileLayer[ilayer]);
-    mPixelChipHitmapLayer[ilayer] = new TH2D(Form("Pixel_Hitmap_%d", ilayer), Form("Pixel hitmap in layer %d", ilayer), pixel_columns, -0.5, pixel_columns - 0.5, pixel_rows, -0.5, pixel_rows - 0.5);
-    mPixelChipHitmapLayer[ilayer]->SetStats(false);
-    getObjectsManager()->startPublishing(mPixelChipHitmapLayer[ilayer]);
-    mPixelSegmentHitProfileLayer[ilayer] = new TProfile2D(Form("Pixel_Segment_Hitprofile_%d", ilayer), Form("Pixel hit profile in layer %d", ilayer), segments_colums, -0.5, segments_colums - 0.5, segments_rows, -0.5, segments_rows - 0.5);
-    mPixelSegmentHitProfileLayer[ilayer]->SetStats(false);
-    getObjectsManager()->startPublishing(mPixelSegmentHitProfileLayer[ilayer]);
-    mPixelSegmentHitmapLayer[ilayer] = new TH2D(Form("Pixel_Segment_Hitmap_%d", ilayer), Form("Pixel hitmap in layer %d", ilayer), segments_colums, -0.5, segments_colums - 0.5, segments_rows, -0.5, segments_rows - 0.5);
-    mPixelSegmentHitmapLayer[ilayer]->SetStats(false);
-    getObjectsManager()->startPublishing(mPixelSegmentHitmapLayer[ilayer]);
-    mPixelHitDistribitionLayer[ilayer] = new TH2D(Form("Pixel_Hitdist_%d", ilayer), Form("Pixel hit distribution in layer %d", ilayer), pixel_chips, -0.5, pixel_chips - 0.5, 101, -0.5, 100.5);
-    mPixelHitDistribitionLayer[ilayer]->SetStats(false);
-    getObjectsManager()->startPublishing(mPixelHitDistribitionLayer[ilayer]);
-    mPixelHitsTriggerLayer[ilayer] = new TH1D(Form("Pixel_NumberHitsTrigger_%d", ilayer), Form("Number of hits per trigger in layer %d", ilayer), 1001, -0.5, 1000.5);
-    mPixelHitsTriggerLayer[ilayer]->SetStats(false);
-    getObjectsManager()->startPublishing(mPixelHitsTriggerLayer[ilayer]);
+    for (int ifee = 0; ifee < 4; ifee++) {
+      mPixelLaneIDChipIDFEE[ifee] = new TH2D(Form("Pixel_LaneIDChipID_FEE%d", ifee), Form("Lane ID vs. Chip ID for FEE %d; Lane ID; ChipID", ifee), 57, -0.5, 56.5, 31, -0.5, 30.5);
+      mPixelLaneIDChipIDFEE[ifee]->SetDirectory(nullptr);
+      getObjectsManager()->startPublishing(mPixelLaneIDChipIDFEE[ifee]);
+    }
+
+    constexpr int PIXEL_LAYERS = 2;
+    auto& refmapping = mPixelMapper->getMapping(0);
+    auto pixel_segments = getNumberOfPixelSegments(mPixelMapper->getMappingType());
+    auto pixel_columns = refmapping.getNumberOfColumns(),
+         pixel_rows = refmapping.getNumberOfRows(),
+         pixel_chips = pixel_columns * pixel_rows,
+         segments_colums = pixel_columns * pixel_segments.first,
+         segments_rows = pixel_rows * pixel_segments.second;
+    std::array<int, 2> pixelLayerIndex = { { 10, 5 } };
+    ILOG(Info, Support) << "Setup acceptance histograms " << pixel_columns << " colums and " << pixel_rows << " rows (" << pixel_chips << " chips)" << ENDM;
+    for (int ilayer = 0; ilayer < PIXEL_LAYERS; ilayer++) {
+      mPixelChipHitProfileLayer[ilayer] = new TProfile2D(Form("Pixel_Hitprofile_%d", ilayer), Form("Pixel hit profile in layer %d; X; Y", pixelLayerIndex[ilayer]), pixel_columns, -0.5, pixel_columns - 0.5, pixel_rows, -0.5, pixel_rows - 0.5);
+      mPixelChipHitProfileLayer[ilayer]->SetStats(false);
+      getObjectsManager()->startPublishing(mPixelChipHitProfileLayer[ilayer]);
+      mPixelChipHitmapLayer[ilayer] = new TH2D(Form("Pixel_Hitmap_%d", ilayer), Form("Pixel hitmap in layer %d; X; Y", pixelLayerIndex[ilayer]), pixel_columns, -0.5, pixel_columns - 0.5, pixel_rows, -0.5, pixel_rows - 0.5);
+      mPixelChipHitmapLayer[ilayer]->SetStats(false);
+      getObjectsManager()->startPublishing(mPixelChipHitmapLayer[ilayer]);
+      mPixelSegmentHitProfileLayer[ilayer] = new TProfile2D(Form("Pixel_Segment_Hitprofile_%d", ilayer), Form("Pixel hit profile in layer %d; X; Y", pixelLayerIndex[ilayer]), segments_colums, -0.5, segments_colums - 0.5, segments_rows, -0.5, segments_rows - 0.5);
+      mPixelSegmentHitProfileLayer[ilayer]->SetStats(false);
+      getObjectsManager()->startPublishing(mPixelSegmentHitProfileLayer[ilayer]);
+      mPixelSegmentHitmapLayer[ilayer] = new TH2D(Form("Pixel_Segment_Hitmap_%d", ilayer), Form("Pixel hitmap in layer %d; X; Y", pixelLayerIndex[ilayer]), segments_colums, -0.5, segments_colums - 0.5, segments_rows, -0.5, segments_rows - 0.5);
+      mPixelSegmentHitmapLayer[ilayer]->SetStats(false);
+      getObjectsManager()->startPublishing(mPixelSegmentHitmapLayer[ilayer]);
+      mPixelHitDistribitionLayer[ilayer] = new TH2D(Form("Pixel_Hitdist_%d", ilayer), Form("Pixel hit distribution in layer %d; Number of hits / chip; Number of events", pixelLayerIndex[ilayer]), pixel_chips, -0.5, pixel_chips - 0.5, 101, -0.5, 100.5);
+      mPixelHitDistribitionLayer[ilayer]->SetStats(false);
+      getObjectsManager()->startPublishing(mPixelHitDistribitionLayer[ilayer]);
+      mPixelHitsTriggerLayer[ilayer] = new TH1D(Form("Pixel_NumberHitsTrigger_%d", ilayer), Form("Number of hits per trigger in layer %d; Number of hits / layer; Number of events", pixelLayerIndex[ilayer]), 1500, 0, 15000.);
+      mPixelHitsTriggerLayer[ilayer]->SetStats(false);
+      getObjectsManager()->startPublishing(mPixelHitsTriggerLayer[ilayer]);
+    }
+    mHitSegmentCounter.resize(segments_colums * segments_rows);
   }
-  mHitSegmentCounter.resize(segments_colums * segments_rows);
 }
 
 void TestbeamRawTask::startOfActivity(Activity& activity)
@@ -259,15 +342,19 @@ void TestbeamRawTask::monitorData(o2::framework::ProcessingContext& ctx)
               // Data ready
               if (currentendpoint == 1) {
                 // Pad data
-                ILOG(Debug, Support) << "Processing PAD data" << ENDM;
-                auto payloadsizeGBT = rawbuffer.size() * sizeof(char) / sizeof(PadGBTWord);
-                processPadPayload(gsl::span<const PadGBTWord>(reinterpret_cast<const PadGBTWord*>(rawbuffer.data()), payloadsizeGBT));
+                if (!mDisablePads) {
+                  ILOG(Debug, Support) << "Processing PAD data" << ENDM;
+                  auto payloadsizeGBT = rawbuffer.size() * sizeof(char) / sizeof(PadGBTWord);
+                  processPadPayload(gsl::span<const PadGBTWord>(reinterpret_cast<const PadGBTWord*>(rawbuffer.data()), payloadsizeGBT));
+                }
               } else if (currentendpoint == 0) {
                 // Pixel data
-                auto feeID = o2::raw::RDHUtils::getFEEID(rdh);
-                ILOG(Debug, Support) << "Processing Pixel data from FEE " << feeID << ENDM;
-                auto payloadsizeGBT = rawbuffer.size() * sizeof(char) / sizeof(o2::itsmft::GBTWord);
-                processPixelPayload(gsl::span<const o2::itsmft::GBTWord>(reinterpret_cast<const o2::itsmft::GBTWord*>(rawbuffer.data()), payloadsizeGBT), feeID);
+                if (!mDisablePixels) {
+                  auto feeID = o2::raw::RDHUtils::getFEEID(rdh);
+                  ILOG(Debug, Support) << "Processing Pixel data from FEE " << feeID << ENDM;
+                  auto payloadsizeGBT = rawbuffer.size() * sizeof(char) / sizeof(o2::itsmft::GBTWord);
+                  processPixelPayload(gsl::span<const o2::itsmft::GBTWord>(reinterpret_cast<const o2::itsmft::GBTWord*>(rawbuffer.data()), payloadsizeGBT), feeID);
+                }
               } else {
                 ILOG(Error, Support) << "Unsupported endpoint " << currentendpoint << ENDM;
               }
@@ -331,36 +418,66 @@ void TestbeamRawTask::processPadEvent(gsl::span<const PadGBTWord> padpayload)
   mPadDecoder.reset();
   mPadDecoder.decodeEvent(padpayload);
   const auto& eventdata = mPadDecoder.getData();
-  for (int iasic = 0; iasic < PadData::NASICS; iasic++) {
+  for (int iasic = 0; iasic < PAD_ASICS; iasic++) {
     const auto& asic = eventdata[iasic].getASIC();
     ILOG(Debug, Support) << "ASIC " << iasic << ", Header 0: " << asic.getFirstHeader() << ENDM;
     ILOG(Debug, Support) << "ASIC " << iasic << ", Header 1: " << asic.getSecondHeader() << ENDM;
     int currentchannel = 0;
     for (const auto& chan : asic.getChannels()) {
-      mPadASICChannelADC[iasic]->Fill(currentchannel, chan.getADC());
+      if (chan.getTOT() < mPadTOTCutADC) {
+        mPadASICChannelADC[iasic]->Fill(currentchannel, chan.getADC());
+        auto [column, row] = mPadMapper.getRowColFromChannelID(currentchannel);
+        // temporary mask channel col 7 row 8 in ASIC 0
+        auto mask = (iasic == 0) && ((column == 7) && (row == 8));
+        if (!mask) {
+          mHitMapPadASIC[iasic]->Fill(column, row, chan.getADC());
+        }
+      }
       mPadASICChannelTOA[iasic]->Fill(currentchannel, chan.getTOA());
-      mPadASICChannelTOT[iasic]->Fill(currentchannel, chan.getTOT());
-      auto [column, row] = mPadMapper.getRowColFromChannelID(currentchannel);
-      mHitMapPadASIC[iasic]->Fill(column, row, chan.getADC());
+      if (chan.getTOT()) {
+        mPadASICChannelTOT[iasic]->Fill(currentchannel, chan.getTOT());
+      }
+      if (std::find(mChannelsPadProjections.begin(), mChannelsPadProjections.end(), currentchannel) != mChannelsPadProjections.end()) {
+        auto hist = mPadChannelProjections[iasic]->mHistos.find(currentchannel);
+        if (hist != mPadChannelProjections[iasic]->mHistos.end()) {
+          hist->second->Fill(chan.getADC());
+        }
+      }
       currentchannel++;
     }
     // Fill CMN channels
-    mPadASICChannelADC[iasic]->Fill(currentchannel, asic.getFirstCMN().getADC());
+    if (asic.getFirstCMN().getTOT() < mPadTOTCutADC) {
+      mPadASICChannelADC[iasic]->Fill(currentchannel, asic.getFirstCMN().getADC());
+    }
     mPadASICChannelTOA[iasic]->Fill(currentchannel, asic.getFirstCMN().getTOA());
-    mPadASICChannelTOT[iasic]->Fill(currentchannel, asic.getFirstCMN().getTOT());
+    if (asic.getFirstCMN().getTOT()) {
+      mPadASICChannelTOT[iasic]->Fill(currentchannel, asic.getFirstCMN().getTOT());
+    }
     currentchannel++;
-    mPadASICChannelADC[iasic]->Fill(currentchannel, asic.getSecondCMN().getADC());
+    if (asic.getSecondCMN().getTOT() < mPadTOTCutADC) {
+      mPadASICChannelADC[iasic]->Fill(currentchannel, asic.getSecondCMN().getADC());
+    }
     mPadASICChannelTOA[iasic]->Fill(currentchannel, asic.getSecondCMN().getTOA());
-    mPadASICChannelTOT[iasic]->Fill(currentchannel, asic.getSecondCMN().getTOT());
+    if (asic.getSecondCMN().getTOT()) {
+      mPadASICChannelTOT[iasic]->Fill(currentchannel, asic.getSecondCMN().getTOT());
+    }
     currentchannel++;
     // Fill Calib channels
-    mPadASICChannelADC[iasic]->Fill(currentchannel, asic.getFirstCalib().getADC());
+    if (asic.getFirstCalib().getTOT() < mPadTOTCutADC) {
+      mPadASICChannelADC[iasic]->Fill(currentchannel, asic.getFirstCalib().getADC());
+    }
     mPadASICChannelTOA[iasic]->Fill(currentchannel, asic.getFirstCalib().getTOA());
-    mPadASICChannelTOT[iasic]->Fill(currentchannel, asic.getFirstCalib().getTOT());
+    if (asic.getFirstCalib().getTOT()) {
+      mPadASICChannelTOT[iasic]->Fill(currentchannel, asic.getFirstCalib().getTOT());
+    }
     currentchannel++;
-    mPadASICChannelADC[iasic]->Fill(currentchannel, asic.getSecondCalib().getADC());
+    if (asic.getSecondCalib().getTOT() < mPadTOTCutADC) {
+      mPadASICChannelADC[iasic]->Fill(currentchannel, asic.getSecondCalib().getADC());
+    }
     mPadASICChannelTOA[iasic]->Fill(currentchannel, asic.getSecondCalib().getTOA());
-    mPadASICChannelTOT[iasic]->Fill(currentchannel, asic.getSecondCalib().getTOT());
+    if (asic.getSecondCalib().getTOT()) {
+      mPadASICChannelTOT[iasic]->Fill(currentchannel, asic.getSecondCalib().getTOT());
+    }
     currentchannel++;
   }
 }
@@ -368,7 +485,7 @@ void TestbeamRawTask::processPadEvent(gsl::span<const PadGBTWord> padpayload)
 void TestbeamRawTask::processPixelPayload(gsl::span<const o2::itsmft::GBTWord> pixelpayload, uint16_t feeID)
 {
   auto fee = feeID & 0x00FF,
-       branch = (feeID & 0xFF00) >> 8;
+       branch = (feeID & 0x0F00) >> 8;
   ILOG(Debug, Support) << "Decoded FEE ID " << feeID << " -> FEE " << fee << ", branch " << branch << ENDM;
   auto useFEE = branch * 10 + fee;
   mLinksWithPayloadPixel->Fill(useFEE);
@@ -396,6 +513,7 @@ void TestbeamRawTask::processPixelPayload(gsl::span<const o2::itsmft::GBTWord> p
       nhitsAll += chip.mHits.size();
       mHitsChipPixel->Fill(chip.mHits.size());
       mAverageHitsChipPixel->Fill(useFEE, chip.mChipID, chip.mHits.size());
+      mPixelLaneIDChipIDFEE[fee]->Fill(chip.mLaneID, chip.mChipID);
       chipIDsFound.insert(chip.mChipID);
       if (chip.mHits.size()) {
         chipIDsHits.insert(chip.mChipID);
@@ -407,7 +525,7 @@ void TestbeamRawTask::processPixelPayload(gsl::span<const o2::itsmft::GBTWord> p
         int chipIndex = position.mRow * 7 + position.mColumn;
         mPixelHitDistribitionLayer[layer]->Fill(chipIndex, chip.mHits.size());
         for (auto& hit : chip.mHits) {
-          auto segment = getPixelSegment(hit, mappingtype);
+          auto segment = getPixelSegment(hit, mappingtype, position);
           auto segment_col = position.mColumn * numbersegments.first + segment.first;
           auto segment_row = position.mRow * numbersegments.second + segment.second;
           mPixelSegmentHitmapLayer[layer]->Fill(segment_col, segment_row);
@@ -446,17 +564,21 @@ void TestbeamRawTask::processPixelPayload(gsl::span<const o2::itsmft::GBTWord> p
   }
 }
 
-std::pair<int, int> TestbeamRawTask::getPixelSegment(const PixelHit& hit, PixelMapper::MappingType_t mappingtype) const
+std::pair<int, int> TestbeamRawTask::getPixelSegment(const PixelHit& hit, PixelMapper::MappingType_t mappingtype, const PixelMapping::ChipPosition& chipMapping) const
 {
-  int row = -1, col = -1;
+  int row = -1, col = -1, absColumn = -1, absRow = -1;
   switch (mappingtype) {
     case PixelMapper::MappingType_t::MAPPING_IB:
-      col = hit.mColumn / PIXEL_COL_SEGMENSIZE_IB;
-      row = hit.mRow / PIXEL_ROW_SEGMENTSIZE_IB;
+      absColumn = chipMapping.mInvertColumn ? PIXEL_COLS_IB - hit.mColumn : hit.mColumn;
+      absRow = chipMapping.mInvertRow ? PIXEL_ROWS_IB - hit.mRow : hit.mRow;
+      col = absColumn / PIXEL_COL_SEGMENSIZE_IB;
+      row = absRow / PIXEL_ROW_SEGMENTSIZE_IB;
       break;
     case PixelMapper::MappingType_t::MAPPING_OB:
-      col = hit.mColumn / PIXEL_COL_SEGMENSIZE_OB;
-      row = hit.mRow / PIXEL_ROW_SEGMENTSIZE_OB;
+      absColumn = chipMapping.mInvertColumn ? PIXEL_COLS_OB - hit.mColumn : hit.mColumn;
+      absRow = chipMapping.mInvertRow ? PIXEL_ROWS_OB - hit.mRow : hit.mRow;
+      col = absColumn / PIXEL_COL_SEGMENSIZE_OB;
+      row = absRow / PIXEL_ROW_SEGMENTSIZE_OB;
       break;
     default:
       break;
@@ -498,55 +620,120 @@ void TestbeamRawTask::reset()
   // clean all the monitor objects here
 
   ILOG(Info, Support) << "Resetting the histogram" << ENDM;
-  mPayloadSizePadsGBT->Reset();
-  for (auto padadc : mPadASICChannelADC) {
-    padadc->Reset();
-  }
-  for (auto padtoa : mPadASICChannelTOA) {
-    padtoa->Reset();
-  }
-  for (auto padtot : mPadASICChannelTOT) {
-    padtot->Reset();
-  }
-  for (auto hitmap : mHitMapPadASIC) {
-    hitmap->Reset();
-  }
-
-  if (mLinksWithPayloadPixel) {
-    mLinksWithPayloadPixel->Reset();
-  }
-  if (mTriggersFeePixel) {
-    mTriggersFeePixel->Reset();
-  }
-  if (mAverageHitsChipPixel) {
-    mAverageHitsChipPixel->Reset();
-  }
-  if (mHitsChipPixel) {
-    mHitsChipPixel->Reset();
-  }
-  if (mPixelHitsTriggerAll) {
-    mPixelHitsTriggerAll->Reset();
-  }
-  if (mPixelChipsIDsFound) {
-    mPixelChipsIDsFound->Reset();
+  if (!mDisablePads) {
+    mPayloadSizePadsGBT->Reset();
+    for (auto padadc : mPadASICChannelADC) {
+      if (padadc) {
+        padadc->Reset();
+      }
+    }
+    for (auto padtoa : mPadASICChannelTOA) {
+      if (padtoa) {
+        padtoa->Reset();
+      }
+    }
+    for (auto padtot : mPadASICChannelTOT) {
+      if (padtot) {
+        padtot->Reset();
+      }
+    }
+    for (auto hitmap : mHitMapPadASIC) {
+      if (hitmap) {
+        hitmap->Reset();
+      }
+    }
+    for (auto& projections : mPadChannelProjections) {
+      if (projections) {
+        projections->reset();
+      }
+    }
   }
 
-  for (auto& hist : mPixelChipHitProfileLayer) {
-    hist->Reset();
+  if (!mDisablePixels) {
+    if (mLinksWithPayloadPixel) {
+      mLinksWithPayloadPixel->Reset();
+    }
+    if (mTriggersFeePixel) {
+      mTriggersFeePixel->Reset();
+    }
+    if (mAverageHitsChipPixel) {
+      mAverageHitsChipPixel->Reset();
+    }
+    if (mHitsChipPixel) {
+      mHitsChipPixel->Reset();
+    }
+    if (mPixelHitsTriggerAll) {
+      mPixelHitsTriggerAll->Reset();
+    }
+    if (mPixelChipsIDsFound) {
+      mPixelChipsIDsFound->Reset();
+    }
+
+    for (auto& hist : mPixelLaneIDChipIDFEE) {
+      if (hist) {
+        hist->Reset();
+      }
+    }
+
+    for (auto& hist : mPixelChipHitProfileLayer) {
+      if (hist) {
+        hist->Reset();
+      }
+    }
+    for (auto& hist : mPixelChipHitmapLayer) {
+      if (hist) {
+        hist->Reset();
+      }
+    }
+    for (auto& hist : mPixelSegmentHitProfileLayer) {
+      if (hist) {
+        hist->Reset();
+      }
+    }
+    for (auto& hist : mPixelSegmentHitmapLayer) {
+      if (hist) {
+        hist->Reset();
+      }
+    }
+    for (auto& hist : mPixelHitDistribitionLayer) {
+      if (hist) {
+        hist->Reset();
+      }
+    }
+    for (auto& hist : mPixelHitsTriggerLayer) {
+      if (hist) {
+        hist->Reset();
+      }
+    }
   }
-  for (auto& hist : mPixelChipHitmapLayer) {
-    hist->Reset();
+}
+
+TestbeamRawTask::PadChannelProjections::~PadChannelProjections()
+{
+  for (auto& [chan, hist] : mHistos) {
+    delete hist;
   }
-  for (auto& hist : mPixelSegmentHitProfileLayer) {
-    hist->Reset();
+}
+
+void TestbeamRawTask::PadChannelProjections::init(const std::vector<int> channels, int ASICid)
+{
+  for (auto chan : channels) {
+    auto hist = new TH1D(Form("Pad_ProjADC_ASIC%d_Chan%d", ASICid, chan), Form("Pad ADC projection ASIC %d channel %d", ASICid, chan), 101, -0.5, 100.5);
+    hist->SetStats(false);
+    mHistos.insert({ chan, hist });
   }
-  for (auto& hist : mPixelSegmentHitmapLayer) {
-    hist->Reset();
+}
+
+void TestbeamRawTask::PadChannelProjections::startPublishing(o2::quality_control::core::ObjectsManager& mgr)
+{
+  for (auto& [chan, hist] : mHistos) {
+    mgr.startPublishing(hist);
   }
-  for (auto& hist : mPixelHitDistribitionLayer) {
-    hist->Reset();
-  }
-  for (auto& hist : mPixelHitsTriggerLayer) {
+}
+
+void TestbeamRawTask::PadChannelProjections::reset()
+{
+  for (auto& [chan, hist] : mHistos) {
     hist->Reset();
   }
 }


### PR DESCRIPTION
- Add option to disable Pads and Pixels separately (in case of running only with one FOCAL-E system only)
- E-Pad:
  - Add ADC projections for Pads in the central beam region for MIP validation
  - Apply cut on the TOT value for ADC histos for Pads
  - Implement pixel internal orientation for OB setup
  - Mask noisy pad channel in ASIC 0 in hitmap
- E-Pixel:
  - Adapt mapping for OB setup (lanes 6, 8, 22 and 24, discard lanes > 28, control histograms)
  - Increase range of number of pixel histograms (needed in order to reconstruct the full shower)
  - Use absolute layer index (pad+pixel) in pixel histogram title