### PR TITLE
ITS Tracks online: new MOs resetting each cycle

### DIFF
--- a/Modules/ITS/include/ITS/ITSTrackTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackTask.h
@@ -62,6 +62,7 @@ class ITSTrackTask : public TaskInterface
 
   std::vector<TObject*> mPublishedObjects;
   TH1D* hNClusters;
+  TH1D* hNClustersReset;
   TH1D* hTrackEta;
   TH1D* hTrackPhi;
   TH1D* hVerticesRof;
@@ -72,6 +73,7 @@ class ITSTrackTask : public TaskInterface
   TH1D* hVertexContributors;
   TH1D* hAssociatedClusterFraction;
   TH1D* hNtracks;
+  TH1D* hNtracksReset;
   TH2D* hNClustersPerTrackEta;
   TH2D* hClusterVsBunchCrossing;
   TH2D* hNClusterVsChipITS;
@@ -83,6 +85,7 @@ class ITSTrackTask : public TaskInterface
   Int_t mDoTTree = 0;
   Int_t mNTracks = 0;
   Int_t mNRofs = 0;
+  bool isNewCycle = true;
   int nBCbins = 103;
   long int mTimestamp = -1;
   int nVertices = 0;

--- a/Modules/ITS/src/ITSRawTask.cxx
+++ b/Modules/ITS/src/ITSRawTask.cxx
@@ -200,7 +200,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
   getProcessStatus(ctx.inputs().get<int>("Finish"), FileFinish);
   updateFile(ctx.inputs().get<int>("Run"), ctx.inputs().get<int>("EP"), FileID);
 
-  //Will Fix Later//
+  // Will Fix Later//
 
   int ResetDecision = ctx.inputs().get<int>("in");
   ILOG(Info, Support) << "Reset Histogram Decision = " << ResetDecision
@@ -245,7 +245,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
     //    mNEvent = pixeldata.getROFrame();
     mNEvent = events.get()[i].NEvent;
     i++;
-    //cout << "Event Compare: " << NEvent << ", " << NEventPre << endl;
+    // cout << "Event Compare: " << NEvent << ", " << NEventPre << endl;
 
     if (mNEvent % occUpdateFrequency == 0 && mNEvent > 0 && mNEvent != mNEventPre) {
       updateOccupancyPlots(mNEventPre);
@@ -339,7 +339,7 @@ void ITSRawTask::monitorData(o2::framework::ProcessingContext& ctx)
   if (mNEventPre > 0) {
     updateOccupancyPlots(mNEventPre);
   }
-  //cout << "EndUpdateOcc " << NEventPre <<endl;
+  // cout << "EndUpdateOcc " << NEventPre <<endl;
   end = std::chrono::high_resolution_clock::now();
   difference = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
   ILOG(Info, Support) << "Time After Loop = " << difference / 1000.0 << "s"
@@ -401,7 +401,7 @@ void ITSRawTask::createGlobalHistos()
   hErrorFile = new TH2D("General/ErrorFile", "Decoding Errors vs File ID", NFiles + 1, -0.5, NFiles + 0.5, NError, 0.5, NError + 0.5);
   formatAxes(hErrorFile, "File ID (data-link)", "Error ID");
   formatStatistics(hErrorFile);
-  //format2DZaxis(hErrorFile);
+  // format2DZaxis(hErrorFile);
   hErrorFile->GetZaxis()->SetTitle("Counts");
   hErrorFile->SetMinimum(0);
 
@@ -640,7 +640,7 @@ void ITSRawTask::addMetadata(int runID, int EpID, int fileID)
 void ITSRawTask::getProcessStatus(int aInfoFile, int& aFileFinish)
 {
   aFileFinish = aInfoFile % 10;
-  //cout<<"aInfoFile = "<<aInfoFile<<endl;
+  // cout<<"aInfoFile = "<<aInfoFile<<endl;
   FileRest = (aInfoFile - aFileFinish) / 10;
 
   ILOG(Info, Support) << "FileFinish = " << aFileFinish << ENDM;
@@ -668,8 +668,8 @@ void ITSRawTask::updateFile(int aRunID, int aEpID, int aFileID)
     hFileNameInfo->Fill(0.5);
     hFileNameInfo->SetTitle(Form("Current File Name: %s", FileName.Data()));
     mTotalFileDone = mTotalFileDone + 1;
-    //hInfoCanvas->SetBinContent(1,FileID);
-    //hInfoCanvas->SetBinContent(2,TotalFileDone);
+    // hInfoCanvas->SetBinContent(1,FileID);
+    // hInfoCanvas->SetBinContent(2,TotalFileDone);
     ptFileName->Clear();
     ptNFile->Clear();
     ptFileName->AddText(Form("File Being Proccessed: %s", FileName.Data()));
@@ -760,7 +760,7 @@ void ITSRawTask::updateOccupancyPlots(int nEvents)
     if (!mlayerEnable[iLayer]) {
       continue;
     }
-    //hEtaPhiHitmap[iLayer]->Reset();
+    // hEtaPhiHitmap[iLayer]->Reset();
     for (int iStave = 0; iStave < NStaves[iLayer]; iStave++) {
       for (int iHic = 0; iHic < nHicPerStave[iLayer]; iHic++) {
         for (int iChip = 0; iChip < nChipsPerHic[iLayer]; iChip++) {
@@ -805,7 +805,7 @@ void ITSRawTask::enableLayers()
   for (int i = 0; i < 7; i++) {
     mlayerEnable[i] = stoi(enable[i]);
   }
-  //cout << "LayerEnable = " << " layer0 = " << layerEnable[0] << " layer5 = " << layerEnable[5] <<  endl;
+  // cout << "LayerEnable = " << " layer0 = " << layerEnable[0] << " layer5 = " << layerEnable[5] <<  endl;
 }
 
 } // namespace its

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -310,7 +310,6 @@ void ITSTrackTask::reset()
   hNClustersPerTrackEta->Reset();
   hClusterVsBunchCrossing->Reset();
   hNClusterVsChipITS->Reset();
-
 }
 
 void ITSTrackTask::createAllHistos()

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -291,10 +291,10 @@ void ITSTrackTask::endOfActivity(Activity& /*activity*/)
 
 void ITSTrackTask::reset()
 {
+
   ILOG(Debug, Devel) << "Resetting the histograms" << ENDM;
   hAngularDistribution->Reset();
   hNClusters->Reset();
-  hNClustersReset->Reset();
   hTrackPhi->Reset();
   hTrackEta->Reset();
   hVerticesRof->Reset();
@@ -307,10 +307,10 @@ void ITSTrackTask::reset()
 
   hAssociatedClusterFraction->Reset();
   hNtracks->Reset();
-  hNtracksReset->Reset();
   hNClustersPerTrackEta->Reset();
   hClusterVsBunchCrossing->Reset();
   hNClusterVsChipITS->Reset();
+
 }
 
 void ITSTrackTask::createAllHistos()

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -44,6 +44,7 @@ ITSTrackTask::ITSTrackTask() : TaskInterface()
 ITSTrackTask::~ITSTrackTask()
 {
   delete hNClusters;
+  delete hNClustersReset;
   delete hTrackEta;
   delete hTrackPhi;
   delete hAngularDistribution;
@@ -53,6 +54,7 @@ ITSTrackTask::~ITSTrackTask()
   delete hVertexContributors;
   delete hAssociatedClusterFraction;
   delete hNtracks;
+  delete hNtracksReset;
   delete hNClustersPerTrackEta;
   delete hClusterVsBunchCrossing;
   delete hNClusterVsChipITS;
@@ -88,12 +90,19 @@ void ITSTrackTask::startOfActivity(Activity& /*activity*/)
 void ITSTrackTask::startOfCycle()
 {
   ILOG(Debug, Devel) << "startOfCycle" << ENDM;
+  isNewCycle = true;
 }
 
 void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
   ILOG(Info, Support) << "START DOING QC General" << ENDM;
+
+  if (isNewCycle) {
+    hNClustersReset->Reset();
+    hNtracksReset->Reset();
+    isNewCycle = false;
+  }
 
   if (mTimestamp == -1) { // get dict from ccdb
     mTimestamp = std::stol(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "dicttimestamp", "0"));
@@ -197,6 +206,7 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
       hTrackPhi->Fill(out.getPhi());
       hAngularDistribution->Fill(Eta, out.getPhi());
       hNClusters->Fill(track.getNumberOfClusters());
+      hNClustersReset->Fill(track.getNumberOfClusters());
 
       vMap.emplace_back(track.getPattern());
       vEta.emplace_back(Eta);
@@ -224,6 +234,7 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
     float clusterRatio = nTotCls > 0 ? (float)nClusterCntTrack / (float)nTotCls : -1;
     hAssociatedClusterFraction->Fill(clusterRatio);
     hNtracks->Fill(nTracks);
+    hNtracksReset->Fill(nTracks);
 
     const auto bcdata = trackRofArr[iROF].getBCData();
     hClusterVsBunchCrossing->Fill(bcdata.bc, clusterRatio);
@@ -283,6 +294,7 @@ void ITSTrackTask::reset()
   ILOG(Debug, Devel) << "Resetting the histograms" << ENDM;
   hAngularDistribution->Reset();
   hNClusters->Reset();
+  hNClustersReset->Reset();
   hTrackPhi->Reset();
   hTrackEta->Reset();
   hVerticesRof->Reset();
@@ -295,6 +307,7 @@ void ITSTrackTask::reset()
 
   hAssociatedClusterFraction->Reset();
   hNtracks->Reset();
+  hNtracksReset->Reset();
   hNClustersPerTrackEta->Reset();
   hClusterVsBunchCrossing->Reset();
   hNClusterVsChipITS->Reset();
@@ -321,6 +334,12 @@ void ITSTrackTask::createAllHistos()
   addObject(hNClusters);
   formatAxes(hNClusters, "Number of clusters per Track", "Counts", 1, 1.10);
   hNClusters->SetStats(0);
+
+  hNClustersReset = new TH1D("NClustersReset", "NClustersReset", 15, -0.5, 14.5);
+  hNClustersReset->SetTitle("hNClusters in one cycle");
+  addObject(hNClustersReset);
+  formatAxes(hNClustersReset, "Number of clusters per Track", "Counts", 1, 1.10);
+  hNClustersReset->SetStats(0);
 
   hTrackEta = new TH1D("EtaDistribution", "EtaDistribution", 40, -2.0, 2.0);
   hTrackEta->SetBit(TH1::kIsAverage);
@@ -377,6 +396,12 @@ void ITSTrackTask::createAllHistos()
   addObject(hNtracks);
   formatAxes(hNtracks, "# tracks", "Counts", 1, 1.10);
   hNtracks->SetStats(0);
+
+  hNtracksReset = new TH1D("NtracksReset", "NtracksReset", (int)mNtracksMAX, 0, mNtracksMAX);
+  hNtracksReset->SetTitle("The number of tracks event by event for last QC cycle");
+  addObject(hNtracksReset);
+  formatAxes(hNtracksReset, "# tracks", "Counts", 1, 1.10);
+  hNtracksReset->SetStats(0);
 
   hNClustersPerTrackEta = new TH2D("NClustersPerTrackEta", "NClustersPerTrackEta", 400, -2.0, 2.0, 15, -0.5, 14.5);
   hNClustersPerTrackEta->SetBit(TH1::kIsAverage);


### PR DESCRIPTION
Added two new MO resetting each cycle, which will be used in PP trends:
1) Number of tracks per event
2) Number of clusters used to reconstruct track