### PR TITLE
Do not set facility to PostProcessing in PostProcessingDevice constructor

### DIFF
--- a/Framework/src/PostProcessingDevice.cxx
+++ b/Framework/src/PostProcessingDevice.cxx
@@ -41,7 +41,6 @@ PostProcessingDevice::PostProcessingDevice(const PostProcessingRunnerConfig& run
     mDeviceName(createPostProcessingIdString() + "-" + runnerConfig.taskName),
     mRunnerConfig(runnerConfig)
 {
-  core::QcInfoLogger::setFacility("PostProcessing");
 }
 
 void PostProcessingDevice::init(framework::InitContext& ctx)


### PR DESCRIPTION
This constructor is invoked already in defineDataProcessing(), so any QC process which has a PP task in the workflow will run this line.