### PR TITLE
TRD tracked matched pulseheight fixup

### DIFF
--- a/Modules/TRD/include/TRD/PulseHeightTrackMatch.h
+++ b/Modules/TRD/include/TRD/PulseHeightTrackMatch.h
@@ -69,6 +69,9 @@ class PulseHeightTrackMatch final : public TaskInterface
   std::shared_ptr<TH1F> mParsingTimePerTF;
   std::shared_ptr<TH1F> mTracksPerEvent;
   std::shared_ptr<TH1F> mTrackletsPerMatchedTrack;
+  std::shared_ptr<TH1F> mDebugCounter;
+  std::shared_ptr<TH1F> mTriggerMatches;
+  std::shared_ptr<TH1F> mTriggerRecordsMatchesDigits;
   std::shared_ptr<TProfile> mPulseHeightpro = nullptr;
   std::shared_ptr<TProfile2D> mPulseHeightperchamber = nullptr;
   // information pulled from ccdb


### PR DESCRIPTION
Pulseheight spectrum that is matched to tracks does not account for when the pileup info is not there, and time is 0.

Additional plots added, for expert for diagnostics.