### PR TITLE
Update ITCClusterTask

### DIFF
--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -57,45 +57,47 @@ class ITSClusterTask : public TaskInterface
   void addObject(TObject* aObject);
   void getJsonParameters();
   void createAllHistos();
-  void updateOccMonitorPlots();
 
   static constexpr int NLayer = 7;
   static constexpr int NLayerIB = 3;
-  TH2F* hClusterVsBunchCrossing;
+
   std::vector<TObject*> mPublishedObjects;
-  TH1F* hClusterSizeSummaryIB[7][48][9];
+
+  // Inner barrel
   TH1F* hClusterTopologySummaryIB[7][48][9];
   TH1F* hGroupedClusterSizeSummaryIB[7][48][9];
 
-  TH1F* hClusterSizeLayerSummary[7];
-  TH1F* hClusterTopologyLayerSummary[7];
-  TH1F* hGroupedClusterSizeLayerSummary[7];
-
   TH2F* hAverageClusterOccupancySummaryIB[7];
-  TH2F* hAverageClusterOccupancyMonitorIB[7]; // will be used in online data monitoring, showing occupation for the last N ROFs
   TH2F* hAverageClusterSizeSummaryIB[7];
-  TH2F* hAverageClusterSizeMonitorIB[7];
 
-  Int_t mClusterOccupancyIB[7][48][9];
-  Int_t mClusterOccupancyIBmonitor[7][48][9];
+  int mClusterOccupancyIB[7][48][9];
 
+  // Outer barrel
   TH1F* hGroupedClusterSizeSummaryOB[7][48];
   TH1F* hClusterSizeSummaryOB[7][48];
   TH1F* hClusterTopologySummaryOB[7][48];
 
   TH2F* hAverageClusterOccupancySummaryOB[7];
-  TH2F* hAverageClusterOccupancyMonitorOB[7]; // will be used in online data monitoring, showing occupation for the last N ROFs
   TH2F* hAverageClusterSizeSummaryOB[7];
-  TH2F* hAverageClusterSizeMonitorOB[7];
 
-  //  THnSparseD *sClustersSize[7];
+  int mClusterOccupancyOB[7][48][28];
+
+  // Layer synnary
+  TH1F* hClusterSizeLayerSummary[7];
+  TH1F* hClusterTopologyLayerSummary[7];
+  TH1F* hGroupedClusterSizeLayerSummary[7];
+
+  // General
+  TH2F* hClusterVsBunchCrossing;
   TH2F* mGeneralOccupancy;
+
+  int mClusterSize[7][48][28]; //[#layers][max staves][max lanes / chips]
+  int nClusters[7][48][28];
 
   const int mOccUpdateFrequency = 100000;
   int mDoPublish1DSummary = 0;
   int mNThreads = 1;
   int mNRofs = 0;
-  int mNRofsMonitor = 0;
   int nBCbins = 103;
   long int mTimestamp = -1;
   std::string mGeomPath = "./";
@@ -112,11 +114,6 @@ class ITSClusterTask : public TaskInterface
   const std::string mYlabels[NLayer * 2] = { "L6B(S24#rightarrow47)", "L5B(S21#rightarrow41)", "L4B(S15#rightarrow29)", "L3B(S12#rightarrow23)", "L2B(S10#rightarrow19)", "L1B(S08#rightarrow15)", "L0B(S06#rightarrow11)", "L0T(S00#rightarrow05)", "L1T(S00#rightarrow07)", "L2T(S00#rightarrow09)", "L3T(S00#rightarrow11)", "L4T(S00#rightarrow14)", "L5T(S00#rightarrow20)", "L6T(S00#rightarrow23)" };
 
   int mEnableLayers[7];
-  int mClusterSize[7][48][28] = { { { 0 } } }; //[#layers][max staves][max lanes / chips]
-  double mClusterSizeMonitor[7][48][28] = { { { 0 } } };
-  int nClusters[7][48][28] = { { { 0 } } };
-  Int_t mClusterOccupancyOB[7][48][28] = { { { 0 } } };
-  Int_t mClusterOccupancyOBmonitor[7][48][28] = { { { 0 } } };
 
   o2::itsmft::TopologyDictionary* mDict;
   o2::its::GeometryTGeo* mGeom;

--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -58,41 +58,47 @@ class ITSClusterTask : public TaskInterface
   void getJsonParameters();
   void createAllHistos();
 
+
   static constexpr int NLayer = 7;
   static constexpr int NLayerIB = 3;
 
   std::vector<TObject*> mPublishedObjects;
 
   // Inner barrel
-  TH1F* hClusterTopologySummaryIB[7][48][9];
-  TH1F* hGroupedClusterSizeSummaryIB[7][48][9];
+  TH1F* hClusterTopologySummaryIB[NLayer][48][9];
+  TH1F* hGroupedClusterSizeSummaryIB[NLayer][48][9];
 
-  TH2F* hAverageClusterOccupancySummaryIB[7];
-  TH2F* hAverageClusterSizeSummaryIB[7];
+  TH2F* hAverageClusterOccupancySummaryIB[NLayer];
+  TH2F* hAverageClusterSizeSummaryIB[NLayer];
 
-  int mClusterOccupancyIB[7][48][9];
+  int mClusterOccupancyIB[NLayer][48][9];
 
   // Outer barrel
-  TH1F* hGroupedClusterSizeSummaryOB[7][48];
-  TH1F* hClusterSizeSummaryOB[7][48];
-  TH1F* hClusterTopologySummaryOB[7][48];
+  TH1F* hGroupedClusterSizeSummaryOB[NLayer][48];
+  TH1F* hClusterSizeSummaryOB[NLayer][48];
+  TH1F* hClusterTopologySummaryOB[NLayer][48];
 
-  TH2F* hAverageClusterOccupancySummaryOB[7];
-  TH2F* hAverageClusterSizeSummaryOB[7];
+  TH2F* hAverageClusterOccupancySummaryOB[NLayer];
+  TH2F* hAverageClusterSizeSummaryOB[NLayer];
 
-  int mClusterOccupancyOB[7][48][28];
+  int mClusterOccupancyOB[NLayer][48][28];
 
   // Layer synnary
-  TH1F* hClusterSizeLayerSummary[7];
-  TH1F* hClusterTopologyLayerSummary[7];
-  TH1F* hGroupedClusterSizeLayerSummary[7];
+  TH1F* hClusterSizeLayerSummary[NLayer];
+  TH1F* hClusterTopologyLayerSummary[NLayer];
+  TH1F* hGroupedClusterSizeLayerSummary[NLayer];
 
   // General
   TH2F* hClusterVsBunchCrossing;
   TH2F* mGeneralOccupancy;
 
-  int mClusterSize[7][48][28]; //[#layers][max staves][max lanes / chips]
-  int nClusters[7][48][28];
+  // Coarse checks
+
+  TH2F* hAverageClusterOccupancySummaryZPhi[NLayer];
+  TH2F* hAverageClusterSizeSummaryZPhi[NLayer];
+
+  int mClusterSize[NLayer][48][28]; //[#layers][max staves][max lanes / chips]
+  int nClusters[NLayer][48][28];
 
   const int mOccUpdateFrequency = 100000;
   int mDoPublish1DSummary = 0;
@@ -104,8 +110,9 @@ class ITSClusterTask : public TaskInterface
   TString xLabel;
   std::string mGeoTimestamp = "1640991600000";
   int mLocalGeometryFile = 1;
+  int mDoPublishDetailedSummary = 0;
 
-  const int mNStaves[7] = { 12, 16, 20, 24, 30, 42, 48 };
+  const int mNStaves[NLayer] = { 12, 16, 20, 24, 30, 42, 48 };
   const int mNHicPerStave[NLayer] = { 1, 1, 1, 8, 8, 14, 14 };
   const int mNChipsPerHic[NLayer] = { 9, 9, 9, 14, 14, 14, 14 };
   const int mNLanePerHic[NLayer] = { 3, 3, 3, 2, 2, 2, 2 };
@@ -113,7 +120,7 @@ class ITSClusterTask : public TaskInterface
   const int StaveBoundary[NLayer + 1] = { 0, 12, 28, 48, 72, 102, 144, 192 };
   const std::string mYlabels[NLayer * 2] = { "L6B(S24#rightarrow47)", "L5B(S21#rightarrow41)", "L4B(S15#rightarrow29)", "L3B(S12#rightarrow23)", "L2B(S10#rightarrow19)", "L1B(S08#rightarrow15)", "L0B(S06#rightarrow11)", "L0T(S00#rightarrow05)", "L1T(S00#rightarrow07)", "L2T(S00#rightarrow09)", "L3T(S00#rightarrow11)", "L4T(S00#rightarrow14)", "L5T(S00#rightarrow20)", "L6T(S00#rightarrow23)" };
 
-  int mEnableLayers[7];
+  int mEnableLayers[NLayer];
 
   o2::itsmft::TopologyDictionary* mDict;
   o2::its::GeometryTGeo* mGeom;

--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -73,50 +73,42 @@ class ITSClusterTask : public TaskInterface
   std::vector<TObject*> mPublishedObjects;
 
   // Inner barrel
-  TH1F* hClusterTopologySummaryIB[NLayer][48][9];
-  TH1F* hGroupedClusterSizeSummaryIB[NLayer][48][9];
+  TH1F* hClusterTopologySummaryIB[NLayer][48][9] = { { { nullptr } } };
+  TH1F* hGroupedClusterSizeSummaryIB[NLayer][48][9] = { { { nullptr } } };
 
-  TH2F* hAverageClusterOccupancySummaryIB[NLayer];
-  TH2F* hAverageClusterSizeSummaryIB[NLayer];
+  TH2F* hAverageClusterOccupancySummaryIB[NLayer] = { nullptr };
+  TH2F* hAverageClusterSizeSummaryIB[NLayer] = { nullptr };
 
-  int mClusterOccupancyIB[NLayer][48][9];
+  int mClusterOccupancyIB[NLayer][48][9] = { { { 0 } } };
 
   // Outer barrel
-  TH1F* hGroupedClusterSizeSummaryOB[NLayer][48];
-  TH1F* hClusterSizeSummaryOB[NLayer][48];
-  TH1F* hClusterTopologySummaryOB[NLayer][48];
+  TH1F* hGroupedClusterSizeSummaryOB[NLayer][48] = { { nullptr } };
+  TH1F* hClusterSizeSummaryOB[NLayer][48] = { { nullptr } };
+  TH1F* hClusterTopologySummaryOB[NLayer][48] = { { nullptr } };
 
-  TH2F* hAverageClusterOccupancySummaryOB[NLayer];
-  TH2F* hAverageClusterSizeSummaryOB[NLayer];
+  TH2F* hAverageClusterOccupancySummaryOB[NLayer] = { nullptr };
+  TH2F* hAverageClusterSizeSummaryOB[NLayer] = { nullptr };
 
-  int mClusterOccupancyOB[NLayer][48][28];
+  int mClusterOccupancyOB[NLayer][48][28] = { { { 0 } } };
 
   // Layer synnary
-  TH1F* hClusterSizeLayerSummary[NLayer];
-  TH1F* hClusterTopologyLayerSummary[NLayer];
-  TH1F* hGroupedClusterSizeLayerSummary[NLayer];
+  TH1F* hClusterSizeLayerSummary[NLayer] = { nullptr };
+  TH1F* hClusterTopologyLayerSummary[NLayer] = { nullptr };
+  TH1F* hGroupedClusterSizeLayerSummary[NLayer] = { nullptr };
 
   // General
-  TH2F* hClusterVsBunchCrossing;
-  TH2F* mGeneralOccupancy;
+  TH2F* hClusterVsBunchCrossing = nullptr;
+  TH2F* mGeneralOccupancy = nullptr;
 
   // Coarse checks
-  TH2F* hAverageClusterOccupancySummaryCoarse[NLayer];
-  TH2F* hAverageClusterSizeSummaryCoarse[NLayer];
+  TH2F* hAverageClusterOccupancySummaryCoarse[NLayer] = { nullptr };
+  TH2F* hAverageClusterSizeSummaryCoarse[NLayer] = { nullptr };
 
-  TH2F* hAverageClusterOccupancySummaryZPhi[NLayer];
-  TH2F* hAverageClusterSizeSummaryZPhi[NLayer];
+  TH2F* hAverageClusterOccupancySummaryZPhi[NLayer] = { nullptr };
+  TH2F* hAverageClusterSizeSummaryZPhi[NLayer] = { nullptr };
 
-  int mClusterSize[NLayer][48][28]; //[#layers][max staves][max lanes / chips]
-  int nClusters[NLayer][48][28];
-
-  // plotting coarse check
-  float offset_vert[NLayer] = { 0.125, 0.115, 0.115, 0.11, 0.105, 0.10, 0.10 };
-  float size_stave[NLayer] = { 0.025, 0.025, 0.025, 0.015, 0.015, 0.015, 0.015 };
-  float top_margin[NLayer] = { 0.075, 0.08, 0.085, 0.09, 0.095, 0.1, 0.095 };
-
-  float offset_hor = 0.125;
-  float offset_hor_lane = 0.11;
+  int mClusterSize[NLayer][48][28] = { { { 0 } } }; //[#layers][max staves][max lanes / chips]
+  int nClusters[NLayer][48][28] = { { { 0 } } };
 
   // Edges of space binning within chips (local frame coordinates)
   std::vector<float> vRphiBinsIB;
@@ -124,10 +116,10 @@ class ITSClusterTask : public TaskInterface
   std::vector<float> vRphiBinsOB;
   std::vector<float> vZBinsOB;
 
-  int nZBinsIB;
-  int nRphiBinsIB;
-  int nRphiBinsOB;
-  int nZBinsOB;
+  int nZBinsIB = 1;
+  int nRphiBinsIB = 1;
+  int nRphiBinsOB = 1;
+  int nZBinsOB = 1;
 
   const int mOccUpdateFrequency = 100000;
   int mDoPublish1DSummary = 0;
@@ -149,10 +141,10 @@ class ITSClusterTask : public TaskInterface
   const int StaveBoundary[NLayer + 1] = { 0, 12, 28, 48, 72, 102, 144, 192 };
   const std::string mYlabels[NLayer * 2] = { "L6B(S24#rightarrow47)", "L5B(S21#rightarrow41)", "L4B(S15#rightarrow29)", "L3B(S12#rightarrow23)", "L2B(S10#rightarrow19)", "L1B(S08#rightarrow15)", "L0B(S06#rightarrow11)", "L0T(S00#rightarrow05)", "L1T(S00#rightarrow07)", "L2T(S00#rightarrow09)", "L3T(S00#rightarrow11)", "L4T(S00#rightarrow14)", "L5T(S00#rightarrow20)", "L6T(S00#rightarrow23)" };
 
-  int mEnableLayers[NLayer];
+  int mEnableLayers[NLayer] = { 0 };
 
-  o2::itsmft::TopologyDictionary* mDict;
-  o2::its::GeometryTGeo* mGeom;
+  o2::itsmft::TopologyDictionary* mDict = nullptr;
+  o2::its::GeometryTGeo* mGeom = nullptr;
 
   const char* OBLabel34[16] = { "HIC1L_B0_ln7", "HIC1L_A8_ln6", "HIC2L_B0_ln8", "HIC2L_A8_ln5", "HIC3L_B0_ln9", "HIC3L_A8_ln4", "HIC4L_B0_ln10", "HIC4L_A8_ln3", "HIC1U_B0_ln21", "HIC1U_A8_ln20", "HIC2U_B0_ln22", "HIC2U_A8_ln19", "HIC3U_B0_ln23", "HIC3U_A8_ln18", "HIC4U_B0_ln24", "HIC4U_A8_ln17" };
   const char* OBLabel56[28] = { "HIC1L_B0_ln7", "HIC1L_A8_ln6", "HIC2L_B0_ln8", "HIC2L_A8_ln5", "HIC3L_B0_ln9", "HIC3L_A8_ln4", "HIC4L_B0_ln10", "HIC4L_A8_ln3", "HIC5L_B0_ln11", "HIC5L_A8_ln2", "HIC6L_B0_ln12", "HIC6L_A8_ln1", "HIC7L_B0_ln13", "HIC7L_A8_ln0", "HIC1U_B0_ln21", "HIC1U_A8_ln20", "HIC2U_B0_ln22", "HIC2U_A8_ln19", "HIC3U_B0_ln23", "HIC3U_A8_ln18", "HIC4U_B0_ln24", "HIC4U_A8_ln17", "HIC5U_B0_ln25", "HIC5U_A8_ln16", "HIC6U_B0_ln26", "HIC6U_A8_ln15", "HIC7U_B0_ln27", "HIC7U_A8_ln14" };

--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -51,6 +51,12 @@ class ITSClusterTask : public TaskInterface
   void endOfActivity(Activity& activity) override;
   void reset() override;
 
+  // coarse checks
+  void setRphiBinningIB(std::vector<float> bins = { -0.75, -0.60, -0.45, -0.30, -0.15, 0, 0.15, 0.30, 0.45, 0.60, 0.76 });
+  void setZBinningIB(std::vector<float> bins = { -1.5, -1.20, -0.9, -0.6, -0.3, 0, 0.3, 0.6, 0.9, 1.2, 1.51 });
+  void setRphiBinningOB(std::vector<float> bins = { -0.75, -0.35, 0, 0.35, 0.76 });
+  void setZBinningOB(std::vector<float> bins = { -1.5, -0.75, 0., 0.75, 1.51 });
+
  private:
   void publishHistos();
   void formatAxes(TH1* h, const char* xTitle, const char* yTitle, float xOffset = 1., float yOffset = 1.);
@@ -58,6 +64,8 @@ class ITSClusterTask : public TaskInterface
   void getJsonParameters();
   void createAllHistos();
 
+  float getHorizontalBin(float z, int chip, int layer, int lane = 0);
+  float getVerticalBin(float rphi, int stave, int layer);
 
   static constexpr int NLayer = 7;
   static constexpr int NLayerIB = 3;
@@ -93,12 +101,33 @@ class ITSClusterTask : public TaskInterface
   TH2F* mGeneralOccupancy;
 
   // Coarse checks
+  TH2F* hAverageClusterOccupancySummaryCoarse[NLayer];
+  TH2F* hAverageClusterSizeSummaryCoarse[NLayer];
 
   TH2F* hAverageClusterOccupancySummaryZPhi[NLayer];
   TH2F* hAverageClusterSizeSummaryZPhi[NLayer];
 
   int mClusterSize[NLayer][48][28]; //[#layers][max staves][max lanes / chips]
   int nClusters[NLayer][48][28];
+
+  // plotting coarse check
+  float offset_vert[NLayer] = { 0.125, 0.115, 0.115, 0.11, 0.105, 0.10, 0.10 };
+  float size_stave[NLayer] = { 0.025, 0.025, 0.025, 0.015, 0.015, 0.015, 0.015 };
+  float top_margin[NLayer] = { 0.075, 0.08, 0.085, 0.09, 0.095, 0.1, 0.095 };
+
+  float offset_hor = 0.125;
+  float offset_hor_lane = 0.11;
+
+  // Edges of space binning within chips (local frame coordinates)
+  std::vector<float> vRphiBinsIB;
+  std::vector<float> vZBinsIB;
+  std::vector<float> vRphiBinsOB;
+  std::vector<float> vZBinsOB;
+
+  int nZBinsIB;
+  int nRphiBinsIB;
+  int nRphiBinsOB;
+  int nZBinsOB;
 
   const int mOccUpdateFrequency = 100000;
   int mDoPublish1DSummary = 0;

--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -28,8 +28,8 @@
 #include <ITSBase/GeometryTGeo.h>
 #include <Framework/TimingInfo.h>
 
-class TH1D;
-class TH2D;
+class TH1F;
+class TH2F;
 
 using namespace o2::quality_control::core;
 
@@ -61,35 +61,35 @@ class ITSClusterTask : public TaskInterface
 
   static constexpr int NLayer = 7;
   static constexpr int NLayerIB = 3;
-  TH2D* hClusterVsBunchCrossing;
+  TH2F* hClusterVsBunchCrossing;
   std::vector<TObject*> mPublishedObjects;
-  TH1D* hClusterSizeSummaryIB[7][48][9];
-  TH1D* hClusterTopologySummaryIB[7][48][9];
-  TH1D* hGroupedClusterSizeSummaryIB[7][48][9];
+  TH1F* hClusterSizeSummaryIB[7][48][9];
+  TH1F* hClusterTopologySummaryIB[7][48][9];
+  TH1F* hGroupedClusterSizeSummaryIB[7][48][9];
 
-  TH1D* hClusterSizeLayerSummary[7];
-  TH1D* hClusterTopologyLayerSummary[7];
-  TH1D* hGroupedClusterSizeLayerSummary[7];
+  TH1F* hClusterSizeLayerSummary[7];
+  TH1F* hClusterTopologyLayerSummary[7];
+  TH1F* hGroupedClusterSizeLayerSummary[7];
 
-  TH2D* hAverageClusterOccupancySummaryIB[7];
-  TH2D* hAverageClusterOccupancyMonitorIB[7]; // will be used in online data monitoring, showing occupation for the last N ROFs
-  TH2D* hAverageClusterSizeSummaryIB[7];
-  TH2D* hAverageClusterSizeMonitorIB[7];
+  TH2F* hAverageClusterOccupancySummaryIB[7];
+  TH2F* hAverageClusterOccupancyMonitorIB[7]; // will be used in online data monitoring, showing occupation for the last N ROFs
+  TH2F* hAverageClusterSizeSummaryIB[7];
+  TH2F* hAverageClusterSizeMonitorIB[7];
 
   Int_t mClusterOccupancyIB[7][48][9];
   Int_t mClusterOccupancyIBmonitor[7][48][9];
 
-  TH1D* hGroupedClusterSizeSummaryOB[7][48];
-  TH1D* hClusterSizeSummaryOB[7][48];
-  TH1D* hClusterTopologySummaryOB[7][48];
+  TH1F* hGroupedClusterSizeSummaryOB[7][48];
+  TH1F* hClusterSizeSummaryOB[7][48];
+  TH1F* hClusterTopologySummaryOB[7][48];
 
-  TH2D* hAverageClusterOccupancySummaryOB[7];
-  TH2D* hAverageClusterOccupancyMonitorOB[7]; // will be used in online data monitoring, showing occupation for the last N ROFs
-  TH2D* hAverageClusterSizeSummaryOB[7];
-  TH2D* hAverageClusterSizeMonitorOB[7];
+  TH2F* hAverageClusterOccupancySummaryOB[7];
+  TH2F* hAverageClusterOccupancyMonitorOB[7]; // will be used in online data monitoring, showing occupation for the last N ROFs
+  TH2F* hAverageClusterSizeSummaryOB[7];
+  TH2F* hAverageClusterSizeMonitorOB[7];
 
   //  THnSparseD *sClustersSize[7];
-  TH2D* mGeneralOccupancy;
+  TH2F* mGeneralOccupancy;
 
   const int mOccUpdateFrequency = 100000;
   int mDoPublish1DSummary = 0;

--- a/Modules/ITS/itsCluster.json
+++ b/Modules/ITS/itsCluster.json
@@ -1,6 +1,5 @@
 {
-
-   "qc": {
+  "qc": {
     "config": {
       "database": {
         "implementation": "CCDB",
@@ -23,12 +22,12 @@
         "url": "http://alice-ccdb.cern.ch"
       }
     },
-   "tasks": {
+    "tasks": {
       "ITSClusterTask": {
         "active": "true",
         "className": "o2::quality_control_modules::its::ITSClusterTask",
         "moduleName": "QcITS",
-	"detectorName": "ITS",	
+        "detectorName": "ITS",
         "cycleDurationSeconds": "180",
         "maxNumberCycles": "-1",
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
@@ -37,18 +36,17 @@
           "name": "compclus"
         },
         "location": "remote",
-              "taskParameters": {
-              "layer": "1111111",
-              "nThreads": "1",
-              "nBCbins" : "103",
-	      "dicttimestamp" : "0",
-	      "geomPath": "./",
-              "publishSummary1D": "0",
-              "isLocalGeometry": "0",
-              "geomstamp": "1640991600000"
-      
+        "taskParameters": {
+          "layer": "1111111",
+          "nThreads": "1",
+          "nBCbins": "103",
+          "dicttimestamp": "0",
+          "geomPath": "./",
+          "publishSummary1D": "0",
+          "publishDetailedSummary": "1",
+          "isLocalGeometry": "0",
+          "geomstamp": "1640991600000"
         }
- 
       }
     },
     "checks": {
@@ -59,47 +57,49 @@
         "policy": "OnEachSeparately",
         "detectorName": "ITS",
         "checkParameters": {
-          "maxcluoccL0" : "5",
-          "maxcluoccL1" : "4",
-          "maxcluoccL2" : "3",
-          "maxcluoccL3" : "2",
-          "maxcluoccL4" : "1",
-          "maxcluoccL5" : "1",
-          "maxcluoccL6" : "1",
-          "skipxbinsoccupancy" : "",
-          "skipybinsoccupancy" : ""
+          "maxcluoccL0": "5",
+          "maxcluoccL1": "4",
+          "maxcluoccL2": "3",
+          "maxcluoccL3": "2",
+          "maxcluoccL4": "1",
+          "maxcluoccL5": "1",
+          "maxcluoccL6": "1",
+          "skipxbinsoccupancy": "",
+          "skipybinsoccupancy": ""
         },
-        "dataSource": [{
-          "type": "Task",
-          "name": "ITSClusterTask",
-          "MOs": ["Layer0/AverageClusterSize","Layer1/AverageClusterSize","Layer2/AverageClusterSize","Layer3/AverageClusterSize","Layer4/AverageClusterSize","Layer5/AverageClusterSize","Layer6/AverageClusterSize", "General/General_Occupancy"]
-
-          }]
-        }
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "ITSClusterTask",
+            "MOs": [
+              "Layer0/AverageClusterSize",
+              "Layer1/AverageClusterSize",
+              "Layer2/AverageClusterSize",
+              "Layer3/AverageClusterSize",
+              "Layer4/AverageClusterSize",
+              "Layer5/AverageClusterSize",
+              "Layer6/AverageClusterSize",
+              "General/General_Occupancy"
+            ]
+          }
+        ]
+      }
     }
-   },
-
+  },
   "dataSamplingPolicies": [
     {
-    	    "id": "compclus",
-            "active": "true",
-            "machines": [],
-            "query": "compclus:ITS/COMPCLUSTERS/0;clustersrof:ITS/CLUSTERSROF/0;patterns:ITS/PATTERNS/0",
-            "samplingConditions": [
-                {
-                    "condition": "random",
-                    "fraction": "1",
-                    "seed": "1441"
-                }
-            ],
-
-	    "blocking": "false"
+      "id": "compclus",
+      "active": "true",
+      "machines": [],
+      "query": "compclus:ITS/COMPCLUSTERS/0;clustersrof:ITS/CLUSTERSROF/0;patterns:ITS/PATTERNS/0",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
     }
   ]
-
 }
-                                                                                                                               
-
-
-
-

--- a/Modules/ITS/src/ITSClusterCheck.cxx
+++ b/Modules/ITS/src/ITSClusterCheck.cxx
@@ -40,7 +40,7 @@ Quality ITSClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
     result = Quality::Good;
 
     if (iter->second->getName().find("AverageClusterSize") != std::string::npos) {
-      auto* h = dynamic_cast<TH2D*>(iter->second->getObject());
+      auto* h = dynamic_cast<TH2F*>(iter->second->getObject());
       for (int ilayer = 0; ilayer < NLayer; ilayer++) {
         result.addMetadata(Form("Layer%d", ilayer), "good");
         if (iter->second->getName().find(Form("Layer%d", ilayer)) != std::string::npos && h->GetMaximum() > averageClusterSizeLimit[ilayer]) {
@@ -51,7 +51,7 @@ Quality ITSClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
     }
 
     if (iter->second->getName().find("General_Occupancy") != std::string::npos) {
-      auto* hp = dynamic_cast<TH2D*>(iter->second->getObject());
+      auto* hp = dynamic_cast<TH2F*>(iter->second->getObject());
       std::vector<int> skipxbins = convertToIntArray(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "skipxbinsoccupancy", ""));
       std::vector<int> skipybins = convertToIntArray(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "skipybinsoccupancy", ""));
       std::vector<std::pair<int, int>> xypairs;
@@ -102,7 +102,7 @@ Quality ITSClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
   return result;
 } // end check
 
-std::string ITSClusterCheck::getAcceptedType() { return "TH2D"; }
+std::string ITSClusterCheck::getAcceptedType() { return "TH2F"; }
 
 void ITSClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
@@ -112,7 +112,7 @@ void ITSClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkR
   Double_t positionX, positionY;
 
   if (mo->getName().find("AverageClusterSize") != std::string::npos) {
-    auto* h = dynamic_cast<TH2D*>(mo->getObject());
+    auto* h = dynamic_cast<TH2F*>(mo->getObject());
     std::string histoName = mo->getName();
     int iLayer = histoName[histoName.find("Layer") + 5] - 48; // Searching for position of "Layer" in the name of the file, then +5 is the NUMBER of the layer, -48 is conversion to int
 
@@ -137,7 +137,7 @@ void ITSClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkR
   }
 
   if (mo->getName().find("General_Occupancy") != std::string::npos) {
-    auto* h = dynamic_cast<TH2D*>(mo->getObject());
+    auto* h = dynamic_cast<TH2F*>(mo->getObject());
     if (checkResult == Quality::Good) {
       status = "Quality::GOOD";
       textColor = kGreen;

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -559,6 +559,7 @@ void ITSClusterTask::getJsonParameters()
   mGeomPath = o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "geomPath", mGeomPath);
   mDoPublish1DSummary = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "publishSummary1D", mDoPublish1DSummary);
   std::string LayerConfig = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "layer", "0000000");
+  mDoPublishDetailedSummary = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "publishDetailedSummary", mDoPublishDetailedSummary);
 
   for (int ilayer = 0; ilayer < NLayer; ilayer++) {
     if (LayerConfig[ilayer] != '0') {

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -86,7 +86,6 @@ ITSClusterTask::~ITSClusterTask()
         delete hGroupedClusterSizeSummaryOB[iLayer][iStave];
       }
     }
-    ILOG(Info, Support) << "Deleting new plots" << ENDM;
     delete hAverageClusterOccupancySummaryCoarse[iLayer];
     delete hAverageClusterSizeSummaryCoarse[iLayer];
     delete hAverageClusterOccupancySummaryZPhi[iLayer];
@@ -251,12 +250,13 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       }
 
       // Transformation to the local --> global
-      auto gloC = mGeom->getMatrixL2G(ChipID) * locC; // TODO: fix global coordinates
-      float phi = (float)TMath::ATan2(locC.Y(), locC.X());
+      mGeom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::L2G));
+      auto gloC = mGeom->getMatrixL2G(ChipID) * locC;
+      float phi = (float)TMath::ATan2(gloC.Y(), gloC.X());
 
       phi = (float)(phi * 180 / TMath::Pi());
-      hAverageClusterOccupancySummaryZPhi[lay]->Fill(locC.Z(), 5);
-      hAverageClusterSizeSummaryZPhi[lay]->Fill(locC.Z(), phi, (float)npix);
+      hAverageClusterOccupancySummaryZPhi[lay]->Fill(gloC.Z(), phi);
+      hAverageClusterSizeSummaryZPhi[lay]->Fill(gloC.Z(), phi, (float)npix);
 
       hAverageClusterOccupancySummaryCoarse[lay]->Fill(getHorizontalBin(locC.Z(), chip, lay, lane), getVerticalBin(locC.X(), sta, lay));
       hAverageClusterSizeSummaryCoarse[lay]->Fill(getHorizontalBin(locC.Z(), chip, lay, lane), getVerticalBin(locC.X(), sta, lay), (float)npix);
@@ -623,8 +623,10 @@ void ITSClusterTask::createAllHistos()
         hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_h2);
 
         TLatex* latex_h1 = new TLatex(-1.5 * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], nRphiBinsOB / 8 + (j - 1) * nRphiBinsOB, Form("#bf{Stave %d}", j - 1));
+        latex_h1->SetTextSize(0.03);
         hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_h1);
         TLatex* latex_h2 = new TLatex(-1.5 * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], nRphiBinsOB / 8 + (j - 1) * nRphiBinsOB, Form("#bf{Stave %d}", j - 1));
+        latex_h2->SetTextSize(0.03);
         hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_h2);
       }
     }

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -86,6 +86,7 @@ ITSClusterTask::~ITSClusterTask()
         delete hGroupedClusterSizeSummaryOB[iLayer][iStave];
       }
     }
+    ILOG(Info, Support) << "Deleting new plots" << ENDM;
     delete hAverageClusterOccupancySummaryCoarse[iLayer];
     delete hAverageClusterSizeSummaryCoarse[iLayer];
     delete hAverageClusterOccupancySummaryZPhi[iLayer];
@@ -545,6 +546,86 @@ void ITSClusterTask::createAllHistos()
           hAverageClusterSizeSummaryOB[iLayer]->GetXaxis()->SetBinLabel(iLane + 1, xLabel);
           hAverageClusterOccupancySummaryOB[iLayer]->GetXaxis()->SetBinLabel(iLane + 1, xLabel);
         }
+      }
+    }
+
+    // Add lines and labels to coarse checks
+    for (int i = 1; i <= (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer]); i++) // vertical
+    {
+      if (iLayer < NLayerIB) {
+        if (i != (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer])) { // black lines
+          TLine* l_v1 = new TLine(i * nZBinsIB - 0.5, -0.5, i * nZBinsIB - 0.5, mNStaves[iLayer] * nRphiBinsIB - 0.5);
+          l_v1->SetLineWidth(2);
+          hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_v1);
+          TLine* l_v2 = new TLine(i * nZBinsIB - 0.5, -0.5, i * nZBinsIB - 0.5, mNStaves[iLayer] * nRphiBinsIB - 0.5);
+          l_v2->SetLineWidth(2);
+          hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_v2);
+        }
+        TLatex* latex_v1 = new TLatex(nZBinsIB / 4 + (i - 1) * nZBinsIB, -1 * nRphiBinsIB, Form("#bf{Chip %d}", i - 1));
+        hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_v1);
+        TLatex* latex_v2 = new TLatex(nZBinsIB / 4 + (i - 1) * nZBinsIB, -1 * nRphiBinsIB, Form("#bf{Chip %d}", i - 1));
+        hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_v2);
+      } else {
+        if (i != (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer])) { // black lines
+          TLine* l_v1 = new TLine(i * nZBinsOB - 0.5, -0.5, i * nZBinsOB - 0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5);
+          l_v1->SetLineWidth(2);
+          hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_v1);
+          TLine* l_v2 = new TLine(i * nZBinsOB - 0.5, -0.5, i * nZBinsOB - 0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5);
+          l_v2->SetLineWidth(2);
+          hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_v2);
+        }
+      }
+    }
+    if (iLayer >= NLayerIB) {
+      for (int i = 1; i <= (mNLanePerHic[iLayer] * mNHicPerStave[iLayer]); i++) // vertical
+      {
+        if (i != mNLanePerHic[iLayer] * mNHicPerStave[iLayer]) { // red lines
+          TLine* l_red1 = new TLine(i * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] - 0.5, -0.5, i * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] - 0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5);
+          l_red1->SetLineColor(kRed);
+          l_red1->SetLineWidth(2);
+          hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_red1);
+          TLine* l_red2 = new TLine(i * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] - 0.5, -0.5, i * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] - 0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5);
+          l_red2->SetLineColor(kRed);
+          l_red2->SetLineWidth(2);
+          hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_red2);
+        }
+        std::string xLabel = (iLayer < 5) ? Form("#bf{%s}", OBLabel34[i - 1]) : Form("#bf{%s}", OBLabel56[i - 1]);
+        TLatex* latex_v1 = new TLatex(nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] / 2 + (i - 1) * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], -1 * nRphiBinsOB, xLabel.c_str());
+        latex_v1->SetTextAngle(-20);
+        latex_v1->SetTextSize(0.03);
+        hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_v1);
+        TLatex* latex_v2 = new TLatex(nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] / 2 + (i - 1) * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], -1 * nRphiBinsOB, xLabel.c_str());
+        latex_v2->SetTextAngle(-20);
+        latex_v2->SetTextSize(0.03);
+        hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_v2);
+      }
+    }
+    for (int j = 1; j <= mNStaves[iLayer]; j++) // horizontal
+    {
+      if (iLayer < NLayerIB) {
+        TLine* l_h1 = new TLine(-0.5, j * nRphiBinsIB - 0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB) - 0.5, j * nRphiBinsIB - 0.5);
+        l_h1->SetLineWidth(2);
+        hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_h1);
+        TLine* l_h2 = new TLine(-0.5, j * nRphiBinsIB - 0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB) - 0.5, j * nRphiBinsIB - 0.5);
+        l_h2->SetLineWidth(2);
+        hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_h2);
+
+        TLatex* latex_h1 = new TLatex(-1 * nZBinsIB, nRphiBinsIB / 4 + (j - 1) * nRphiBinsIB, Form("#bf{Stave %d}", j - 1));
+        hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_h1);
+        TLatex* latex_h2 = new TLatex(-1 * nZBinsIB, nRphiBinsIB / 4 + (j - 1) * nRphiBinsIB, Form("#bf{Stave %d}", j - 1));
+        hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_h2);
+      } else {
+        TLine* l_h1 = new TLine(-0.5, j * nRphiBinsOB - 0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB) - 0.5, j * nRphiBinsOB - 0.5);
+        l_h1->SetLineWidth(2);
+        hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_h1);
+        TLine* l_h2 = new TLine(-0.5, j * nRphiBinsOB - 0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB) - 0.5, j * nRphiBinsOB - 0.5);
+        l_h2->SetLineWidth(2);
+        hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(l_h2);
+
+        TLatex* latex_h1 = new TLatex(-1.5 * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], nRphiBinsOB / 8 + (j - 1) * nRphiBinsOB, Form("#bf{Stave %d}", j - 1));
+        hAverageClusterOccupancySummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_h1);
+        TLatex* latex_h2 = new TLatex(-1.5 * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], nRphiBinsOB / 8 + (j - 1) * nRphiBinsOB, Form("#bf{Stave %d}", j - 1));
+        hAverageClusterSizeSummaryCoarse[iLayer]->GetListOfFunctions()->Add(latex_h2);
       }
     }
   }

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -598,25 +598,25 @@ void ITSClusterTask::publishHistos()
 void ITSClusterTask::setRphiBinningIB(std::vector<float> bins)
 {
   vRphiBinsIB = bins;
-  nRphiBinsIB = (int)vRphiBinsIB.size();
+  nRphiBinsIB = (int)vRphiBinsIB.size() - 1;
 }
 
 void ITSClusterTask::setZBinningIB(std::vector<float> bins)
 {
   vZBinsIB = bins;
-  nZBinsIB = (int)vZBinsIB.size();
+  nZBinsIB = (int)vZBinsIB.size() - 1;
 }
 
 void ITSClusterTask::setRphiBinningOB(std::vector<float> bins)
 {
   vRphiBinsOB = bins;
-  nRphiBinsOB = (int)vRphiBinsIB.size();
+  nRphiBinsOB = (int)vRphiBinsOB.size() - 1;
 }
 
 void ITSClusterTask::setZBinningOB(std::vector<float> bins)
 {
   vZBinsOB = bins;
-  nZBinsOB = (int)vZBinsIB.size();
+  nZBinsOB = (int)vZBinsOB.size() - 1;
 }
 
 float ITSClusterTask::getHorizontalBin(float z, int chip, int layer, int lane)
@@ -639,7 +639,7 @@ float ITSClusterTask::getHorizontalBin(float z, int chip, int layer, int lane)
                               [](const float& comp1, const float& comp2) { return comp1 < comp2; });
     index_z = std::distance(vZBinsOB.begin(), iter_z) - 1;
     chip_index = chip % (mNChipsPerHic[layer] / mNLanePerHic[layer]) + (lane * (mNChipsPerHic[layer] / mNLanePerHic[layer]));
-    return_index = (double)(nZBinsOB * chip_index + index_z);
+    return_index = (float)(nZBinsOB * chip_index + index_z);
   }
   return return_index;
 }
@@ -662,7 +662,7 @@ float ITSClusterTask::getVerticalBin(float rphi, int stave, int layer)
     iter_rphi = std::upper_bound(vRphiBinsOB.begin(), vRphiBinsOB.end(), rphi,
                                  [](const float& comp1, const float& comp2) { return comp1 < comp2; });
     index_rphi = std::distance(vRphiBinsOB.begin(), iter_rphi) - 1;
-    return_index = (double)(stave * nRphiBinsOB + index_rphi);
+    return_index = (float)(stave * nRphiBinsOB + index_rphi);
   }
   return return_index;
 }

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -52,7 +52,7 @@ ITSClusterTask::ITSClusterTask() : TaskInterface() {}
 ITSClusterTask::~ITSClusterTask()
 {
   delete hClusterVsBunchCrossing;
-  for (Int_t iLayer = 0; iLayer < NLayer; iLayer++) {
+  for (int iLayer = 0; iLayer < NLayer; iLayer++) {
 
     if (!mEnableLayers[iLayer])
       continue;
@@ -65,12 +65,10 @@ ITSClusterTask::~ITSClusterTask()
     if (iLayer < 3) {
 
       delete hAverageClusterOccupancySummaryIB[iLayer];
-      delete hAverageClusterOccupancyMonitorIB[iLayer];
       delete hAverageClusterSizeSummaryIB[iLayer];
-      delete hAverageClusterSizeMonitorIB[iLayer];
 
-      for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
-        for (Int_t iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
+      for (int iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
+        for (int iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
 
           delete hClusterTopologySummaryIB[iLayer][iStave][iChip];
           delete hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip];
@@ -79,11 +77,9 @@ ITSClusterTask::~ITSClusterTask()
     } else {
 
       delete hAverageClusterOccupancySummaryOB[iLayer];
-      delete hAverageClusterOccupancyMonitorOB[iLayer];
       delete hAverageClusterSizeSummaryOB[iLayer];
-      delete hAverageClusterSizeMonitorOB[iLayer];
 
-      for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
+      for (int iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
 
         delete hClusterSizeSummaryOB[iLayer][iStave];
         delete hClusterTopologySummaryOB[iLayer][iStave];
@@ -209,10 +205,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (lay < 3) {
 
         mClusterOccupancyIB[lay][sta][chip]++;
-        mClusterOccupancyIBmonitor[lay][sta][chip]++;
 
         mClusterSize[lay][sta][chip] += npix;
-        mClusterSizeMonitor[lay][sta][chip] += npix;
         nClusters[lay][sta][chip]++;
         hClusterTopologySummaryIB[lay][sta][chip]->Fill(ClusterID);
 
@@ -226,10 +220,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       } else {
 
         mClusterOccupancyOB[lay][sta][lane]++;
-        mClusterOccupancyOBmonitor[lay][sta][lane]++;
 
         mClusterSize[lay][sta][lane] += npix;
-        mClusterSizeMonitor[lay][sta][lane] += npix;
         nClusters[lay][sta][lane]++;
 
         hClusterTopologySummaryOB[lay][sta]->Fill(ClusterID);
@@ -246,18 +238,17 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
 
   mNRofs += clusRofArr.size();        // USED to calculate occupancy for the whole run
-  mNRofsMonitor += clusRofArr.size(); // Occupancy in the last N ROFs
 
   if (mNRofs > 0) {
-    for (Int_t iLayer = 0; iLayer < NLayer; iLayer++) {
+    for (int iLayer = 0; iLayer < NLayer; iLayer++) {
 
       if (!mEnableLayers[iLayer])
         continue;
 
-      for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
+      for (int iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
 
         if (iLayer < 3) {
-          for (Int_t iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
+          for (int iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
             hAverageClusterOccupancySummaryIB[iLayer]->SetBinContent(iChip + 1, iStave + 1, 1. * mClusterOccupancyIB[iLayer][iStave][iChip] / mNRofs);
             hAverageClusterOccupancySummaryIB[iLayer]->SetBinError(iChip + 1, iStave + 1, 1e-15);
             hAverageClusterSizeSummaryIB[iLayer]->SetBinContent(iChip + 1, iStave + 1, nClusters[iLayer][iStave][iChip] != 0 ? (double)mClusterSize[iLayer][iStave][iChip] / nClusters[iLayer][iStave][iChip] : 0.);
@@ -269,7 +260,7 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
           mGeneralOccupancy->SetBinError(xbin, ybin, 1e-15);
         } else {
 
-          for (Int_t iLane = 0; iLane < mNLanePerHic[iLayer] * mNHicPerStave[iLayer]; iLane++) {
+          for (int iLane = 0; iLane < mNLanePerHic[iLayer] * mNHicPerStave[iLayer]; iLane++) {
             hAverageClusterOccupancySummaryOB[iLayer]->SetBinContent(iLane + 1, iStave + 1, 1. * mClusterOccupancyOB[iLayer][iStave][iLane] / mNRofs / (mNChipsPerHic[iLayer] / mNLanePerHic[iLayer])); // 14 To have occupation per chip -> 7 because we're considering lanes
             hAverageClusterOccupancySummaryOB[iLayer]->SetBinError(iLane + 1, iStave + 1, 1e-15);                                                                                                       // 14 To have occupation per chip
             hAverageClusterSizeSummaryOB[iLayer]->SetBinContent(iLane + 1, iStave + 1, nClusters[iLayer][iStave][iLane] != 0 ? (double)mClusterSize[iLayer][iStave][iLane] / nClusters[iLayer][iStave][iLane] : 0.);
@@ -284,45 +275,9 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     }
   }
 
-  if (mNRofsMonitor >= mOccUpdateFrequency) {
-    updateOccMonitorPlots();
-    mNRofsMonitor = 0;
-    memset(mClusterOccupancyIBmonitor, 0, sizeof(mClusterOccupancyIBmonitor));
-    memset(mClusterOccupancyOBmonitor, 0, sizeof(mClusterOccupancyOBmonitor));
-  }
-
   end = std::chrono::high_resolution_clock::now();
   difference = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
   ILOG(Info, Support) << "Time in QC Cluster Task:  " << difference << ENDM;
-}
-
-void ITSClusterTask::updateOccMonitorPlots()
-{
-
-  for (Int_t iLayer = 0; iLayer < NLayer; iLayer++) {
-
-    if (!mEnableLayers[iLayer])
-      continue;
-
-    for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++)
-      if (iLayer < 3) {
-
-        for (Int_t iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
-          hAverageClusterOccupancyMonitorIB[iLayer]->SetBinContent(iChip + 1, iStave + 1, 1. * mClusterOccupancyIBmonitor[iLayer][iStave][iChip] / mNRofsMonitor);
-          hAverageClusterOccupancyMonitorIB[iLayer]->SetBinError(iChip + 1, iStave + 1, 1e-15);
-          hAverageClusterSizeMonitorIB[iLayer]->SetBinContent(iChip + 1, iStave + 1, nClusters[iLayer][iStave][iChip] != 0 ? mClusterSizeMonitor[iLayer][iStave][iChip] / nClusters[iLayer][iStave][iChip] : 0.);
-          hAverageClusterSizeMonitorIB[iLayer]->SetBinError(iChip + 1, iStave + 1, 1e-15);
-        }
-      } else {
-
-        for (Int_t iLane = 0; iLane < mNLanePerHic[iLayer] * mNHicPerStave[iLayer]; iLane++) {
-          hAverageClusterOccupancyMonitorOB[iLayer]->SetBinContent(iLane + 1, iStave + 1, 1. * mClusterOccupancyOBmonitor[iLayer][iStave][iLane] / mNRofsMonitor / (14 / 2)); // 7 To have occupation per chip
-          hAverageClusterOccupancyMonitorOB[iLayer]->SetBinError(iLane + 1, iStave + 1, 1e-15);
-          hAverageClusterSizeMonitorOB[iLayer]->SetBinContent(iLane + 1, iStave + 1, nClusters[iLayer][iStave][iLane] != 0 ? mClusterSizeMonitor[iLayer][iStave][iLane] / nClusters[iLayer][iStave][iLane] : 0.);
-          hAverageClusterSizeMonitorOB[iLayer]->SetBinError(iLane + 1, iStave + 1, 1e-15);
-        }
-      }
-  }
 }
 
 void ITSClusterTask::endOfCycle()
@@ -341,7 +296,7 @@ void ITSClusterTask::reset()
   hClusterVsBunchCrossing->Reset();
   mGeneralOccupancy->Reset();
 
-  for (Int_t iLayer = 0; iLayer < NLayer; iLayer++) {
+  for (int iLayer = 0; iLayer < NLayer; iLayer++) {
     if (!mEnableLayers[iLayer])
       continue;
     // sClustersSize[iLayer]->Reset();
@@ -351,11 +306,9 @@ void ITSClusterTask::reset()
 
     if (iLayer < 3) {
       hAverageClusterOccupancySummaryIB[iLayer]->Reset();
-      hAverageClusterOccupancyMonitorIB[iLayer]->Reset();
       hAverageClusterSizeSummaryIB[iLayer]->Reset();
-      hAverageClusterSizeMonitorIB[iLayer]->Reset();
-      for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
-        for (Int_t iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
+      for (int iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
+        for (int iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
           hClusterTopologySummaryIB[iLayer][iStave][iChip]->Reset();
           hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip]->Reset();
         }
@@ -363,10 +316,7 @@ void ITSClusterTask::reset()
     } else {
       hAverageClusterOccupancySummaryOB[iLayer]->Reset();
       hAverageClusterSizeSummaryOB[iLayer]->Reset();
-      hAverageClusterOccupancyMonitorOB[iLayer]->Reset();
-      hAverageClusterSizeMonitorOB[iLayer]->Reset();
-      for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
-
+      for (int iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
         hClusterTopologySummaryOB[iLayer][iStave]->Reset();
         hGroupedClusterSizeSummaryOB[iLayer][iStave]->Reset();
       }
@@ -383,7 +333,7 @@ void ITSClusterTask::createAllHistos()
   formatAxes(hClusterVsBunchCrossing, "Bunch Crossing ID", "Number of clusters with npix > 2 in ROF", 1, 1.10);
   hClusterVsBunchCrossing->SetStats(0);
 
-  for (Int_t iLayer = 0; iLayer < NLayer; iLayer++) {
+  for (int iLayer = 0; iLayer < NLayer; iLayer++) {
     if (!mEnableLayers[iLayer])
       continue;
 
@@ -416,15 +366,6 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterOccupancySummaryIB[iLayer]->GetYaxis()->SetLabelSize(0.02);
       hAverageClusterOccupancySummaryIB[iLayer]->GetXaxis()->SetLabelSize(0.02);
 
-      hAverageClusterOccupancyMonitorIB[iLayer] = new TH2F(Form("Layer%d/ClusterOccupationForLastNROFS", iLayer), Form("Layer%dClusterOccupancyForLastNROFS", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
-      hAverageClusterOccupancyMonitorIB[iLayer]->SetTitle(Form("Cluster Occupancy for the last NROFs on Layer %d", iLayer));
-      addObject(hAverageClusterOccupancyMonitorIB[iLayer]);
-      formatAxes(hAverageClusterOccupancyMonitorIB[iLayer], "Chip Number", "Stave Number", 1, 1.10);
-      hAverageClusterOccupancyMonitorIB[iLayer]->SetStats(0);
-      hAverageClusterOccupancyMonitorIB[iLayer]->SetBit(TH1::kIsAverage);
-      hAverageClusterOccupancyMonitorIB[iLayer]->GetYaxis()->SetLabelSize(0.02);
-      hAverageClusterOccupancyMonitorIB[iLayer]->GetXaxis()->SetLabelSize(0.02);
-
       hAverageClusterSizeSummaryIB[iLayer] = new TH2F(Form("Layer%d/AverageClusterSize", iLayer), Form("Layer%dAverageClusterSize", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterSizeSummaryIB[iLayer]->SetTitle(Form("Average Cluster Size  on Layer %d", iLayer));
       addObject(hAverageClusterSizeSummaryIB[iLayer]);
@@ -434,22 +375,11 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterSizeSummaryIB[iLayer]->GetYaxis()->SetLabelSize(0.02);
       hAverageClusterSizeSummaryIB[iLayer]->GetXaxis()->SetLabelSize(0.02);
 
-      hAverageClusterSizeMonitorIB[iLayer] = new TH2F(Form("Layer%d/AverageClusterSizeForLastNROFS", iLayer), Form("Layer%dAverageClusterSizeForLastNROFS", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
-      hAverageClusterSizeMonitorIB[iLayer]->SetTitle(Form("Average Cluster Size for the last NROFs on Layer %d", iLayer));
-      addObject(hAverageClusterSizeMonitorIB[iLayer]);
-      formatAxes(hAverageClusterSizeMonitorIB[iLayer], "Chip Number", "Stave Number", 1, 1.10);
-      hAverageClusterSizeMonitorIB[iLayer]->SetStats(0);
-      hAverageClusterSizeMonitorIB[iLayer]->SetBit(TH1::kIsAverage);
-      hAverageClusterSizeMonitorIB[iLayer]->GetYaxis()->SetLabelSize(0.02);
-      hAverageClusterSizeMonitorIB[iLayer]->GetXaxis()->SetLabelSize(0.02);
-
-      for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
+      for (int iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
         hAverageClusterSizeSummaryIB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
-        hAverageClusterSizeMonitorIB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
         hAverageClusterOccupancySummaryIB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
-        hAverageClusterOccupancyMonitorIB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
 
-        for (Int_t iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
+        for (int iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
           hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip] = new TH1F(Form("Layer%d/Stave%d/CHIP%d/ClusterSizeGrouped", iLayer, iStave, iChip), Form("Layer%dStave%dCHIP%dClusterSizeGroped", iLayer, iStave, iChip), 100, 0, 100);
           hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip]->SetTitle(Form("Cluster Size for grouped topologies on Layer %d Stave %d Chip %d", iLayer, iStave, iChip));
           if (mDoPublish1DSummary == 1)
@@ -463,9 +393,7 @@ void ITSClusterTask::createAllHistos()
           formatAxes(hClusterTopologySummaryIB[iLayer][iStave][iChip], "Cluster topology (ID)", "Counts", 1, 1.10);
 
           hAverageClusterSizeSummaryIB[iLayer]->GetXaxis()->SetBinLabel(iChip + 1, Form("Chip %i", iChip));
-          hAverageClusterSizeMonitorIB[iLayer]->GetXaxis()->SetBinLabel(iChip + 1, Form("Chip %i", iChip));
           hAverageClusterOccupancySummaryIB[iLayer]->GetXaxis()->SetBinLabel(iChip + 1, Form("Chip %i", iChip));
-          hAverageClusterOccupancyMonitorIB[iLayer]->GetXaxis()->SetBinLabel(iChip + 1, Form("Chip %i", iChip));
         }
       }
     } else {
@@ -480,16 +408,6 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterOccupancySummaryOB[iLayer]->GetXaxis()->SetLabelSize(0.02);
       hAverageClusterOccupancySummaryOB[iLayer]->GetXaxis()->SetTitleOffset(1.2);
 
-      hAverageClusterOccupancyMonitorOB[iLayer] = new TH2F(Form("Layer%d/ClusterOccupationForLastNROFS", iLayer), Form("Layer%dClusterOccupancyForLastNROFS", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
-      hAverageClusterOccupancyMonitorOB[iLayer]->SetTitle(Form("Cluster Occupancy in last NROFS on Layer %d", iLayer));
-      addObject(hAverageClusterOccupancyMonitorOB[iLayer]);
-      formatAxes(hAverageClusterOccupancyMonitorOB[iLayer], "", "Stave Number", 1, 1.10);
-      hAverageClusterOccupancyMonitorOB[iLayer]->SetStats(0);
-      hAverageClusterOccupancyMonitorOB[iLayer]->SetBit(TH1::kIsAverage);
-      hAverageClusterOccupancyMonitorOB[iLayer]->GetYaxis()->SetLabelSize(0.02);
-      hAverageClusterOccupancyMonitorOB[iLayer]->GetXaxis()->SetLabelSize(0.02);
-      hAverageClusterOccupancyMonitorOB[iLayer]->GetXaxis()->SetTitleOffset(1.2);
-
       hAverageClusterSizeSummaryOB[iLayer] = new TH2F(Form("Layer%d/AverageClusterSize", iLayer), Form("Layer%dAverageClusterSize", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterSizeSummaryOB[iLayer]->SetTitle(Form("Average Cluster Size  on Layer %d", iLayer));
       addObject(hAverageClusterSizeSummaryOB[iLayer]);
@@ -501,18 +419,7 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterSizeSummaryOB[iLayer]->GetXaxis()->SetLabelSize(0.02);
       hAverageClusterSizeSummaryOB[iLayer]->GetXaxis()->SetTitleOffset(1.2);
 
-      hAverageClusterSizeMonitorOB[iLayer] = new TH2F(Form("Layer%d/AverageClusterSizeForLastNROFS", iLayer), Form("Layer%dAverageClusterSizeForLastNROFS", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
-      hAverageClusterSizeMonitorOB[iLayer]->SetTitle(Form("Average Cluster Size for the last NROFs on Layer %d", iLayer));
-      addObject(hAverageClusterSizeMonitorOB[iLayer]);
-      formatAxes(hAverageClusterSizeMonitorOB[iLayer], "", "Stave Number", 1, 1.10);
-      hAverageClusterSizeMonitorOB[iLayer]->SetStats(0);
-      hAverageClusterSizeMonitorOB[iLayer]->SetOption("colz");
-      hAverageClusterSizeMonitorOB[iLayer]->SetBit(TH1::kIsAverage);
-      hAverageClusterSizeMonitorOB[iLayer]->GetYaxis()->SetLabelSize(0.02);
-      hAverageClusterSizeMonitorOB[iLayer]->GetXaxis()->SetLabelSize(0.02);
-      hAverageClusterSizeMonitorOB[iLayer]->GetXaxis()->SetTitleOffset(1.2);
-
-      for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
+      for (int iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
 
         hClusterSizeSummaryOB[iLayer][iStave] = new TH1F(Form("Layer%d/Stave%d/ClusterSize", iLayer, iStave), Form("Layer%dStave%dClusterSize", iLayer, iStave), 100, 0, 100);
         hClusterSizeSummaryOB[iLayer][iStave]->SetTitle(Form("Cluster Size summary for Layer %d Stave %d", iLayer, iStave));
@@ -533,15 +440,11 @@ void ITSClusterTask::createAllHistos()
         formatAxes(hClusterTopologySummaryOB[iLayer][iStave], "Cluster toplogy (ID)", "Counts", 1, 1.10);
 
         hAverageClusterSizeSummaryOB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
-        hAverageClusterSizeMonitorOB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
         hAverageClusterOccupancySummaryOB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
-        hAverageClusterOccupancyMonitorOB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
-        for (Int_t iLane = 0; iLane < mNLanePerHic[iLayer] * mNHicPerStave[iLayer]; iLane++) { // are used in TH2 construction, no need to keep on ccdb
+        for (int iLane = 0; iLane < mNLanePerHic[iLayer] * mNHicPerStave[iLayer]; iLane++) { // are used in TH2 construction, no need to keep on ccdb
           (iLayer < 5) ? (xLabel = Form("%s", OBLabel34[iLane])) : (xLabel = Form("%s", OBLabel56[iLane]));
           hAverageClusterSizeSummaryOB[iLayer]->GetXaxis()->SetBinLabel(iLane + 1, xLabel);
-          hAverageClusterSizeMonitorOB[iLayer]->GetXaxis()->SetBinLabel(iLane + 1, xLabel);
           hAverageClusterOccupancySummaryOB[iLayer]->GetXaxis()->SetBinLabel(iLane + 1, xLabel);
-          hAverageClusterOccupancyMonitorOB[iLayer]->GetXaxis()->SetBinLabel(iLane + 1, xLabel);
         }
       }
     }

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -32,6 +32,8 @@
 #include "CCDB/CCDBTimeStampUtils.h"
 #include <Framework/InputRecord.h>
 #include <THnSparse.h>
+#include <TH1F.h>
+#include <TH2F.h>
 #include "Common/Utils.h"
 
 #ifdef WITH_OPENMP
@@ -114,7 +116,7 @@ void ITSClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   createAllHistos();
 
-  mGeneralOccupancy = new TH2D("General/General_Occupancy", "General Cluster Occupancy (max n_clusters/event/chip)", 24, -12, 12, 14, 0, 14);
+  mGeneralOccupancy = new TH2F("General/General_Occupancy", "General Cluster Occupancy (max n_clusters/event/chip)", 24, -12, 12, 14, 0, 14);
 
   addObject(mGeneralOccupancy);
   mGeneralOccupancy->SetStats(0);
@@ -375,7 +377,7 @@ void ITSClusterTask::reset()
 void ITSClusterTask::createAllHistos()
 {
 
-  hClusterVsBunchCrossing = new TH2D("BunchCrossingIDvsClusters", "BunchCrossingIDvsClusters", nBCbins, 0, 4095, 100, 0, 1000);
+  hClusterVsBunchCrossing = new TH2F("BunchCrossingIDvsClusters", "BunchCrossingIDvsClusters", nBCbins, 0, 4095, 100, 0, 1000);
   hClusterVsBunchCrossing->SetTitle("#clusters vs BC id for clusters with npix > 2");
   addObject(hClusterVsBunchCrossing);
   formatAxes(hClusterVsBunchCrossing, "Bunch Crossing ID", "Number of clusters with npix > 2 in ROF", 1, 1.10);
@@ -385,19 +387,19 @@ void ITSClusterTask::createAllHistos()
     if (!mEnableLayers[iLayer])
       continue;
 
-    hClusterSizeLayerSummary[iLayer] = new TH1D(Form("Layer%d/AverageClusterSizeSummary", iLayer), Form("Layer%dAverageClusterSizeSummary", iLayer), 100, 0, 100);
+    hClusterSizeLayerSummary[iLayer] = new TH1F(Form("Layer%d/AverageClusterSizeSummary", iLayer), Form("Layer%dAverageClusterSizeSummary", iLayer), 100, 0, 100);
     hClusterSizeLayerSummary[iLayer]->SetTitle(Form("Cluster size summary for Layer %d", iLayer));
     addObject(hClusterSizeLayerSummary[iLayer]);
     formatAxes(hClusterSizeLayerSummary[iLayer], "Cluster Size (pixels)", "counts", 1, 1.10);
     hClusterSizeLayerSummary[iLayer]->SetStats(0);
 
-    hGroupedClusterSizeLayerSummary[iLayer] = new TH1D(Form("Layer%d/AverageGroupedClusterSizeSummary", iLayer), Form("Layer%dAverageGroupedClusterSizeSummary", iLayer), 100, 0, 100);
+    hGroupedClusterSizeLayerSummary[iLayer] = new TH1F(Form("Layer%d/AverageGroupedClusterSizeSummary", iLayer), Form("Layer%dAverageGroupedClusterSizeSummary", iLayer), 100, 0, 100);
     hGroupedClusterSizeLayerSummary[iLayer]->SetTitle(Form("Cluster size summary for Layer %d", iLayer));
     addObject(hGroupedClusterSizeLayerSummary[iLayer]);
     formatAxes(hGroupedClusterSizeLayerSummary[iLayer], "Grouped Cluster Size (pixels)", "counts", 1, 1.10);
     hGroupedClusterSizeLayerSummary[iLayer]->SetStats(0);
 
-    hClusterTopologyLayerSummary[iLayer] = new TH1D(Form("Layer%d/ClusterTopologySummary", iLayer), Form("Layer%dClusterTopologySummary", iLayer), 300, 0, 300);
+    hClusterTopologyLayerSummary[iLayer] = new TH1F(Form("Layer%d/ClusterTopologySummary", iLayer), Form("Layer%dClusterTopologySummary", iLayer), 300, 0, 300);
     hClusterTopologyLayerSummary[iLayer]->SetTitle(Form("Cluster topology summary for Layer %d", iLayer));
     addObject(hClusterTopologyLayerSummary[iLayer]);
     formatAxes(hClusterTopologyLayerSummary[iLayer], "Cluster Topology (ID)", "counts", 1, 1.10);
@@ -405,7 +407,7 @@ void ITSClusterTask::createAllHistos()
 
     if (iLayer < 3) {
 
-      hAverageClusterOccupancySummaryIB[iLayer] = new TH2D(Form("Layer%d/ClusterOccupation", iLayer), Form("Layer%dClusterOccupancy", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
+      hAverageClusterOccupancySummaryIB[iLayer] = new TH2F(Form("Layer%d/ClusterOccupation", iLayer), Form("Layer%dClusterOccupancy", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterOccupancySummaryIB[iLayer]->SetTitle(Form("Cluster Occupancy on Layer %d", iLayer));
       addObject(hAverageClusterOccupancySummaryIB[iLayer]);
       formatAxes(hAverageClusterOccupancySummaryIB[iLayer], "Chip Number", "Stave Number", 1, 1.10);
@@ -414,7 +416,7 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterOccupancySummaryIB[iLayer]->GetYaxis()->SetLabelSize(0.02);
       hAverageClusterOccupancySummaryIB[iLayer]->GetXaxis()->SetLabelSize(0.02);
 
-      hAverageClusterOccupancyMonitorIB[iLayer] = new TH2D(Form("Layer%d/ClusterOccupationForLastNROFS", iLayer), Form("Layer%dClusterOccupancyForLastNROFS", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
+      hAverageClusterOccupancyMonitorIB[iLayer] = new TH2F(Form("Layer%d/ClusterOccupationForLastNROFS", iLayer), Form("Layer%dClusterOccupancyForLastNROFS", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterOccupancyMonitorIB[iLayer]->SetTitle(Form("Cluster Occupancy for the last NROFs on Layer %d", iLayer));
       addObject(hAverageClusterOccupancyMonitorIB[iLayer]);
       formatAxes(hAverageClusterOccupancyMonitorIB[iLayer], "Chip Number", "Stave Number", 1, 1.10);
@@ -423,7 +425,7 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterOccupancyMonitorIB[iLayer]->GetYaxis()->SetLabelSize(0.02);
       hAverageClusterOccupancyMonitorIB[iLayer]->GetXaxis()->SetLabelSize(0.02);
 
-      hAverageClusterSizeSummaryIB[iLayer] = new TH2D(Form("Layer%d/AverageClusterSize", iLayer), Form("Layer%dAverageClusterSize", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
+      hAverageClusterSizeSummaryIB[iLayer] = new TH2F(Form("Layer%d/AverageClusterSize", iLayer), Form("Layer%dAverageClusterSize", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterSizeSummaryIB[iLayer]->SetTitle(Form("Average Cluster Size  on Layer %d", iLayer));
       addObject(hAverageClusterSizeSummaryIB[iLayer]);
       formatAxes(hAverageClusterSizeSummaryIB[iLayer], "Chip Number", "Stave Number", 1, 1.10);
@@ -432,7 +434,7 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterSizeSummaryIB[iLayer]->GetYaxis()->SetLabelSize(0.02);
       hAverageClusterSizeSummaryIB[iLayer]->GetXaxis()->SetLabelSize(0.02);
 
-      hAverageClusterSizeMonitorIB[iLayer] = new TH2D(Form("Layer%d/AverageClusterSizeForLastNROFS", iLayer), Form("Layer%dAverageClusterSizeForLastNROFS", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
+      hAverageClusterSizeMonitorIB[iLayer] = new TH2F(Form("Layer%d/AverageClusterSizeForLastNROFS", iLayer), Form("Layer%dAverageClusterSizeForLastNROFS", iLayer), mNChipsPerHic[iLayer], 0, mNChipsPerHic[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterSizeMonitorIB[iLayer]->SetTitle(Form("Average Cluster Size for the last NROFs on Layer %d", iLayer));
       addObject(hAverageClusterSizeMonitorIB[iLayer]);
       formatAxes(hAverageClusterSizeMonitorIB[iLayer], "Chip Number", "Stave Number", 1, 1.10);
@@ -448,13 +450,13 @@ void ITSClusterTask::createAllHistos()
         hAverageClusterOccupancyMonitorIB[iLayer]->GetYaxis()->SetBinLabel(iStave + 1, Form("Stave %i", iStave));
 
         for (Int_t iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
-          hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip] = new TH1D(Form("Layer%d/Stave%d/CHIP%d/ClusterSizeGrouped", iLayer, iStave, iChip), Form("Layer%dStave%dCHIP%dClusterSizeGroped", iLayer, iStave, iChip), 100, 0, 100);
+          hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip] = new TH1F(Form("Layer%d/Stave%d/CHIP%d/ClusterSizeGrouped", iLayer, iStave, iChip), Form("Layer%dStave%dCHIP%dClusterSizeGroped", iLayer, iStave, iChip), 100, 0, 100);
           hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip]->SetTitle(Form("Cluster Size for grouped topologies on Layer %d Stave %d Chip %d", iLayer, iStave, iChip));
           if (mDoPublish1DSummary == 1)
             addObject(hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip]);
           formatAxes(hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip], "Cluster size (Pixel)", "Counts", 1, 1.10);
 
-          hClusterTopologySummaryIB[iLayer][iStave][iChip] = new TH1D(Form("Layer%d/Stave%d/CHIP%d/ClusterTopology", iLayer, iStave, iChip), Form("Layer%dStave%dCHIP%dClusterTopology", iLayer, iStave, iChip), 300, 0, 300);
+          hClusterTopologySummaryIB[iLayer][iStave][iChip] = new TH1F(Form("Layer%d/Stave%d/CHIP%d/ClusterTopology", iLayer, iStave, iChip), Form("Layer%dStave%dCHIP%dClusterTopology", iLayer, iStave, iChip), 300, 0, 300);
           hClusterTopologySummaryIB[iLayer][iStave][iChip]->SetTitle(Form("Cluster Topology on Layer %d Stave %d Chip %d", iLayer, iStave, iChip));
           if (mDoPublish1DSummary == 1)
             addObject(hClusterTopologySummaryIB[iLayer][iStave][iChip]);
@@ -468,7 +470,7 @@ void ITSClusterTask::createAllHistos()
       }
     } else {
 
-      hAverageClusterOccupancySummaryOB[iLayer] = new TH2D(Form("Layer%d/ClusterOccupation", iLayer), Form("Layer%dClusterOccupancy", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
+      hAverageClusterOccupancySummaryOB[iLayer] = new TH2F(Form("Layer%d/ClusterOccupation", iLayer), Form("Layer%dClusterOccupancy", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterOccupancySummaryOB[iLayer]->SetTitle(Form("Cluster Occupancy on Layer %d", iLayer));
       addObject(hAverageClusterOccupancySummaryOB[iLayer]);
       formatAxes(hAverageClusterOccupancySummaryOB[iLayer], "", "Stave Number", 1, 1.10);
@@ -478,7 +480,7 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterOccupancySummaryOB[iLayer]->GetXaxis()->SetLabelSize(0.02);
       hAverageClusterOccupancySummaryOB[iLayer]->GetXaxis()->SetTitleOffset(1.2);
 
-      hAverageClusterOccupancyMonitorOB[iLayer] = new TH2D(Form("Layer%d/ClusterOccupationForLastNROFS", iLayer), Form("Layer%dClusterOccupancyForLastNROFS", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
+      hAverageClusterOccupancyMonitorOB[iLayer] = new TH2F(Form("Layer%d/ClusterOccupationForLastNROFS", iLayer), Form("Layer%dClusterOccupancyForLastNROFS", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterOccupancyMonitorOB[iLayer]->SetTitle(Form("Cluster Occupancy in last NROFS on Layer %d", iLayer));
       addObject(hAverageClusterOccupancyMonitorOB[iLayer]);
       formatAxes(hAverageClusterOccupancyMonitorOB[iLayer], "", "Stave Number", 1, 1.10);
@@ -488,7 +490,7 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterOccupancyMonitorOB[iLayer]->GetXaxis()->SetLabelSize(0.02);
       hAverageClusterOccupancyMonitorOB[iLayer]->GetXaxis()->SetTitleOffset(1.2);
 
-      hAverageClusterSizeSummaryOB[iLayer] = new TH2D(Form("Layer%d/AverageClusterSize", iLayer), Form("Layer%dAverageClusterSize", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
+      hAverageClusterSizeSummaryOB[iLayer] = new TH2F(Form("Layer%d/AverageClusterSize", iLayer), Form("Layer%dAverageClusterSize", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterSizeSummaryOB[iLayer]->SetTitle(Form("Average Cluster Size  on Layer %d", iLayer));
       addObject(hAverageClusterSizeSummaryOB[iLayer]);
       formatAxes(hAverageClusterSizeSummaryOB[iLayer], "", "Stave Number", 1, 1.10);
@@ -499,7 +501,7 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterSizeSummaryOB[iLayer]->GetXaxis()->SetLabelSize(0.02);
       hAverageClusterSizeSummaryOB[iLayer]->GetXaxis()->SetTitleOffset(1.2);
 
-      hAverageClusterSizeMonitorOB[iLayer] = new TH2D(Form("Layer%d/AverageClusterSizeForLastNROFS", iLayer), Form("Layer%dAverageClusterSizeForLastNROFS", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
+      hAverageClusterSizeMonitorOB[iLayer] = new TH2F(Form("Layer%d/AverageClusterSizeForLastNROFS", iLayer), Form("Layer%dAverageClusterSizeForLastNROFS", iLayer), mNLanePerHic[iLayer] * mNHicPerStave[iLayer], 0, mNLanePerHic[iLayer] * mNHicPerStave[iLayer], mNStaves[iLayer], 0, mNStaves[iLayer]);
       hAverageClusterSizeMonitorOB[iLayer]->SetTitle(Form("Average Cluster Size for the last NROFs on Layer %d", iLayer));
       addObject(hAverageClusterSizeMonitorOB[iLayer]);
       formatAxes(hAverageClusterSizeMonitorOB[iLayer], "", "Stave Number", 1, 1.10);
@@ -512,19 +514,19 @@ void ITSClusterTask::createAllHistos()
 
       for (Int_t iStave = 0; iStave < mNStaves[iLayer]; iStave++) {
 
-        hClusterSizeSummaryOB[iLayer][iStave] = new TH1D(Form("Layer%d/Stave%d/ClusterSize", iLayer, iStave), Form("Layer%dStave%dClusterSize", iLayer, iStave), 100, 0, 100);
+        hClusterSizeSummaryOB[iLayer][iStave] = new TH1F(Form("Layer%d/Stave%d/ClusterSize", iLayer, iStave), Form("Layer%dStave%dClusterSize", iLayer, iStave), 100, 0, 100);
         hClusterSizeSummaryOB[iLayer][iStave]->SetTitle(Form("Cluster Size summary for Layer %d Stave %d", iLayer, iStave));
         if (mDoPublish1DSummary == 1)
           addObject(hClusterSizeSummaryOB[iLayer][iStave]);
         formatAxes(hClusterSizeSummaryOB[iLayer][iStave], "Cluster size (Pixel)", "Counts", 1, 1.10);
 
-        hGroupedClusterSizeSummaryOB[iLayer][iStave] = new TH1D(Form("Layer%d/Stave%d/GroupedClusterSize", iLayer, iStave), Form("Layer%dStave%dGroupedClusterSize", iLayer, iStave), 100, 0, 100);
+        hGroupedClusterSizeSummaryOB[iLayer][iStave] = new TH1F(Form("Layer%d/Stave%d/GroupedClusterSize", iLayer, iStave), Form("Layer%dStave%dGroupedClusterSize", iLayer, iStave), 100, 0, 100);
         hGroupedClusterSizeSummaryOB[iLayer][iStave]->SetTitle(Form("Grouped Cluster Size summary for Layer %d Stave %d", iLayer, iStave));
         if (mDoPublish1DSummary == 1)
           addObject(hGroupedClusterSizeSummaryOB[iLayer][iStave]);
         formatAxes(hGroupedClusterSizeSummaryOB[iLayer][iStave], "Cluster size (Pixel)", "Counts", 1, 1.10);
 
-        hClusterTopologySummaryOB[iLayer][iStave] = new TH1D(Form("Layer%d/Stave%d/ClusterTopology", iLayer, iStave), Form("Layer%dStave%dClusterTopology", iLayer, iStave), 300, 0, 300);
+        hClusterTopologySummaryOB[iLayer][iStave] = new TH1F(Form("Layer%d/Stave%d/ClusterTopology", iLayer, iStave), Form("Layer%dStave%dClusterTopology", iLayer, iStave), 300, 0, 300);
         hClusterTopologySummaryOB[iLayer][iStave]->SetTitle(Form("Cluster Toplogy summary for Layer %d Stave %d", iLayer, iStave));
         if (mDoPublish1DSummary == 1)
           addObject(hClusterTopologySummaryOB[iLayer][iStave]);


### PR DESCRIPTION
Whit this PR:
- all TH*D are changed to TH*F
- unused plots are removed (monitor plots)
- z-phi cluster occupancy and size plots are added
- detailed (finer binning) cluster occupancy and size plots are added

Example of new QC layout can be found here: https://qcg-test.cern.ch/?page=layoutShow&layoutId=63c7b384f53a750fbab2821a