### PR TITLE
TPC: Update QualityObserver

### DIFF
--- a/Modules/TPC/include/TPC/QualityObserver.h
+++ b/Modules/TPC/include/TPC/QualityObserver.h
@@ -74,6 +74,8 @@ class QualityObserver : public PostProcessingInterface
   bool mViewDetails;
   std::unordered_map<std::string, std::vector<std::string>> mReasons;
   std::unordered_map<std::string, std::vector<std::string>> mComments;
+  std::string mQualityDetailChoice;
+  std::unordered_map<std::string, bool> mQualityDetails;
 };
 
 } // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/run/tpcQCQualityObserver.json
+++ b/Modules/TPC/run/tpcQCQualityObserver.json
@@ -30,6 +30,7 @@
         "detectorName": "TPC",
         "qualityObserverName": "TestObserver",
         "observeDetails": "true", 
+        "qualityDetailChoice": "Null, Good, Medium, Bad",
         "qualityObserverConfig": [
           {
             "groupTitle": "Tracks Trending",


### PR DESCRIPTION
Update includes: 
- New option in json called `qualityDetailChoice`. This allows to select for which qualities the reasons and comments of the check result are shown. Example `"qualityDetailChoice": "Medium, Bad"` will only show reasons and comments for checks with medium or bad quality. Full list of options: `"qualityDetailChoice": "Null, Good, Medium, Bad"`
- Fix to (hopefully) solve the EOR crash. `finalize` function should not delete pointer to canvas