### PR TITLE
Optimise TRD TrackingTask

### DIFF
--- a/Modules/TRD/TRDQC.json
+++ b/Modules/TRD/TRDQC.json
@@ -123,7 +123,7 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "tracks:TRD/TRACKINGQC;trigrectrk:TRD/TRGREC_ITSTPC"
+          "query": "tracksqc:TRD/TRACKINGQC;tracksTRD:TRD/MATCH_ITSTPC;trigrectrk:TRD/TRGREC_ITSTPC"
         },
         "taskParameters": {
           "pTminvalue": "0.0"

--- a/Modules/TRD/src/TrackingTask.cxx
+++ b/Modules/TRD/src/TrackingTask.cxx
@@ -85,7 +85,7 @@ void TrackingTask::monitorData(o2::framework::ProcessingContext& ctx)
     int end = start + tracktrig.getNumberOfTracks();
     mNtracks->Fill(tracktrig.getNumberOfTracks());
     for (int itrack = start; itrack < end; ++itrack) {
-      auto& trackTRD = trackTRDArr[itrack];
+      const auto& trackTRD = trackTRDArr[itrack];
       // remove tracks with pt below threshold
       if (trackTRD.getPt() < mPtMin) {
         continue;
@@ -98,17 +98,12 @@ void TrackingTask::monitorData(o2::framework::ProcessingContext& ctx)
       mTrackEta->Fill(trackTRD.getEta());
       // find charge bin of the track
       int charge = trackTRD.getCharge() > 0 ? 0 : 1;
-      // flag to fill objects only once per track
-      bool fillOnce = false;
+      // eta-phi distribution of tracklets per layer
+      mTrackletsEtaPhi[charge]->Fill(trackTRD.getEta(), trackTRD.getPhiPos(), trackTRD.getNtracklets());
       for (int iLayer = 0; iLayer < NLAYER; iLayer++) {
         // skip layers with no tracklet
         if (trackTRD.getTrackletIndex(iLayer) < 0) {
           continue;
-        }
-        if (!fillOnce) {
-          // eta-phi distribution of tracklets per layer
-          mTrackletsEtaPhi[charge]->Fill(trackTRD.getEta(), trackTRD.getPhiPos(), trackTRD.getNtracklets());
-          fillOnce = true;
         }
         // eta-phi distribution per layer
         mTracksEtaPhiPerLayer[charge][iLayer]->Fill(trackTRD.getEta(), trackTRD.getPhiPos());
@@ -206,7 +201,7 @@ void TrackingTask::buildHistograms()
 
   mTrackPt = new TH1D("TrackPt", "p_{T} Distribution", 100, 0.0, 10.0);
   axisConfig(mTrackPt, "p_{T}", "Counts", "", 1, 1.0, 1.1);
-  publishObject(mTrackPt);
+  publishObject(mTrackPt, "", "logx");
 
   mTrackChi2 = new TH1D("TrackChi2", "Reduced Chi2Distribution", 100, 0.0, 10.0);
   axisConfig(mTrackChi2, "reduced #chi^{2}", "Counts", "", 1, 1.0, 1.1);


### PR DESCRIPTION
1. Removed mixing of `TrackTriggerRecord` and `TrackQC` classes.
2. Now, track variables like eta, phi etc. are taken from `TrackTRD`.
3. While `TrackQC` is only used for residuals related information.
4. Required queries are added to the json.