### PR TITLE
ITS Track: added option to normalize by nROF + 6 new plots

### DIFF
--- a/Modules/ITS/include/ITS/ITSTrackTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackTask.h
@@ -73,6 +73,12 @@ class ITSTrackTask : public TaskInterface
   TH1D* hAssociatedClusterFraction;
   TH1D* hNtracks;
   TH2D* hNClustersPerTrackEta;
+  TH2D* hNClustersPerTrackPhi;
+  TH2D* hHitFirstLayerPhiAll;
+  TH2D* hHitFirstLayerPhi4cls;
+  TH2D* hHitFirstLayerPhi5cls;
+  TH2D* hHitFirstLayerPhi6cls;
+  TH2D* hHitFirstLayerPhi7cls;
   TH2D* hClusterVsBunchCrossing;
   TH2D* hNClusterVsChipITS;
 
@@ -81,16 +87,14 @@ class ITSTrackTask : public TaskInterface
   float mVertexRsize = 0.8;
   Int_t mNtracksMAX = 100;
   Int_t mDoTTree = 0;
-  Int_t mNTracks = 0;
+  // mDoNorm: 0 = no normalization, 1 = normalization by nVertices, 2 = normalization by nRofs
+  Int_t mDoNorm = 1;
   Int_t mNRofs = 0;
   int nBCbins = 103;
   long int mTimestamp = -1;
   int nVertices = 0;
   double mChipBins[2125]; // x bins for cos(lambda) plot
   double mCoslBins[25];   // y bins for cos(lambda) plot
-
-  const int NROFOCCUPANCY = 100;
-  Int_t mNClusters = 0;
 
   TTree* tClusterMap;
   //  Int_t mNtracksInROF;

--- a/Modules/ITS/itsTrack.json
+++ b/Modules/ITS/itsTrack.json
@@ -43,7 +43,8 @@
 	  "NtracksMAX"  : "100",
           "doTTree": "0",
           "nBCbins": "103",
-          "dicttimestamp" : "0"
+          "dicttimestamp" : "0",
+          "doNorm" : "1"
         }
 
       }
@@ -80,7 +81,7 @@
              "samplingConditions" : [
                {
                  "condition" : "random",
-                 "fraction" : "0.3",
+                 "fraction" : "1",
                  "seed" : "1441"
                }
              ],

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -69,6 +69,7 @@ void ITSTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
   mNtracksMAX = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "NtracksMAX", mNtracksMAX);
   mDoTTree = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "doTTree", mDoTTree);
   nBCbins = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "nBCbins", nBCbins);
+  mDoNorm = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "doNorm", mDoNorm);
 
   createAllHistos();
   publishHistos();
@@ -117,10 +118,28 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
   auto pattIt = clusPatternArr.begin();
 
   // multiply angular distributions before re-filling
-  hTrackEta->Scale((double)nVertices);
-  hTrackPhi->Scale((double)nVertices);
-  hAngularDistribution->Scale((double)nVertices);
-  hNClustersPerTrackEta->Scale((double)nVertices);
+  if (mDoNorm) {
+    hTrackEta->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                        : 1.);
+    hTrackPhi->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                        : 1.);
+    hAngularDistribution->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                                   : 1.);
+    hNClustersPerTrackEta->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                                    : 1.);
+    hNClustersPerTrackPhi->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                                    : 1.);
+    hHitFirstLayerPhiAll->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                                   : 1.);
+    hHitFirstLayerPhi4cls->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                                    : 1.);
+    hHitFirstLayerPhi5cls->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                                    : 1.);
+    hHitFirstLayerPhi6cls->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                                    : 1.);
+    hHitFirstLayerPhi7cls->Scale((mDoNorm == 1 && nVertices > 0) ? (double)nVertices : mDoNorm == 2 ? (double)mNRofs
+                                                                                                    : 1.);
+  }
 
   // Multiply cos(lambda) plot before refilling
   for (int ix = 1; ix <= hNClusterVsChipITS->GetNbinsX(); ix++) {
@@ -203,6 +222,22 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
       vPhi.emplace_back(out.getPhi());
 
       hNClustersPerTrackEta->Fill(Eta, track.getNumberOfClusters());
+      hNClustersPerTrackPhi->Fill(out.getPhi(), track.getNumberOfClusters());
+      for (int iLayer = 0; iLayer < NLayer; iLayer++) {
+        if (track.getPattern() & (0x1 << iLayer)) { // check first layer (from inside) on which there is a hit
+          hHitFirstLayerPhiAll->Fill(out.getPhi(), iLayer);
+          if (track.getNumberOfClusters() == 4) {
+            hHitFirstLayerPhi4cls->Fill(out.getPhi(), iLayer);
+          } else if (track.getNumberOfClusters() == 5) {
+            hHitFirstLayerPhi5cls->Fill(out.getPhi(), iLayer);
+          } else if (track.getNumberOfClusters() == 6) {
+            hHitFirstLayerPhi6cls->Fill(out.getPhi(), iLayer);
+          } else if (track.getNumberOfClusters() == 7) {
+            hHitFirstLayerPhi7cls->Fill(out.getPhi(), iLayer);
+          }
+          break;
+        }
+      }
       nClusterCntTrack += track.getNumberOfClusters();
       for (int icluster = 0; icluster < track.getNumberOfClusters(); icluster++) {
         const int index = clusIdx[track.getFirstClusterEntry() + icluster];
@@ -232,22 +267,30 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
       tClusterMap->Fill();
   } // end loop on ROFs
 
-  mNTracks += trackArr.size();
-  mNClusters += clusArr.size();
   mNRofs += trackRofArr.size();
 
-  if (mNRofs >= NROFOCCUPANCY) {
-    mNTracks = 0;
-    mNRofs = 0;
-    mNClusters = 0;
-  }
-
   // Scale angular distributions by latest number of vertices
-  if (nVertices > 0) {
-    hAngularDistribution->Scale(1. / (double)nVertices);
-    hTrackEta->Scale(1. / (double)nVertices);
-    hTrackPhi->Scale(1. / (double)nVertices);
-    hNClustersPerTrackEta->Scale(1. / (double)nVertices);
+  if (mDoNorm) {
+    hAngularDistribution->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                                        : 1.);
+    hTrackEta->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                             : 1.);
+    hTrackPhi->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                             : 1.);
+    hNClustersPerTrackEta->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                                         : 1.);
+    hNClustersPerTrackPhi->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                                         : 1.);
+    hHitFirstLayerPhiAll->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                                        : 1.);
+    hHitFirstLayerPhi4cls->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                                         : 1.);
+    hHitFirstLayerPhi5cls->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                                         : 1.);
+    hHitFirstLayerPhi6cls->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                                         : 1.);
+    hHitFirstLayerPhi7cls->Scale((mDoNorm == 1 && nVertices > 0) ? 1. / (double)nVertices : mDoNorm == 2 ? 1. / (double)mNRofs
+                                                                                                         : 1.);
   }
 
   // Normalize hNClusterVsChipITS to the clusters per chip
@@ -296,6 +339,12 @@ void ITSTrackTask::reset()
   hAssociatedClusterFraction->Reset();
   hNtracks->Reset();
   hNClustersPerTrackEta->Reset();
+  hNClustersPerTrackPhi->Reset();
+  hHitFirstLayerPhiAll->Reset();
+  hHitFirstLayerPhi4cls->Reset();
+  hHitFirstLayerPhi5cls->Reset();
+  hHitFirstLayerPhi6cls->Reset();
+  hHitFirstLayerPhi7cls->Reset();
   hClusterVsBunchCrossing->Reset();
   hNClusterVsChipITS->Reset();
 }
@@ -310,7 +359,9 @@ void ITSTrackTask::createAllHistos()
     addObject(tClusterMap);
 
   hAngularDistribution = new TH2D("AngularDistribution", "AngularDistribution", 40, -2.0, 2.0, 60, 0, TMath::TwoPi());
-  hAngularDistribution->SetBit(TH1::kIsAverage);
+  if (mDoNorm) {
+    hAngularDistribution->SetBit(TH1::kIsAverage);
+  }
   hAngularDistribution->SetTitle("AngularDistribution");
   addObject(hAngularDistribution);
   formatAxes(hAngularDistribution, "#eta", "#phi", 1, 1.10);
@@ -323,7 +374,9 @@ void ITSTrackTask::createAllHistos()
   hNClusters->SetStats(0);
 
   hTrackEta = new TH1D("EtaDistribution", "EtaDistribution", 40, -2.0, 2.0);
-  hTrackEta->SetBit(TH1::kIsAverage);
+  if (mDoNorm) {
+    hTrackEta->SetBit(TH1::kIsAverage);
+  }
   hTrackEta->SetTitle("Eta Distribution of tracks / n_vertices with at least 3 contrib");
   hTrackEta->SetMinimum(0);
   addObject(hTrackEta);
@@ -331,7 +384,9 @@ void ITSTrackTask::createAllHistos()
   hTrackEta->SetStats(0);
 
   hTrackPhi = new TH1D("PhiDistribution", "PhiDistribution", 65, -0.1, TMath::TwoPi());
-  hTrackPhi->SetBit(TH1::kIsAverage);
+  if (mDoNorm) {
+    hTrackPhi->SetBit(TH1::kIsAverage);
+  }
   hTrackPhi->SetTitle("Phi Distribution of tracks / n_vertices with at least 3 contrib");
   hTrackPhi->SetMinimum(0);
   addObject(hTrackPhi);
@@ -379,11 +434,67 @@ void ITSTrackTask::createAllHistos()
   hNtracks->SetStats(0);
 
   hNClustersPerTrackEta = new TH2D("NClustersPerTrackEta", "NClustersPerTrackEta", 400, -2.0, 2.0, 15, -0.5, 14.5);
-  hNClustersPerTrackEta->SetBit(TH1::kIsAverage);
+  if (mDoNorm) {
+    hNClustersPerTrackEta->SetBit(TH1::kIsAverage);
+  }
   hNClustersPerTrackEta->SetTitle("Eta vs NClusters Per Track");
   addObject(hNClustersPerTrackEta);
   formatAxes(hNClustersPerTrackEta, "#eta", "# of Clusters per Track", 1, 1.10);
   hNClustersPerTrackEta->SetStats(0);
+
+  hNClustersPerTrackPhi = new TH2D("NClustersPerTrackPhi", "NClustersPerTrackPhi", 65, -0.1, TMath::TwoPi(), 15, -0.5, 14.5);
+  if (mDoNorm) {
+    hNClustersPerTrackPhi->SetBit(TH1::kIsAverage);
+  }
+  hNClustersPerTrackPhi->SetTitle("Phi vs NClusters Per Track");
+  addObject(hNClustersPerTrackPhi);
+  formatAxes(hNClustersPerTrackPhi, "#phi", "# of Clusters per Track", 1, 1.10);
+  hNClustersPerTrackPhi->SetStats(0);
+
+  hHitFirstLayerPhiAll = new TH2D("HitFirstLayerAll", "HitFirstLayerPhiAll", 65, -0.1, TMath::TwoPi(), 4, -0.5, 3.5);
+  if (mDoNorm) {
+    hHitFirstLayerPhiAll->SetBit(TH1::kIsAverage);
+  }
+  hHitFirstLayerPhiAll->SetTitle("Layer with 1st track hit vs Phi - all tracks");
+  addObject(hHitFirstLayerPhiAll);
+  formatAxes(hHitFirstLayerPhiAll, "#phi", "Layer with 1st hit", 1, 1.10);
+  hHitFirstLayerPhiAll->SetStats(0);
+
+  hHitFirstLayerPhi4cls = new TH2D("HitFirstLayer4cls", "HitFirstLayerPhi4cls", 65, -0.1, TMath::TwoPi(), 4, -0.5, 3.5);
+  if (mDoNorm) {
+    hHitFirstLayerPhi4cls->SetBit(TH1::kIsAverage);
+  }
+  hHitFirstLayerPhi4cls->SetTitle("Layer with 1st track hit vs Phi - 4 cls tracks");
+  addObject(hHitFirstLayerPhi4cls);
+  formatAxes(hHitFirstLayerPhi4cls, "#phi", "Layer with 1st hit", 1, 1.10);
+  hHitFirstLayerPhi4cls->SetStats(0);
+
+  hHitFirstLayerPhi5cls = new TH2D("HitFirstLayer5cls", "HitFirstLayerPhi5cls", 65, -0.1, TMath::TwoPi(), 4, -0.5, 3.5);
+  if (mDoNorm) {
+    hHitFirstLayerPhi5cls->SetBit(TH1::kIsAverage);
+  }
+  hHitFirstLayerPhi5cls->SetTitle("Layer with 1st track hit vs Phi - 5 cls tracks");
+  addObject(hHitFirstLayerPhi5cls);
+  formatAxes(hHitFirstLayerPhi5cls, "#phi", "Layer with 1st hit", 1, 1.10);
+  hHitFirstLayerPhi5cls->SetStats(0);
+
+  hHitFirstLayerPhi6cls = new TH2D("HitFirstLayer6cls", "HitFirstLayerPhi6cls", 65, -0.1, TMath::TwoPi(), 4, -0.5, 3.5);
+  if (mDoNorm) {
+    hHitFirstLayerPhi6cls->SetBit(TH1::kIsAverage);
+  }
+  hHitFirstLayerPhi6cls->SetTitle("Layer with 1st track hit vs Phi - 6 cls tracks");
+  addObject(hHitFirstLayerPhi6cls);
+  formatAxes(hHitFirstLayerPhi6cls, "#phi", "Layer with 1st hit", 1, 1.10);
+  hHitFirstLayerPhi6cls->SetStats(0);
+
+  hHitFirstLayerPhi7cls = new TH2D("HitFirstLayer7cls", "HitFirstLayerPhi7cls", 65, -0.1, TMath::TwoPi(), 4, -0.5, 3.5);
+  if (mDoNorm) {
+    hHitFirstLayerPhi7cls->SetBit(TH1::kIsAverage);
+  }
+  hHitFirstLayerPhi7cls->SetTitle("Layer with 1st track hit vs Phi - 7 cls tracks");
+  addObject(hHitFirstLayerPhi7cls);
+  formatAxes(hHitFirstLayerPhi7cls, "#phi", "Layer with 1st hit", 1, 1.10);
+  hHitFirstLayerPhi7cls->SetStats(0);
 
   hClusterVsBunchCrossing = new TH2D("BunchCrossingIDvsClusterRatio", "BunchCrossingIDvsClusterRatio", nBCbins, 0, 4095, 100, 0, 1);
   hClusterVsBunchCrossing->SetTitle("Bunch Crossing ID vs Cluster Ratio");


### PR DESCRIPTION
Added in this PR:
- option `doNorm` to do: 0 = no normalization, 1 = normalization by nVertices, 2 = normalization by nROFs. The last one has to be used with cosmics. 
- 1 new plot with #clusters_per_tracks vs phi (was existing only the one vs eta)
- 5 new plots with "Layer with 1st hit" (check where a track has the first hit) vs phi for tracks with 4,5,6,7 clusters and any number of clusters

Plots intended for ITS experts and introduced to better understand the track distributions in case of holes in the acceptance (i.e. missing stave(s)). 