### PR TITLE
[WIP] TRD fix ccdb object time requesting [O2-3592]

### DIFF
--- a/Modules/TRD/include/TRD/DigitsTask.h
+++ b/Modules/TRD/include/TRD/DigitsTask.h
@@ -56,7 +56,6 @@ class DigitsTask final : public TaskInterface
   void buildHistograms();
   void drawLinesMCM(TH2F* histo);
   void drawTrdLayersGrid(TH2F* hist);
-  void retrieveCCDBSettings();
   void drawLinesOnPulseHeight(TH1F* h);
   void fillLinesOnHistsPerLayer(int iLayer);
   void drawHashOnLayers(int layer, int hcid, int col, int rowstart, int rowend);
@@ -69,7 +68,6 @@ class DigitsTask final : public TaskInterface
   unsigned int mPulseHeightThreshold;
   std::pair<float, float> mDriftRegion;
   std::pair<float, float> mPulseHeightPeakRegion;
-  long int mTimestamp;
 
   std::shared_ptr<TH1F> mDigitsPerEvent;
   std::shared_ptr<TH1F> mEventswDigitsPerTimeFrame;
@@ -112,8 +110,8 @@ class DigitsTask final : public TaskInterface
   //  std::array<std::shared_ptr<TH1F>, 540> mPulseHeightPerChamber_1D; // ph2DSM;
   std::vector<TH2F*> mLayers;
   // information pulled from ccdb
-  o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
-  o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
+  const o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
+  const o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
   std::string mChambersToIgnore;
   std::bitset<o2::trd::constants::MAXCHAMBER> mChambersToIgnoreBP;
 };

--- a/Modules/TRD/include/TRD/PulseHeight.h
+++ b/Modules/TRD/include/TRD/PulseHeight.h
@@ -52,10 +52,8 @@ class PulseHeight final : public TaskInterface
   void endOfActivity(const Activity& activity) override;
   void reset() override;
   void buildHistograms();
-  void retrieveCCDBSettings();
 
  private:
-  long int mTimestamp;
   std::shared_ptr<TH1F> mPulseHeight = nullptr;
   std::shared_ptr<TH1F> mPulseHeightScaled = nullptr;
   std::shared_ptr<TH2F> mTotalPulseHeight2D = nullptr;
@@ -70,7 +68,7 @@ class PulseHeight final : public TaskInterface
   std::shared_ptr<TH1F> mPulseHeightDuration;
   std::shared_ptr<TH1F> mPulseHeightDuration1;
   std::shared_ptr<TH1F> mPulseHeightDurationDiff;
-  o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
+  const o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
   std::shared_ptr<TProfile> mPulseHeightpro = nullptr;
   std::shared_ptr<TProfile2D> mPulseHeightperchamber = nullptr;
 };

--- a/Modules/TRD/include/TRD/PulseHeightCheck.h
+++ b/Modules/TRD/include/TRD/PulseHeightCheck.h
@@ -39,7 +39,6 @@ class PulseHeightCheck : public o2::quality_control::checker::CheckInterface
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
   void buildChamberIgnoreBP();
-  long int mTimeStamp;
   std::pair<float, float> mDriftRegion;
   std::pair<float, float> mPulseHeightPeakRegion;
   unsigned int mPulseHeightMinSum;

--- a/Modules/TRD/include/TRD/TrackletsCheck.h
+++ b/Modules/TRD/include/TRD/TrackletsCheck.h
@@ -40,10 +40,8 @@ class TrackletsCheck : public o2::quality_control::checker::CheckInterface
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
 
-  void retrieveCCDBSettings();
 
  private:
-  long int mTimestamp;
   float mIntegralThreshold;
   float mRatioThreshold;
   float mZeroBinRatioThreshold;

--- a/Modules/TRD/include/TRD/TrackletsTask.h
+++ b/Modules/TRD/include/TRD/TrackletsTask.h
@@ -50,7 +50,6 @@ class TrackletsTask final : public TaskInterface
   void endOfActivity(const Activity& activity) override;
   void reset() override;
   void buildHistograms();
-  void retrieveCCDBSettings();
   void drawLinesMCM(TH2F* histo);
   void drawTrdLayersGrid(TH2F* hist);
   void buildTrackletLayers();
@@ -86,8 +85,8 @@ class TrackletsTask final : public TaskInterface
   std::array<TH2F*, 6> mLayers;
 
   // data to pull from CCDB
-  o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
-  o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
+  const o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
+  const o2::trd::HalfChamberStatusQC* mChamberStatus = nullptr;
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/src/PulseHeightCheck.cxx
+++ b/Modules/TRD/src/PulseHeightCheck.cxx
@@ -38,15 +38,6 @@ namespace o2::quality_control_modules::trd
 
 void PulseHeightCheck::configure()
 {
-  if (auto param = mCustomParameters.find("ccdbtimestamp"); param != mCustomParameters.end()) {
-    mTimeStamp = std::stol(mCustomParameters["ccdbtimestamp"]);
-    ILOG(Debug, Support) << "configure() : using ccdbtimestamp = " << mTimeStamp << ENDM;
-  } else {
-    mTimeStamp = o2::ccdb::getCurrentTimestamp();
-    ILOG(Debug, Support) << "configure() : using default timestam of now = " << mTimeStamp << ENDM;
-  }
-  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setTimestamp(mTimeStamp);
   ILOG(Debug, Devel) << "initialize PulseHeight" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
   if (auto param = mCustomParameters.find("driftregionstart"); param != mCustomParameters.end()) {
     mDriftRegion.first = stof(param->second);

--- a/Modules/TRD/src/TrackletsCheck.cxx
+++ b/Modules/TRD/src/TrackletsCheck.cxx
@@ -32,17 +32,8 @@ using namespace o2::quality_control;
 namespace o2::quality_control_modules::trd
 {
 
-void TrackletsCheck::retrieveCCDBSettings()
+void TrackletsCheck::configure()
 {
-  if (auto param = mCustomParameters.find("ccdbtimestamp"); param != mCustomParameters.end()) {
-    mTimestamp = std::stol(mCustomParameters["ccdbtimestamp"]);
-    ILOG(Debug, Support) << "configure() : using ccdbtimestamp = " << mTimestamp << ENDM;
-  } else {
-    mTimestamp = o2::ccdb::getCurrentTimestamp();
-    ILOG(Debug, Support) << "configure() : using default timestam of now = " << mTimestamp << ENDM;
-  }
-  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setTimestamp(mTimestamp);
   if (auto param = mCustomParameters.find("integralthreshold"); param != mCustomParameters.end()) {
     mIntegralThreshold = std::stol(mCustomParameters["integralthreshold"]);
     ILOG(Debug, Support) << "configure() : using integral threshold = " << mIntegralThreshold << ENDM;

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -374,6 +374,28 @@ void TrackletsTask::startOfCycle()
 
 void TrackletsTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
+  //get ccdb objects if not already retrieved:
+  if (mNoiseMap == nullptr) {
+    ILOG(Info, Support) << "Getting noisemap from ccdb" << ENDM;
+    auto mNoiseMapPtr = ctx.inputs().get<o2::trd::NoiseStatusMCM*>("clnoisemap");
+    mNoiseMap = mNoiseMapPtr.get();
+    ILOG(Info, Support) << "NoiseMap loaded" << ENDM;
+    if (mNoiseMap == nullptr) {
+      ILOG(Error, Support) << "NoiseMap never loaded, leaving monitor" << ENDM;
+      return;
+    }
+  }
+  if (mChamberStatus == nullptr) {
+    ILOG(Info, Support) << "Getting chamber status from ccdb" << ENDM;
+    auto mChamberStatusPtr = ctx.inputs().get<o2::trd::HalfChamberStatusQC*>("clchamberstatus");
+    mChamberStatus = mChamberStatusPtr.get();
+    if (mChamberStatus == nullptr) {
+      ILOG(Error, Support) << "Chamber Status never loaded, leaving monitor" << ENDM;
+      return;
+    }
+    ILOG(Info, Support) << "Chamber Status loaded" << ENDM;
+  }
+
   for (auto&& input : ctx.inputs()) {
     if (input.header != nullptr && input.payload != nullptr) {
 


### PR DESCRIPTION
Fix O2-3592.

Redo the way timestamps are set for ccdb objects.
Objects now defined in the json file as a query input.