### PR TITLE
use ubuntu-22.04 for release alidist bumps action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   bump_alidist:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - run: curl -L https://github.com/github/hub/releases/download/v2.12.7/hub-linux-amd64-2.12.7.tgz | tar xz
       - run: |


### PR DESCRIPTION
As in the message of the failed alidist bump:

> This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. For more details, see https://github.com/actions/runner-images/issues/6002

> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002