### PR TITLE
Do not check empty MOs, sanitize testCheck, compute aggregated Activity for QO

### DIFF
--- a/Framework/include/QualityControl/Check.h
+++ b/Framework/include/QualityControl/Check.h
@@ -73,9 +73,6 @@ class Check
   //TODO: Unique Input string
   static o2::header::DataDescription createCheckDataDescription(const std::string& checkName);
 
-  // For testing purpose
-  void setCheckInterface(CheckInterface* checkInterface) { mCheckInterface = checkInterface; };
-
   UpdatePolicyType getUpdatePolicyType() const;
   std::vector<std::string> getObjectsNames() const;
   bool getAllObjectsOption() const;

--- a/Framework/src/RootClassFactory.cxx
+++ b/Framework/src/RootClassFactory.cxx
@@ -31,7 +31,7 @@ void loadLibrary(const std::string& moduleName)
   ILOG(Info, Devel) << "Loading library " << library << ENDM;
   int libLoaded = gSystem->Load(library.c_str(), "", true);
   if (libLoaded < 0) {
-    BOOST_THROW_EXCEPTION(FatalException() << errinfo_details("Failed to load Detector Publisher Library"));
+    BOOST_THROW_EXCEPTION(FatalException() << errinfo_details("Failed to load the library " + library));
   }
 }
 


### PR DESCRIPTION
I added a protection to avoid checking MOs which are nullptr, which testCheck previously abused for no good reason.

Also, most of the tests in testCheck did not have any sense, they tested a dummy class that was written in testCheck. I replaced them with something more meaningful.

The main point of this commit is that now Check computes the aggregated activity, though it is not used yet to store objects, this will come later.