### PR TITLE
[FOCAL-8] Apply pedestal subtraction for pad ADCs

### DIFF
--- a/Modules/FOCAL/CMakeLists.txt
+++ b/Modules/FOCAL/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcFOCAL PUBLIC O2QualityControl O2::DetectorsRaw O2::Headers O2::ITSMFTReconstruction O2::DataFormatsFOCAL O2::FOCALReconstruction)
+target_link_libraries(O2QcFOCAL PUBLIC O2QualityControl O2::DetectorsRaw O2::Headers O2::ITSMFTReconstruction O2::DataFormatsFOCAL O2::FOCALReconstruction O2::FOCALCalib)
 
 install(TARGETS O2QcFOCAL
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
+++ b/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
@@ -33,6 +33,11 @@ class TH1;
 class TH2;
 class TProfile2D;
 
+namespace o2::focal
+{
+class PadPedestal;
+}
+
 using namespace o2::quality_control::core;
 
 namespace o2::quality_control_modules::focal
@@ -85,6 +90,7 @@ class TestbeamRawTask final : public TaskInterface
   o2::focal::PadDecoder mPadDecoder;                                              ///< Decoder for pad data
   o2::focal::PadMapper mPadMapper;                                                ///< Mapping for Pads
   o2::focal::PixelDecoder mPixelDecoder;                                          ///< Decoder for pixel data
+  o2::focal::PadPedestal* mPadPedestalHandler = nullptr;                          ///< Pedestal handler for pad pedestal subtraction
   std::unique_ptr<o2::focal::PixelMapper> mPixelMapper;                           ///< Testbeam mapping for pixels
   std::unordered_map<o2::InteractionRecord, int> mPixelNHitsAll;                  ///< Number of hits / event all layers
   std::array<std::unordered_map<o2::InteractionRecord, int>, 2> mPixelNHitsLayer; ///< Number of hits / event layer
@@ -94,6 +100,7 @@ class TestbeamRawTask final : public TaskInterface
   bool mDebugMode = false;                                                        ///< Additional debug verbosity
   bool mDisablePads = false;                                                      ///< Disable pads
   bool mDisablePixels = false;                                                    ///< Disable pixels
+  bool mEnablePedestalSubtraction = false;                                        ///< Enable pedestal subtraction pads
 
   /////////////////////////////////////////////////////////////////////////////////////
   /// Pad histograms


### PR DESCRIPTION
Pedestal subtraction configurable, must be enabled via task parameter "SubtractPadPedestals"

Adds dependency on lightweight FOCALCalib library