### PR TITLE
TRD remove bug causing labels QC-941

### DIFF
--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -363,24 +363,9 @@ void DigitsTask::buildHistograms()
     getObjectsManager()->startPublishing(h);
   }
 
-  /*  int cn = 0;
-  int sm = 0;
-
-  for (int count = 0; count < 540; ++count) {
-    sm = count / 30;
-    std::string label = fmt::format("PulseHeightPerChamber/pulseheight_{0:02d}_{1}_{2}", sm, cn / 6, cn % 6);
-    std::string title = fmt::format("{0:02d}_{1}_{2};Timebin;Chamber", sm, cn / 6, cn % 6);
-    TH1F* h = new TH1F(label.c_str(), title.c_str(), 30, -0.5, 29.5);
-    mPulseHeightPerChamber_1D[count].reset(h);
-    getObjectsManager()->startPublishing(h);
-    cn++;
-    if (cn > 29)
-      cn = 0;
-  }
-*/
   for (int iLayer = 0; iLayer < 6; ++iLayer) {
     mLayers.push_back(new TH2F(Form("DigitsPerLayer/layer%i", iLayer), Form("Digit count per pad in layer %i;stack;sector", iLayer), 76, -0.5, 75.5, 2592, -0.5, 2591.5));
-    auto xax = mLayers.back()->GetXaxis();
+/*    auto xax = mLayers.back()->GetXaxis();
     xax->SetBinLabel(8, "0");
     xax->SetBinLabel(24, "1");
     xax->SetBinLabel(38, "2");
@@ -398,7 +383,7 @@ void DigitsTask::buildHistograms()
     yax->SetTicks("-");
     yax->SetTickSize(0.01);
     yax->SetLabelSize(0.045);
-    yax->SetLabelOffset(0.01);
+    yax->SetLabelOffset(0.01);*/
     mLayers.back()->SetStats(0);
     drawTrdLayersGrid(mLayers.back());
     fillLinesOnHistsPerLayer(iLayer);

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -365,25 +365,25 @@ void DigitsTask::buildHistograms()
 
   for (int iLayer = 0; iLayer < 6; ++iLayer) {
     mLayers.push_back(new TH2F(Form("DigitsPerLayer/layer%i", iLayer), Form("Digit count per pad in layer %i;stack;sector", iLayer), 76, -0.5, 75.5, 2592, -0.5, 2591.5));
-/*    auto xax = mLayers.back()->GetXaxis();
-    xax->SetBinLabel(8, "0");
-    xax->SetBinLabel(24, "1");
-    xax->SetBinLabel(38, "2");
-    xax->SetBinLabel(52, "3");
-    xax->SetBinLabel(68, "4");
-    xax->SetTicks("-");
-    xax->SetTickSize(0.01);
-    xax->SetLabelSize(0.045);
-    xax->SetLabelOffset(0.01);
-    auto yax = mLayers.back()->GetYaxis();
-    for (int iSec = 0; iSec < 18; ++iSec) {
-      auto lbl = std::to_string(iSec);
-      yax->SetBinLabel(iSec * 144 + 72, lbl.c_str());
-    }
-    yax->SetTicks("-");
-    yax->SetTickSize(0.01);
-    yax->SetLabelSize(0.045);
-    yax->SetLabelOffset(0.01);*/
+    /*    auto xax = mLayers.back()->GetXaxis();
+        xax->SetBinLabel(8, "0");
+        xax->SetBinLabel(24, "1");
+        xax->SetBinLabel(38, "2");
+        xax->SetBinLabel(52, "3");
+        xax->SetBinLabel(68, "4");
+        xax->SetTicks("-");
+        xax->SetTickSize(0.01);
+        xax->SetLabelSize(0.045);
+        xax->SetLabelOffset(0.01);
+        auto yax = mLayers.back()->GetYaxis();
+        for (int iSec = 0; iSec < 18; ++iSec) {
+          auto lbl = std::to_string(iSec);
+          yax->SetBinLabel(iSec * 144 + 72, lbl.c_str());
+        }
+        yax->SetTicks("-");
+        yax->SetTickSize(0.01);
+        yax->SetLabelSize(0.045);
+        yax->SetLabelOffset(0.01);*/
     mLayers.back()->SetStats(0);
     drawTrdLayersGrid(mLayers.back());
     fillLinesOnHistsPerLayer(iLayer);

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -236,7 +236,7 @@ void TrackletsTask::buildTrackletLayers()
 {
   for (int iLayer = 0; iLayer < 6; ++iLayer) {
     mLayers[iLayer] = new TH2F(Form("TrackletsPerLayer/layer%i", iLayer), Form("Tracklet count per mcm in layer %i;stack;sector", iLayer), 76, -0.5, 75.5, 144, -0.5, 143.5);
-
+/*
     auto xax = mLayers[iLayer]->GetXaxis();
     xax->SetBinLabel(8, "0");
     xax->SetBinLabel(24, "1");
@@ -257,7 +257,7 @@ void TrackletsTask::buildTrackletLayers()
     yax->SetTicks("");
     yax->SetTickSize(0.01);
     yax->SetLabelSize(0.045);
-    yax->SetLabelOffset(0.01);
+    yax->SetLabelOffset(0.01);*/
     mLayers[iLayer]->SetStats(0);
 
     drawTrdLayersGrid(mLayers[iLayer]);

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -236,28 +236,28 @@ void TrackletsTask::buildTrackletLayers()
 {
   for (int iLayer = 0; iLayer < 6; ++iLayer) {
     mLayers[iLayer] = new TH2F(Form("TrackletsPerLayer/layer%i", iLayer), Form("Tracklet count per mcm in layer %i;stack;sector", iLayer), 76, -0.5, 75.5, 144, -0.5, 143.5);
-/*
-    auto xax = mLayers[iLayer]->GetXaxis();
-    xax->SetBinLabel(8, "0");
-    xax->SetBinLabel(24, "1");
-    xax->SetBinLabel(38, "2");
-    xax->SetBinLabel(52, "3");
-    xax->SetBinLabel(68, "4");
+    /*
+        auto xax = mLayers[iLayer]->GetXaxis();
+        xax->SetBinLabel(8, "0");
+        xax->SetBinLabel(24, "1");
+        xax->SetBinLabel(38, "2");
+        xax->SetBinLabel(52, "3");
+        xax->SetBinLabel(68, "4");
 
-    xax->SetTicks("-");
-    xax->SetTickSize(0.01);
-    xax->SetLabelSize(0.045);
-    xax->SetLabelOffset(0.01);
-    auto yax = mLayers[iLayer]->GetYaxis();
-    for (int iSec = 0; iSec < 18; ++iSec) {
-      auto lbl = std::to_string(iSec);
-      yax->SetBinLabel(iSec * 8 + 4, lbl.c_str());
-    }
+        xax->SetTicks("-");
+        xax->SetTickSize(0.01);
+        xax->SetLabelSize(0.045);
+        xax->SetLabelOffset(0.01);
+        auto yax = mLayers[iLayer]->GetYaxis();
+        for (int iSec = 0; iSec < 18; ++iSec) {
+          auto lbl = std::to_string(iSec);
+          yax->SetBinLabel(iSec * 8 + 4, lbl.c_str());
+        }
 
-    yax->SetTicks("");
-    yax->SetTickSize(0.01);
-    yax->SetLabelSize(0.045);
-    yax->SetLabelOffset(0.01);*/
+        yax->SetTicks("");
+        yax->SetTickSize(0.01);
+        yax->SetLabelSize(0.045);
+        yax->SetLabelOffset(0.01);*/
     mLayers[iLayer]->SetStats(0);
 
     drawTrdLayersGrid(mLayers[iLayer]);


### PR DESCRIPTION
Remove the labels from the layer plots of digits and tracklets.
I still cant replicate the problem causing the qc05 to fill the disk with logs. It is clearly coming from the labels of these graphs.
I can replicate the same error message but it would be on the epn and only after adding code to fill all bins with labels, unlike the commented out sections of the code in this PR.

A more permanent solution will come later.