### PR TITLE
MCH: various fixes to post-processing and checks

### DIFF
--- a/Modules/MUON/MCH/include/MCH/Helpers.h
+++ b/Modules/MUON/MCH/include/MCH/Helpers.h
@@ -137,6 +137,26 @@ struct CcdbObjectHelper {
 
 //_________________________________________________________________________________________
 
+struct QualityObjectHelper {
+  QualityObjectHelper();
+  QualityObjectHelper(std::string p, std::string n);
+
+  bool update(o2::quality_control::repository::DatabaseInterface* qcdb,
+              long timeStamp = -1,
+              const o2::quality_control::core::Activity& activity = {});
+  void setStartIme();
+  long getTimeStamp() { return mTimeStamp; }
+
+  std::shared_ptr<o2::quality_control::core::QualityObject> mObject;
+  bool mUpdated{ false };
+  std::string mPath;
+  std::string mName;
+  uint64_t mTimeStart{ 0 };
+  uint64_t mTimeStamp{ 0 };
+};
+
+//_________________________________________________________________________________________
+
 class TrendGraph : public TCanvas
 {
  public:

--- a/Modules/MUON/MCH/include/MCH/QualityPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/QualityPostProcessing.h
@@ -67,7 +67,7 @@ class QualityPostProcessing : public PostProcessingInterface
   std::string mMessageNull;
 
   // CCDB object accessors
-  std::vector<CcdbObjectHelper> mCcdbObjects;
+  std::vector<QualityObjectHelper> mCcdbObjects;
   std::vector<std::string> mCheckerMessages;
 
   // Quality histograms ===============================================

--- a/Modules/MUON/MCH/src/DecodingCheck.cxx
+++ b/Modules/MUON/MCH/src/DecodingCheck.cxx
@@ -25,7 +25,6 @@
 #include <TH2.h>
 #include <TList.h>
 #include <TMath.h>
-#include <TPaveText.h>
 #include <TLine.h>
 #include <iostream>
 #include <fstream>
@@ -209,31 +208,11 @@ void DecodingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
     l->SetLineStyle(kDashed);
     h->GetListOfFunctions()->Add(l);
 
-    TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-    msg->SetBorderSize(0);
-
     if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("All errors within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-
       h->SetFillColor(kGreen);
     } else if (checkResult == Quality::Bad) {
-      ILOG(Debug, Devel) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Too many errors, call MCH on-call.");
-      msg->SetFillColor(kRed);
-
       h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
-      ILOG(Debug, Devel) << "Quality::medium, setting to orange";
-
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, check Infologger");
-      msg->SetFillColor(kYellow);
       h->SetFillColor(kOrange);
     }
     h->SetLineColor(kBlack);
@@ -258,31 +237,11 @@ void DecodingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
     l->SetLineStyle(kDashed);
     h->GetListOfFunctions()->Add(l);
 
-    TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-    msg->SetBorderSize(0);
-
     if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("All errors within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-
       h->SetFillColor(kGreen);
     } else if (checkResult == Quality::Bad) {
-      ILOG(Debug, Devel) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Too many errors, call MCH on-call.");
-      msg->SetFillColor(kRed);
-
       h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
-      ILOG(Debug, Devel) << "Quality::medium, setting to orange";
-
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, check Infologger");
-      msg->SetFillColor(kYellow);
       h->SetFillColor(kOrange);
     }
     h->SetLineColor(kBlack);

--- a/Modules/MUON/MCH/src/DigitsCheck.cxx
+++ b/Modules/MUON/MCH/src/DigitsCheck.cxx
@@ -26,7 +26,6 @@
 #include <TCanvas.h>
 #include <TList.h>
 #include <TMath.h>
-#include <TPaveText.h>
 #include <TLine.h>
 #include <iostream>
 #include <fstream>
@@ -199,7 +198,7 @@ Quality DigitsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
 
     if (matchHistName(mo->getName(), mGoodChanFracRatioHistName)) {
       TH1F* h = getHisto<TH1F>(mo);
-      if (h) {
+      if (h && h->GetEntries() > 0) {
         auto q = checkBadChannelsRatio(h);
         mQualityChecker.addCheckResult(q);
       }
@@ -265,31 +264,12 @@ void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
     h->SetDrawOption("colz");
     h->SetMinimum(mRatePlotScaleMin);
     h->SetMaximum(mRatePlotScaleMax);
-    TPaveText* msg = new TPaveText(0.1, 0.9, 0.9, 0.95, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-    msg->SetBorderSize(0);
 
     if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("All occupancies within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-
       h->SetFillColor(kGreen);
     } else if (checkResult == Quality::Bad) {
-      LOG(info) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Call MCH experts");
-      msg->SetFillColor(kRed);
-
       h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
-      LOG(info) << "Quality::medium, setting to orange";
-
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, call MCH experts");
-      msg->SetFillColor(kYellow);
       h->SetFillColor(kOrange);
     }
     h->SetLineColor(kBlack);
@@ -362,33 +342,11 @@ void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
       h->GetListOfFunctions()->Add(l);
     }
 
-    h->SetFillColor(kGreen);
-
-    TPaveText* msg = new TPaveText(0.1, 0.903, 0.9, 0.945, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-    msg->SetBorderSize(0);
-
     if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("All occupancies within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-
       h->SetFillColor(kGreen);
     } else if (checkResult == Quality::Bad) {
-      LOG(info) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Call MCH experts");
-      msg->SetFillColor(kRed);
-
       h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
-      LOG(info) << "Quality::medium, setting to orange";
-
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, call MCH experts");
-      msg->SetFillColor(kYellow);
       h->SetFillColor(kOrange);
     }
     h->SetLineColor(kBlack);
@@ -442,33 +400,11 @@ void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
       h->GetListOfFunctions()->Add(l);
     }
 
-    h->SetFillColor(kGreen);
-
-    TPaveText* msg = new TPaveText(0.1, 0.903, 0.9, 0.945, "NDC");
-    h->GetListOfFunctions()->Add(msg);
-    msg->SetName(Form("%s_msg", mo->GetName()));
-    msg->SetBorderSize(0);
-
     if (checkResult == Quality::Good) {
-      msg->Clear();
-      msg->AddText("All occupancies within limits: OK!!!");
-      msg->SetFillColor(kGreen);
-
       h->SetFillColor(kGreen);
     } else if (checkResult == Quality::Bad) {
-      LOG(info) << "Quality::Bad, setting to red";
-      //
-      msg->Clear();
-      msg->AddText("Call MCH experts");
-      msg->SetFillColor(kRed);
-
       h->SetFillColor(kRed);
     } else if (checkResult == Quality::Medium) {
-      LOG(info) << "Quality::medium, setting to orange";
-
-      msg->Clear();
-      msg->AddText("No entries. If MCH in the run, call MCH experts");
-      msg->SetFillColor(kYellow);
       h->SetFillColor(kOrange);
     }
     h->SetLineColor(kBlack);

--- a/Modules/MUON/MCH/src/MCHAggregator.cxx
+++ b/Modules/MUON/MCH/src/MCHAggregator.cxx
@@ -29,12 +29,6 @@ std::map<std::string, Quality> MCHAggregator::aggregate(QualityObjectsMapType& q
 {
   std::map<std::string, Quality> result;
 
-  ILOG(Info, Devel) << "Entered MCHAggregator::aggregate" << ENDM;
-  ILOG(Info, Devel) << "   received a list of size : " << qoMap.size() << ENDM;
-  for (const auto& item : qoMap) {
-    ILOG(Info, Devel) << "Object: " << (*item.second) << ENDM;
-  }
-
   // we return the worse quality of all the objects we receive
   Quality current = Quality::Good;
   for (auto qo : qoMap) {
@@ -43,7 +37,6 @@ std::map<std::string, Quality> MCHAggregator::aggregate(QualityObjectsMapType& q
     }
   }
 
-  ILOG(Info, Devel) << "   result: " << current << ENDM;
   result["MCHQuality"] = current;
 
   return result;

--- a/Modules/MUON/MCH/src/PreclustersCheck.cxx
+++ b/Modules/MUON/MCH/src/PreclustersCheck.cxx
@@ -27,7 +27,6 @@
 #include <TList.h>
 #include <TLine.h>
 #include <TMath.h>
-#include <TPaveText.h>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -317,29 +316,11 @@ void PreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality check
     if ((mo->getName().find("MeanEfficiencyB") != std::string::npos) ||
         (mo->getName().find("MeanEfficiencyNB") != std::string::npos) ||
         (mo->getName().find("MeanEfficiencyRefRatio") != std::string::npos)) {
-      TPaveText* msg = new TPaveText(0.3, 0.9, 0.7, 0.95, "NDC");
-      h->GetListOfFunctions()->Add(msg);
-      msg->SetName(Form("%s_msg", mo->GetName()));
-
       if (checkResult == Quality::Good) {
-        msg->Clear();
-        msg->AddText("Pseudo-efficiency consistently within limits: OK!!!");
-        msg->SetFillColor(kGreen);
-
         h->SetFillColor(kGreen);
       } else if (checkResult == Quality::Bad) {
-        LOG(info) << "Quality::Bad, setting to red";
-        msg->Clear();
-        msg->AddText("Call MCH experts");
-        msg->SetFillColor(kRed);
-
         h->SetFillColor(kRed);
       } else if (checkResult == Quality::Medium) {
-        LOG(info) << "Quality::medium, setting to orange";
-        msg->Clear();
-        msg->AddText("No entries. If MCH in the run, call MCH experts");
-        msg->SetFillColor(kYellow);
-
         h->SetFillColor(kOrange);
       }
       h->SetLineColor(kBlack);

--- a/Modules/MUON/MCH/src/QualityPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/QualityPostProcessing.cxx
@@ -85,7 +85,7 @@ void QualityPostProcessing::update(Trigger t, framework::ServiceRegistryRef serv
 
   for (auto& obj : mCcdbObjects) {
     if (obj.update(&qcdb, t.timestamp, t.activity)) {
-      auto qo = obj.get<QualityObject>();
+      auto qo = obj.mObject;
       if (qo) {
         auto time = obj.getTimeStamp() / 1000; // ROOT expects seconds since epoch
         int Q = 0;
@@ -103,14 +103,17 @@ void QualityPostProcessing::update(Trigger t, framework::ServiceRegistryRef serv
           Qstr = fmt::format("#color[{}]", kGreen + 2) + "{Good}";
         }
 
-        auto iter1 = mHistogramsQuality.find(obj.mName);
-        if (iter1 != mHistogramsQuality.end()) {
-          iter1->second->Fill(Q + 0.5);
-        }
+        // only update plots/trends when the object is updated
+        if (obj.mUpdated) {
+          auto iter1 = mHistogramsQuality.find(obj.mName);
+          if (iter1 != mHistogramsQuality.end()) {
+            iter1->second->Fill(Q + 0.5);
+          }
 
-        auto iter2 = mTrendsQuality.find(obj.mName);
-        if (iter2 != mTrendsQuality.end()) {
-          iter2->second->update(time, qo->getQuality());
+          auto iter2 = mTrendsQuality.find(obj.mName);
+          if (iter2 != mTrendsQuality.end()) {
+            iter2->second->update(time, qo->getQuality());
+          }
         }
 
         if (qo->getName() == mAggregatedQualityName) {


### PR DESCRIPTION
- fixed retrieval of QualityObjects from CCDB
- fixed display of QualityObjects in summary canvas when objects are not updated
- fixed bug in check of "good channels ratio" plot when no reference is available
- removed verbose infologger messages
- made plots and reductors optional in post-processing configuration
- removed PaveText panel with check result on individual plots