### PR TITLE
TPC: Fix for IDC displaying in the QCG

### DIFF
--- a/Modules/TPC/run/tpcQCIDCs.json
+++ b/Modules/TPC/run/tpcQCIDCs.json
@@ -17,7 +17,7 @@
         "url": ""
       },
       "conditionDB": {
-        "url": "ccdb-test.cern.ch:8080"
+        "url": "http://alice-ccdb.cern.ch"
       }
     },
     "postprocessing": {
@@ -26,7 +26,7 @@
         "className": "o2::quality_control_modules::tpc::IDCs",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
-        "dataSourceURL": "ccdb-test.cern.ch:8080",
+        "dataSourceURL": "http://alice-ccdb.cern.ch",
         "timestamps_comment": [ "Put the timestamp of the corresponding file you want to look for in the timestamps array.",
                                 "You can either put a timestamp for every object or leave the array empty to take the latest file from the CCDB.",
                                 "An empty array to get the the latest version will be the main use case.",
@@ -51,8 +51,8 @@
         ],
         "histogramRanges_comment" : [ "nBins", "min", "max" ],
         "histogramRanges": [
-          { "IDCZero" : [ "250",  "0", "100000" ] },
-          { "IDCOne" : [ "40",  "0", "2" ] },
+          { "IDCZero" : [ "250",  "0", "2.5" ] },
+          { "IDCOne" : [ "250",  "0", "0.5" ] },
           { "IDCDelta" : [ "100",  "-1.02", "-0.94" ] },
           { "FourierCoeffs" : [ "600",  "-20", "20" ] }
         ],
@@ -63,8 +63,6 @@
         "updateTrigger": [
           "once"
         ],
-        "stopTrigger_comment": [ "To keep the task running until it is stopped manually set the trigger on the update of a non-existing object, e.g. 'newobject:ccdb:TPC/ThisDoesNotExist'",
-                                 "There will be a end of run trigger implemented so the above workaround can be abandoned later." ],
         "stopTrigger": [
           "userorcontrol"
         ]

--- a/Modules/TPC/src/IDCs.cxx
+++ b/Modules/TPC/src/IDCs.cxx
@@ -136,6 +136,15 @@ void IDCs::initialize(Trigger, framework::ServiceRegistryRef)
 
 void IDCs::update(Trigger, framework::ServiceRegistryRef)
 {
+  mIDCZeroRadialProf.get()->Clear();
+  mIDCZeroStacksA.get()->Clear();
+  mIDCZeroStacksC.get()->Clear();
+  mIDCDeltaStacksA.get()->Clear();
+  mIDCDeltaStacksC.get()->Clear();
+  mIDCOneSides1D.get()->Clear();
+  mFourierCoeffsA.get()->Clear();
+  mFourierCoeffsC.get()->Clear();
+
   auto idcZeroA = mCdbApi.retrieveFromTFileAny<IDCZero>(CDBTypeMap.at(CDBType::CalIDC0A), std::map<std::string, std::string>{}, mTimestamps["IDCZero"]);
   auto idcZeroC = mCdbApi.retrieveFromTFileAny<IDCZero>(CDBTypeMap.at(CDBType::CalIDC0C), std::map<std::string, std::string>{}, mTimestamps["IDCZero"]);
   auto idcDeltaA = mCdbApi.retrieveFromTFileAny<IDCDelta<unsigned char>>(CDBTypeMap.at(CDBType::CalIDCDeltaA), std::map<std::string, std::string>{}, mTimestamps["IDCDelta"]);


### PR DESCRIPTION
This fixes the problem that only the very first IDC QC objects in a run were properly displayed in the QCG.