### PR TITLE
bug fix in tof digit qc

### DIFF
--- a/Modules/TOF/src/TaskDigits.cxx
+++ b/Modules/TOF/src/TaskDigits.cxx
@@ -364,6 +364,10 @@ void TaskDigits::monitorData(o2::framework::ProcessingContext& ctx)
         bcCorrCable += o2::constants::lhc::LHCMaxBunches;
       }
 
+      if (bcCorrCable >= o2::constants::lhc::LHCMaxBunches) {
+        bcCorrCable -= o2::constants::lhc::LHCMaxBunches;
+      }
+
       ndigitsPerBC[row.mFirstIR.orbit % nOrbits][bcCorrCable]++;
 
       ndigitsPerCrate[crateECH]++;


### PR DESCRIPTION
@chiarazampolli , @ercolessi , @njacazio 
Fix of a bug causing a crash in async reconstruction (apass2). 
A protection added for rare case, not spotted in apass1 probably because we move to 100% sampling only in apass2.