### PR TITLE
MFT: check for empty zones in summary histograms

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTClusterCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterCheck.h
@@ -37,9 +37,14 @@ class QcMFTClusterCheck : public o2::quality_control::checker::CheckInterface
   ~QcMFTClusterCheck() override = default;
 
   // Override interface
+  void configure() override;
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
+
+ private:
+  int mZoneThresholdMedium;
+  int mZoneThresholdBad;
 
   ClassDefOverride(QcMFTClusterCheck, 2);
 };

--- a/Modules/MFT/include/MFT/QcMFTDigitCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitCheck.h
@@ -36,9 +36,14 @@ class QcMFTDigitCheck : public o2::quality_control::checker::CheckInterface
   ~QcMFTDigitCheck() override = default;
 
   // Override interface
+  void configure() override;
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
+
+ private:
+  int mZoneThresholdMedium;
+  int mZoneThresholdBad;
 
   ClassDefOverride(QcMFTDigitCheck, 2);
 };

--- a/Modules/MFT/qc-mft-cluster.json
+++ b/Modules/MFT/qc-mft-cluster.json
@@ -54,6 +54,10 @@
           "name" : "MFTClusterTask",
           "MOs" : ["mClusterOccupancy","mClusterPatternIndex","mClusterSizeSummary", "mGroupedClusterSizeSummary", "mClusterOccupancySummary"]
         } ],
+        "checkParameters" : {
+          "ZoneThresholdMedium" : "2",
+          "ZoneThresholdBad" : "5"
+        },
         "className" : "o2::quality_control_modules::mft::QcMFTClusterCheck",
         "moduleName" : "QcMFT",
         "detectorName" : "MFT",

--- a/Modules/MFT/qc-mft-digit.json
+++ b/Modules/MFT/qc-mft-digit.json
@@ -53,6 +53,10 @@
         "moduleName" : "QcMFT",
         "detectorName" : "MFT",
         "policy" : "OnEachSeparately",
+        "checkParameters" : {
+          "ZoneThresholdMedium" : "2",
+          "ZoneThresholdBad" : "5"
+        },
         "dataSource" : [ {
           "type" : "Task",
           "name" : "MFTDigitTask",

--- a/Modules/MFT/src/QcMFTClusterCheck.cxx
+++ b/Modules/MFT/src/QcMFTClusterCheck.cxx
@@ -33,6 +33,20 @@ using namespace std;
 namespace o2::quality_control_modules::mft
 {
 
+void QcMFTClusterCheck::configure()
+{
+
+  // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
+  if (auto param = mCustomParameters.find("ZoneThresholdMedium"); param != mCustomParameters.end()) {
+    ILOG(Info, Support) << "Custom parameter - ZoneThresholdMedium: " << param->second << ENDM;
+    mZoneThresholdMedium = stoi(param->second);
+  }
+  if (auto param = mCustomParameters.find("ZoneThresholdBad"); param != mCustomParameters.end()) {
+    ILOG(Info, Support) << "Custom parameter - ZoneThresholdBad: " << param->second << ENDM;
+    mZoneThresholdBad = stoi(param->second);
+  }
+}
+
 Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
   Quality result = Quality::Null;
@@ -96,13 +110,27 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
       auto* histogram = dynamic_cast<TH2F*>(mo->getObject());
 
       float den = histogram->GetBinContent(0, 0); // normalisation stored in the uderflow bin
+      float nEmptyBins = 0;                       // number of empty zones stored here
 
       for (int iBinX = 0; iBinX < histogram->GetNbinsX(); iBinX++) {
         for (int iBinY = 0; iBinY < histogram->GetNbinsY(); iBinY++) {
           float num = histogram->GetBinContent(iBinX + 1, iBinY + 1);
           float ratio = (den > 0) ? (num / den) : 0.0;
           histogram->SetBinContent(iBinX + 1, iBinY + 1, ratio);
+          if ((histogram->GetBinContent(iBinX + 1, iBinY + 1)) == 0) {
+            nEmptyBins = nEmptyBins + 1;
+          }
         }
+      }
+
+      if (nEmptyBins <= mZoneThresholdMedium) {
+        result = Quality::Good;
+      }
+      if (nEmptyBins > mZoneThresholdMedium && nEmptyBins <= mZoneThresholdBad) {
+        result = Quality::Medium;
+      }
+      if (nEmptyBins > mZoneThresholdBad) {
+        result = Quality::Bad;
       }
     }
   }
@@ -133,6 +161,30 @@ void QcMFTClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality chec
       histogram->SetLineColor(kOrange);
       TLatex* tl = new TLatex(350, 1.05 * histogram->GetMaximum(), "#color[800]{Dummy check status: Medium!}");
       histogram->GetListOfFunctions()->Add(tl);
+      tl->Draw();
+    }
+  }
+
+  if (mo->getName().find("mClusterOccupancySummary") != std::string::npos) {
+    auto* hOccupancySummary = dynamic_cast<TH2F*>(mo->getObject());
+
+    if (checkResult == Quality::Good) {
+      LOG(info) << "Quality::Good";
+      TLatex* tl = new TLatex(0.15, 6.0, "Quality Good");
+      tl->SetTextColor(kGreen);
+      hOccupancySummary->GetListOfFunctions()->Add(tl);
+      tl->Draw();
+    } else if (checkResult == Quality::Medium) {
+      LOG(info) << "Quality::Medium";
+      TLatex* tl = new TLatex(0.15, 6.0, "Quality medium: notify the on-call by mail");
+      tl->SetTextColor(kOrange);
+      hOccupancySummary->GetListOfFunctions()->Add(tl);
+      tl->Draw();
+    } else if (checkResult == Quality::Bad) {
+      LOG(info) << "Quality::Bad";
+      TLatex* tl = new TLatex(0.15, 6.0, "Quality bad: call the on-call!");
+      tl->SetTextColor(kRed);
+      hOccupancySummary->GetListOfFunctions()->Add(tl);
       tl->Draw();
     }
   }

--- a/Modules/MFT/src/QcMFTDigitTask.cxx
+++ b/Modules/MFT/src/QcMFTDigitTask.cxx
@@ -109,14 +109,14 @@ void QcMFTDigitTask::initialize(o2::framework::InitContext& /*ctx*/)
     936, -0.5, 935.5);
   mDigitChipOccupancy->SetStats(0);
   getObjectsManager()->startPublishing(mDigitChipOccupancy.get());
-  getObjectsManager()->setDefaultDrawOptions(mDigitChipOccupancy.get(), "hist");
+  getObjectsManager()->setDisplayHint(mDigitChipOccupancy.get(), "hist");
 
   mDigitDoubleColumnSensorIndices = std::make_unique<TH2F>("mDigitDoubleColumnSensorIndices",
                                                            "Double Column vs Chip ID;Double Column;Chip ID",
                                                            512, -0.5, 511.5, 936, -0.5, 935.5);
   mDigitDoubleColumnSensorIndices->SetStats(0);
   getObjectsManager()->startPublishing(mDigitDoubleColumnSensorIndices.get());
-  getObjectsManager()->setDefaultDrawOptions(mDigitDoubleColumnSensorIndices.get(), "colz");
+  getObjectsManager()->setDisplayHint(mDigitDoubleColumnSensorIndices.get(), "colz");
 
   if (mNoiseScan == 1) { // to be executed only for special runs
     mDigitChipStdDev = std::make_unique<TH1F>(
@@ -151,7 +151,7 @@ void QcMFTDigitTask::initialize(o2::framework::InitContext& /*ctx*/)
   mDigitOccupancySummary->GetYaxis()->SetBinLabel(8, "h1-z3");
   mDigitOccupancySummary->SetStats(0);
   getObjectsManager()->startPublishing(mDigitOccupancySummary.get());
-  getObjectsManager()->setDefaultDrawOptions(mDigitOccupancySummary.get(), "colz");
+  getObjectsManager()->setDisplayHint(mDigitOccupancySummary.get(), "colz");
 
   mDigitsROFSize = std::make_unique<TH1F>("mDigitsROFSize", "Distribution of the #digits per ROF; # digits per ROF; # entries", maxDigitROFSize, 0, maxDigitROFSize);
   mDigitsROFSize->SetStats(0);

--- a/Modules/MFT/src/QcMFTDigitTask.cxx
+++ b/Modules/MFT/src/QcMFTDigitTask.cxx
@@ -153,7 +153,7 @@ void QcMFTDigitTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mDigitOccupancySummary.get());
   getObjectsManager()->setDefaultDrawOptions(mDigitOccupancySummary.get(), "colz");
 
-  mDigitsROFSize = std::make_unique<TH1F>("mDigitsROFSize", "ROF size in # digits; ROF Size (# digits); # entries", maxDigitROFSize, 0, maxDigitROFSize);
+  mDigitsROFSize = std::make_unique<TH1F>("mDigitsROFSize", "Distribution of the #digits per ROF; # digits per ROF; # entries", maxDigitROFSize, 0, maxDigitROFSize);
   mDigitsROFSize->SetStats(0);
   getObjectsManager()->startPublishing(mDigitsROFSize.get());
   getObjectsManager()->setDisplayHint(mDigitsROFSize.get(), "logx logy");


### PR DESCRIPTION
Added a checker for empty zones in summary histograms for digits and clusters per zone. 