### PR TITLE
TPC: IDC task update - visualize most recent data

### DIFF
--- a/Modules/TPC/include/TPC/DCSPTemperature.h
+++ b/Modules/TPC/include/TPC/DCSPTemperature.h
@@ -63,22 +63,6 @@ class DCSPTemperature : public quality_control::postprocessing::PostProcessingIn
   /// \param services Interface containing optional interfaces, for example DatabaseInterface
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistryRef) override;
 
-  /// \brief Splits strings
-  /// Splits strings at delimiter and puts the tokens into a vector
-  /// \param inString  String to be split
-  /// \param delimiter  Delimiter where string should be split
-  std::vector<std::string> splitString(const std::string inString, const char* delimiter);
-
-  /// \brief Extracts the "Valid from" timestamp from metadata
-  long getTimestamp(const std::string metaInfo);
-
-  /// \brief Gives a vector of timestamps for data to be processed
-  /// Gives a vector of time stamps of x files (x=nFiles) in path which are older than a given time stamp (limit)
-  /// \param path  File path in the CCDB
-  /// \param nFiles  Number of files that shall be processed
-  /// \param limit  Most recent timestamp to be processed
-  std::vector<long> getDataTimestamps(const std::string_view path, const unsigned int nFiles, const long limit);
-
  private:
   o2::tpc::qc::DCSPTemperature mDCSPTemp;
   o2::ccdb::CcdbApi mCdbApi;

--- a/Modules/TPC/include/TPC/IDCs.h
+++ b/Modules/TPC/include/TPC/IDCs.h
@@ -72,6 +72,7 @@ class IDCs : public quality_control::postprocessing::PostProcessingInterface
   o2::tpc::IDCCCDBHelper<unsigned char> mCCDBHelper;
   o2::ccdb::CcdbApi mCdbApi;
   std::string mHost;
+  bool mDoIDCDelta = false;
   std::unique_ptr<TCanvas> mIDCZeroScale;
   std::unique_ptr<TCanvas> mIDCZerOverview;
   std::unique_ptr<TCanvas> mIDCZeroSides;

--- a/Modules/TPC/include/TPC/Utility.h
+++ b/Modules/TPC/include/TPC/Utility.h
@@ -19,9 +19,11 @@
 
 #include "QualityControl/ObjectsManager.h"
 
+#include "TPCBase/CalDet.h"
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/WorkflowHelper.h"
 #include "Framework/ProcessingContext.h"
+#include "CCDB/CcdbApi.h"
 
 #include <TCanvas.h>
 
@@ -58,5 +60,16 @@ void clearCanvases(std::vector<std::unique_ptr<TCanvas>>& canvases);
 /// \param input InputReconrd from the ProcessingContext
 /// \return getWorkflowTPCInput_ret object for easy cluster access
 std::unique_ptr<o2::tpc::internal::getWorkflowTPCInput_ret> clusterHandler(o2::framework::InputRecord& inputs, int verbosity = 0, unsigned long tpcSectorMask = 0xFFFFFFFFF);
+
+/// \brief Extracts the "Valid from" timestamp from metadata
+void getTimestamp(const std::string& metaInfo, std::vector<long>& timeStamps);
+
+/// \brief Gives a vector of timestamps for data to be processed
+/// Gives a vector of time stamps of x files (x=nFiles) in path which are older than a given time stamp (limit)
+/// \param url CCDB URL
+/// \param path File path in the CCDB
+/// \param nFiles Number of files that shall be processed
+/// \param limit Most recent timestamp to be processed
+std::vector<long> getDataTimestamps(const o2::ccdb::CcdbApi& cdbApi, const std::string_view path, const unsigned int nFiles, const long limit);
 } // namespace o2::quality_control_modules::tpc
 #endif // QUALITYCONTROL_TPCUTILITY_H

--- a/Modules/TPC/run/tpcQCIDCs.json
+++ b/Modules/TPC/run/tpcQCIDCs.json
@@ -52,7 +52,7 @@
         "histogramRanges_comment" : [ "nBins", "min", "max" ],
         "histogramRanges": [
           { "IDCZero" : [ "250",  "0", "2.5" ] },
-          {"IDCZeroOveview" : [ "250",  "-20", "20" ] },
+          { "IDCZeroOveview" : [ "250",  "-20", "20" ] },
           { "IDCOne" : [ "250",  "0", "0.5" ] },
           { "IDCDelta" : [ "100",  "-1.02", "-0.94" ] },
           { "FourierCoeffs" : [ "600",  "-20", "20" ] }

--- a/Modules/TPC/src/DCSPTemperature.cxx
+++ b/Modules/TPC/src/DCSPTemperature.cxx
@@ -20,6 +20,7 @@
 // QC includes
 #include "QualityControl/QcInfoLogger.h"
 #include "TPC/DCSPTemperature.h"
+#include "TPC/Utility.h"
 
 // root includes
 #include "TCanvas.h"
@@ -95,7 +96,7 @@ void DCSPTemperature::initialize(Trigger, framework::ServiceRegistryRef)
 
 void DCSPTemperature::update(Trigger, framework::ServiceRegistryRef)
 {
-  std::vector<long> usedTimestamps = getDataTimestamps("TPC/Calib/Temperature", mNFiles, mTimestamp);
+  std::vector<long> usedTimestamps = getDataTimestamps(mCdbApi, "TPC/Calib/Temperature", mNFiles, mTimestamp);
   for (auto& timestamp : usedTimestamps) {
     mData.emplace_back(mCdbApi.retrieveFromTFileAny<o2::tpc::dcs::Temperature>("TPC/Calib/Temperature", mLookupMap, timestamp));
   }
@@ -108,71 +109,6 @@ void DCSPTemperature::finalize(Trigger, framework::ServiceRegistryRef)
   for (auto& canv : mDCSPTemp.getCanvases()) {
     getObjectsManager()->stopPublishing(canv);
   }
-}
-
-std::vector<std::string> DCSPTemperature::splitString(const std::string inString, const char* delimiter)
-{
-  std::vector<std::string> outVec;
-  std::string placeholder;
-  std::istringstream stream(inString);
-  std::string token;
-  while (std::getline(stream, token, *delimiter)) {
-    if (token == "") {
-      if (!placeholder.empty()) {
-        outVec.emplace_back(placeholder);
-        placeholder.clear();
-      }
-    } else {
-      placeholder.append(token + "\n");
-    }
-  }
-  return std::move(outVec);
-}
-
-long DCSPTemperature::getTimestamp(const std::string metaInfo)
-{
-  std::string result_str;
-  long result;
-  std::string token = "Validity: ";
-  if (metaInfo.find(token) == std::string::npos) {
-    return -1;
-  }
-  int start = metaInfo.find(token) + token.size();
-  int end = metaInfo.find(" -", start);
-  result_str = metaInfo.substr(start, end - start);
-  std::string::size_type sz;
-  result = std::stol(result_str, &sz);
-  return result;
-}
-
-std::vector<long> DCSPTemperature::getDataTimestamps(const std::string_view path, const unsigned int nFiles, const long limit)
-{
-  std::vector<long> outVec;
-  std::vector<std::string> fileList = splitString(mCdbApi.list(path.data()), "\n");
-
-  if (limit == -1) {
-    for (unsigned int i = 1; i <= nFiles; i++) {
-      long timeStamp = getTimestamp(fileList.at(i));
-      if (timeStamp != -1) {
-        outVec.emplace_back(timeStamp);
-      }
-    }
-  } else {
-    std::vector<std::string> tmpFiles;
-    for (auto& file : fileList) {
-      if (getTimestamp(file) <= limit) {
-        tmpFiles.emplace_back(file);
-      }
-    }
-    for (unsigned int i = 1; i <= nFiles; i++) {
-      long timeStamp = getTimestamp(tmpFiles.at(i));
-      if (timeStamp != -1) {
-        outVec.emplace_back(timeStamp);
-      }
-    }
-  }
-  std::sort(outVec.begin(), outVec.end());
-  return std::move(outVec);
 }
 
 } // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/src/IDCs.cxx
+++ b/Modules/TPC/src/IDCs.cxx
@@ -23,11 +23,13 @@
 // QC includes
 #include "QualityControl/QcInfoLogger.h"
 #include "TPC/IDCs.h"
+#include "TPC/Utility.h"
 
 // root includes
 #include "TCanvas.h"
 
 #include <fmt/format.h>
+#include <boost/optional/optional.hpp>
 
 using namespace o2::quality_control::postprocessing;
 using namespace o2::tpc;
@@ -107,6 +109,22 @@ void IDCs::configure(const boost::property_tree::ptree& config)
   }
 
   mHost = config.get<std::string>("qc.postprocessing." + id + ".dataSourceURL");
+
+  boost::optional<const boost::property_tree::ptree&> doDeltaExists = config.get_child_optional("qc.postprocessing." + id + ".doIDCDelta");
+  if (doDeltaExists) {
+    auto doDelta = config.get<std::string>("qc.postprocessing." + id + ".doIDCDelta");
+    if (doDelta == "1" || doDelta == "true" || doDelta == "True" || doDelta == "TRUE" || doDelta == "yes") {
+      mDoIDCDelta = true;
+    } else if (doDelta == "0" || doDelta == "false" || doDelta == "False" || doDelta == "FALSE" || doDelta == "no") {
+      mDoIDCDelta = false;
+    } else {
+      mDoIDCDelta = false;
+      ILOG(Warning, Support) << "No valid input for 'doIDCDelta'. Using default value 'false'." << ENDM;
+    }
+  } else {
+    mDoIDCDelta = false;
+    ILOG(Warning, Support) << "Option 'doIDCDelta' is missing. Using default value 'false'." << ENDM;
+  }
 }
 
 void IDCs::initialize(Trigger, framework::ServiceRegistryRef)
@@ -119,22 +137,23 @@ void IDCs::initialize(Trigger, framework::ServiceRegistryRef)
   mIDCZeroStacksA = std::make_unique<TCanvas>("c_GEMStacks_IDC0_1D_ASide");
   mIDCZeroStacksC = std::make_unique<TCanvas>("c_GEMStacks_IDC0_1D_CSide");
 
-  mIDCDeltaStacksA = std::make_unique<TCanvas>("c_GEMStacks_IDCDelta_1D_ASide");
-  mIDCDeltaStacksC = std::make_unique<TCanvas>("c_GEMStacks_IDCDelta_1D_CSide");
-
   mIDCOneSides1D = std::make_unique<TCanvas>("c_sides_IDC1_1D");
 
   mFourierCoeffsA = std::make_unique<TCanvas>("c_FourierCoefficients_1D_ASide");
   mFourierCoeffsC = std::make_unique<TCanvas>("c_FourierCoefficients_1D_CSide");
+
+  if (mDoIDCDelta) {
+    mIDCDeltaStacksA = std::make_unique<TCanvas>("c_GEMStacks_IDCDelta_1D_ASide");
+    mIDCDeltaStacksC = std::make_unique<TCanvas>("c_GEMStacks_IDCDelta_1D_CSide");
+    getObjectsManager()->startPublishing(mIDCDeltaStacksA.get());
+    getObjectsManager()->startPublishing(mIDCDeltaStacksC.get());
+  }
 
   getObjectsManager()->startPublishing(mIDCZeroScale.get());
   getObjectsManager()->startPublishing(mIDCZerOverview.get());
   getObjectsManager()->startPublishing(mIDCZeroRadialProf.get());
   getObjectsManager()->startPublishing(mIDCZeroStacksA.get());
   getObjectsManager()->startPublishing(mIDCZeroStacksC.get());
-
-  getObjectsManager()->startPublishing(mIDCDeltaStacksA.get());
-  getObjectsManager()->startPublishing(mIDCDeltaStacksC.get());
 
   getObjectsManager()->startPublishing(mIDCOneSides1D.get());
 
@@ -144,62 +163,91 @@ void IDCs::initialize(Trigger, framework::ServiceRegistryRef)
 
 void IDCs::update(Trigger, framework::ServiceRegistryRef)
 {
+  std::vector<long> availableTimestampsIDCZeroA = getDataTimestamps(mCdbApi, CDBTypeMap.at(CDBType::CalIDC0A), 1, mTimestamps["IDCZero"]);
+  std::vector<long> availableTimestampsIDCZeroC = getDataTimestamps(mCdbApi, CDBTypeMap.at(CDBType::CalIDC0C), 1, mTimestamps["IDCZero"]);
+  std::vector<long> availableTimestampsIDCOneA = getDataTimestamps(mCdbApi, CDBTypeMap.at(CDBType::CalIDC1A), 1, mTimestamps["IDCOne"]);
+  std::vector<long> availableTimestampsIDCOneC = getDataTimestamps(mCdbApi, CDBTypeMap.at(CDBType::CalIDC1C), 1, mTimestamps["IDCOne"]);
+  std::vector<long> availableTimestampsFFTA = getDataTimestamps(mCdbApi, CDBTypeMap.at(CDBType::CalIDCFourierA), 1, mTimestamps["FourierCoeffs"]);
+  std::vector<long> availableTimestampsFFTC = getDataTimestamps(mCdbApi, CDBTypeMap.at(CDBType::CalIDCFourierC), 1, mTimestamps["FourierCoeffs"]);
+  std::vector<long> availableTimestampsIDCDeltaA{ 0 };
+  std::vector<long> availableTimestampsIDCDeltaC{ 0 };
+
+  if (mDoIDCDelta) {
+    availableTimestampsIDCDeltaA = getDataTimestamps(mCdbApi, CDBTypeMap.at(CDBType::CalIDCDeltaA), 1, mTimestamps["IDCDelta"]);
+    availableTimestampsIDCDeltaC = getDataTimestamps(mCdbApi, CDBTypeMap.at(CDBType::CalIDCDeltaC), 1, mTimestamps["IDCDelta"]);
+  }
+
   mIDCZeroScale.get()->Clear();
   mIDCZerOverview.get()->Clear();
   mIDCZeroRadialProf.get()->Clear();
   mIDCZeroStacksA.get()->Clear();
   mIDCZeroStacksC.get()->Clear();
-  mIDCDeltaStacksA.get()->Clear();
-  mIDCDeltaStacksC.get()->Clear();
   mIDCOneSides1D.get()->Clear();
   mFourierCoeffsA.get()->Clear();
   mFourierCoeffsC.get()->Clear();
 
-  auto idcZeroA = mCdbApi.retrieveFromTFileAny<IDCZero>(CDBTypeMap.at(CDBType::CalIDC0A), std::map<std::string, std::string>{}, mTimestamps["IDCZero"]);
-  auto idcZeroC = mCdbApi.retrieveFromTFileAny<IDCZero>(CDBTypeMap.at(CDBType::CalIDC0C), std::map<std::string, std::string>{}, mTimestamps["IDCZero"]);
-  auto idcDeltaA = mCdbApi.retrieveFromTFileAny<IDCDelta<unsigned char>>(CDBTypeMap.at(CDBType::CalIDCDeltaA), std::map<std::string, std::string>{}, mTimestamps["IDCDelta"]);
-  auto idcDeltaC = mCdbApi.retrieveFromTFileAny<IDCDelta<unsigned char>>(CDBTypeMap.at(CDBType::CalIDCDeltaC), std::map<std::string, std::string>{}, mTimestamps["IDCDelta"]);
-  auto idcOneA = mCdbApi.retrieveFromTFileAny<IDCOne>(CDBTypeMap.at(CDBType::CalIDC1A), std::map<std::string, std::string>{}, mTimestamps["IDCOne"]);
-  auto idcOneC = mCdbApi.retrieveFromTFileAny<IDCOne>(CDBTypeMap.at(CDBType::CalIDC1C), std::map<std::string, std::string>{}, mTimestamps["IDCOne"]);
-  auto idcFFTA = mCdbApi.retrieveFromTFileAny<FourierCoeff>(CDBTypeMap.at(CDBType::CalIDCFourierA), std::map<std::string, std::string>{}, mTimestamps["FourierCoeffs"]);
-  auto idcFFTC = mCdbApi.retrieveFromTFileAny<FourierCoeff>(CDBTypeMap.at(CDBType::CalIDCFourierC), std::map<std::string, std::string>{}, mTimestamps["FourierCoeffs"]);
+  if (mDoIDCDelta) {
+    mIDCDeltaStacksA.get()->Clear();
+    mIDCDeltaStacksC.get()->Clear();
+  }
 
-  mCCDBHelper.setIDCZero(idcZeroA, Side::A);
-  mCCDBHelper.setIDCZero(idcZeroC, Side::C);
-  mCCDBHelper.setIDCDelta(idcDeltaA, Side::A);
-  mCCDBHelper.setIDCDelta(idcDeltaC, Side::C);
-  mCCDBHelper.setIDCOne(idcOneA, Side::A);
-  mCCDBHelper.setIDCOne(idcOneC, Side::C);
-  mCCDBHelper.setFourierCoeffs(idcFFTA, Side::A);
-  mCCDBHelper.setFourierCoeffs(idcFFTC, Side::C);
+  o2::tpc::IDCZero* idcZeroA = nullptr;
+  o2::tpc::IDCZero* idcZeroC = nullptr;
+  o2::tpc::IDCDelta<unsigned char>* idcDeltaA = nullptr;
+  o2::tpc::IDCDelta<unsigned char>* idcDeltaC = nullptr;
+  o2::tpc::IDCOne* idcOneA = nullptr;
+  o2::tpc::IDCOne* idcOneC = nullptr;
+  o2::tpc::FourierCoeff* idcFFTA = nullptr;
+  o2::tpc::FourierCoeff* idcFFTC = nullptr;
+
+  idcZeroA = mCdbApi.retrieveFromTFileAny<IDCZero>(CDBTypeMap.at(CDBType::CalIDC0A), std::map<std::string, std::string>{}, availableTimestampsIDCZeroA[0]);
+  idcZeroC = mCdbApi.retrieveFromTFileAny<IDCZero>(CDBTypeMap.at(CDBType::CalIDC0C), std::map<std::string, std::string>{}, availableTimestampsIDCZeroC[0]);
+  if (mDoIDCDelta) {
+    idcDeltaA = mCdbApi.retrieveFromTFileAny<IDCDelta<unsigned char>>(CDBTypeMap.at(CDBType::CalIDCDeltaA), std::map<std::string, std::string>{}, availableTimestampsIDCDeltaA[0]);
+    idcDeltaC = mCdbApi.retrieveFromTFileAny<IDCDelta<unsigned char>>(CDBTypeMap.at(CDBType::CalIDCDeltaC), std::map<std::string, std::string>{}, availableTimestampsIDCDeltaC[0]);
+  }
+  idcOneA = mCdbApi.retrieveFromTFileAny<IDCOne>(CDBTypeMap.at(CDBType::CalIDC1A), std::map<std::string, std::string>{}, availableTimestampsIDCOneA[0]);
+  idcOneC = mCdbApi.retrieveFromTFileAny<IDCOne>(CDBTypeMap.at(CDBType::CalIDC1C), std::map<std::string, std::string>{}, availableTimestampsIDCOneC[0]);
+  idcFFTA = mCdbApi.retrieveFromTFileAny<FourierCoeff>(CDBTypeMap.at(CDBType::CalIDCFourierA), std::map<std::string, std::string>{}, availableTimestampsFFTA[0]);
+  idcFFTC = mCdbApi.retrieveFromTFileAny<FourierCoeff>(CDBTypeMap.at(CDBType::CalIDCFourierC), std::map<std::string, std::string>{}, availableTimestampsFFTC[0]);
 
   if (idcZeroA && idcZeroC) {
+    mCCDBHelper.setIDCZero(idcZeroA, Side::A);
+    mCCDBHelper.setIDCZero(idcZeroC, Side::C);
     // scale IDCZero to the sum of IDCZeros
     mCCDBHelper.setIDCZeroScale(true);
     mCCDBHelper.drawIDCZeroScale(mIDCZeroScale.get(), true);
     mCCDBHelper.drawIDCZeroStackCanvas(mIDCZeroStacksA.get(), Side::A, "IDC0", mRanges["IDCZero"].at(0), mRanges["IDCZero"].at(1), mRanges["IDCZero"].at(2));
     mCCDBHelper.drawIDCZeroStackCanvas(mIDCZeroStacksC.get(), Side::C, "IDC0", mRanges["IDCZero"].at(0), mRanges["IDCZero"].at(1), mRanges["IDCZero"].at(2));
     mCCDBHelper.drawIDCZeroRadialProfile(mIDCZeroRadialProf.get(), mRanges["IDCZero"].at(0), mRanges["IDCZero"].at(1), mRanges["IDCZero"].at(2));
+
+    const auto& calDet = mCCDBHelper.getIDCZeroCalDet();
+    o2::tpc::painter::draw(calDet, mRanges["IDCZeroOveview"].at(0), mRanges["IDCZeroOveview"].at(1), mRanges["IDCZeroOveview"].at(2), mIDCZerOverview.get());
   }
-  const auto& calDet = mCCDBHelper.getIDCZeroCalDet();
-  o2::tpc::painter::draw(calDet, mRanges["IDCZeroOveview"].at(0), mRanges["IDCZeroOveview"].at(1), mRanges["IDCZeroOveview"].at(2), mIDCZerOverview.get());
+
   if (idcDeltaA) {
+    mCCDBHelper.setIDCDelta(idcDeltaA, Side::A);
     mCCDBHelper.drawIDCZeroStackCanvas(mIDCDeltaStacksA.get(), Side::A, "IDCDelta", mRanges["IDCDelta"].at(0), mRanges["IDCDelta"].at(1), mRanges["IDCDelta"].at(2));
   }
 
   if (idcDeltaC) {
+    mCCDBHelper.setIDCDelta(idcDeltaC, Side::C);
     mCCDBHelper.drawIDCZeroStackCanvas(mIDCDeltaStacksC.get(), Side::C, "IDCDelta", mRanges["IDCDelta"].at(0), mRanges["IDCDelta"].at(1), mRanges["IDCDelta"].at(2));
   }
 
   if (idcOneA && idcOneC) {
+    mCCDBHelper.setIDCOne(idcOneA, Side::A);
+    mCCDBHelper.setIDCOne(idcOneC, Side::C);
     mCCDBHelper.drawIDCOneCanvas(mIDCOneSides1D.get(), mRanges["IDCOne"].at(0), mRanges["IDCOne"].at(1), mRanges["IDCOne"].at(2));
   }
 
   if (idcFFTA) {
+    mCCDBHelper.setFourierCoeffs(idcFFTA, Side::A);
     mCCDBHelper.drawFourierCoeff(mFourierCoeffsA.get(), Side::A, mRanges["FourierCoeffs"].at(0), mRanges["FourierCoeffs"].at(1), mRanges["FourierCoeffs"].at(2));
   }
 
   if (idcFFTC) {
+    mCCDBHelper.setFourierCoeffs(idcFFTC, Side::C);
     mCCDBHelper.drawFourierCoeff(mFourierCoeffsC.get(), Side::C, mRanges["IDCZeroOveview"].at(0), mRanges["IDCZeroOveview"].at(1), mRanges["IDCZeroOveview"].at(2));
   }
 
@@ -230,13 +278,15 @@ void IDCs::finalize(Trigger, framework::ServiceRegistryRef)
   getObjectsManager()->stopPublishing(mIDCZeroStacksA.get());
   getObjectsManager()->stopPublishing(mIDCZeroStacksC.get());
 
-  getObjectsManager()->stopPublishing(mIDCDeltaStacksA.get());
-  getObjectsManager()->stopPublishing(mIDCDeltaStacksC.get());
-
   getObjectsManager()->stopPublishing(mIDCOneSides1D.get());
 
   getObjectsManager()->stopPublishing(mFourierCoeffsA.get());
   getObjectsManager()->stopPublishing(mFourierCoeffsC.get());
+
+  if (mDoIDCDelta) {
+    getObjectsManager()->stopPublishing(mIDCDeltaStacksA.get());
+    getObjectsManager()->stopPublishing(mIDCDeltaStacksC.get());
+  }
 }
 
 } // namespace o2::quality_control_modules::tpc


### PR DESCRIPTION
This adds the possibility for the IDC task to fetch the latest data from the ccdb regardless of the validity range and given timestamp. The functionality was moved from the temperature task to the Utility class. Therefore, the temperature task was also adjusted.

In addition, the option to exclude IDCDelta entirely from being visualized via the config file was added. The option is `doIDCDelta`.