### PR TITLE
TRD fix layer plots

### DIFF
--- a/Modules/TRD/include/TRD/DigitsTask.h
+++ b/Modules/TRD/include/TRD/DigitsTask.h
@@ -66,6 +66,7 @@ class DigitsTask final : public TaskInterface
  private:
   // limits
   bool mSkipSharedDigits;
+  bool mLayerLabelsIgnore = false;
   unsigned int mPulseHeightThreshold;
   std::pair<float, float> mDriftRegion;
   std::pair<float, float> mPulseHeightPeakRegion;

--- a/Modules/TRD/include/TRD/TrackletsTask.h
+++ b/Modules/TRD/include/TRD/TrackletsTask.h
@@ -59,6 +59,7 @@ class TrackletsTask final : public TaskInterface
 
  private:
   long int mTimestamp;
+  bool mLayerLabelsIgnore = false;
   std::array<TH2F*, 18> moHCMCM;
   std::array<TH1F*, 18> mTrackletQ0perSector;
   std::array<TH1F*, 18> mTrackletQ1perSector;

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -17,6 +17,7 @@
 #include <TCanvas.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <THashList.h>
 #include <TLine.h>
 #include <sstream>
 #include <string>
@@ -235,29 +236,35 @@ void TrackletsTask::drawHashOnLayers(int layer, int hcid, int rowstart, int rowe
 void TrackletsTask::buildTrackletLayers()
 {
   for (int iLayer = 0; iLayer < 6; ++iLayer) {
-    mLayers[iLayer] = new TH2F(Form("TrackletsPerLayer/layer%i", iLayer), Form("Tracklet count per mcm in layer %i;stack;sector", iLayer), 76, -0.5, 75.5, 144, -0.5, 143.5);
-    /*
-        auto xax = mLayers[iLayer]->GetXaxis();
-        xax->SetBinLabel(8, "0");
-        xax->SetBinLabel(24, "1");
-        xax->SetBinLabel(38, "2");
-        xax->SetBinLabel(52, "3");
-        xax->SetBinLabel(68, "4");
+    mLayers[iLayer] = new TH2F(Form("TrackletsPerLayer/layer%i", iLayer), Form("Tracklet count per mcm in layer %i;Stack;Sector", iLayer), 76, -0.5, 75.5, 144, -0.5, 143.5);
+    auto xax = mLayers[iLayer]->GetXaxis();
+    auto yax = mLayers[iLayer]->GetYaxis();
+    if (!mLayerLabelsIgnore) {
+      xax->SetNdivisions(5);
+      xax->SetBinLabel(8, "0");
+      xax->SetBinLabel(24, "1");
+      xax->SetBinLabel(38, "2");
+      xax->SetBinLabel(52, "3");
+      xax->SetBinLabel(68, "4");
+      xax->SetTicks("");
+      xax->SetTickSize(0.0);
+      xax->SetLabelSize(0.045);
+      xax->SetLabelOffset(0.005);
+      xax->SetTitleOffset(0.95);
+      xax->CenterTitle(true);
+      yax->SetNdivisions(18);
+      for (int iSec = 0; iSec < 18; ++iSec) {
+        auto lbl = std::to_string(iSec);
+        yax->SetBinLabel(iSec * 8 + 4, lbl.c_str());
+      }
+      yax->SetTicks("");
+      yax->SetTickSize(0.0);
+      yax->SetLabelSize(0.045);
+      yax->SetLabelOffset(0.001);
+      yax->SetTitleOffset(0.40);
+      yax->CenterTitle(true);
+    }
 
-        xax->SetTicks("-");
-        xax->SetTickSize(0.01);
-        xax->SetLabelSize(0.045);
-        xax->SetLabelOffset(0.01);
-        auto yax = mLayers[iLayer]->GetYaxis();
-        for (int iSec = 0; iSec < 18; ++iSec) {
-          auto lbl = std::to_string(iSec);
-          yax->SetBinLabel(iSec * 8 + 4, lbl.c_str());
-        }
-
-        yax->SetTicks("");
-        yax->SetTickSize(0.01);
-        yax->SetLabelSize(0.045);
-        yax->SetLabelOffset(0.01);*/
     mLayers[iLayer]->SetStats(0);
 
     drawTrdLayersGrid(mLayers[iLayer]);
@@ -266,6 +273,24 @@ void TrackletsTask::buildTrackletLayers()
     getObjectsManager()->startPublishing(mLayers[iLayer]);
     getObjectsManager()->setDefaultDrawOptions(mLayers[iLayer]->GetName(), "COLZ");
     getObjectsManager()->setDisplayHint(mLayers[iLayer], "logz");
+    // check axises :
+
+    /*    std::cout << "Test Tracklet Xlabels for layer : " << iLayer << std::endl;
+        auto binsizex=xax->GetNbins();
+        auto labelsx=xax->GetLabels();
+        auto labelssizex=labelsx->GetSize();
+        std::cout << "binsize:" << binsizex << "  labelsize:" << labelssizex << std::endl;
+        if(binsizex!= labelssizex){
+          std::cout << "binsize != labsize ?= " << binsizex << "!=" << labelssizex << std::endl;
+        }
+        std::cout << "Test Tracklet Ylabels for layer : " << iLayer << std::endl;
+        auto binsizey=yax->GetNbins();
+        auto labelsy=yax->GetLabels();
+        auto labelssizey=labelsy->GetSize();
+        std::cout << "binsize:" << binsizey << "  labelsize:" << labelssizey << std::endl;
+        if(binsizey!= labelssizey){
+          std::cout << "binsize != labsize ?= " << binsizey << "!=" << labelssizey << std::endl;
+        }  */
   }
 }
 
@@ -310,6 +335,10 @@ void TrackletsTask::initialize(o2::framework::InitContext& /*ctx*/)
   } else {
     mMarkerSize = 3; // a plus sign
     ILOG(Debug, Support) << "configure() : using default markersize = " << mMarkerSize << ENDM;
+  }
+  if (auto param = mCustomParameters.find("ignorelayerlabels"); param != mCustomParameters.end()) {
+    mLayerLabelsIgnore = stoi(param->second);
+    ILOG(Debug, Support) << "configure() : ignoring labels on layer plots = " << mLayerLabelsIgnore << ENDM;
   }
 
   retrieveCCDBSettings();


### PR DESCRIPTION
Originally the labels were added to name the sector on the x-axis and the sector on the y-axis, so xmax of 5 and y max of 18.
y had 144 or 2952 bins, x had 76.
so 5!=76 and 18!=144 or 2952.
This then hits the root merger code causing stderr messages with number of bins not equal to number of labels.
There was an update of making all the additional labels " ", this hits another piece of code that complains about like labels causing the middle of each stack to get an update.

Changing the spectra to have only 5 divisions along x-axis and 18 along y axis, this seems to prevent root from hitting the numberbins != numberoflabels, although still true.

Addtionally, given that I never did directly replicate the errors, there is a configuration parameter around the labels, so that if it breaks again, this can be added to the json and the labels switched off.