### PR TITLE
Aggregator Runner should follow the QC device naming convention

### DIFF
--- a/Framework/include/QualityControl/AggregatorRunner.h
+++ b/Framework/include/QualityControl/AggregatorRunner.h
@@ -106,7 +106,7 @@ class AggregatorRunner : public framework::Task
   const std::vector<std::shared_ptr<Aggregator>>& getAggregators() const { return mAggregators; }
 
   static framework::DataProcessorLabel getLabel() { return { "qc-aggregator" }; }
-  static std::string createAggregatorRunnerIdString() { return "QC-AGGREGATOR-RUNNER"; };
+  static std::string createAggregatorRunnerIdString() { return "qc-aggregator"; };
   static std::string createAggregatorRunnerName();
   static header::DataDescription createAggregatorRunnerDataDescription(const std::string& aggregatorName);
 

--- a/Framework/test/testAggregatorRunner.cxx
+++ b/Framework/test/testAggregatorRunner.cxx
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(test_aggregator_runner)
   InitContext initContext{ cfReg, sReg };
   aggregatorRunner.init(initContext);
 
-  BOOST_CHECK_EQUAL(aggregatorRunner.getDeviceName(), "QC-AGGREGATOR-RUNNER");
+  BOOST_CHECK_EQUAL(aggregatorRunner.getDeviceName(), "qc-aggregator");
 
   // check the reordering
   const std::vector<std::shared_ptr<Aggregator>> aggregators = aggregatorRunner.getAggregators();

--- a/Framework/test/testInfrastructureGenerator.cxx
+++ b/Framework/test/testInfrastructureGenerator.cxx
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(qc_factory_remote_test)
   auto aggregator = std::find_if(
     workflow.begin(), workflow.end(),
     [](const DataProcessorSpec& d) {
-      return d.name == "QC-AGGREGATOR-RUNNER" &&
+      return d.name == "qc-aggregator" &&
              d.inputs.size() == 4 &&
              d.outputs.size() == 0;
     });
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(qc_factory_standalone_test)
   auto aggregator = std::find_if(
     workflow.begin(), workflow.end(),
     [](const DataProcessorSpec& d) {
-      return d.name == "QC-AGGREGATOR-RUNNER" &&
+      return d.name == "qc-aggregator" &&
              d.inputs.size() == 4 &&
              d.outputs.size() == 0;
     });
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(qc_infrastructure_remote_batch_test)
   auto aggregator = std::find_if(
     workflow.begin(), workflow.end(),
     [](const DataProcessorSpec& d) {
-      return d.name == "QC-AGGREGATOR-RUNNER" &&
+      return d.name == "qc-aggregator" &&
              d.inputs.size() == 4 &&
              d.outputs.size() == 0;
     });


### PR DESCRIPTION
Others use "qc-check-...", "qc-task-...", etc, so the aggregator runner stands out to me.