### PR TITLE
ITS Decoding Errors: fixed scaling of FEEid plots

### DIFF
--- a/Modules/ITS/include/ITS/ITSDecodingErrorTask.h
+++ b/Modules/ITS/include/ITS/ITSDecodingErrorTask.h
@@ -22,9 +22,8 @@
 #include <TH1.h>
 #include <TH2.h>
 
-class TH2I;
-class TH1I;
-class TH2F;
+class TH2D;
+class TH1D;
 
 using namespace o2::quality_control::core;
 
@@ -65,8 +64,8 @@ class ITSDecodingErrorTask final : public TaskInterface
   TH1D* mChipErrorPlots;
   TH1D* mLinkErrorPlots;
   TH2D* mChipErrorVsChipid[7]; // chip ErrorVsChipid
-  TH2I* mLinkErrorVsFeeid;     // link ErrorVsFeeid
-  TH2I* mChipErrorVsFeeid;     // chip ErrorVsFeeid
+  TH2D* mLinkErrorVsFeeid;     // link ErrorVsFeeid
+  TH2D* mChipErrorVsFeeid;     // chip ErrorVsFeeid
 };
 
 } // namespace o2::quality_control_modules::its

--- a/Modules/ITS/src/ITSDecodingErrorTask.cxx
+++ b/Modules/ITS/src/ITSDecodingErrorTask.cxx
@@ -51,7 +51,7 @@ void ITSDecodingErrorTask::initialize(o2::framework::InitContext& /*ctx*/)
 
 void ITSDecodingErrorTask::createDecodingPlots()
 {
-  mLinkErrorVsFeeid = new TH2I("General/LinkErrorVsFeeid", "GBTLink errors per FeeId", NFees, 0, NFees, o2::itsmft::GBTLinkDecodingStat::NErrorsDefined, 0.5, o2::itsmft::GBTLinkDecodingStat::NErrorsDefined + 0.5);
+  mLinkErrorVsFeeid = new TH2D("General/LinkErrorVsFeeid", "GBTLink errors per FeeId", NFees, 0, NFees, o2::itsmft::GBTLinkDecodingStat::NErrorsDefined, 0.5, o2::itsmft::GBTLinkDecodingStat::NErrorsDefined + 0.5);
   mLinkErrorVsFeeid->SetMinimum(0);
   mLinkErrorVsFeeid->SetStats(0);
   getObjectsManager()->startPublishing(mLinkErrorVsFeeid);
@@ -61,7 +61,7 @@ void ITSDecodingErrorTask::createDecodingPlots()
     mChipErrorVsChipid[ilayer]->SetStats(0);
     getObjectsManager()->startPublishing(mChipErrorVsChipid[ilayer]);
   }
-  mChipErrorVsFeeid = new TH2I("General/ChipErrorVsFeeid", "Chip decoding errors per FeeId", NFees, 0, NFees, o2::itsmft::ChipStat::NErrorsDefined, 0.5, o2::itsmft::ChipStat::NErrorsDefined + 0.5);
+  mChipErrorVsFeeid = new TH2D("General/ChipErrorVsFeeid", "Chip decoding errors per FeeId", NFees, 0, NFees, o2::itsmft::ChipStat::NErrorsDefined, 0.5, o2::itsmft::ChipStat::NErrorsDefined + 0.5);
   mChipErrorVsFeeid->SetMinimum(0);
   mChipErrorVsFeeid->SetStats(0);
   getObjectsManager()->startPublishing(mChipErrorVsFeeid);
@@ -124,11 +124,6 @@ void ITSDecodingErrorTask::monitorData(o2::framework::ProcessingContext& ctx)
   auto decErrors = ctx.inputs().get<gsl::span<o2::itsmft::ChipError>>("decerrors");
 
   // multiply Error distributions before re-filling
-  mLinkErrorVsFeeid->Scale((double)mTFCount);
-  mChipErrorVsFeeid->Scale((double)mTFCount);
-  for (int ilayer = 0; ilayer < 7; ilayer++) {
-    mChipErrorVsChipid[ilayer]->Scale((double)mTFCount);
-  }
   for (const auto& le : linkErrors) {
     int istave = (int)(le.feeID & 0x00ff);
     int ilink = (int)((le.feeID & 0x0f00) >> 8);
@@ -167,15 +162,6 @@ void ITSDecodingErrorTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
 
   end = std::chrono::high_resolution_clock::now();
-  mTFCount++; // Number of TF
-  // Scale error distributions by latest number of TF
-  if (mTFCount > 0) {
-    mLinkErrorVsFeeid->Scale(1. / (double)mTFCount);
-    mChipErrorVsFeeid->Scale(1. / (double)mTFCount);
-    for (int ilayer = 0; ilayer < 7; ilayer++) {
-      mChipErrorVsChipid[ilayer]->Scale(1. / (double)mTFCount);
-    }
-  }
 }
 
 void ITSDecodingErrorTask::getParameters()


### PR DESCRIPTION
This commit fixes a problem when some plots was showing fraction of TFs into error state. For now, all plots provides TF counts. 

