### PR TITLE
TPC: Update CheckOfTrendings for multiple pads 

### DIFF
--- a/Modules/TPC/include/TPC/CheckOfTrendings.h
+++ b/Modules/TPC/include/TPC/CheckOfTrendings.h
@@ -11,6 +11,7 @@
 ///
 /// \file   CheckOfTrendings.h
 /// \author Laura Serksnyte
+/// \author Marcel Lesch
 ///
 
 #ifndef QC_MODULE_TPC_CHECKOFTRENDINGS_H
@@ -44,8 +45,9 @@ class CheckOfTrendings : public o2::quality_control::checker::CheckInterface
 
  private:
   ClassDefOverride(CheckOfTrendings, 2);
-  void calculateStatistics(const double* yValues, const double* yErrors, bool useErrors, const int firstPoint, const int lastPoint, double& mean, double& stddevOfMean);
   void getGraphs(TCanvas* canv, std::vector<TGraph*>& graphs);
+  void calculateStatistics(const double* yValues, const double* yErrors, bool useErrors, const int firstPoint, const int lastPoint, double& mean, double& stddevOfMean);
+  std::string createMetaData(std::vector<std::string> pointMetaData);
   std::string mCheckChoice;
   float mExpectedPhysicsValue;
   float mNSigmaExpectedPhysicsValue;
@@ -64,10 +66,8 @@ class CheckOfTrendings : public o2::quality_control::checker::CheckInterface
   int mPointToTakeForRangeCheck;
   int mPointToTakeForZeroCheck;
 
-  std::string mBadString = "";
-  std::string mMediumString = "";
-  std::string mGoodString = "";
-  std::string mNullString = "";
+  std::unordered_map<std::string, std::vector<std::string>> mPadMetaData;
+  std::vector<Quality> mPadQualities;
 
   std::string mMetadataComment;
 

--- a/Modules/TPC/include/TPC/CheckOfTrendings.h
+++ b/Modules/TPC/include/TPC/CheckOfTrendings.h
@@ -59,8 +59,7 @@ class CheckOfTrendings : public o2::quality_control::checker::CheckInterface
   float mRangeBad;
   bool mSliceTrend;
 
-  double mMean = 0;
-  float mStdev;
+  std::vector<float> mStdev;
 
   int mPointToTakeForExpectedValueCheck;
   int mPointToTakeForMeanCheck;

--- a/Modules/TPC/include/TPC/CheckOfTrendings.h
+++ b/Modules/TPC/include/TPC/CheckOfTrendings.h
@@ -28,6 +28,7 @@ namespace o2::quality_control_modules::tpc
 /// \brief  Check if the a new data point in trend is not 3sigma or 6 sigma away from the average value
 ///
 /// \author Laura Serksnyte
+/// \author Marcel Lesch
 class CheckOfTrendings : public o2::quality_control::checker::CheckInterface
 {
 

--- a/Modules/TPC/include/TPC/CheckOfTrendings.h
+++ b/Modules/TPC/include/TPC/CheckOfTrendings.h
@@ -45,7 +45,7 @@ class CheckOfTrendings : public o2::quality_control::checker::CheckInterface
  private:
   ClassDefOverride(CheckOfTrendings, 2);
   void calculateStatistics(const double* yValues, const double* yErrors, bool useErrors, const int firstPoint, const int lastPoint, double& mean, double& stddevOfMean);
-  TGraph* getGraph(TCanvas* canv);
+  void getGraphs(TCanvas* canv, std::vector<TGraph*>& graphs);
   std::string mCheckChoice;
   float mExpectedPhysicsValue;
   float mNSigmaExpectedPhysicsValue;

--- a/Modules/TPC/run/tpcQCCheckTrending.json
+++ b/Modules/TPC/run/tpcQCCheckTrending.json
@@ -65,7 +65,7 @@
 
         "stopTrigger_comment": [ "Parameters are needed to choose if check should be performed only as last point comparison to average or average comparison to expected value." ],
         "checkParameters": {
-          "CheckChoice" : "Mean, ExpectedValue, Range",
+          "CheckChoice" : "Zero, Mean",
           "SliceTrending" : "false",
           "expectedPhysicsValue" : "0.1",
           "EPV_comment" : "This value is used for the Expected Physics Value and the Range Check",
@@ -97,7 +97,7 @@
 
         "stopTrigger_comment": [ "Parameters are needed to choose if check should be performed only as last point comparison to average or average comparison to expected value." ],
         "checkParameters": {
-          "CheckChoice" : "Mean, ExpectedValue, Range",
+          "CheckChoice" : "Zero, Mean",
           "SliceTrending" : "true",
           "expectedPhysicsValue" : "0.1",
           "EPV_comment" : "This value is used for the Expected Physics Value and the Range Check",

--- a/Modules/TPC/run/tpcQCCheckTrending.json
+++ b/Modules/TPC/run/tpcQCCheckTrending.json
@@ -117,6 +117,32 @@
       }
      },
     "postprocessing": {
+      "TestQualityCheckerTrending": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::QualityObserver",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "qualityObserverName": "TestQualityCheckerTrending",
+        "observeDetails": "true", 
+        "qualityDetailChoice": "Null, Good, Medium, Bad",
+        "qualityObserverConfig": [
+          {
+            "groupTitle": "Tracks Trending",
+            "path": "TPC/QO/",
+            "inputObjects": [ "CheckOfTrack_Trending/Tracks_Trending/hEta_StatMean_Trend", "CheckOfTrack_Trending_Slice/Tracks_Trending_Slice/hEta_StatMean_Trend" ],
+            "inputObjectTitles": [ "Eta, Mean Trend, Framework Trend",  "Eta, Mean Trend, Slice Trend" ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "10 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
       "PID_Trending": {
         "active": "false",
         "className": "o2::quality_control::postprocessing::TrendingTask",
@@ -420,7 +446,7 @@
             "path": "TPC/MO/Tracks",
             "names": [  "hEta" ],
             "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
-            "axisDivision": [ [ ] ],
+            "axisDivision": [ [ "-1.0", "-0.5", "0.0", "0.5", "1.0" ] ],
             "moduleName": "QcCommon"
           }
         ],

--- a/Modules/TPC/src/CheckOfTrendings.cxx
+++ b/Modules/TPC/src/CheckOfTrendings.cxx
@@ -522,7 +522,7 @@ void CheckOfTrendings::beautify(std::shared_ptr<MonitorObject> mo, Quality check
     // InfoBox
     std::string checkMessage;
     TPaveText* msg = new TPaveText(0.5, 0.75, 0.9, 0.9, "NDC");
-    msg->SetName(Form("%s_msg_%d", mo->GetName(), iGraph));
+    msg->SetName(Form("%s_msg_%zu", mo->GetName(), iGraph));
     graphs[iGraph]->GetListOfFunctions()->Add(msg);
 
     if (mPadQualities[iGraph] == Quality::Good) {

--- a/Modules/TPC/src/CheckOfTrendings.cxx
+++ b/Modules/TPC/src/CheckOfTrendings.cxx
@@ -137,7 +137,7 @@ Quality CheckOfTrendings::check(std::map<std::string, std::shared_ptr<MonitorObj
   if (graphs.size() == 0) {
     ILOG(Fatal, Support) << "Could not retrieve any TGraph for CheckOfTrendings" << ENDM;
   }
-  for (int iGraph = 0; iGraph < graphs.size(); iGraph++) {
+  for (size_t iGraph = 0; iGraph < graphs.size(); iGraph++) {
     if (!graphs[iGraph]) { // if there is no TGraph, give an error and break
       ILOG(Fatal, Support) << "TGraph number " << iGraph << " is NULL." << ENDM;
     }
@@ -146,7 +146,7 @@ Quality CheckOfTrendings::check(std::map<std::string, std::shared_ptr<MonitorObj
     ILOG(Fatal, Support) << "Multiple Graphs found even though this is not a slice trending" << ENDM;
   }
 
-  for (int iGraph = 0; iGraph < graphs.size(); iGraph++) {
+  for (size_t iGraph = 0; iGraph < graphs.size(); iGraph++) {
     std::string padNullString = "";
     std::string padBadString = "";
     std::string padMediumString = "";
@@ -198,7 +198,7 @@ Quality CheckOfTrendings::check(std::map<std::string, std::shared_ptr<MonitorObj
           ILOG(Warning, Support) << "Last point for check of mean has negative error" << ENDM;
         }
 
-        double totalError = sqrt(stddevOfMean * stddevOfMean + lastPointError * lastPointError);
+        const double totalError = sqrt(stddevOfMean * stddevOfMean + lastPointError * lastPointError);
         double nSigma = -1.;
         if (totalError != 0.) {
           nSigma = std::abs(y_last - mean) / totalError;
@@ -307,11 +307,11 @@ Quality CheckOfTrendings::check(std::map<std::string, std::shared_ptr<MonitorObj
 
     // Quality aggregation
     if (qualitiesOfPad.size() >= 1) {
-      auto Worst_Quality_Pad = std::max_element(qualitiesOfPad.begin(), qualitiesOfPad.end(),
+      auto worst_Quality_Pad = std::max_element(qualitiesOfPad.begin(), qualitiesOfPad.end(),
                                                 [](const Quality& q1, const Quality& q2) {
                                                   return q1.isBetterThan(q2);
                                                 });
-      mPadQualities.push_back(*Worst_Quality_Pad);
+      mPadQualities.push_back(*worst_Quality_Pad);
     } else {
       mPadQualities.push_back(Quality::Null);
       padNullString += "No Checks performed for pad " + std::to_string(iGraph) + " \n";
@@ -321,7 +321,7 @@ Quality CheckOfTrendings::check(std::map<std::string, std::shared_ptr<MonitorObj
     mPadMetaData[Quality::Bad.getName()].push_back(padBadString);
     mPadMetaData[Quality::Medium.getName()].push_back(padMediumString);
     mPadMetaData[Quality::Good.getName()].push_back(padGoodString);
-  } // for(int iGraph = 0; iGraph < graphs.size(); iGraph++)
+  } // for(size_t iGraph = 0; iGraph < graphs.size(); iGraph++)
 
   // Final Aggregation of qualities and metadata of all Pads
   std::string totalBadString = "";
@@ -331,11 +331,11 @@ Quality CheckOfTrendings::check(std::map<std::string, std::shared_ptr<MonitorObj
   Quality totalQuality = Quality::Null;
 
   if (mPadQualities.size() >= 1) {
-    auto Worst_Quality = std::max_element(mPadQualities.begin(), mPadQualities.end(),
+    auto worst_Quality = std::max_element(mPadQualities.begin(), mPadQualities.end(),
                                           [](const Quality& q1, const Quality& q2) {
                                             return q1.isBetterThan(q2);
                                           });
-    totalQuality = *Worst_Quality;
+    totalQuality = *worst_Quality;
 
     // MetaData aggregation from all pads
     totalBadString = createMetaData(mPadMetaData[Quality::Bad.getName()]);
@@ -370,7 +370,7 @@ void CheckOfTrendings::beautify(std::shared_ptr<MonitorObject> mo, Quality check
   if (graphs.size() == 0) {
     ILOG(Fatal, Support) << "Could not retrieve any TGraph for CheckOfTrendings" << ENDM;
   }
-  for (int iGraph = 0; iGraph < graphs.size(); iGraph++) {
+  for (size_t iGraph = 0; iGraph < graphs.size(); iGraph++) {
     if (!graphs[iGraph]) { // if there is no TGraph, give an error and break
       ILOG(Fatal, Support) << "TGraph number " << iGraph << " is NULL." << ENDM;
     }
@@ -379,7 +379,7 @@ void CheckOfTrendings::beautify(std::shared_ptr<MonitorObject> mo, Quality check
     ILOG(Fatal, Support) << "Multiple Graphs found even though this is not a slice trending" << ENDM;
   }
 
-  for (int iGraph = 0; iGraph < graphs.size(); iGraph++) {
+  for (size_t iGraph = 0; iGraph < graphs.size(); iGraph++) {
     graphs[iGraph]->SetLineColor(kBlack);
     double xMin = graphs[iGraph]->GetXaxis()->GetXmin();
     double xMax = graphs[iGraph]->GetXaxis()->GetXmax();
@@ -558,7 +558,7 @@ void CheckOfTrendings::beautify(std::shared_ptr<MonitorObject> mo, Quality check
       checkMessage.erase(0, pos + delimiter.length());
     }
     msg->AddText(checkResult.getMetadata("Comment", "").c_str());
-  } // for(int iGraph = 0; iGraph < graphs.size(); iGraph++)
+  } // for(size_t iGraph = 0; iGraph < graphs.size(); iGraph++)
 }
 
 void CheckOfTrendings::getGraphs(TCanvas* canv, std::vector<TGraph*>& graphs)
@@ -615,7 +615,7 @@ void CheckOfTrendings::calculateStatistics(const double* yValues, const double* 
   } else {
     // In case of errors, we set our weights equal to 1/sigma_i^2
     const std::vector<double> vErr(yErrors + firstPoint, yErrors + lastPoint);
-    for (int i = 0; i < v.size(); i++) {
+    for (size_t i = 0; i < v.size(); i++) {
       weight = 1. / std::pow(vErr[i], 2.);
       sum += v[i] * weight;
       sumSquare += v[i] * v[i] * weight;
@@ -656,7 +656,7 @@ std::string CheckOfTrendings::createMetaData(std::vector<std::string> pointMetaD
     std::string rangeString = "";
     std::string zeroString = "";
 
-    for (int i; i < pointMetaData.size(); i++) {
+    for (size_t i = 0; i < pointMetaData.size(); i++) {
       if (pointMetaData.at(i).find("MeanCheck") != std::string::npos) {
         meanString += " " + std::to_string(i) + ",";
       }


### PR DESCRIPTION
Update contains: 
- Option that multiple trendings on a canvas can be checked in parallel (e.g. output of SliceTrendingTask) 
- Bug fix: sometimes array for uncertainties is non-zero, but all contents are zero. In this case, don't use uncertainties of single points in the checking