### PR TITLE
MCH: fix clustermap filling in QC tracks

### DIFF
--- a/Modules/MUON/Common/etc/qc-tracks-mch.json
+++ b/Modules/MUON/Common/etc/qc-tracks-mch.json
@@ -23,7 +23,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/CLUSTERDIGITS"
+          "query": "trackMCH:MCH/TRACKS;trackMCHROF:MCH/TRACKROFS;trackMCHTRACKCLUSTERS:MCH/TRACKCLUSTERS"
         },
         "taskParameters": {
           "maxTracksPerTF": "600",

--- a/Modules/MUON/Common/src/MuonTrack.cxx
+++ b/Modules/MUON/Common/src/MuonTrack.cxx
@@ -14,7 +14,6 @@
 
 #include <DataFormatsITSMFT/ROFRecord.h>
 #include <DataFormatsMCH/Cluster.h>
-#include <DataFormatsMCH/Digit.h>
 #include <DataFormatsMCH/ROFRecord.h>
 #include <DataFormatsMFT/TrackMFT.h>
 #include <DataFormatsMCH/TrackMCH.h>

--- a/Modules/MUON/Common/src/TracksTask.cxx
+++ b/Modules/MUON/Common/src/TracksTask.cxx
@@ -13,14 +13,8 @@
 
 #include "MUONCommon/Helpers.h"
 #include "QualityControl/ObjectsManager.h"
-#include <DataFormatsMCH/Cluster.h>
-#include <DataFormatsMCH/Digit.h>
-#include <DataFormatsMCH/ROFRecord.h>
-#include <DataFormatsMCH/TrackMCH.h>
 #include <Framework/DataRefUtils.h>
 #include <Framework/InputRecord.h>
-#include <ReconstructionDataFormats/TrackMCHMID.h>
-#include <ReconstructionDataFormats/GlobalFwdTrack.h>
 #include <gsl/span>
 
 namespace o2::quality_control_modules::muon
@@ -123,10 +117,6 @@ bool TracksTask::assertInputs(o2::framework::ProcessingContext& ctx)
     ILOG(Info, Support) << "no mch track clusters available on input" << ENDM;
     return false;
   }
-  if (!ctx.inputs().isValid("mchtrackdigits")) {
-    ILOG(Info, Support) << "no mch track digits available on input" << ENDM;
-    return false;
-  }
   if (mSrc[GID::Source::MCHMID] == 1) {
     if (!ctx.inputs().isValid("matchMCHMID")) {
       ILOG(Info, Support) << "no muon (mch+mid) track available on input" << ENDM;
@@ -165,11 +155,6 @@ void TracksTask::monitorData(o2::framework::ProcessingContext& ctx)
   mRecoCont.collectData(ctx, *mDataRequest.get());
 
   ILOG(Info, Devel) << "Debug: Collected data" << ENDM;
-
-  auto tracks = mRecoCont.getMCHTracks();
-  auto rofs = mRecoCont.getMCHTracksROFRecords();
-  auto clusters = mRecoCont.getMCHTrackClusters();
-  auto digits = ctx.inputs().get<gsl::span<o2::mch::Digit>>("mchtrackdigits");
 
   if (mSrc[GID::MCH] == 1) {
     ILOG(Info, Devel) << "Debug: MCH requested" << ENDM;

--- a/Modules/MUON/MCH/etc/qc-tracks.json
+++ b/Modules/MUON/MCH/etc/qc-tracks.json
@@ -23,7 +23,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "tracks:MCH/TRACKS;trackrofs:MCH/TRACKROFS;trackclusters:MCH/TRACKCLUSTERS;trackdigits:MCH/CLUSTERDIGITS"
+          "query": "tracks:MCH/TRACKS;trackrofs:MCH/TRACKROFS;trackclusters:MCH/TRACKCLUSTERS"
         },
         "taskParameters": {
           "maxTracksPerTF": "10"

--- a/Modules/MUON/MCH/include/MCH/MergeableTH1MPVPerDECycle.h
+++ b/Modules/MUON/MCH/include/MCH/MergeableTH1MPVPerDECycle.h
@@ -27,11 +27,6 @@
 
 #include "Mergers/MergeInterface.h"
 #include "MCHRawElecMap/Mapper.h"
-#ifdef HAVE_DIGIT_IN_DATAFORMATS
-#include "DataFormatsMCH/Digit.h"
-#else
-#include "MCHBase/Digit.h"
-#endif
 #include "MCHConstants/DetectionElements.h"
 
 using namespace std;

--- a/Modules/MUON/MCH/include/MCH/MergeableTH1PseudoEfficiencyPerDE.h
+++ b/Modules/MUON/MCH/include/MCH/MergeableTH1PseudoEfficiencyPerDE.h
@@ -26,11 +26,6 @@
 
 #include "Mergers/MergeInterface.h"
 #include "MCHRawElecMap/Mapper.h"
-#ifdef HAVE_DIGIT_IN_DATAFORMATS
-#include "DataFormatsMCH/Digit.h"
-#else
-#include "MCHBase/Digit.h"
-#endif
 #include "MCH/GlobalHistogram.h"
 #include "MCHConstants/DetectionElements.h"
 

--- a/Modules/MUON/MCH/include/MCH/MergeableTH1PseudoEfficiencyPerDECycle.h
+++ b/Modules/MUON/MCH/include/MCH/MergeableTH1PseudoEfficiencyPerDECycle.h
@@ -25,12 +25,6 @@
 #include <algorithm>
 
 #include "Mergers/MergeInterface.h"
-#include "MCHRawElecMap/Mapper.h"
-#ifdef HAVE_DIGIT_IN_DATAFORMATS
-#include "DataFormatsMCH/Digit.h"
-#else
-#include "MCHBase/Digit.h"
-#endif
 
 using namespace std;
 namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/TracksTask.h
+++ b/Modules/MUON/MCH/include/MCH/TracksTask.h
@@ -18,6 +18,7 @@
 #include <TProfile.h>
 #include <gsl/span>
 #include <memory>
+#include "MCHGeometryTransformer/Transformations.h"
 
 namespace o2::mch
 {
@@ -97,6 +98,7 @@ class TracksTask /*final*/ : public TaskInterface
 
   o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
   o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
+  std::unique_ptr<o2::mch::geo::TransformationCreator> mTransformation;
 };
 
 template <typename T>

--- a/Modules/MUON/MCH/src/TracksTask.cxx
+++ b/Modules/MUON/MCH/src/TracksTask.cxx
@@ -13,7 +13,6 @@
 
 #include "CommonConstants/LHCConstants.h"
 #include <DataFormatsMCH/Cluster.h>
-#include <DataFormatsMCH/Digit.h>
 #include <DataFormatsMCH/ROFRecord.h>
 #include <DataFormatsMCH/TrackMCH.h>
 #include <DetectorsBase/GeometryManager.h>

--- a/Modules/MUON/MCH/src/TracksTask.cxx
+++ b/Modules/MUON/MCH/src/TracksTask.cxx
@@ -175,11 +175,22 @@ ROOT::Math::PxPyPzMVector getMomentum4D(const o2::mch::TrackMCH& track)
 
 void TracksTask::fillClusterHistos(gsl::span<const o2::mch::Cluster> clusters)
 {
+  if (mTransformation.get() == nullptr) {
+    // should not happen, but better be safe than sorry
+    return;
+  }
   for (const auto& cluster : clusters) {
     int deId = cluster.getDEId();
     const o2::mch::mapping::Segmentation& seg = o2::mch::mapping::segmentation(deId);
     int b, nb;
-    seg.findPadPairByPosition(cluster.getX(), cluster.getY(), b, nb);
+
+    o2::math_utils::Point3D<double> global{ cluster.getX(),
+                                            cluster.getY(), cluster.getZ() };
+    auto t = (*mTransformation)(deId).Inverse();
+    auto local = t(global);
+
+    seg.findPadPairByPosition(local.X(), local.Y(), b, nb);
+
     if (b >= 0) {
       int dsId = seg.padDualSampaId(b);
       mNofClustersPerDualSampa->Fill(dsbinx(deId, dsId));
@@ -214,6 +225,11 @@ void TracksTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
   if (!assertInputs(ctx)) {
     return;
+  }
+
+  if (mTransformation.get() == nullptr && gGeoManager != nullptr) {
+    ILOG(Info, Support) << "get transformation from gGeoManager" << ENDM;
+    mTransformation = std::make_unique<o2::mch::geo::TransformationCreator>(o2::mch::geo::transformationFromTGeoManager(*gGeoManager));
   }
 
   auto tracks = ctx.inputs().get<gsl::span<o2::mch::TrackMCH>>("tracks");


### PR DESCRIPTION
Also remove unused lines of code (referencing Digit where they are not needed).
As far as I can tell the Digit are not used in any of the two QC tracks (MUON/Common or MCH) so I've removed them from the respective queries in the sample jsons as well.

Tested mainly starting from a `mchtracks.root` file (instead of a full reco workflow) to check we're only using information we actually have in the file.

```
o2-mch-tracks-reader-workflow --hbfutils-config $HOME/Downloads/o2_tfidinfo.root --infile $HOME/Downloads/mchtracks.root | o2-qc --config json://./mch-tracks-2.json --local-batch="qc-2.root" | o2-dpl-run -b
```

@aferrero2707 we'll definitely need to consolidate our MCH track QC, but this PR should solve the immediate problem of no longer having the cluster map available _and_ correctly filled.
