### PR TITLE
MFT: add histos with information about associated clusters 

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTTrackTask.h
+++ b/Modules/MFT/include/MFT/QcMFTTrackTask.h
@@ -52,11 +52,6 @@ class QcMFTTrackTask /*final*/ : public TaskInterface // todo add back the "fina
   void endOfActivity(Activity& activity) override;
   void reset() override;
 
-  double orbitToSeconds(uint32_t orbit, uint32_t refOrbit)
-  {
-    return (orbit - refOrbit) * o2::constants::lhc::LHCOrbitNS / 1E9;
-  }
-
  private:
   std::unique_ptr<TH1F> mNumberOfTracksPerTF = nullptr;
   std::unique_ptr<TH1F> mTrackNumberOfClusters = nullptr;
@@ -80,9 +75,8 @@ class QcMFTTrackTask /*final*/ : public TaskInterface // todo add back the "fina
   std::unique_ptr<TH1F> mTrackTanl = nullptr;
   std::unique_ptr<TH1F> mTrackROFNEntries = nullptr;
   std::unique_ptr<TH1F> mTracksBC = nullptr;
-  std::unique_ptr<TH1F> mNOfTracksTime = nullptr;
-
-  uint32_t mRefOrbit = -1; // Reference orbit used in relative time calculation
+  std::unique_ptr<TH1F> mAssociatedClusterFraction = nullptr;
+  std::unique_ptr<TH2F> mClusterRatioVsBunchCrossing = nullptr; 
 
   static constexpr array<short, 7> sMinNClustersList = { 4, 5, 6, 7, 8, 9, 10 };
 };

--- a/Modules/MFT/include/MFT/QcMFTTrackTask.h
+++ b/Modules/MFT/include/MFT/QcMFTTrackTask.h
@@ -76,7 +76,7 @@ class QcMFTTrackTask /*final*/ : public TaskInterface // todo add back the "fina
   std::unique_ptr<TH1F> mTrackROFNEntries = nullptr;
   std::unique_ptr<TH1F> mTracksBC = nullptr;
   std::unique_ptr<TH1F> mAssociatedClusterFraction = nullptr;
-  std::unique_ptr<TH2F> mClusterRatioVsBunchCrossing = nullptr; 
+  std::unique_ptr<TH2F> mClusterRatioVsBunchCrossing = nullptr;
 
   static constexpr array<short, 7> sMinNClustersList = { 4, 5, 6, 7, 8, 9, 10 };
 };

--- a/Modules/MFT/mft-tracks.json
+++ b/Modules/MFT/mft-tracks.json
@@ -51,7 +51,7 @@
       "id" : "mft-track",
       "active" : "true",
       "machines" : [],
-      "query" : "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0",
+      "query" : "tracks:MFT/TRACKS/0;tracksrofs:MFT/MFTTrackROF/0;clustersrofs:MFT/CLUSTERSROF/0",
       "samplingConditions" : [
         {
           "condition" : "random",

--- a/Modules/MFT/src/QcMFTTrackTask.cxx
+++ b/Modules/MFT/src/QcMFTTrackTask.cxx
@@ -75,7 +75,7 @@ void QcMFTTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   // Creating histos
 
-  double maxTracksPerTF = 400;
+  double maxTracksPerTF = 5000;
 
   mNumberOfTracksPerTF = std::make_unique<TH1F>("mMFTTracksPerTF",
                                                 "Number of tracks per TimeFrame; Number of tracks per TF", maxTracksPerTF, -0.5, maxTracksPerTF - 0.5);
@@ -156,10 +156,18 @@ void QcMFTTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mTracksBC.get());
   getObjectsManager()->setDisplayHint(mTracksBC.get(), "hist");
 
-  mNOfTracksTime = std::make_unique<TH1F>("mNOfTracksTime", "Number of tracks per time bin; time (s); # entries", NofTimeBins, 0, MaxDuration);
-  mNOfTracksTime->SetMinimum(0.1);
-  getObjectsManager()->startPublishing(mNOfTracksTime.get());
-  getObjectsManager()->setDisplayHint(mNOfTracksTime.get(), "hist");
+  mAssociatedClusterFraction = std::make_unique<TH1F>("mAssociatedClusterFraction", "Fraction of clusters in tracks; Clusters in tracks / All clusters; # entries", 100, 0, 1);
+  getObjectsManager()->startPublishing(mAssociatedClusterFraction.get());
+  getObjectsManager()->setDisplayHint(mAssociatedClusterFraction.get(), "hist logy");
+
+
+  mClusterRatioVsBunchCrossing = std::make_unique<TH2F>("mClusterRatioVsBunchCrossing","Bunch Crossing ID vs Cluster Ratio;BC ID;Fraction of clusters in tracks", 
+  o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches, 100, 0, 1);
+  getObjectsManager()->startPublishing(mClusterRatioVsBunchCrossing.get());
+  getObjectsManager()->setDisplayHint(mClusterRatioVsBunchCrossing.get(), "colz logz");
+  
+
+
 }
 
 void QcMFTTrackTask::startOfActivity(Activity& /*activity*/)
@@ -180,22 +188,37 @@ void QcMFTTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
   // get the tracks
   const auto tracks = ctx.inputs().get<gsl::span<o2::mft::TrackMFT>>("tracks");
   const auto tracksrofs = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("tracksrofs");
-
-  // get correct timing info of the first TF orbit
-  if (mRefOrbit == -1) {
-    mRefOrbit = ctx.services().get<o2::framework::TimingInfo>().firstTForbit;
-  }
+  const auto clustersrofs = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clustersrofs");
 
   // fill the tracks histogram
 
   mNumberOfTracksPerTF->Fill(tracks.size());
 
-  for (const auto& rof : tracksrofs) {
-    mTrackROFNEntries->Fill(rof.getNEntries());
-    mTracksBC->Fill(rof.getBCData().bc, rof.getNEntries());
-    float seconds = orbitToSeconds(rof.getBCData().orbit, mRefOrbit) + rof.getBCData().bc * o2::constants::lhc::LHCBunchSpacingNS * 1e-9;
-    mNOfTracksTime->Fill(seconds, rof.getNEntries());
+  for (int iROF = 0; iROF < tracksrofs.size(); iROF++) {
+    int nClusterCountTrack = 0;
+    int nTracks = tracksrofs[iROF].getNEntries();
+
+    mTrackROFNEntries->Fill(nTracks); 
+
+    int start = tracksrofs[iROF].getFirstEntry();
+    int end = start + tracksrofs[iROF].getNEntries();
+
+    for (int itrack=start; itrack<end;itrack++){
+      auto& track = tracks[itrack];
+      nClusterCountTrack += track.getNumberOfPoints();
+    }
+
+    int nTotalClusters = clustersrofs[iROF].getNEntries();
+
+    float clusterRatio = nTotalClusters > 0 ? (float)nClusterCountTrack / (float)nTotalClusters : -1;
+
+    const auto bcData = tracksrofs[iROF].getBCData();
+    mTracksBC->Fill(bcData.bc, nTracks);
+    mAssociatedClusterFraction->Fill(clusterRatio);
+    mClusterRatioVsBunchCrossing->Fill(bcData.bc, clusterRatio);
   }
+
+
 
   for (auto& oneTrack : tracks) {
     mTrackNumberOfClusters->Fill(oneTrack.getNumberOfPoints());
@@ -278,7 +301,8 @@ void QcMFTTrackTask::reset()
   mTrackTanl->Reset();
   mTrackROFNEntries->Reset();
   mTracksBC->Reset();
-  mNOfTracksTime->Reset();
+  mAssociatedClusterFraction->Reset();
+  mClusterRatioVsBunchCrossing->Reset();
 }
 
 } // namespace o2::quality_control_modules::mft

--- a/Modules/MFT/src/QcMFTTrackTask.cxx
+++ b/Modules/MFT/src/QcMFTTrackTask.cxx
@@ -160,14 +160,10 @@ void QcMFTTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mAssociatedClusterFraction.get());
   getObjectsManager()->setDisplayHint(mAssociatedClusterFraction.get(), "hist logy");
 
-
-  mClusterRatioVsBunchCrossing = std::make_unique<TH2F>("mClusterRatioVsBunchCrossing","Bunch Crossing ID vs Cluster Ratio;BC ID;Fraction of clusters in tracks", 
-  o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches, 100, 0, 1);
+  mClusterRatioVsBunchCrossing = std::make_unique<TH2F>("mClusterRatioVsBunchCrossing", "Bunch Crossing ID vs Cluster Ratio;BC ID;Fraction of clusters in tracks",
+                                                        o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches, 100, 0, 1);
   getObjectsManager()->startPublishing(mClusterRatioVsBunchCrossing.get());
   getObjectsManager()->setDisplayHint(mClusterRatioVsBunchCrossing.get(), "colz logz");
-  
-
-
 }
 
 void QcMFTTrackTask::startOfActivity(Activity& /*activity*/)
@@ -198,12 +194,12 @@ void QcMFTTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
     int nClusterCountTrack = 0;
     int nTracks = tracksrofs[iROF].getNEntries();
 
-    mTrackROFNEntries->Fill(nTracks); 
+    mTrackROFNEntries->Fill(nTracks);
 
     int start = tracksrofs[iROF].getFirstEntry();
     int end = start + tracksrofs[iROF].getNEntries();
 
-    for (int itrack=start; itrack<end;itrack++){
+    for (int itrack = start; itrack < end; itrack++) {
       auto& track = tracks[itrack];
       nClusterCountTrack += track.getNumberOfPoints();
     }
@@ -217,8 +213,6 @@ void QcMFTTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
     mAssociatedClusterFraction->Fill(clusterRatio);
     mClusterRatioVsBunchCrossing->Fill(bcData.bc, clusterRatio);
   }
-
-
 
   for (auto& oneTrack : tracks) {
     mTrackNumberOfClusters->Fill(oneTrack.getNumberOfPoints());


### PR DESCRIPTION
- add new histos with information about associated clusters: fraction of clusters associated to tracks (1D and 2D with corresponding BCid)
- change range of TracksPerTF histo
- remove "tracks per time" histogram