### PR TITLE
Use unique bindings in ROOT file source outputs

### DIFF
--- a/Framework/include/QualityControl/RootFileSource.h
+++ b/Framework/include/QualityControl/RootFileSource.h
@@ -33,6 +33,8 @@ class RootFileSource : public framework::Task
   void init(framework::InitContext& ictx) override;
   void run(framework::ProcessingContext& pctx) override;
 
+  static framework::OutputLabel outputBinding(const std::string& detectorCode, const std::string& taskName);
+
  private:
   std::string mFilePath;
 };

--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -323,7 +323,7 @@ framework::WorkflowSpec InfrastructureGenerator::generateRemoteBatchInfrastructu
     if (taskSpec.active) {
       auto taskConfig = TaskRunnerFactory::extractConfig(infrastructureSpec.common, taskSpec, 0, 1);
       fileSourceOutputs.push_back(taskConfig.moSpec);
-      fileSourceOutputs.back().binding.value = taskSpec.taskName;
+      fileSourceOutputs.back().binding = RootFileSource::outputBinding(taskSpec.detectorName, taskSpec.taskName);
     }
   }
   if (fileSourceOutputs.size() > 0) {


### PR DESCRIPTION
fixes the problem of objects from different detectors arriving to different check sinks