### PR TITLE
If possible, use --id argument instead runQC as IL facility

### DIFF
--- a/Framework/src/runQC.cxx
+++ b/Framework/src/runQC.cxx
@@ -168,7 +168,15 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
     ILOG_INST.filterDiscardDebug(infologgerFilterDiscardDebug);
     ILOG_INST.filterDiscardLevel(infologgerDiscardLevel);
     ILOG_INST.filterDiscardSetFile(infologgerDiscardFile.c_str(), 0, 0, 0, true /*Do not store Debug messages in file*/);
-    o2::quality_control::core::QcInfoLogger::setFacility("runQC");
+
+    std::string id = "runQC";
+    for (size_t i = 0; i < config.argc(); i++) {
+      if (std::strcmp(config.argv()[i], "--id") == 0 && i + 1 < config.argc()) {
+        id = config.argv()[i + 1];
+        break;
+      }
+    }
+    o2::quality_control::core::QcInfoLogger::setFacility(id);
 
     ILOG(Info, Devel) << "Using config file '" << qcConfigurationSource << "'" << ENDM;
     auto keyValuesToOverride = quality_control::core::parseOverrideValues(config.options().get<std::string>("override-values"));


### PR DESCRIPTION
This a rather hacky way to retrieve the identity of a Data Processor before it defines its workflow.

This does not work, probably because "--id" is not one of the expected parameters for the user workflow:
```
auto id = config.options().hasOption("id") && config.options().isSet("id") ? config.options().get<std::string>("id") : "runQC";
```

While this improves the situation, we will still have e.g. "qc-task-ITS-ITSFEE" (device id) at the beginning of the task lifetime, but "task/ITSFEE" once it fully initializes. We could consider using device ID throughout the lifetime, to be consistent.