### PR TITLE
Use 1D representation of MID strip occupancy

### DIFF
--- a/Modules/MUON/MID/CMakeLists.txt
+++ b/Modules/MUON/MID/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(
           src/CalibMQcCheck.cxx
           src/CalibMQcTask.cxx
           src/DigitsHelper.cxx
+          src/HistoHelper.cxx
   )
 
 target_include_directories(
@@ -47,6 +48,7 @@ add_root_dictionary(
           include/MID/CalibMQcTask.h
           include/MID/CalibMQcCheck.h
           include/MID/DigitsHelper.h
+          include/MID/HistoHelper.h
   LINKDEF include/MID/LinkDef.h)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/MID DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/QualityControl")

--- a/Modules/MUON/MID/CMakeLists.txt
+++ b/Modules/MUON/MID/CMakeLists.txt
@@ -15,15 +15,16 @@ target_sources(
           src/CalibQcCheck.cxx
           src/CalibQcTask.cxx
           src/CalibMQcCheck.cxx
-          src/CalibMQcTask.cxx)
+          src/CalibMQcTask.cxx
+          src/DigitsHelper.cxx
+  )
 
 target_include_directories(
   O2QcMID
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcMID PUBLIC O2QualityControl O2QcMUONCommon O2::MIDRaw O2::MIDQC O2::MIDSimulation
-                                     O2::MIDWorkflow)
+target_link_libraries(O2QcMID PUBLIC O2QualityControl O2QcMUONCommon O2::MIDRaw O2::MIDQC O2::MIDWorkflow O2::MIDGlobalMapping)
 
 install(
   TARGETS O2QcMID
@@ -41,10 +42,11 @@ add_root_dictionary(
           include/MID/ClustQcTask.h
           include/MID/TracksQcCheck.h
           include/MID/TracksQcTask.h
-	  include/MID/CalibQcTask.h
-	  include/MID/CalibQcCheck.h
-	  include/MID/CalibMQcTask.h
-	  include/MID/CalibMQcCheck.h
+          include/MID/CalibQcTask.h
+          include/MID/CalibQcCheck.h
+          include/MID/CalibMQcTask.h
+          include/MID/CalibMQcCheck.h
+          include/MID/DigitsHelper.h
   LINKDEF include/MID/LinkDef.h)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/MID DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/QualityControl")

--- a/Modules/MUON/MID/include/MID/CalibMQcTask.h
+++ b/Modules/MUON/MID/include/MID/CalibMQcTask.h
@@ -17,15 +17,15 @@
 #define QC_MODULE_MID_MIDCALIBMQCTASK_H
 
 #include "QualityControl/TaskInterface.h"
-#include "MIDRaw/CrateMasks.h"
-#include "MIDRaw/Decoder.h"
-#include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/FEEIdConfig.h"
-#include "MIDBase/Mapping.h"
+
+#include <array>
+#include <memory>
+#include "MID/DigitsHelper.h"
 
 class TH1F;
 class TH2F;
-class TProfile2D;
+class TH1F;
+class TH2F;
 
 using namespace o2::quality_control::core;
 
@@ -52,67 +52,20 @@ class CalibMQcTask final : public TaskInterface
   void reset() override;
 
  private:
-  ///////////////////////////
-  int mTF = 0;
-  int mNoiseROF = 0;
-  int mDeadROF = 0;
-  int mBadROF = 0;
+  void resetDisplayHistos();
+  DigitsHelper mDigitsHelper; ///! Digits helper
 
-  o2::mid::Mapping mMapping; ///< Mapping
+  std::unique_ptr<TH1F> mNoise{ nullptr };
+  std::array<std::unique_ptr<TH2F>, 4> mBendNoiseMap{};
+  std::array<std::unique_ptr<TH2F>, 4> mNBendNoiseMap{};
 
-  std::shared_ptr<TH1F> mMMultNoiseMT11B{ nullptr };
-  std::shared_ptr<TH1F> mMMultNoiseMT11NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultNoiseMT12B{ nullptr };
-  std::shared_ptr<TH1F> mMMultNoiseMT12NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultNoiseMT21B{ nullptr };
-  std::shared_ptr<TH1F> mMMultNoiseMT21NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultNoiseMT22B{ nullptr };
-  std::shared_ptr<TH1F> mMMultNoiseMT22NB{ nullptr };
+  std::unique_ptr<TH1F> mDead{ nullptr };
+  std::array<std::unique_ptr<TH2F>, 4> mBendDeadMap{};
+  std::array<std::unique_ptr<TH2F>, 4> mNBendDeadMap{};
 
-  std::shared_ptr<TH2I> mMBendNoiseMap11{ nullptr };
-  std::shared_ptr<TH2I> mMBendNoiseMap12{ nullptr };
-  std::shared_ptr<TH2I> mMBendNoiseMap21{ nullptr };
-  std::shared_ptr<TH2I> mMBendNoiseMap22{ nullptr };
-  std::shared_ptr<TH2I> mMNBendNoiseMap11{ nullptr };
-  std::shared_ptr<TH2I> mMNBendNoiseMap12{ nullptr };
-  std::shared_ptr<TH2I> mMNBendNoiseMap21{ nullptr };
-  std::shared_ptr<TH2I> mMNBendNoiseMap22{ nullptr };
-
-  std::shared_ptr<TH1F> mMMultDeadMT11B{ nullptr };
-  std::shared_ptr<TH1F> mMMultDeadMT11NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultDeadMT12B{ nullptr };
-  std::shared_ptr<TH1F> mMMultDeadMT12NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultDeadMT21B{ nullptr };
-  std::shared_ptr<TH1F> mMMultDeadMT21NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultDeadMT22B{ nullptr };
-  std::shared_ptr<TH1F> mMMultDeadMT22NB{ nullptr };
-
-  std::shared_ptr<TH2I> mMBendDeadMap11{ nullptr };
-  std::shared_ptr<TH2I> mMBendDeadMap12{ nullptr };
-  std::shared_ptr<TH2I> mMBendDeadMap21{ nullptr };
-  std::shared_ptr<TH2I> mMBendDeadMap22{ nullptr };
-  std::shared_ptr<TH2I> mMNBendDeadMap11{ nullptr };
-  std::shared_ptr<TH2I> mMNBendDeadMap12{ nullptr };
-  std::shared_ptr<TH2I> mMNBendDeadMap21{ nullptr };
-  std::shared_ptr<TH2I> mMNBendDeadMap22{ nullptr };
-
-  std::shared_ptr<TH1F> mMMultBadMT11B{ nullptr };
-  std::shared_ptr<TH1F> mMMultBadMT11NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultBadMT12B{ nullptr };
-  std::shared_ptr<TH1F> mMMultBadMT12NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultBadMT21B{ nullptr };
-  std::shared_ptr<TH1F> mMMultBadMT21NB{ nullptr };
-  std::shared_ptr<TH1F> mMMultBadMT22B{ nullptr };
-  std::shared_ptr<TH1F> mMMultBadMT22NB{ nullptr };
-
-  std::shared_ptr<TH2I> mMBendBadMap11{ nullptr };
-  std::shared_ptr<TH2I> mMBendBadMap12{ nullptr };
-  std::shared_ptr<TH2I> mMBendBadMap21{ nullptr };
-  std::shared_ptr<TH2I> mMBendBadMap22{ nullptr };
-  std::shared_ptr<TH2I> mMNBendBadMap11{ nullptr };
-  std::shared_ptr<TH2I> mMNBendBadMap12{ nullptr };
-  std::shared_ptr<TH2I> mMNBendBadMap21{ nullptr };
-  std::shared_ptr<TH2I> mMNBendBadMap22{ nullptr };
+  std::unique_ptr<TH1F> mBad{ nullptr };
+  std::array<std::unique_ptr<TH2F>, 4> mBendBadMap{};
+  std::array<std::unique_ptr<TH2F>, 4> mNBendBadMap{};
 };
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/include/MID/CalibQcTask.h
+++ b/Modules/MUON/MID/include/MID/CalibQcTask.h
@@ -17,15 +17,13 @@
 #define QC_MODULE_MID_MIDCALIBQCTASK_H
 
 #include "QualityControl/TaskInterface.h"
-#include "MIDRaw/CrateMasks.h"
-#include "MIDRaw/Decoder.h"
-#include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/FEEIdConfig.h"
-#include "MIDBase/Mapping.h"
+
+#include <array>
+#include <memory>
+#include "MID/DigitsHelper.h"
 
 class TH1F;
 class TH2F;
-class TProfile2D;
 
 using namespace o2::quality_control::core;
 
@@ -52,51 +50,29 @@ class CalibQcTask final : public TaskInterface
   void reset() override;
 
  private:
-  ///////////////////////////
-  int mTF = 0;
-  int mNoiseROF = 0;
-  int mDeadROF = 0;
-  o2::mid::Mapping mMapping; ///< Mapping
+  void resetDisplayHistos();
 
-  std::shared_ptr<TH1F> mNbTimeFrame{ nullptr };
-  std::shared_ptr<TH1F> mNbNoiseROF{ nullptr };
-  std::shared_ptr<TH1F> mNbDeadROF{ nullptr };
+  DigitsHelper mDigitsHelper; ///! Digits helper
 
-  std::shared_ptr<TH1F> mMultNoiseMT11B{ nullptr };
-  std::shared_ptr<TH1F> mMultNoiseMT11NB{ nullptr };
-  std::shared_ptr<TH1F> mMultNoiseMT12B{ nullptr };
-  std::shared_ptr<TH1F> mMultNoiseMT12NB{ nullptr };
-  std::shared_ptr<TH1F> mMultNoiseMT21B{ nullptr };
-  std::shared_ptr<TH1F> mMultNoiseMT21NB{ nullptr };
-  std::shared_ptr<TH1F> mMultNoiseMT22B{ nullptr };
-  std::shared_ptr<TH1F> mMultNoiseMT22NB{ nullptr };
+  std::unique_ptr<TH1F> mNbTimeFrame{ nullptr };
+  std::unique_ptr<TH1F> mNbNoiseROF{ nullptr };
+  std::unique_ptr<TH1F> mNbDeadROF{ nullptr };
 
-  std::shared_ptr<TH2F> mBendNoiseMap11{ nullptr };
-  std::shared_ptr<TH2F> mBendNoiseMap12{ nullptr };
-  std::shared_ptr<TH2F> mBendNoiseMap21{ nullptr };
-  std::shared_ptr<TH2F> mBendNoiseMap22{ nullptr };
-  std::shared_ptr<TH2F> mNBendNoiseMap11{ nullptr };
-  std::shared_ptr<TH2F> mNBendNoiseMap12{ nullptr };
-  std::shared_ptr<TH2F> mNBendNoiseMap21{ nullptr };
-  std::shared_ptr<TH2F> mNBendNoiseMap22{ nullptr };
+  std::array<std::unique_ptr<TH1F>, 4> mMultNoiseB{};
+  std::array<std::unique_ptr<TH1F>, 4> mMultNoiseNB{};
 
-  std::shared_ptr<TH1F> mMultDeadMT11B{ nullptr };
-  std::shared_ptr<TH1F> mMultDeadMT11NB{ nullptr };
-  std::shared_ptr<TH1F> mMultDeadMT12B{ nullptr };
-  std::shared_ptr<TH1F> mMultDeadMT12NB{ nullptr };
-  std::shared_ptr<TH1F> mMultDeadMT21B{ nullptr };
-  std::shared_ptr<TH1F> mMultDeadMT21NB{ nullptr };
-  std::shared_ptr<TH1F> mMultDeadMT22B{ nullptr };
-  std::shared_ptr<TH1F> mMultDeadMT22NB{ nullptr };
+  std::unique_ptr<TH1F> mNoise{ nullptr };
 
-  std::shared_ptr<TH2F> mBendDeadMap11{ nullptr };
-  std::shared_ptr<TH2F> mBendDeadMap12{ nullptr };
-  std::shared_ptr<TH2F> mBendDeadMap21{ nullptr };
-  std::shared_ptr<TH2F> mBendDeadMap22{ nullptr };
-  std::shared_ptr<TH2F> mNBendDeadMap11{ nullptr };
-  std::shared_ptr<TH2F> mNBendDeadMap12{ nullptr };
-  std::shared_ptr<TH2F> mNBendDeadMap21{ nullptr };
-  std::shared_ptr<TH2F> mNBendDeadMap22{ nullptr };
+  std::array<std::unique_ptr<TH2F>, 4> mBendNoiseMap{};
+  std::array<std::unique_ptr<TH2F>, 4> mNBendNoiseMap{};
+
+  std::array<std::unique_ptr<TH1F>, 4> mMultDeadB{};
+  std::array<std::unique_ptr<TH1F>, 4> mMultDeadNB{};
+
+  std::unique_ptr<TH1F> mDead{ nullptr };
+
+  std::array<std::unique_ptr<TH2F>, 4> mBendDeadMap{};
+  std::array<std::unique_ptr<TH2F>, 4> mNBendDeadMap{};
 };
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/include/MID/DigitsHelper.h
+++ b/Modules/MUON/MID/include/MID/DigitsHelper.h
@@ -1,0 +1,118 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   DigitsHelper.h
+/// \author Diego Stocco
+
+#ifndef QC_MODULE_MID_DIGITSHELPER_H
+#define QC_MODULE_MID_DIGITSHELPER_H
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include "DataFormatsMID/ColumnData.h"
+
+class TH1F;
+class TH2F;
+class TH1;
+class TH2;
+
+namespace o2::quality_control_modules::mid
+{
+class DigitsHelper
+{
+ public:
+  /// Default ctr
+  DigitsHelper();
+
+  /// Default destructor
+  ~DigitsHelper() = default;
+
+  /// @brief Make the 1D histogram with the number of time a strip was fired
+  /// @param name Histogram name
+  /// @param title Histogram title
+  /// @return Histogram 1D
+  TH1F makeStripHisto(const std::string name, const std::string title) const;
+
+  /// @brief Make the histogram with the 2D representation of the fired strips
+  /// @param name Histogram name
+  /// @param title Histogram title
+  /// @param cathode Bending (0) or Non-bending (1) plane
+  /// @return Histogram 2D
+  TH2F makeStripMapHisto(std::string name, std::string title, int cathode) const;
+
+  /// @brief Make the histogram with the 2D representation of the fired boards
+  /// @param name Histogram name
+  /// @param title Histogram title
+  /// @return Histogram 2D
+  TH2F makeBoardMapHisto(std::string name, std::string title) const;
+
+  /// @brief Count the number of fired strips
+  /// @param col Column Data
+  /// @param cathode Bending (0) or Non-bending (1) plane
+  /// @return Number of fired strips
+  unsigned long countDigits(const o2::mid::ColumnData& col, int cathode = -1) const;
+
+  /// @brief Fill the 1D histogram with the number of time a strip was fired
+  /// @param col Column Data
+  /// @param histo Pointer to the histogram
+  void fillStripHisto(const o2::mid::ColumnData& col, TH1* histo) const;
+
+  /// @brief Fill the 2D representation of the fired strips/boards from the 1D histogram
+  /// @param stripHisto Input 1D histogram
+  /// @param stripHistosB Array with the 2D representation of the fired strips in the bending plane per chamber
+  /// @param stripHistosNB Array with the 2D representation of the fired strips in the non-bending plane per chamber
+  /// @param boardHistos Array with the 2D representation of the fired boards per chamber. Last histogram is the sum of the previous four
+  void fillMapHistos(const TH1* stripHisto, std::array<std::unique_ptr<TH2F>, 4>& stripHistosB, std::array<std::unique_ptr<TH2F>, 4>& stripHistosNB, std::array<std::unique_ptr<TH2F>, 5>& boardHistos) const;
+
+  /// @brief Fill the 2D representation of the fired strips from the 1D histogram
+  /// @param stripHisto Input 1D histogram
+  /// @param stripHistosB Array with the 2D representation of the fired strips in the bending plane per chamber
+  /// @param stripHistosNB Array with the 2D representation of the fired strips in the non-bending plane per chamber
+  void fillMapHistos(const TH1* stripHisto, std::array<std::unique_ptr<TH2F>, 4>& stripHistosB, std::array<std::unique_ptr<TH2F>, 4>& stripHistosNB) const;
+
+  /// @brief Fill the 2D representation of the fired strips/boards from the 1D histogram for a specific chamber
+  /// @param stripHisto Input 1D histogram
+  /// @param stripHistosB 2D representation of the fired strips in the bending plane
+  /// @param stripHistosNB 2D representation of the fired strips in the non-bending plane
+  /// @param boardHistos  2D representation of the fired boards per chamber
+  /// @param chamber Selected chamber
+  void fillMapHistos(const TH1* stripHisto, TH2* stripHistosB, TH2* stripHistosNB, TH2* boardHistos, int chamber) const;
+
+  struct StripInfo {
+    int deId;     ///< Detection element ID
+    int columnId; ///< Column ID
+    int lineId;   ///< Line ID
+    int stripId;  ///< Strip ID
+    int cathode;  ///< Bending (0) or Non-bending (1) plane
+    int xwidth;   ///< Width X
+    int ywidth;   ///< Width y
+  };
+
+  struct ColumnInfo {
+    int firstLine; ///< First line in column
+    int lastLine;  ///< Last line in column
+    int nStripsNB; ///< Number of strips in the NB plane
+  };
+
+ private:
+  std::unordered_map<int, int> mStripsMap{};  ///! Map from id to index
+  std::vector<StripInfo> mStripsInfo;         ///! Strips info
+  std::array<ColumnInfo, 72 * 7> mColumnInfo; ///! Column info
+  void fillMapHistos(const StripInfo& info, TH2* stripHistoB, TH2* stripHistoNB, TH2* boardHisto, int wgt) const;
+
+  inline int getColumnIdx(int columnId, int deId) const { return 7 * deId + columnId; }
+};
+
+} // namespace o2::quality_control_modules::mid
+
+#endif

--- a/Modules/MUON/MID/include/MID/DigitsQcCheck.h
+++ b/Modules/MUON/MID/include/MID/DigitsQcCheck.h
@@ -19,6 +19,10 @@
 
 #include "QualityControl/CheckInterface.h"
 
+#include <unordered_map>
+#include "QualityControl/Quality.h"
+#include "MID/HistoHelper.h"
+
 namespace o2::quality_control_modules::mid
 {
 
@@ -39,34 +43,18 @@ class DigitsQcCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
-  double mMeanMultThreshold;
-  double mMinMultThreshold;
-  float mDigitTF = 0;
-  int mOrbTF = 32;
-  // float scaleTime = 0.0114048; // 128 orb/TF * 3564 BC/orb * 25ns
-  float scaleTime = 0.0000891; // 3564 BC/orb * 25ns
-  int mscale = 0;
-  int mLocalBoardScale;
-  int mNbEmptyLocalBoard;
-  float mLocalBoardThreshold;
-  int mNbBadLocalBoard;
-  int mBadLB;
-  int mEmptyLB;
-  float mMultTab[8];
+  double mMeanMultThreshold = 10.;   ///! Upper threshold on mean multiplicity
+  double mMinMultThreshold = 0.001;  ///! Lower threshold on mean multiplicity
+  double mLocalBoardScale = 100.;    ///! Local board scale in kHz
+  int mNbEmptyLocalBoard = 117;      ///! Maximum number of allowed empty boards
+  double mLocalBoardThreshold = 400; ///! Threshold on board multiplicity (kHz)
+  int mNbBadLocalBoard = 10;         ///! Maximum number of local boards above threshold
 
-  Quality result = Quality::Null;
-  Quality resultBMT11 = Quality::Null;
-  Quality resultBMT12 = Quality::Null;
-  Quality resultBMT21 = Quality::Null;
-  Quality resultBMT22 = Quality::Null;
-  Quality resultNBMT11 = Quality::Null;
-  Quality resultNBMT12 = Quality::Null;
-  Quality resultNBMT21 = Quality::Null;
-  Quality resultNBMT22 = Quality::Null;
+  std::unordered_map<std::string, Quality> mQualityMap; ///! Quality map
 
-  Quality QualLocBoards = Quality::Null;
+  HistoHelper mHistoHelper; ///! Histogram helper
 
-  ClassDefOverride(DigitsQcCheck, 2);
+  ClassDefOverride(DigitsQcCheck, 3);
 };
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/include/MID/DigitsQcTask.h
+++ b/Modules/MUON/MID/include/MID/DigitsQcTask.h
@@ -19,18 +19,18 @@
 #ifndef QC_MODULE_MID_MIDDIGITSQCTASK_H
 #define QC_MODULE_MID_MIDDIGITSQCTASK_H
 
+#include <array>
+#include <memory>
+
+#include <TH1.h>
+#include <TH2.h>
+
 #include "QualityControl/TaskInterface.h"
-#include "MUONCommon/MergeableTH2Ratio.h"
-#include "MIDQC/RawDataChecker.h"
-#include "MIDRaw/CrateMasks.h"
-#include "MIDRaw/Decoder.h"
-#include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/FEEIdConfig.h"
 #include "MIDBase/Mapping.h"
+#include "MID/DigitsHelper.h"
 
 class TH1F;
 class TH2F;
-class TProfile;
 
 using namespace o2::quality_control::core;
 
@@ -45,7 +45,7 @@ class DigitsQcTask final : public TaskInterface
   /// \brief Constructor
   DigitsQcTask() = default;
   /// Destructor
-  ~DigitsQcTask() override;
+  ~DigitsQcTask() override = default;
 
   // Definition of the methods for the template method pattern
   void initialize(o2::framework::InitContext& ctx) override;
@@ -57,52 +57,27 @@ class DigitsQcTask final : public TaskInterface
   void reset() override;
 
  private:
-  std::shared_ptr<TH2F> mHitsMapB{ nullptr };
-  std::shared_ptr<TH2F> mHitsMapNB{ nullptr };
-  std::shared_ptr<TH2F> mOrbitsMapB{ nullptr };
-  std::shared_ptr<TH2F> mOrbitsMapNB{ nullptr };
+  void resetDisplayHistos();
 
-  std::shared_ptr<TH1F> mROFSizeB{ nullptr };
-  std::shared_ptr<TH1F> mROFSizeNB{ nullptr };
+  DigitsHelper mDigitsHelper; ///! Digits helper
 
-  std::shared_ptr<TH2F> mROFTimeDiff{ nullptr };
+  std::unique_ptr<TH2F> mROFTimeDiff{ nullptr };
 
-  ///////////////////////////
-  int mROF = 0;
-  int mDigitTF = 0;
-  float mDigitReset = 1;     //
-  o2::mid::Mapping mMapping; ///< Mapping
+  std::unique_ptr<TH1F> mNbDigitTF{ nullptr };
 
-  std::shared_ptr<TH1F> mNbDigitTF{ nullptr };
+  std::array<std::unique_ptr<TH1F>, 5> mMultHitB{};
+  std::array<std::unique_ptr<TH1F>, 5> mMultHitNB{};
+  std::unique_ptr<TH1F> mMeanMultiHits;
 
-  std::shared_ptr<TH1F> mMultHitMT11B{ nullptr };
-  std::shared_ptr<TH1F> mMultHitMT11NB{ nullptr };
-  std::shared_ptr<TH1F> mMultHitMT12B{ nullptr };
-  std::shared_ptr<TH1F> mMultHitMT12NB{ nullptr };
-  std::shared_ptr<TH1F> mMultHitMT21B{ nullptr };
-  std::shared_ptr<TH1F> mMultHitMT21NB{ nullptr };
-  std::shared_ptr<TH1F> mMultHitMT22B{ nullptr };
-  std::shared_ptr<TH1F> mMultHitMT22NB{ nullptr };
-  std::shared_ptr<TH1F> mMeanMultiHits{ nullptr };
+  std::array<std::unique_ptr<TH2F>, 5> mLocalBoardsMap{};
+  std::unique_ptr<TH1F> mHits;
 
-  std::shared_ptr<TH2F> mLocalBoardsMap{ nullptr };
-  std::shared_ptr<TH2F> mLocalBoardsMap11{ nullptr };
-  std::shared_ptr<TH2F> mLocalBoardsMap12{ nullptr };
-  std::shared_ptr<TH2F> mLocalBoardsMap21{ nullptr };
-  std::shared_ptr<TH2F> mLocalBoardsMap22{ nullptr };
+  std::array<std::unique_ptr<TH2F>, 4> mBendHitsMap{};
+  std::array<std::unique_ptr<TH2F>, 4> mNBendHitsMap{};
 
-  std::shared_ptr<TH2F> mBendHitsMap11{ nullptr };
-  std::shared_ptr<TH2F> mBendHitsMap12{ nullptr };
-  std::shared_ptr<TH2F> mBendHitsMap21{ nullptr };
-  std::shared_ptr<TH2F> mBendHitsMap22{ nullptr };
+  std::unique_ptr<TH1F> mDigitBCCounts{ nullptr };
 
-  std::shared_ptr<TH2F> mNBendHitsMap11{ nullptr };
-  std::shared_ptr<TH2F> mNBendHitsMap12{ nullptr };
-  std::shared_ptr<TH2F> mNBendHitsMap21{ nullptr };
-  std::shared_ptr<TH2F> mNBendHitsMap22{ nullptr };
-
-  std::shared_ptr<TH1F> mDigitBCCounts{ nullptr };
-  // std::shared_ptr<TProfile> mDigitBCCounts{ nullptr };
+  bool mResetAtCycle = false; ///< Reset histograms at each cycle
 };
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/include/MID/HistoHelper.h
+++ b/Modules/MUON/MID/include/MID/HistoHelper.h
@@ -1,0 +1,101 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   HistoHelper.h
+/// \author Diego Stocco
+
+#ifndef QC_MODULE_MID_HISTOHELPER_H
+#define QC_MODULE_MID_HISTOHELPER_H
+
+#include <string>
+#include <unordered_map>
+
+#include "QualityControl/Quality.h"
+
+class TH1;
+class TLatex;
+
+namespace o2::quality_control_modules::mid
+{
+class HistoHelper
+{
+
+ public:
+  /// @brief Default ctr
+  HistoHelper();
+
+  /// Default destructor
+  ~HistoHelper() = default;
+
+  /// @brief Sets the number of analyzed TFs
+  /// @param nTFs Number of analyzed TFs
+  void setNTFs(unsigned long int nTFs) { mNTFs = nTFs; }
+
+  /// @brief Gets number of analyzed TFs
+  /// @return Number of analyzed TFs
+  unsigned long int getNTFs() const { return mNTFs; }
+
+  /// @brief Sets the number of orbits per TF
+  /// @param nOrbitsPerTF number of orbits per TF
+  void setNOrbitsPerTF(unsigned long int nOrbitsPerTF) { mNOrbitsPerTF = nOrbitsPerTF; }
+
+  /// @brief Convert the number of analyzed TFs in seconds
+  /// @return Duration in seconds of the analyzed TFs
+  double getNTFsAsSeconds() const { return mNTFs * mNOrbitsPerTF * 0.0000891; }
+
+  /// @brief Scale the histogram to the inverse of the analyzed TF duration (result in Hz)
+  /// @param histo Histogram to normalize
+  void normalizeHistoToHz(TH1* histo) const;
+
+  /// @brief Scale the histogram to the inverse of the analyzed TF duration (result in kHz)
+  /// @param histo Histogram to normalize
+  void normalizeHistoTokHz(TH1* histo) const;
+
+  /// @brief Updates the histogram title
+  /// @param histo Histogram to update
+  /// @param append Text to append
+  void updateTitle(TH1* histo, std::string suffix) const;
+
+  /// @brief Returns the current time
+  /// @return Current time
+  std::string getCurrentTime() const;
+
+  /// @brief Adds a TLatex to the histogram list of functions
+  /// @param histo Histogram to modify
+  /// @param xmin Bottom-left x position
+  /// @param ymin Bottom-left y position
+  /// @param color Text color
+  /// @param text Text
+  void addLatex(TH1* histo, double xmin, double ymin, int color, std::string text) const;
+
+  /// @brief Gets the color for this quality
+  /// @param quality QC Quality
+  /// @return Color as integer
+  int getColor(const o2::quality_control::core::Quality& quality) const;
+
+  /// @brief Add number of TFs in the title
+  /// @param histo Histogram to update
+  void updateTitleWithNTF(TH1* histo) const;
+
+ private:
+  /// @brief Normalizes the histogram to the inverse of the analyzed TF duration
+  /// @param histo Histogram to normalize
+  /// @param scale Additional scaling factor
+  bool normalizeHisto(TH1* histo, double scale) const;
+
+  unsigned long int mNTFs = 0;          ///! Number of TFs
+  unsigned long int mNOrbitsPerTF = 32; ///! Number of orbits per TF
+  std::unordered_map<unsigned int, int> mColors;
+};
+
+} // namespace o2::quality_control_modules::mid
+
+#endif

--- a/Modules/MUON/MID/include/MID/LinkDef.h
+++ b/Modules/MUON/MID/include/MID/LinkDef.h
@@ -16,5 +16,6 @@
 #pragma link C++ class o2::quality_control_modules::mid::CalibMQcTask + ;
 #pragma link C++ class o2::quality_control_modules::mid::CalibMQcCheck + ;
 #pragma link C++ class o2::quality_control_modules::mid::DigitsHelper + ;
+#pragma link C++ class o2::quality_control_modules::mid::HistoHelper + ;
 
 #endif

--- a/Modules/MUON/MID/include/MID/LinkDef.h
+++ b/Modules/MUON/MID/include/MID/LinkDef.h
@@ -15,5 +15,6 @@
 #pragma link C++ class o2::quality_control_modules::mid::CalibQcCheck + ;
 #pragma link C++ class o2::quality_control_modules::mid::CalibMQcTask + ;
 #pragma link C++ class o2::quality_control_modules::mid::CalibMQcCheck + ;
+#pragma link C++ class o2::quality_control_modules::mid::DigitsHelper + ;
 
 #endif

--- a/Modules/MUON/MID/src/CalibMQcTask.cxx
+++ b/Modules/MUON/MID/src/CalibMQcTask.cxx
@@ -12,34 +12,18 @@
 ///
 /// \author Valerie Ramillien
 
-#include <TStyle.h>
-#include <TCanvas.h>
-#include <TH1.h>
-#include <TH2.h>
-#include <TFile.h>
-#include <TProfile2D.h>
+#include "MID/CalibMQcTask.h"
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <string>
-#include <vector>
+#include "fmt/format.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TStyle.h"
 
 #include "QualityControl/QcInfoLogger.h"
-#include "MID/CalibMQcTask.h"
-#include <Framework/InputRecord.h>
-#include "Framework/DataRefUtils.h"
-#include "DataFormatsMID/ColumnData.h"
-#include "DataFormatsMID/ROBoard.h"
-#include "DataFormatsMID/ROFRecord.h"
-#include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/FEEIdConfig.h"
-#include "MIDBase/DetectorParameters.h"
-#include "MIDBase/GeometryParameters.h"
-#include "MIDWorkflow/ColumnDataSpecsUtils.h"
 
-#define MID_NDE 72
-#define MID_NCOL 7
+#include "Framework/InputRecord.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "MIDWorkflow/ColumnDataSpecsUtils.h"
 
 namespace o2::quality_control_modules::mid
 {
@@ -50,843 +34,119 @@ CalibMQcTask::~CalibMQcTask()
 
 void CalibMQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info, Devel) << "initialize CalibMQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
-  // std::cout << "!!!! START initialize CalibQcTask Test !!!! " << std::endl;
-  /////////////////
-
   gStyle->SetPalette(kRainBow);
 
-  //////////////////////////////////
-  /// Noise strips Histograms :: ///
-  //////////////////////////////////
-  mMMultNoiseMT11B = std::make_shared<TH1F>("MMultNoiseMT11B", "Multiplicity Noise strips - MT11 bending plane", 300, 0, 300);
-  mMMultNoiseMT11NB = std::make_shared<TH1F>("MMultNoiseMT11NB", "Multiplicity Noise strips - MT11 non-bending plane", 300, 0, 300);
-  mMMultNoiseMT12B = std::make_shared<TH1F>("MMultNoiseMT12B", "Multiplicity Noise strips - MT12 bending plane", 300, 0, 300);
-  mMMultNoiseMT12NB = std::make_shared<TH1F>("MMultNoiseMT12NB", "Multiplicity Noise strips - MT12 non-bending plane", 300, 0, 300);
-  mMMultNoiseMT21B = std::make_shared<TH1F>("MMultNoiseMT21B", "Multiplicity Noise strips - MT21 bending plane", 300, 0, 300);
-  mMMultNoiseMT21NB = std::make_shared<TH1F>("MMultNoiseMT21NB", "Multiplicity Noise strips - MT21 non-bending plane", 300, 0, 300);
-  mMMultNoiseMT22B = std::make_shared<TH1F>("MMultNoiseMT22B", "Multiplicity Noise strips - MT22 bending plane", 300, 0, 300);
-  mMMultNoiseMT22NB = std::make_shared<TH1F>("MMultNoiseMT22NB", "Multiplicity Noise strips - MT22 non-bending plane", 300, 0, 300);
-  getObjectsManager()->startPublishing(mMMultNoiseMT11B.get());
-  getObjectsManager()->startPublishing(mMMultNoiseMT11NB.get());
-  getObjectsManager()->startPublishing(mMMultNoiseMT12B.get());
-  getObjectsManager()->startPublishing(mMMultNoiseMT12NB.get());
-  getObjectsManager()->startPublishing(mMMultNoiseMT21B.get());
-  getObjectsManager()->startPublishing(mMMultNoiseMT21NB.get());
-  getObjectsManager()->startPublishing(mMMultNoiseMT22B.get());
-  getObjectsManager()->startPublishing(mMMultNoiseMT22NB.get());
+  std::array<string, 4> chId{ "11", "12", "21", "22" };
 
-  mMBendNoiseMap11 = std::make_shared<TH2I>("MBendNoiseMap11", "Bending Noise Map MT11", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendNoiseMap11.get());
-  mMBendNoiseMap11->GetXaxis()->SetTitle("Column");
-  mMBendNoiseMap11->GetYaxis()->SetTitle("Line");
-  mMBendNoiseMap11->SetOption("colz");
-  mMBendNoiseMap11->SetStats(0);
+  mNoise = std::make_unique<TH1F>(mDigitsHelper.makeStripHisto("MNoiseStrips", "Noise strips"));
+  getObjectsManager()->startPublishing(mNoise.get());
 
-  mMBendNoiseMap12 = std::make_shared<TH2I>("MBendNoiseMap12", "Bending Noise Map MT12", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendNoiseMap12.get());
-  mMBendNoiseMap12->GetXaxis()->SetTitle("Column");
-  mMBendNoiseMap12->GetYaxis()->SetTitle("Line");
-  mMBendNoiseMap12->SetOption("colz");
-  mMBendNoiseMap12->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mBendNoiseMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("MBendNoiseMap{}", chId[ich]), fmt::format("Bending Noise Map MT{}", chId[ich]), 0));
+    getObjectsManager()->startPublishing(mBendNoiseMap[ich].get());
+  }
 
-  mMBendNoiseMap21 = std::make_shared<TH2I>("MBendNoiseMap21", "Bending Noise Map MT21", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendNoiseMap21.get());
-  mMBendNoiseMap21->GetXaxis()->SetTitle("Column");
-  mMBendNoiseMap21->GetYaxis()->SetTitle("Line");
-  mMBendNoiseMap21->SetOption("colz");
-  mMBendNoiseMap21->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mNBendNoiseMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("MNBendNoiseMap{}", chId[ich]), fmt::format("Non-Bending Noise Map MT{}", chId[ich]), 1));
+    getObjectsManager()->startPublishing(mNBendNoiseMap[ich].get());
+  }
 
-  mMBendNoiseMap22 = std::make_shared<TH2I>("MBendNoiseMap22", "Bending Noise Map MT22", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendNoiseMap22.get());
-  mMBendNoiseMap22->GetXaxis()->SetTitle("Column");
-  mMBendNoiseMap22->GetYaxis()->SetTitle("Line");
-  mMBendNoiseMap22->SetOption("colz");
-  mMBendNoiseMap22->SetStats(0);
+  mDead = std::make_unique<TH1F>(mDigitsHelper.makeStripHisto("MDeadStrips", "Dead strips"));
+  getObjectsManager()->startPublishing(mDead.get());
 
-  mMNBendNoiseMap11 = std::make_shared<TH2I>("MNBendNoiseMap11", "Non-Bending Noise Map MT11", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendNoiseMap11.get());
-  mMNBendNoiseMap11->GetXaxis()->SetTitle("Column");
-  mMNBendNoiseMap11->GetYaxis()->SetTitle("Line");
-  mMNBendNoiseMap11->SetOption("colz");
-  mMNBendNoiseMap11->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mBendDeadMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("MBendDeadMap{}", chId[ich]), fmt::format("Bending Dead Map MT{}", chId[ich]), 0));
+    getObjectsManager()->startPublishing(mBendDeadMap[ich].get());
+  }
 
-  mMNBendNoiseMap12 = std::make_shared<TH2I>("MNBendNoiseMap12", "Non-Bending Noise Map MT12", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendNoiseMap12.get());
-  mMNBendNoiseMap12->GetXaxis()->SetTitle("Column");
-  mMNBendNoiseMap12->GetYaxis()->SetTitle("Line");
-  mMNBendNoiseMap12->SetOption("colz");
-  mMNBendNoiseMap12->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mNBendDeadMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("MNBendDeadMap{}", chId[ich]), fmt::format("Non-Bending Dead Map MT{}", chId[ich]), 1));
+    getObjectsManager()->startPublishing(mNBendDeadMap[ich].get());
+  }
 
-  mMNBendNoiseMap21 = std::make_shared<TH2I>("MNBendNoiseMap21", "Non-Bending Noise Map MT21", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendNoiseMap21.get());
-  mMNBendNoiseMap21->GetXaxis()->SetTitle("Column");
-  mMNBendNoiseMap21->GetYaxis()->SetTitle("Line");
-  mMNBendNoiseMap21->SetOption("colz");
-  mMNBendNoiseMap21->SetStats(0);
+  mBad = std::make_unique<TH1F>(mDigitsHelper.makeStripHisto("MBadStrips", "Bad strips"));
+  getObjectsManager()->startPublishing(mBad.get());
 
-  mMNBendNoiseMap22 = std::make_shared<TH2I>("MNBendNoiseMap22", "Non-Bending Noise Map MT22", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendNoiseMap22.get());
-  mMNBendNoiseMap22->GetXaxis()->SetTitle("Column");
-  mMNBendNoiseMap22->GetYaxis()->SetTitle("Line");
-  mMNBendNoiseMap22->SetOption("colz");
-  mMNBendNoiseMap22->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mBendBadMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("MBendBadMap{}", chId[ich]), fmt::format("Bending Bad Map MT{}", chId[ich]), 0));
+    getObjectsManager()->startPublishing(mBendBadMap[ich].get());
+  }
 
-  /////////////////////////////////
-  /// Dead strips Histograms :: ///
-  /////////////////////////////////
-  mMMultDeadMT11B = std::make_shared<TH1F>("MMultDeadMT11B", "Multiplicity Dead strips - MT11 bending plane", 300, 0, 300);
-  mMMultDeadMT11NB = std::make_shared<TH1F>("MMultDeadMT11NB", "Multiplicity Dead strips - MT11 non-bending plane", 300, 0, 300);
-  mMMultDeadMT12B = std::make_shared<TH1F>("MMultDeadMT12B", "Multiplicity Dead strips - MT12 bending plane", 300, 0, 300);
-  mMMultDeadMT12NB = std::make_shared<TH1F>("MMultDeadMT12NB", "MultiplicityDead  strips - MT12 non-bending plane", 300, 0, 300);
-  mMMultDeadMT21B = std::make_shared<TH1F>("MMultDeadMT21B", "Multiplicity Dead strips - MT21 bending plane", 300, 0, 300);
-  mMMultDeadMT21NB = std::make_shared<TH1F>("MMultDeadMT21NB", "Multiplicity Dead strips - MT21 non-bending plane", 300, 0, 300);
-  mMMultDeadMT22B = std::make_shared<TH1F>("MMultDeadMT22B", "Multiplicity Dead strips - MT22 bending plane", 300, 0, 300);
-  mMMultDeadMT22NB = std::make_shared<TH1F>("MMultDeadMT22NB", "Multiplicity Dead strips - MT22 non-bending plane", 300, 0, 300);
-  getObjectsManager()->startPublishing(mMMultDeadMT11B.get());
-  getObjectsManager()->startPublishing(mMMultDeadMT11NB.get());
-  getObjectsManager()->startPublishing(mMMultDeadMT12B.get());
-  getObjectsManager()->startPublishing(mMMultDeadMT12NB.get());
-  getObjectsManager()->startPublishing(mMMultDeadMT21B.get());
-  getObjectsManager()->startPublishing(mMMultDeadMT21NB.get());
-  getObjectsManager()->startPublishing(mMMultDeadMT22B.get());
-  getObjectsManager()->startPublishing(mMMultDeadMT22NB.get());
-
-  mMBendDeadMap11 = std::make_shared<TH2I>("MBendDeadMap11", "Bending Dead Map MT11", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendDeadMap11.get());
-  mMBendDeadMap11->GetXaxis()->SetTitle("Column");
-  mMBendDeadMap11->GetYaxis()->SetTitle("Line");
-  mMBendDeadMap11->SetOption("colz");
-  mMBendDeadMap11->SetStats(0);
-
-  mMBendDeadMap12 = std::make_shared<TH2I>("MBendDeadMap12", "Bending Dead Map MT12", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendDeadMap12.get());
-  mMBendDeadMap12->GetXaxis()->SetTitle("Column");
-  mMBendDeadMap12->GetYaxis()->SetTitle("Line");
-  mMBendDeadMap12->SetOption("colz");
-  mMBendDeadMap12->SetStats(0);
-
-  mMBendDeadMap21 = std::make_shared<TH2I>("MBendDeadMap21", "Bending Dead Map MT21", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendDeadMap21.get());
-  mMBendDeadMap21->GetXaxis()->SetTitle("Column");
-  mMBendDeadMap21->GetYaxis()->SetTitle("Line");
-  mMBendDeadMap21->SetOption("colz");
-  mMBendDeadMap21->SetStats(0);
-
-  mMBendDeadMap22 = std::make_shared<TH2I>("MBendDeadMap22", "Bending Dead Map MT22", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendDeadMap22.get());
-  mMBendDeadMap22->GetXaxis()->SetTitle("Column");
-  mMBendDeadMap22->GetYaxis()->SetTitle("Line");
-  mMBendDeadMap22->SetOption("colz");
-  mMBendDeadMap22->SetStats(0);
-
-  mMNBendDeadMap11 = std::make_shared<TH2I>("MNBendDeadMap11", "Non-Bending Dead Map MT11", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendDeadMap11.get());
-  mMNBendDeadMap11->GetXaxis()->SetTitle("Column");
-  mMNBendDeadMap11->GetYaxis()->SetTitle("Line");
-  mMNBendDeadMap11->SetOption("colz");
-  mMNBendDeadMap11->SetStats(0);
-
-  mMNBendDeadMap12 = std::make_shared<TH2I>("MNBendDeadMap12", "Non-Bending Dead Map MT12", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendDeadMap12.get());
-  mMNBendDeadMap12->GetXaxis()->SetTitle("Column");
-  mMNBendDeadMap12->GetYaxis()->SetTitle("Line");
-  mMNBendDeadMap12->SetOption("colz");
-  mMNBendDeadMap12->SetStats(0);
-
-  mMNBendDeadMap21 = std::make_shared<TH2I>("MNBendDeadMap21", "Non-Bending Dead Map MT21", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendDeadMap21.get());
-  mMNBendDeadMap21->GetXaxis()->SetTitle("Column");
-  mMNBendDeadMap21->GetYaxis()->SetTitle("Line");
-  mMNBendDeadMap21->SetOption("colz");
-  mMNBendDeadMap21->SetStats(0);
-
-  mMNBendDeadMap22 = std::make_shared<TH2I>("MNBendDeadMap22", "Non-Bending Dead Map MT22", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendDeadMap22.get());
-  mMNBendDeadMap22->GetXaxis()->SetTitle("Column");
-  mMNBendDeadMap22->GetYaxis()->SetTitle("Line");
-  mMNBendDeadMap22->SetOption("colz");
-  mMNBendDeadMap22->SetStats(0);
-
-  /////////////////////////////////
-  /// Bad strips Histograms ::  ///
-  /////////////////////////////////
-
-  mMMultBadMT11B = std::make_shared<TH1F>("MMultBadMT11B", "Multiplicity Bad strips - MT11 bending plane", 300, 0, 300);
-  mMMultBadMT11NB = std::make_shared<TH1F>("MMultBadMT11NB", "Multiplicity Bad strips - MT11 non-bending plane", 300, 0, 300);
-  mMMultBadMT12B = std::make_shared<TH1F>("MMultBadMT12B", "Multiplicity Bad strips - MT12 bending plane", 300, 0, 300);
-  mMMultBadMT12NB = std::make_shared<TH1F>("MMultBadMT12NB", "MultiplicityBad  strips - MT12 non-bending plane", 300, 0, 300);
-  mMMultBadMT21B = std::make_shared<TH1F>("MMultBadMT21B", "Multiplicity Bad strips - MT21 bending plane", 300, 0, 300);
-  mMMultBadMT21NB = std::make_shared<TH1F>("MMultBadMT21NB", "Multiplicity Bad strips - MT21 non-bending plane", 300, 0, 300);
-  mMMultBadMT22B = std::make_shared<TH1F>("MMultBadMT22B", "Multiplicity Bad strips - MT22 bending plane", 300, 0, 300);
-  mMMultBadMT22NB = std::make_shared<TH1F>("MMultBadMT22NB", "Multiplicity Bad strips - MT22 non-bending plane", 300, 0, 300);
-  getObjectsManager()->startPublishing(mMMultBadMT11B.get());
-  getObjectsManager()->startPublishing(mMMultBadMT11NB.get());
-  getObjectsManager()->startPublishing(mMMultBadMT12B.get());
-  getObjectsManager()->startPublishing(mMMultBadMT12NB.get());
-  getObjectsManager()->startPublishing(mMMultBadMT21B.get());
-  getObjectsManager()->startPublishing(mMMultBadMT21NB.get());
-  getObjectsManager()->startPublishing(mMMultBadMT22B.get());
-  getObjectsManager()->startPublishing(mMMultBadMT22NB.get());
-
-  mMBendBadMap11 = std::make_shared<TH2I>("MBendBadMap11", "Bending Bad Map MT11", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendBadMap11.get());
-  mMBendBadMap11->GetXaxis()->SetTitle("Column");
-  mMBendBadMap11->GetYaxis()->SetTitle("Line");
-  mMBendBadMap11->SetOption("colz");
-  mMBendBadMap11->SetStats(0);
-
-  mMBendBadMap12 = std::make_shared<TH2I>("MBendBadMap12", "Bending Bad Map MT12", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendBadMap12.get());
-  mMBendBadMap12->GetXaxis()->SetTitle("Column");
-  mMBendBadMap12->GetYaxis()->SetTitle("Line");
-  mMBendBadMap12->SetOption("colz");
-  mMBendBadMap12->SetStats(0);
-
-  mMBendBadMap21 = std::make_shared<TH2I>("MBendBadMap21", "Bending Bad Map MT21", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendBadMap21.get());
-  mMBendBadMap21->GetXaxis()->SetTitle("Column");
-  mMBendBadMap21->GetYaxis()->SetTitle("Line");
-  mMBendBadMap21->SetOption("colz");
-  mMBendBadMap21->SetStats(0);
-
-  mMBendBadMap22 = std::make_shared<TH2I>("MBendBadMap22", "Bending Bad Map MT22", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mMBendBadMap22.get());
-  mMBendBadMap22->GetXaxis()->SetTitle("Column");
-  mMBendBadMap22->GetYaxis()->SetTitle("Line");
-  mMBendBadMap22->SetOption("colz");
-  mMBendBadMap22->SetStats(0);
-
-  mMNBendBadMap11 = std::make_shared<TH2I>("MNBendBadMap11", "Non-Bending Bad Map MT11", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendBadMap11.get());
-  mMNBendBadMap11->GetXaxis()->SetTitle("Column");
-  mMNBendBadMap11->GetYaxis()->SetTitle("Line");
-  mMNBendBadMap11->SetOption("colz");
-  mMNBendBadMap11->SetStats(0);
-
-  mMNBendBadMap12 = std::make_shared<TH2I>("MNBendBadMap12", "Non-Bending Bad Map MT12", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendBadMap12.get());
-  mMNBendBadMap12->GetXaxis()->SetTitle("Column");
-  mMNBendBadMap12->GetYaxis()->SetTitle("Line");
-  mMNBendBadMap12->SetOption("colz");
-  mMNBendBadMap12->SetStats(0);
-
-  mMNBendBadMap21 = std::make_shared<TH2I>("MNBendBadMap21", "Non-Bending Bad Map MT21", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendBadMap21.get());
-  mMNBendBadMap21->GetXaxis()->SetTitle("Column");
-  mMNBendBadMap21->GetYaxis()->SetTitle("Line");
-  mMNBendBadMap21->SetOption("colz");
-  mMNBendBadMap21->SetStats(0);
-
-  mMNBendBadMap22 = std::make_shared<TH2I>("MNBendBadMap22", "Non-Bending Bad Map MT22", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mMNBendBadMap22.get());
-  mMNBendBadMap22->GetXaxis()->SetTitle("Column");
-  mMNBendBadMap22->GetYaxis()->SetTitle("Line");
-  mMNBendBadMap22->SetOption("colz");
-  mMNBendBadMap22->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mNBendBadMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("MNBendBadMap{}", chId[ich]), fmt::format("Non-Bending Bad Map MT{}", chId[ich]), 1));
+    getObjectsManager()->startPublishing(mNBendBadMap[ich].get());
+  }
 }
 
 void CalibMQcTask::startOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Devel) << "startOfActivity" << ENDM;
-  // std::cout << "!!!! START startOfActivity a CalibMQcTask TEST   !!!! " << std::endl;
 }
 
 void CalibMQcTask::startOfCycle()
 {
-  ILOG(Info, Devel) << "startOfCycle" << ENDM;
-  // std::cout << "!!!! START startOfCycle CalibMQcTask TEST   !!!! " << std::endl;
 }
 
 void CalibMQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  // std::cout << "!!!! START monitorData CalibMQcTask TEST  !!!! " << std::endl;
-  mTF++;
-  // printf("----------------> %05d TF \n", nTF);
-
-  int multNoiseMT11B = 0;
-  int multNoiseMT12B = 0;
-  int multNoiseMT21B = 0;
-  int multNoiseMT22B = 0;
-  int multNoiseMT11NB = 0;
-  int multNoiseMT12NB = 0;
-  int multNoiseMT21NB = 0;
-  int multNoiseMT22NB = 0;
-
-  int multDeadMT11B = 0;
-  int multDeadMT12B = 0;
-  int multDeadMT21B = 0;
-  int multDeadMT22B = 0;
-  int multDeadMT11NB = 0;
-  int multDeadMT12NB = 0;
-  int multDeadMT21NB = 0;
-  int multDeadMT22NB = 0;
-
-  int multBadMT11B = 0;
-  int multBadMT12B = 0;
-  int multBadMT21B = 0;
-  int multBadMT22B = 0;
-  int multBadMT11NB = 0;
-  int multBadMT12NB = 0;
-  int multBadMT21NB = 0;
-  int multBadMT22NB = 0;
-
   auto noises = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("noisych");
-
-  //  printf("noises ========================================================== \n");
-
-  mNoiseROF++;
-  multNoiseMT11B = 0;
-  multNoiseMT12B = 0;
-  multNoiseMT21B = 0;
-  multNoiseMT22B = 0;
-  multNoiseMT11NB = 0;
-  multNoiseMT12NB = 0;
-  multNoiseMT21NB = 0;
-  multNoiseMT22NB = 0;
-
-  for (auto& noise : noises) { // loop DE //
-
-    // std::cout << "!!!! START monitorData CalibMQcTaskLoop noises (DE)!!!! " << std::endl;
-
-    int deIndex = noise.deId;
-    int colId = noise.columnId;
-    int rpcLine = o2::mid::detparams::getRPCLine(deIndex);
-    int ichamber = o2::mid::detparams::getChamber(deIndex);
-    auto isRightSide = o2::mid::detparams::isRightSide(deIndex);
-    auto detId = o2::mid::detparams::getDEId(isRightSide, ichamber, colId);
-
-    // std::cout << " deId  " << deIndex << std::endl;
-
-    int nZoneHistoX = 1;
-    int nZoneHistoY = 4;
-    double stripYSize = 1. / 16;
-    double stripXSize = 0.25 / 16;
-    if (mMapping.getLastBoardBP(colId, deIndex) == 1) {
-      nZoneHistoX = 2;
-      stripXSize = 0.5 / 16;
-    } else if (mMapping.getLastBoardBP(colId, deIndex) == 0) {
-      nZoneHistoX = 4;
-      stripXSize = 1. / 16;
-    }
-
-    for (int board = mMapping.getFirstBoardBP(colId, deIndex), lastBoard = mMapping.getLastBoardBP(colId, deIndex); board <= lastBoard + 1; board++) {
-      // These are the existing bend boards for this column Id (board = n°board in the column) + 1 (for non-bend)
-      if ((lastBoard < 4) && (board == lastBoard + 1))
-        board = 4;                      // for Non-Bend digits
-      if (noise.patterns[board] != 0) { //  Bend + Non-Bend plane
-        //// Bend Local Boards Display ::
-        double linePos0 = rpcLine;
-
-        //// Strips Display ::
-        int mask = 1;
-
-        double shift = 0; // for central zone with only 3 loc boards
-        if ((colId == 0) && ((rpcLine == 3) || (rpcLine == 5)))
-          nZoneHistoY = 3;
-        if ((colId == 0) && (rpcLine == 5))
-          shift = 0.25;
-
-        for (int j = 0; j < 16; j++) {
-          int fired = 0;
-          if ((noise.patterns[board] & mask) != 0)
-            fired = 1;
-          double lineHitPos = linePos0 + (j * stripXSize);
-          int colj = j;
-          if (mMapping.getNStripsNBP(colId, deIndex) == 8)
-            colj = j * 2; // Bend with only 8 stripY
-          double colHitPos = colId + (colj * stripYSize);
-          // std::cout << " bit (j) =>>  " << j << "  stripXPos = "<< stripXPos <<"  lineHitPos = "<< lineHitPos << std::endl;
-          if (isRightSide) {
-            if (ichamber == 0) {
-              if (board == 4) { // Non-Bend
-                multNoiseMT11NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendNoiseMap11->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multNoiseMT11B++;
-                mMBendNoiseMap11->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 1) {
-              if (board == 4) {
-                multNoiseMT12NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendNoiseMap12->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multNoiseMT12B++;
-                mMBendNoiseMap12->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 2) {
-              if (board == 4) {
-                multNoiseMT21NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendNoiseMap21->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multNoiseMT21B++;
-                mMBendNoiseMap21->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 3) {
-              if (board == 4) {
-                multNoiseMT22NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendNoiseMap22->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multNoiseMT22B++;
-                mMBendNoiseMap22->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            }
-          } else {
-            if (ichamber == 0) {
-              if (board == 4) { // Non-Bend
-                multNoiseMT11NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendNoiseMap11->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multNoiseMT11B++;
-                mMBendNoiseMap11->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 1) {
-              if (board == 4) {
-                multNoiseMT12NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendNoiseMap12->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multNoiseMT12B++;
-                mMBendNoiseMap12->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 2) {
-              if (board == 4) {
-                multNoiseMT21NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendNoiseMap21->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multNoiseMT21B++;
-                mMBendNoiseMap21->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 3) {
-              if (board == 4) {
-                multNoiseMT22NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendNoiseMap22->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multNoiseMT22B++;
-                mMBendNoiseMap22->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            }
-          } // isRightSide
-          mask <<= 1;
-        } // pattern loop 1-16
-      }   // noise.patterns[board] Bend or Non-Bend not empty
-    }     // boards loop  in DE
-  }       // DE loop
-  // Histograms noise strip Multiplicity ::
-  mMMultNoiseMT11B->Fill(multNoiseMT11B);
-  mMMultNoiseMT12B->Fill(multNoiseMT12B);
-  mMMultNoiseMT21B->Fill(multNoiseMT21B);
-  mMMultNoiseMT22B->Fill(multNoiseMT22B);
-  mMMultNoiseMT11NB->Fill(multNoiseMT11NB);
-  mMMultNoiseMT12NB->Fill(multNoiseMT12NB);
-  mMMultNoiseMT21NB->Fill(multNoiseMT21NB);
-  mMMultNoiseMT22NB->Fill(multNoiseMT22NB);
-
   auto deads = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("deadch");
-
-  mDeadROF++;
-
-  multDeadMT11B = 0;
-  multDeadMT12B = 0;
-  multDeadMT21B = 0;
-  multDeadMT22B = 0;
-  multDeadMT11NB = 0;
-  multDeadMT12NB = 0;
-  multDeadMT21NB = 0;
-  multDeadMT22NB = 0;
-
-  // printf(" deadROF =%i ;EventType %02d   ;  \n", deadROF, deadrof.eventType);
-  // if (deadROF != 1)
-  //  continue; /// TEST ONE FET EVENT ONLY !!!
-
-  int Ntest = 0;
-  // loadStripPatterns (ColumnData)
-
-  for (auto& dead : deads) { // loop DE //
-
-    // std::cout << "!!!! START monitorData CalibMQcTaskLoop deads (DE)!!!! " << std::endl;
-
-    int deIndex = dead.deId;
-    int colId = dead.columnId;
-    int rpcLine = o2::mid::detparams::getRPCLine(deIndex);
-    int ichamber = o2::mid::detparams::getChamber(deIndex);
-    auto isRightSide = o2::mid::detparams::isRightSide(deIndex);
-    auto detId = o2::mid::detparams::getDEId(isRightSide, ichamber, colId);
-    Ntest++;
-    // if (ichamber == 0)std::cout << "====> new  ColumnData : Nb = "  << Ntest <<" ich = "<<ichamber<< std::endl;
-
-    int nZoneHistoX = 1;
-    int nZoneHistoY = 4;
-    double stripYSize = 1. / 16;
-    double stripXSize = 0.25 / 16;
-    if (mMapping.getLastBoardBP(colId, deIndex) == 1) {
-      nZoneHistoX = 2;
-      stripXSize = 0.5 / 16;
-    } else if (mMapping.getLastBoardBP(colId, deIndex) == 0) {
-      nZoneHistoX = 4;
-      stripXSize = 1. / 16;
-    }
-    for (int board = mMapping.getFirstBoardBP(colId, deIndex), lastBoard = mMapping.getLastBoardBP(colId, deIndex); board <= lastBoard + 1; board++) {
-      // These are the existing bend boards for this column Id (board = n°board in the column) + 1 (for non-bend)
-
-      if ((lastBoard < 4) && (board == lastBoard + 1))
-        board = 4;                     // for Non-Bend digits
-      if (dead.patterns[board] != 0) { //  Bend + Non-Bend plane
-        //// Bend Local Boards Display ::
-        double linePos0 = rpcLine;
-
-        //// Strips Display ::
-        int mask = 1;
-
-        double shift = 0; // for central zone with only 3 loc boards
-        if ((colId == 0) && ((rpcLine == 3) || (rpcLine == 5)))
-          nZoneHistoY = 3;
-        if ((colId == 0) && (rpcLine == 5))
-          shift = 0.25;
-
-        for (int j = 0; j < 16; j++) {
-          int fired = 0;
-          if ((dead.patterns[board] & mask) != 0)
-            fired = 1;
-          double lineHitPos = linePos0 + (j * stripXSize);
-
-          int colj = j;
-          if (mMapping.getNStripsNBP(colId, deIndex) == 8)
-            colj = j * 2; // Bend with only 8 stripY
-          double colHitPos = colId + (colj * stripYSize);
-          // if (ichamber == 0)std::cout << "col = "<<colId<<" line = "<<linePos0 <<" board = "<<board<<" bit (j) =>>  " << j << "  lineHitPos = "<< lineHitPos << std::endl;
-
-          if (isRightSide) {
-            if (ichamber == 0) {
-              if (board == 4) { // Non-Bend
-                multDeadMT11NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendDeadMap11->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multDeadMT11B++;
-                mMBendDeadMap11->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 1) {
-              if (board == 4) {
-                multDeadMT12NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendDeadMap12->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                            // Bend
-                multDeadMT12B++;
-                mMBendDeadMap12->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 2) {
-              if (board == 4) {
-                multDeadMT21NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendDeadMap21->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                            // Bend
-                multDeadMT21B++;
-                mMBendDeadMap21->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 3) {
-              if (board == 4) {
-                multDeadMT22NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendDeadMap22->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                            // Bend
-                multDeadMT22B++;
-                mMBendDeadMap22->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            }
-          } else {
-            if (ichamber == 0) {
-              if (board == 4) {
-                multDeadMT11NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendDeadMap11->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                             // Bend
-                multDeadMT11B++;
-                mMBendDeadMap11->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 1) {
-              if (board == 4) {
-                multDeadMT12NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendDeadMap12->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                             // Bend
-                multDeadMT12B++;
-                mMBendDeadMap12->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 2) {
-              if (board == 4) {
-                multDeadMT21NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendDeadMap21->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                             // Bend
-                multDeadMT21B++;
-                mMBendDeadMap21->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 3) {
-              if (board == 4) {
-                multDeadMT22NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendDeadMap22->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                             // Bend
-                multDeadMT22B++;
-                mMBendDeadMap22->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            }
-          } // IsRightSide
-          mask <<= 1;
-        } // loop pattern 1-16
-      }   // Dead.patterns[board] Bend or Non-Bend not empty
-    }     // loop board in DE
-  }       // loop DE dead
-  // Histograms Dead Strip Multiplicity ::
-  // std::cout << "!!!! 5 monitorData CalibQcTask !!!! " << std::endl;
-  // printf(" Mult Dead B = %i ; %i   ; %i ; %i \n", multDeadMT11B,  multDeadMT12B, multDeadMT21B, multDeadMT22B);
-  // printf(" Mult Dead NB = %i ; %i   ; %i ; %i \n", multDeadMT11NB,  multDeadMT12NB, multDeadMT21NB, multDeadMT22NB);
-
-  mMMultDeadMT11B->Fill(multDeadMT11B);
-  mMMultDeadMT12B->Fill(multDeadMT12B);
-  mMMultDeadMT21B->Fill(multDeadMT21B);
-  mMMultDeadMT22B->Fill(multDeadMT22B);
-  mMMultDeadMT11NB->Fill(multDeadMT11NB);
-  mMMultDeadMT12NB->Fill(multDeadMT12NB);
-  mMMultDeadMT21NB->Fill(multDeadMT21NB);
-  mMMultDeadMT22NB->Fill(multDeadMT22NB);
-  // std::cout << "!!!! END boards loop in ROF !!!! " << std::endl;
-
-  ////  } //  deadROFs //
-
-  mBadROF++;
-
-  multBadMT11B = 0;
-  multBadMT12B = 0;
-  multBadMT21B = 0;
-  multBadMT22B = 0;
-  multBadMT11NB = 0;
-  multBadMT12NB = 0;
-  multBadMT21NB = 0;
-  multBadMT22NB = 0;
-
   auto bads = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("badch");
-  // printf("----------------> %05d TF \n", nTF);
 
-  // printf("bad :: ========================================================== \n");
-  for (auto& bad : bads) { // loop DE //
-
-    // std::cout << "!!!! START monitorData CalibMQcTaskLoop bads (DE)!!!! " << std::endl;
-
-    int deIndex = bad.deId;
-    int colId = bad.columnId;
-    int rpcLine = o2::mid::detparams::getRPCLine(deIndex);
-    int ichamber = o2::mid::detparams::getChamber(deIndex);
-    auto isRightSide = o2::mid::detparams::isRightSide(deIndex);
-    auto detId = o2::mid::detparams::getDEId(isRightSide, ichamber, colId);
-    Ntest++;
-    // if (ichamber == 0)std::cout << "====> new  ColumnData : Nb = "  << Ntest <<" ich = "<<ichamber<< std::endl;
-
-    int nZoneHistoX = 1;
-    int nZoneHistoY = 4;
-    double stripYSize = 1. / 16;
-    double stripXSize = 0.25 / 16;
-    if (mMapping.getLastBoardBP(colId, deIndex) == 1) {
-      nZoneHistoX = 2;
-      stripXSize = 0.5 / 16;
-    } else if (mMapping.getLastBoardBP(colId, deIndex) == 0) {
-      nZoneHistoX = 4;
-      stripXSize = 1. / 16;
-    }
-    for (int board = mMapping.getFirstBoardBP(colId, deIndex), lastBoard = mMapping.getLastBoardBP(colId, deIndex); board <= lastBoard + 1; board++) {
-      // These are the existing bend boards for this column Id (board = n°board in the column) + 1 (for non-bend)
-
-      if ((lastBoard < 4) && (board == lastBoard + 1))
-        board = 4;                    // for Non-Bend digits
-      if (bad.patterns[board] != 0) { //  Bend + Non-Bend plane
-        //// Bend Local Boards Display ::
-        double linePos0 = rpcLine;
-
-        //// Strips Display ::
-        int mask = 1;
-
-        double shift = 0; // for central zone with only 3 loc boards
-        if ((colId == 0) && ((rpcLine == 3) || (rpcLine == 5)))
-          nZoneHistoY = 3;
-        if ((colId == 0) && (rpcLine == 5))
-          shift = 0.25;
-
-        for (int j = 0; j < 16; j++) {
-          int fired = 0;
-          if ((bad.patterns[board] & mask) != 0)
-            fired = 1;
-          double lineHitPos = linePos0 + (j * stripXSize);
-
-          int colj = j;
-          if (mMapping.getNStripsNBP(colId, deIndex) == 8)
-            colj = j * 2; // Bend with only 8 stripY
-          double colHitPos = colId + (colj * stripYSize);
-          // if (ichamber == 0)std::cout << "col = "<<colId<<" line = "<<linePos0 <<" board = "<<board<<" bit (j) =>>  " << j << "  lineHitPos = "<< lineHitPos << std::endl;
-
-          if (isRightSide) {
-            if (ichamber == 0) {
-              if (board == 4) { // Non-Bend
-                multBadMT11NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendBadMap11->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-              } else { // Bend
-                multBadMT11B++;
-                mMBendBadMap11->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 1) {
-              if (board == 4) {
-                multDeadMT12NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendBadMap12->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                           // Bend
-                multBadMT12B++;
-                mMBendBadMap12->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 2) {
-              if (board == 4) {
-                multBadMT21NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendBadMap21->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                           // Bend
-                multBadMT21B++;
-                mMBendBadMap21->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 3) {
-              if (board == 4) {
-                multBadMT22NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendBadMap22->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                           // Bend
-                multBadMT22B++;
-                mMBendBadMap22->Fill(colId + 0.5, lineHitPos, fired);
-              }
-            }
-          } else {
-            if (ichamber == 0) {
-              if (board == 4) {
-                multBadMT11NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendBadMap11->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                            // Bend
-                multBadMT11B++;
-                mMBendBadMap11->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 1) {
-              if (board == 4) {
-                multBadMT12NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendBadMap12->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                            // Bend
-                multBadMT12B++;
-                mMBendBadMap12->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 2) {
-              if (board == 4) {
-                multBadMT21NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendBadMap21->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                            // Bend
-                multBadMT21B++;
-                mMBendBadMap21->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            } else if (ichamber == 3) {
-              if (board == 4) {
-                multBadMT22NB++;
-                for (int ib = 0; ib < nZoneHistoY; ib++)
-                  mMNBendBadMap22->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-              } else {                                                                            // Bend
-                multBadMT22B++;
-                mMBendBadMap22->Fill(-colId - 0.5, lineHitPos, fired);
-              }
-            }
-          } // IsRightSide
-          mask <<= 1;
-        } // loop pattern 1-16
-      }   // Dead.patterns[board] Bend or Non-Bend not empty
-    }     // loop board in DE
-
-  } // loop DE bad
-
-  mMMultBadMT11B->Fill(multBadMT11B);
-  mMMultBadMT12B->Fill(multBadMT12B);
-  mMMultBadMT21B->Fill(multBadMT21B);
-  mMMultBadMT22B->Fill(multBadMT22B);
-  mMMultBadMT11NB->Fill(multBadMT11NB);
-  mMMultBadMT12NB->Fill(multBadMT12NB);
-  mMMultBadMT21NB->Fill(multBadMT21NB);
-  mMMultBadMT22NB->Fill(multBadMT22NB);
-
-  // std::cout << "!!!! END monitorData CalibQcTask !!!! " << std::endl;
+  for (auto& col : noises) {
+    mDigitsHelper.fillStripHisto(col, mNoise.get());
+  }
+  for (auto& col : deads) {
+    mDigitsHelper.fillStripHisto(col, mDead.get());
+  }
+  for (auto& col : bads) {
+    mDigitsHelper.fillStripHisto(col, mBad.get());
+  }
 }
 
 void CalibMQcTask::endOfCycle()
 {
-  ILOG(Info, Devel) << "endOfCycle" << ENDM;
+  // Fill here the 2D representation of the fired strips
+  // First reset the old histograms
+  resetDisplayHistos();
+
+  // Then fill from the strip histogram
+  mDigitsHelper.fillMapHistos(mNoise.get(), mBendNoiseMap, mNBendNoiseMap);
+  mDigitsHelper.fillMapHistos(mDead.get(), mBendDeadMap, mNBendDeadMap);
+  mDigitsHelper.fillMapHistos(mBad.get(), mBendBadMap, mNBendBadMap);
 }
 
 void CalibMQcTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Devel) << "endOfActivity" << ENDM;
+}
+
+void CalibMQcTask::resetDisplayHistos()
+{
+  for (auto& histo : mBendNoiseMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mNBendNoiseMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mBendDeadMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mNBendDeadMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mBendBadMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mNBendBadMap) {
+    histo->Reset();
+  }
 }
 
 void CalibMQcTask::reset()
 {
-  // clean all the monitor objects here
-
-  ILOG(Info, Devel) << "Resetting the histogram" << ENDM;
-
-  mMMultNoiseMT11B->Reset();
-  mMMultNoiseMT11NB->Reset();
-  mMMultNoiseMT12B->Reset();
-  mMMultNoiseMT12NB->Reset();
-  mMMultNoiseMT21B->Reset();
-  mMMultNoiseMT21NB->Reset();
-  mMMultNoiseMT22B->Reset();
-  mMMultNoiseMT22NB->Reset();
-
-  mMBendNoiseMap11->Reset();
-  mMBendNoiseMap12->Reset();
-  mMBendNoiseMap21->Reset();
-  mMBendNoiseMap22->Reset();
-  mMNBendNoiseMap11->Reset();
-  mMNBendNoiseMap12->Reset();
-  mMNBendNoiseMap21->Reset();
-  mMNBendNoiseMap22->Reset();
-
-  mMMultDeadMT11B->Reset();
-  mMMultDeadMT11NB->Reset();
-  mMMultDeadMT12B->Reset();
-  mMMultDeadMT12NB->Reset();
-  mMMultDeadMT21B->Reset();
-  mMMultDeadMT21NB->Reset();
-  mMMultDeadMT22B->Reset();
-  mMMultDeadMT22NB->Reset();
-
-  mMBendDeadMap11->Reset();
-  mMBendDeadMap12->Reset();
-  mMBendDeadMap21->Reset();
-  mMBendDeadMap22->Reset();
-  mMNBendDeadMap11->Reset();
-  mMNBendDeadMap12->Reset();
-  mMNBendDeadMap21->Reset();
-  mMNBendDeadMap22->Reset();
-
-  mMBendBadMap11->Reset();
-  mMBendBadMap12->Reset();
-  mMBendBadMap21->Reset();
-  mMBendBadMap22->Reset();
-  mMNBendBadMap11->Reset();
-  mMNBendBadMap12->Reset();
-  mMNBendBadMap21->Reset();
-  mMNBendBadMap22->Reset();
+  mNoise->Reset();
+  mDead->Reset();
+  mBad->Reset();
+  resetDisplayHistos();
 }
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/src/CalibQcTask.cxx
+++ b/Modules/MUON/MID/src/CalibQcTask.cxx
@@ -12,33 +12,19 @@
 ///
 /// \author Valerie Ramillien
 
-#include <TCanvas.h>
-#include <TH1.h>
-#include <TH2.h>
-#include <TFile.h>
-#include <TProfile2D.h>
+#include "MID/CalibQcTask.h"
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <string>
-#include <vector>
+#include "fmt/format.h"
+#include "TH1.h"
+#include "TH2.h"
 
 #include "QualityControl/QcInfoLogger.h"
-#include "MID/CalibQcTask.h"
-#include <Framework/InputRecord.h>
-#include "Framework/DataRefUtils.h"
-#include "DataFormatsMID/ColumnData.h"
-#include "DataFormatsMID/ROBoard.h"
-#include "DataFormatsMID/ROFRecord.h"
-#include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/FEEIdConfig.h"
-#include "MIDBase/DetectorParameters.h"
-#include "MIDBase/GeometryParameters.h"
-#include "MIDWorkflow/ColumnDataSpecsUtils.h"
 
-#define MID_NDE 72
-#define MID_NCOL 7
+#include "Framework/InputRecord.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDBase/DetectorParameters.h"
+#include "MIDWorkflow/ColumnDataSpecsUtils.h"
 
 namespace o2::quality_control_modules::mid
 {
@@ -50,555 +36,144 @@ CalibQcTask::~CalibQcTask()
 void CalibQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Info, Devel) << "initialize CalibQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
-  // std::cout << "!!!! START initialize CalibQcTask !!!! " << std::endl;
-  /////////////////
-  mNbTimeFrame = std::make_shared<TH1F>("NbTimeFrame", "NbTimeFrame", 1, 0, 1.);
+  mNbTimeFrame = std::make_unique<TH1F>("NbTimeFrame", "NbTimeFrame", 1, 0, 1.);
   getObjectsManager()->startPublishing(mNbTimeFrame.get());
 
-  mNbDeadROF = std::make_shared<TH1F>("NbDeadROF", "NbDeadROF", 1, 0, 1.);
+  mNbNoiseROF = std::make_unique<TH1F>("NbNoiseROF", "NbNoiseROF", 1, 0, 1.);
+  getObjectsManager()->startPublishing(mNbNoiseROF.get());
+
+  mNbDeadROF = std::make_unique<TH1F>("NbDeadROF", "NbDeadROF", 1, 0, 1.);
   getObjectsManager()->startPublishing(mNbDeadROF.get());
 
-  mNbNoiseROF = std::make_shared<TH1F>("NbNoiseROF", "NbNoiseRF", 1, 0, 1.);
-  getObjectsManager()->startPublishing(mNbNoiseROF.get());
-  /// Noise strips Histograms ::
+  std::array<string, 4> chId{ "11", "12", "21", "22" };
 
-  mMultNoiseMT11B = std::make_shared<TH1F>("MultNoiseMT11B", "Multiplicity Noise strips - MT11 bending plane", 300, 0, 300);
-  mMultNoiseMT11NB = std::make_shared<TH1F>("MultNoiseMT11NB", "Multiplicity Noise strips - MT11 non-bending plane", 300, 0, 300);
-  mMultNoiseMT12B = std::make_shared<TH1F>("MultNoiseMT12B", "Multiplicity Noise strips - MT12 bending plane", 300, 0, 300);
-  mMultNoiseMT12NB = std::make_shared<TH1F>("MultNoiseMT12NB", "Multiplicity Noise strips - MT12 non-bending plane", 300, 0, 300);
-  mMultNoiseMT21B = std::make_shared<TH1F>("MultNoiseMT21B", "Multiplicity Noise strips - MT21 bending plane", 300, 0, 300);
-  mMultNoiseMT21NB = std::make_shared<TH1F>("MultNoiseMT21NB", "Multiplicity Noise strips - MT21 non-bending plane", 300, 0, 300);
-  mMultNoiseMT22B = std::make_shared<TH1F>("MultNoiseMT22B", "Multiplicity Noise strips - MT22 bending plane", 300, 0, 300);
-  mMultNoiseMT22NB = std::make_shared<TH1F>("MultNoiseMT22NB", "Multiplicity Noise strips - MT22 non-bending plane", 300, 0, 300);
-  getObjectsManager()->startPublishing(mMultNoiseMT11B.get());
-  getObjectsManager()->startPublishing(mMultNoiseMT11NB.get());
-  getObjectsManager()->startPublishing(mMultNoiseMT12B.get());
-  getObjectsManager()->startPublishing(mMultNoiseMT12NB.get());
-  getObjectsManager()->startPublishing(mMultNoiseMT21B.get());
-  getObjectsManager()->startPublishing(mMultNoiseMT21NB.get());
-  getObjectsManager()->startPublishing(mMultNoiseMT22B.get());
-  getObjectsManager()->startPublishing(mMultNoiseMT22NB.get());
+  // Noise strips Histograms ::
+  for (int ich = 0; ich < 4; ++ich) {
+    mMultNoiseB[ich] = std::make_unique<TH1F>(fmt::format("MultNoiseMT{}B", chId[ich]).c_str(), fmt::format("Multiplicity Noise strips - MT{} bending plane", chId[ich]).c_str(), 300, 0, 300);
+    getObjectsManager()->startPublishing(mMultNoiseB[ich].get());
+    mMultNoiseNB[ich] = std::make_unique<TH1F>(fmt::format("MultNoiseMT{}NB", chId[ich]).c_str(), fmt::format("Multiplicity Noise strips - MT{} non-bending plane", chId[ich]).c_str(), 300, 0, 300);
+    getObjectsManager()->startPublishing(mMultNoiseNB[ich].get());
+  }
 
-  mBendNoiseMap11 = std::make_shared<TH2F>("BendNoiseMap11", "Bending Noise Map MT11", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendNoiseMap11.get());
-  mBendNoiseMap11->GetXaxis()->SetTitle("Column");
-  mBendNoiseMap11->GetYaxis()->SetTitle("Line");
-  mBendNoiseMap11->SetOption("colz");
-  mBendNoiseMap11->SetStats(0);
+  mNoise = std::make_unique<TH1F>(mDigitsHelper.makeStripHisto("NoiseStrips", "Noise strips"));
+  getObjectsManager()->startPublishing(mNoise.get());
 
-  mBendNoiseMap12 = std::make_shared<TH2F>("BendNoiseMap12", "Bending Noise Map MT12", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendNoiseMap12.get());
-  mBendNoiseMap12->GetXaxis()->SetTitle("Column");
-  mBendNoiseMap12->GetYaxis()->SetTitle("Line");
-  mBendNoiseMap12->SetOption("colz");
-  mBendNoiseMap12->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mBendNoiseMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("BendNoiseMap{}", chId[ich]), fmt::format("Bending Noise Map MT{}", chId[ich]), 0));
+    getObjectsManager()->startPublishing(mBendNoiseMap[ich].get());
+  }
 
-  mBendNoiseMap21 = std::make_shared<TH2F>("BendNoiseMap21", "Bending Noise Map MT21", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendNoiseMap21.get());
-  mBendNoiseMap21->GetXaxis()->SetTitle("Column");
-  mBendNoiseMap21->GetYaxis()->SetTitle("Line");
-  mBendNoiseMap21->SetOption("colz");
-  mBendNoiseMap21->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mNBendNoiseMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("NBendNoiseMap{}", chId[ich]), fmt::format("Non-Bending Noise Map MT{}", chId[ich]), 1));
+    getObjectsManager()->startPublishing(mNBendNoiseMap[ich].get());
+  }
 
-  mBendNoiseMap22 = std::make_shared<TH2F>("BendNoiseMap22", "Bending Noise Map MT22", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendNoiseMap22.get());
-  mBendNoiseMap22->GetXaxis()->SetTitle("Column");
-  mBendNoiseMap22->GetYaxis()->SetTitle("Line");
-  mBendNoiseMap22->SetOption("colz");
-  mBendNoiseMap22->SetStats(0);
+  // Dead strips Histograms ::
+  for (int ich = 0; ich < 4; ++ich) {
+    mMultDeadB[ich] = std::make_unique<TH1F>(fmt::format("MultDeadMT{}B", chId[ich]).c_str(), fmt::format("Multiplicity Dead strips - MT{} bending plane", chId[ich]).c_str(), 300, 0, 300);
+    getObjectsManager()->startPublishing(mMultDeadB[ich].get());
+    mMultDeadNB[ich] = std::make_unique<TH1F>(fmt::format("MultDeadMT{}NB", chId[ich]).c_str(), fmt::format("Multiplicity Dead strips - MT{} non-bending plane", chId[ich]).c_str(), 300, 0, 300);
+    getObjectsManager()->startPublishing(mMultDeadNB[ich].get());
+  }
 
-  mNBendNoiseMap11 = std::make_shared<TH2F>("NBendNoiseMap11", "Non-Bending Noise Map MT11", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendNoiseMap11.get());
-  mNBendNoiseMap11->GetXaxis()->SetTitle("Column");
-  mNBendNoiseMap11->GetYaxis()->SetTitle("Line");
-  mNBendNoiseMap11->SetOption("colz");
-  mNBendNoiseMap11->SetStats(0);
+  mDead = std::make_unique<TH1F>(mDigitsHelper.makeStripHisto("DeadStrips", "Dead strips"));
+  getObjectsManager()->startPublishing(mDead.get());
 
-  mNBendNoiseMap12 = std::make_shared<TH2F>("NBendNoiseMap12", "Non-Bending Noise Map MT12", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendNoiseMap12.get());
-  mNBendNoiseMap12->GetXaxis()->SetTitle("Column");
-  mNBendNoiseMap12->GetYaxis()->SetTitle("Line");
-  mNBendNoiseMap12->SetOption("colz");
-  mNBendNoiseMap12->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mBendDeadMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("BendDeadMap{}", chId[ich]), fmt::format("Bending Dead Map MT{}", chId[ich]), 0));
+    getObjectsManager()->startPublishing(mBendDeadMap[ich].get());
+  }
 
-  mNBendNoiseMap21 = std::make_shared<TH2F>("NBendNoiseMap21", "Non-Bending Noise Map MT21", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendNoiseMap21.get());
-  mNBendNoiseMap21->GetXaxis()->SetTitle("Column");
-  mNBendNoiseMap21->GetYaxis()->SetTitle("Line");
-  mNBendNoiseMap21->SetOption("colz");
-  mNBendNoiseMap21->SetStats(0);
-
-  mNBendNoiseMap22 = std::make_shared<TH2F>("NBendNoiseMap22", "Non-Bending Noise Map MT22", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendNoiseMap22.get());
-  mNBendNoiseMap22->GetXaxis()->SetTitle("Column");
-  mNBendNoiseMap22->GetYaxis()->SetTitle("Line");
-  mNBendNoiseMap22->SetOption("colz");
-  mNBendNoiseMap22->SetStats(0);
-
-  /////////////////
-  /// Dead strips Histograms ::
-  mMultDeadMT11B = std::make_shared<TH1F>("MultDeadMT11B", "Multiplicity Dead strips - MT11 bending plane", 300, 0, 300);
-  mMultDeadMT11NB = std::make_shared<TH1F>("MultDeadMT11NB", "Multiplicity Dead strips - MT11 non-bending plane", 300, 0, 300);
-  mMultDeadMT12B = std::make_shared<TH1F>("MultDeadMT12B", "Multiplicity Dead strips - MT12 bending plane", 300, 0, 300);
-  mMultDeadMT12NB = std::make_shared<TH1F>("MultDeadMT12NB", "MultiplicityDead  strips - MT12 non-bending plane", 300, 0, 300);
-  mMultDeadMT21B = std::make_shared<TH1F>("MultDeadMT21B", "Multiplicity Dead strips - MT21 bending plane", 300, 0, 300);
-  mMultDeadMT21NB = std::make_shared<TH1F>("MultDeadMT21NB", "Multiplicity Dead strips - MT21 non-bending plane", 300, 0, 300);
-  mMultDeadMT22B = std::make_shared<TH1F>("MultDeadMT22B", "Multiplicity Dead strips - MT22 bending plane", 300, 0, 300);
-  mMultDeadMT22NB = std::make_shared<TH1F>("MultDeadMT22NB", "Multiplicity Dead strips - MT22 non-bending plane", 300, 0, 300);
-  getObjectsManager()->startPublishing(mMultDeadMT11B.get());
-  getObjectsManager()->startPublishing(mMultDeadMT11NB.get());
-  getObjectsManager()->startPublishing(mMultDeadMT12B.get());
-  getObjectsManager()->startPublishing(mMultDeadMT12NB.get());
-  getObjectsManager()->startPublishing(mMultDeadMT21B.get());
-  getObjectsManager()->startPublishing(mMultDeadMT21NB.get());
-  getObjectsManager()->startPublishing(mMultDeadMT22B.get());
-  getObjectsManager()->startPublishing(mMultDeadMT22NB.get());
-
-  mBendDeadMap11 = std::make_shared<TH2F>("BendDeadMap11", "Bending Dead Map MT11", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendDeadMap11.get());
-  mBendDeadMap11->GetXaxis()->SetTitle("Column");
-  mBendDeadMap11->GetYaxis()->SetTitle("Line");
-  mBendDeadMap11->SetOption("colz");
-  mBendDeadMap11->SetStats(0);
-
-  mBendDeadMap12 = std::make_shared<TH2F>("BendDeadMap12", "Bending Dead Map MT12", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendDeadMap12.get());
-  mBendDeadMap12->GetXaxis()->SetTitle("Column");
-  mBendDeadMap12->GetYaxis()->SetTitle("Line");
-  mBendDeadMap12->SetOption("colz");
-  mBendDeadMap12->SetStats(0);
-
-  mBendDeadMap21 = std::make_shared<TH2F>("BendDeadMap21", "Bending Dead Map MT21", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendDeadMap21.get());
-  mBendDeadMap21->GetXaxis()->SetTitle("Column");
-  mBendDeadMap21->GetYaxis()->SetTitle("Line");
-  mBendDeadMap21->SetOption("colz");
-  mBendDeadMap21->SetStats(0);
-
-  mBendDeadMap22 = std::make_shared<TH2F>("BendDeadMap22", "Bending Dead Map MT22", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendDeadMap22.get());
-  mBendDeadMap22->GetXaxis()->SetTitle("Column");
-  mBendDeadMap22->GetYaxis()->SetTitle("Line");
-  mBendDeadMap22->SetOption("colz");
-  mBendDeadMap22->SetStats(0);
-
-  mNBendDeadMap11 = std::make_shared<TH2F>("NBendDeadMap11", "Non-Bending Dead Map MT11", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendDeadMap11.get());
-  mNBendDeadMap11->GetXaxis()->SetTitle("Column");
-  mNBendDeadMap11->GetYaxis()->SetTitle("Line");
-  mNBendDeadMap11->SetOption("colz");
-  mNBendDeadMap11->SetStats(0);
-
-  mNBendDeadMap12 = std::make_shared<TH2F>("NBendDeadMap12", "Non-Bending Dead Map MT12", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendDeadMap12.get());
-  mNBendDeadMap12->GetXaxis()->SetTitle("Column");
-  mNBendDeadMap12->GetYaxis()->SetTitle("Line");
-  mNBendDeadMap12->SetOption("colz");
-  mNBendDeadMap12->SetStats(0);
-
-  mNBendDeadMap21 = std::make_shared<TH2F>("NBendDeadMap21", "Non-Bending Dead Map MT21", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendDeadMap21.get());
-  mNBendDeadMap21->GetXaxis()->SetTitle("Column");
-  mNBendDeadMap21->GetYaxis()->SetTitle("Line");
-  mNBendDeadMap21->SetOption("colz");
-  mNBendDeadMap21->SetStats(0);
-
-  mNBendDeadMap22 = std::make_shared<TH2F>("NBendDeadMap22", "Non-Bending Dead Map MT22", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendDeadMap22.get());
-  mNBendDeadMap22->GetXaxis()->SetTitle("Column");
-  mNBendDeadMap22->GetYaxis()->SetTitle("Line");
-  mNBendDeadMap22->SetOption("colz");
-  mNBendDeadMap22->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mNBendDeadMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("NBendDeadMap{}", chId[ich]), fmt::format("Non-Bending Dead Map MT{}", chId[ich]), 1));
+    getObjectsManager()->startPublishing(mNBendDeadMap[ich].get());
+  }
 }
 
 void CalibQcTask::startOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Devel) << "startOfActivity" << ENDM;
 }
 
 void CalibQcTask::startOfCycle()
 {
-  ILOG(Info, Devel) << "startOfCycle" << ENDM;
 }
 
 void CalibQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  // std::cout << "!!!! START monitorData CalibQcTask !!!! " << std::endl;
-  mTF++;
-  // printf("----------------> %05d TF ",nTF);
   mNbTimeFrame->Fill(0.5, 1.);
 
   auto noises = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("noise");
   auto noiserofs = ctx.inputs().get<gsl::span<o2::mid::ROFRecord>>("noiserofs");
 
-  // auto noises = o2::mid::specs::getData(ctx, "digits", o2::mid::EventType::Calib);
-  // auto noiserofs = o2::mid::specs::getRofs(ctx, "digits", o2::mid::EventType::Calib);
-
-  int multNoiseMT11B = 0;
-  int multNoiseMT12B = 0;
-  int multNoiseMT21B = 0;
-  int multNoiseMT22B = 0;
-  int multNoiseMT11NB = 0;
-  int multNoiseMT12NB = 0;
-  int multNoiseMT21NB = 0;
-  int multNoiseMT22NB = 0;
-
-  int multDeadMT11B = 0;
-  int multDeadMT12B = 0;
-  int multDeadMT21B = 0;
-  int multDeadMT22B = 0;
-  int multDeadMT11NB = 0;
-  int multDeadMT12NB = 0;
-  int multDeadMT21NB = 0;
-  int multDeadMT22NB = 0;
-  // printf("========================================================== \n");
-
-  for (const auto& noiserof : noiserofs) { // loop noiseROFs //
-    // printf("========================================================== \n");
-    // printf("%05d noiseROF with first entry %05zu and nentries %02zu , BC %05d, ORB %05d , EventType %02d\n", noiseROF, noiserof.firstEntry, noiserof.nEntries, noiserof.interactionRecord.bc, noiserof.interactionRecord.orbit, (int)noiserof.eventType);
-    //    eventType::  Standard = 0, Calib = 1, FET = 2
-    mNbNoiseROF->Fill(0.5, 1.);
-    mNoiseROF++;
-    multNoiseMT11B = 0;
-    multNoiseMT12B = 0;
-    multNoiseMT21B = 0;
-    multNoiseMT22B = 0;
-    multNoiseMT11NB = 0;
-    multNoiseMT12NB = 0;
-    multNoiseMT21NB = 0;
-    multNoiseMT22NB = 0;
-
-    // printf(" noiseROF =%i ;EventType %02d   ;  \n", noiseROF, noiserof.eventType);
-    //  loadStripPatterns (ColumnData)
-    for (auto& noise : noises.subspan(noiserof.firstEntry, noiserof.nEntries)) { // loop DE //
-      int deIndex = noise.deId;
-      int colId = noise.columnId;
-      int rpcLine = o2::mid::detparams::getRPCLine(deIndex);
-      int ichamber = o2::mid::detparams::getChamber(deIndex);
-      auto isRightSide = o2::mid::detparams::isRightSide(deIndex);
-      auto detId = o2::mid::detparams::getDEId(isRightSide, ichamber, colId);
-
-      int nZoneHistoX = 1;
-      int nZoneHistoY = 4;
-      double stripYSize = 1. / 16;
-      double stripXSize = 0.25 / 16;
-      if (mMapping.getLastBoardBP(colId, deIndex) == 1) {
-        nZoneHistoX = 2;
-        stripXSize = 0.5 / 16;
-      } else if (mMapping.getLastBoardBP(colId, deIndex) == 0) {
-        nZoneHistoX = 4;
-        stripXSize = 1. / 16;
-      }
-
-      for (int board = mMapping.getFirstBoardBP(colId, deIndex), lastBoard = mMapping.getLastBoardBP(colId, deIndex); board <= lastBoard + 1; board++) {
-        // These are the existing bend boards for this column Id (board = n°board in the column) + 1 (for non-bend)
-        if ((lastBoard < 4) && (board == lastBoard + 1))
-          board = 4;                      // for Non-Bend digits
-        if (noise.patterns[board] != 0) { //  Bend + Non-Bend plane
-          //// Bend Local Boards Display ::
-          double linePos0 = rpcLine;
-
-          //// Strips Display ::
-          int mask = 1;
-
-          double shift = 0; // for central zone with only 3 loc boards
-          if ((colId == 0) && ((rpcLine == 3) || (rpcLine == 5)))
-            nZoneHistoY = 3;
-          if ((colId == 0) && (rpcLine == 5))
-            shift = 0.25;
-
-          for (int j = 0; j < 16; j++) {
-            int fired = 0;
-            if ((noise.patterns[board] & mask) != 0)
-              fired = 1;
-            double lineHitPos = linePos0 + (j * stripXSize);
-            int colj = j;
-            if (mMapping.getNStripsNBP(colId, deIndex) == 8)
-              colj = j * 2; // Bend with only 8 stripY
-            double colHitPos = colId + (colj * stripYSize);
-            // std::cout << " bit (j) =>>  " << j << "  stripXPos = "<< stripXPos <<"  lineHitPos = "<< lineHitPos << std::endl;
-            if (isRightSide) {
-              if (ichamber == 0) {
-                if (board == 4) { // Non-Bend
-                  multNoiseMT11NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendNoiseMap11->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multNoiseMT11B++;
-                  mBendNoiseMap11->Fill(colId + 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 1) {
-                if (board == 4) {
-                  multNoiseMT12NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendNoiseMap12->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multNoiseMT12B++;
-                  mBendNoiseMap12->Fill(colId + 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 2) {
-                if (board == 4) {
-                  multNoiseMT21NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendNoiseMap21->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multNoiseMT21B++;
-                  mBendNoiseMap21->Fill(colId + 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 3) {
-                if (board == 4) {
-                  multNoiseMT22NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendNoiseMap22->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multNoiseMT22B++;
-                  mBendNoiseMap22->Fill(colId + 0.5, lineHitPos, fired);
-                }
-              }
-            } else {
-              if (ichamber == 0) {
-                if (board == 4) { // Non-Bend
-                  multNoiseMT11NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendNoiseMap11->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multNoiseMT11B++;
-                  mBendNoiseMap11->Fill(-colId - 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 1) {
-                if (board == 4) {
-                  multNoiseMT12NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendNoiseMap12->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multNoiseMT12B++;
-                  mBendNoiseMap12->Fill(-colId - 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 2) {
-                if (board == 4) {
-                  multNoiseMT21NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendNoiseMap21->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multNoiseMT21B++;
-                  mBendNoiseMap21->Fill(-colId - 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 3) {
-                if (board == 4) {
-                  multNoiseMT22NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendNoiseMap22->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multNoiseMT22B++;
-                  mBendNoiseMap22->Fill(-colId - 0.5, lineHitPos, fired);
-                }
-              }
-            } // isRightSide
-            mask <<= 1;
-          } // pattern loop 1-16
-        }   // noise.patterns[board] Bend or Non-Bend not empty
-      }     // boards loop  in DE
-    }       // DE loop
-    // Histograms noise strip Multiplicity ::
-    mMultNoiseMT11B->Fill(multNoiseMT11B);
-    mMultNoiseMT12B->Fill(multNoiseMT12B);
-    mMultNoiseMT21B->Fill(multNoiseMT21B);
-    mMultNoiseMT22B->Fill(multNoiseMT22B);
-    mMultNoiseMT11NB->Fill(multNoiseMT11NB);
-    mMultNoiseMT12NB->Fill(multNoiseMT12NB);
-    mMultNoiseMT21NB->Fill(multNoiseMT21NB);
-    mMultNoiseMT22NB->Fill(multNoiseMT22NB);
-  } //  noiseROFs //
-
   auto deads = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("dead");
   auto deadrofs = ctx.inputs().get<gsl::span<o2::mid::ROFRecord>>("deadrofs");
 
-  // auto deads = o2::mid::specs::getData(ctx, "digits", o2::mid::EventType::FET);
-  // auto deadrofs = o2::mid::specs::getRofs(ctx, "digits", o2::mid::EventType::FET);
+  // Noise
+  std::array<unsigned long int, 4> evtSizeB{};
+  std::array<unsigned long int, 4> evtSizeNB{};
 
-  // printf("========================================================== \n");
+  for (const auto& rof : noiserofs) {
+    evtSizeB.fill(0);
+    evtSizeNB.fill(0);
+    mNbNoiseROF->Fill(0.5, 1.);
+    for (auto& col : noises.subspan(rof.firstEntry, rof.nEntries)) {
+      auto ich = o2::mid::detparams::getChamber(col.deId);
+      evtSizeB[ich] = mDigitsHelper.countDigits(col, 0);
+      evtSizeNB[ich] = mDigitsHelper.countDigits(col, 1);
+      mDigitsHelper.fillStripHisto(col, mNoise.get());
+    }
+    for (int ich = 0; ich < 4; ++ich) {
+      mMultNoiseB[ich]->Fill(evtSizeB[ich]);
+      mMultNoiseNB[ich]->Fill(evtSizeNB[ich]);
+    }
+  }
 
-  for (const auto& deadrof : deadrofs) { // loop deadROFs //
-    // printf("========================================================== \n");
-    // printf("%05d deadROF with first entry %05zu and nentries %02zu , BC %05d, ORB %05d , EventType %02d\n", deadROF, deadrof.firstEntry, deadrof.nEntries, deadrof.interactionRecord.bc, deadrof.interactionRecord.orbit, (int)deadrof.eventType);
-    //   eventType::  Standard = 0, Calib = 1, FET = 2
+  for (const auto& rof : deadrofs) {
     mNbDeadROF->Fill(0.5, 1.);
-    mDeadROF++;
-
-    multDeadMT11B = 0;
-    multDeadMT12B = 0;
-    multDeadMT21B = 0;
-    multDeadMT22B = 0;
-    multDeadMT11NB = 0;
-    multDeadMT12NB = 0;
-    multDeadMT21NB = 0;
-    multDeadMT22NB = 0;
-
-    // printf(" deadROF =%i ;EventType %02d   ;  \n", deadROF, deadrof.eventType);
-    // if (deadROF != 1)
-    //  continue; /// TEST ONE FET EVENT ONLY !!!
-
-    int Ntest = 0;
-    // loadStripPatterns (ColumnData)
-    for (auto& dead : deads.subspan(deadrof.firstEntry, deadrof.nEntries)) { // loop DE //
-      int deIndex = dead.deId;
-      int colId = dead.columnId;
-      int rpcLine = o2::mid::detparams::getRPCLine(deIndex);
-      int ichamber = o2::mid::detparams::getChamber(deIndex);
-      auto isRightSide = o2::mid::detparams::isRightSide(deIndex);
-      auto detId = o2::mid::detparams::getDEId(isRightSide, ichamber, colId);
-      Ntest++;
-      // if (ichamber == 0)std::cout << "====> new  ColumnData : Nb = "  << Ntest <<" ich = "<<ichamber<< std::endl;
-
-      int nZoneHistoX = 1;
-      int nZoneHistoY = 4;
-      double stripYSize = 1. / 16;
-      double stripXSize = 0.25 / 16;
-      if (mMapping.getLastBoardBP(colId, deIndex) == 1) {
-        nZoneHistoX = 2;
-        stripXSize = 0.5 / 16;
-      } else if (mMapping.getLastBoardBP(colId, deIndex) == 0) {
-        nZoneHistoX = 4;
-        stripXSize = 1. / 16;
-      }
-      for (int board = mMapping.getFirstBoardBP(colId, deIndex), lastBoard = mMapping.getLastBoardBP(colId, deIndex); board <= lastBoard + 1; board++) {
-        // These are the existing bend boards for this column Id (board = n°board in the column) + 1 (for non-bend)
-
-        if ((lastBoard < 4) && (board == lastBoard + 1))
-          board = 4;                     // for Non-Bend digits
-        if (dead.patterns[board] != 0) { //  Bend + Non-Bend plane
-          //// Bend Local Boards Display ::
-          double linePos0 = rpcLine;
-
-          //// Strips Display ::
-          int mask = 1;
-
-          double shift = 0; // for central zone with only 3 loc boards
-          if ((colId == 0) && ((rpcLine == 3) || (rpcLine == 5)))
-            nZoneHistoY = 3;
-          if ((colId == 0) && (rpcLine == 5))
-            shift = 0.25;
-
-          for (int j = 0; j < 16; j++) {
-            int fired = 0;
-            if ((dead.patterns[board] & mask) != 0)
-              fired = 1;
-            double lineHitPos = linePos0 + (j * stripXSize);
-
-            int colj = j;
-            if (mMapping.getNStripsNBP(colId, deIndex) == 8)
-              colj = j * 2; // Bend with only 8 stripY
-            double colHitPos = colId + (colj * stripYSize);
-            // if (ichamber == 0)std::cout << "col = "<<colId<<" line = "<<linePos0 <<" board = "<<board<<" bit (j) =>>  " << j << "  lineHitPos = "<< lineHitPos << std::endl;
-
-            if (isRightSide) {
-              if (ichamber == 0) {
-                if (board == 4) { // Non-Bend
-                  multDeadMT11NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendDeadMap11->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired);
-                } else { // Bend
-                  multDeadMT11B++;
-                  mBendDeadMap11->Fill(colId + 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 1) {
-                if (board == 4) {
-                  multDeadMT12NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendDeadMap12->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-                } else {                                                                           // Bend
-                  multDeadMT12B++;
-                  mBendDeadMap12->Fill(colId + 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 2) {
-                if (board == 4) {
-                  multDeadMT21NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendDeadMap21->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-                } else {                                                                           // Bend
-                  multDeadMT21B++;
-                  mBendDeadMap21->Fill(colId + 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 3) {
-                if (board == 4) {
-                  multDeadMT22NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendDeadMap22->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-                } else {                                                                           // Bend
-                  multDeadMT22B++;
-                  mBendDeadMap22->Fill(colId + 0.5, lineHitPos, fired);
-                }
-              }
-            } else {
-              if (ichamber == 0) {
-                if (board == 4) {
-                  multDeadMT11NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendDeadMap11->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-                } else {                                                                            // Bend
-                  multDeadMT11B++;
-                  mBendDeadMap11->Fill(-colId - 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 1) {
-                if (board == 4) {
-                  multDeadMT12NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendDeadMap12->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-                } else {                                                                            // Bend
-                  multDeadMT12B++;
-                  mBendDeadMap12->Fill(-colId - 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 2) {
-                if (board == 4) {
-                  multDeadMT21NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendDeadMap21->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-                } else {                                                                            // Bend
-                  multDeadMT21B++;
-                  mBendDeadMap21->Fill(-colId - 0.5, lineHitPos, fired);
-                }
-              } else if (ichamber == 3) {
-                if (board == 4) {
-                  multDeadMT22NB++;
-                  for (int ib = 0; ib < nZoneHistoY; ib++)
-                    mNBendDeadMap22->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), fired); // Non-Bend
-                } else {                                                                            // Bend
-                  multDeadMT22B++;
-                  mBendDeadMap22->Fill(-colId - 0.5, lineHitPos, fired);
-                }
-              }
-            } // IsRightSide
-            mask <<= 1;
-          } // loop pattern 1-16
-        }   // Dead.patterns[board] Bend or Non-Bend not empty
-      }     // loop board in DE
-    }       // loop DE
-    // Histograms Dead Strip Multiplicity ::
-    // std::cout << "!!!! 5 monitorData CalibQcTask !!!! " << std::endl;
-    // printf(" Mult Dead B = %i ; %i   ; %i ; %i \n", multDeadMT11B,  multDeadMT12B, multDeadMT21B, multDeadMT22B);
-    // printf(" Mult Dead NB = %i ; %i   ; %i ; %i \n", multDeadMT11NB,  multDeadMT12NB, multDeadMT21NB, multDeadMT22NB);
-
-    mMultDeadMT11B->Fill(multDeadMT11B);
-    mMultDeadMT12B->Fill(multDeadMT12B);
-    mMultDeadMT21B->Fill(multDeadMT21B);
-    mMultDeadMT22B->Fill(multDeadMT22B);
-    mMultDeadMT11NB->Fill(multDeadMT11NB);
-    mMultDeadMT12NB->Fill(multDeadMT12NB);
-    mMultDeadMT21NB->Fill(multDeadMT21NB);
-    mMultDeadMT22NB->Fill(multDeadMT22NB);
-    // std::cout << "!!!! END boards loop in ROF !!!! " << std::endl;
-  } //  deadROFs //
-  // std::cout << "!!!! END monitorData CalibQcTask !!!! " << std::endl;
+    evtSizeB.fill(0);
+    evtSizeNB.fill(0);
+    for (auto& col : deads.subspan(rof.firstEntry, rof.nEntries)) {
+      auto ich = o2::mid::detparams::getChamber(col.deId);
+      evtSizeB[ich] = mDigitsHelper.countDigits(col, 0);
+      evtSizeNB[ich] = mDigitsHelper.countDigits(col, 1);
+      mDigitsHelper.fillStripHisto(col, mDead.get());
+    }
+    for (int ich = 0; ich < 4; ++ich) {
+      mMultDeadB[ich]->Fill(evtSizeB[ich]);
+      mMultDeadNB[ich]->Fill(evtSizeNB[ich]);
+    }
+  }
 }
 
 void CalibQcTask::endOfCycle()
 {
-  ILOG(Info, Devel) << "endOfCycle" << ENDM;
+  // Fill here the 2D representation of the fired strips
+  // First reset the old histograms
+  resetDisplayHistos();
+
+  // Then fill from the strip histogram
+  mDigitsHelper.fillMapHistos(mNoise.get(), mBendNoiseMap, mNBendNoiseMap);
+  mDigitsHelper.fillMapHistos(mDead.get(), mBendDeadMap, mNBendDeadMap);
 }
 
 void CalibQcTask::endOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Devel) << "endOfActivity" << ENDM;
+}
+
+void CalibQcTask::resetDisplayHistos()
+{
+  for (auto& histo : mBendNoiseMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mNBendNoiseMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mBendDeadMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mNBendDeadMap) {
+    histo->Reset();
+  }
 }
 
 void CalibQcTask::reset()
@@ -611,41 +186,15 @@ void CalibQcTask::reset()
   mNbNoiseROF->Reset();
   mNbDeadROF->Reset();
 
-  mMultNoiseMT11B->Reset();
-  mMultNoiseMT11NB->Reset();
-  mMultNoiseMT12B->Reset();
-  mMultNoiseMT12NB->Reset();
-  mMultNoiseMT21B->Reset();
-  mMultNoiseMT21NB->Reset();
-  mMultNoiseMT22B->Reset();
-  mMultNoiseMT22NB->Reset();
-
-  mBendNoiseMap11->Reset();
-  mBendNoiseMap12->Reset();
-  mBendNoiseMap21->Reset();
-  mBendNoiseMap22->Reset();
-  mNBendNoiseMap11->Reset();
-  mNBendNoiseMap12->Reset();
-  mNBendNoiseMap21->Reset();
-  mNBendNoiseMap22->Reset();
-
-  mMultDeadMT11B->Reset();
-  mMultDeadMT11NB->Reset();
-  mMultDeadMT12B->Reset();
-  mMultDeadMT12NB->Reset();
-  mMultDeadMT21B->Reset();
-  mMultDeadMT21NB->Reset();
-  mMultDeadMT22B->Reset();
-  mMultDeadMT22NB->Reset();
-
-  mBendDeadMap11->Reset();
-  mBendDeadMap12->Reset();
-  mBendDeadMap21->Reset();
-  mBendDeadMap22->Reset();
-  mNBendDeadMap11->Reset();
-  mNBendDeadMap12->Reset();
-  mNBendDeadMap21->Reset();
-  mNBendDeadMap22->Reset();
+  for (auto& histo : mMultNoiseB) {
+    histo->Reset();
+  }
+  for (auto& histo : mMultNoiseNB) {
+    histo->Reset();
+  }
+  mNoise->Reset();
+  mDead->Reset();
+  resetDisplayHistos();
 }
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/src/DigitsHelper.cxx
+++ b/Modules/MUON/MID/src/DigitsHelper.cxx
@@ -1,0 +1,231 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   DigitsHelper.h
+/// \author Diego Stocco
+
+#include "MID/DigitsHelper.h"
+
+#include <fmt/format.h>
+#include "TH1.h"
+#include "TH2.h"
+#include "MIDBase/DetectorParameters.h"
+#include "MIDBase/GeometryParameters.h"
+#include "MIDGlobalMapping/GlobalMapper.h"
+
+namespace o2::quality_control_modules::mid
+{
+DigitsHelper::DigitsHelper()
+{
+  mStripsMap.clear();
+  mStripsInfo.clear();
+
+  o2::mid::GlobalMapper gm;
+  auto infos = gm.buildStripsInfo();
+
+  for (size_t idx = 0; idx < infos.size(); ++idx) {
+    mStripsMap[infos[idx].id] = idx;
+    StripInfo si;
+    si.deId = infos[idx].deId;
+    si.columnId = infos[idx].columnId;
+    si.lineId = infos[idx].lineId;
+    si.stripId = infos[idx].stripId;
+    si.cathode = infos[idx].cathode;
+    si.xwidth = std::abs(infos[idx].xwidth);
+    si.ywidth = infos[idx].ywidth;
+    mStripsInfo.emplace_back(si);
+  }
+
+  for (int ide = 0; ide < o2::mid::detparams::NDetectionElements; ++ide) {
+    for (int icol = gm.getMapping().getFirstColumn(ide); icol < 7; ++icol) {
+      int idx = getColumnIdx(icol, ide);
+      mColumnInfo[idx].firstLine = gm.getMapping().getFirstBoardBP(icol, ide);
+      mColumnInfo[idx].lastLine = gm.getMapping().getLastBoardBP(icol, ide);
+      mColumnInfo[idx].nStripsNB = gm.getMapping().getNStripsNBP(icol, ide);
+    }
+  }
+}
+
+TH1F DigitsHelper::makeStripHisto(const std::string name, const std::string title) const
+{
+  TH1F histo(name.c_str(), title.c_str(), mStripsInfo.size(), 0, mStripsInfo.size());
+  histo.SetXTitle("Strip index");
+  return histo;
+}
+
+unsigned long DigitsHelper::countDigits(const o2::mid::ColumnData& col, int cathode) const
+{
+  unsigned long counts = 0;
+  int firstCathode = 0;
+  int lastCathode = 1;
+  if (cathode == 0 || cathode == 1) {
+    firstCathode = lastCathode = cathode;
+  }
+  int lastLine = (cathode == 1) ? 0 : 3;
+  for (int icath = firstCathode; icath <= lastCathode; ++icath) {
+    for (int iline = 0; iline <= lastLine; ++iline) {
+      for (int istrip = 0; istrip < 16; ++istrip) {
+        if (col.isStripFired(istrip, icath, iline)) {
+          ++counts;
+        }
+      }
+    }
+  }
+  return counts;
+}
+
+TH2F DigitsHelper::makeStripMapHisto(std::string name, std::string title, int cathode) const
+{
+  int nBinsX = (cathode == 0) ? 14 : 224;
+  int nBinsY = (cathode == 0) ? 64 * o2::mid::detparams::NRPCLines : 4 * o2::mid::detparams::NRPCLines;
+  TH2F histo = TH2F(name.c_str(), title.c_str(), nBinsX, -7, 7, nBinsY, 0., 9.);
+  histo.SetXTitle("Column");
+  histo.SetYTitle("Line");
+  histo.SetOption("COLZ");
+  histo.SetStats(0);
+  return histo;
+}
+
+TH2F DigitsHelper::makeBoardMapHisto(std::string name, std::string title) const
+{
+  TH2F histo = TH2F(name.c_str(), title.c_str(), 14, -7., 7., 4 * o2::mid::detparams::NRPCLines, 0., 9.);
+  histo.SetXTitle("Column");
+  histo.SetYTitle("Line");
+  histo.SetOption("COLZ");
+  histo.SetStats(0);
+  return histo;
+}
+
+void DigitsHelper::fillMapHistos(const StripInfo& info, TH2* stripHistoB, TH2* stripHistoNB, TH2* boardHisto, int wgt) const
+{
+  int irpc = o2::mid::detparams::getRPCLine(info.deId);
+  bool isRightSide = o2::mid::detparams::isRightSide(info.deId);
+
+  int idx = getColumnIdx(info.columnId, info.deId);
+
+  int firstLine = mColumnInfo[idx].firstLine;
+  int lastLine = mColumnInfo[idx].lastLine;
+
+  int xbinOffsetBoard = 7 - info.columnId;
+  if (isRightSide) {
+    xbinOffsetBoard = 15 - xbinOffsetBoard;
+  }
+  int ybinOffsetBoard = 4 * irpc + 1;
+
+  if (info.cathode == 0) {
+    // BP
+    int ybinOffsetStrip = 64 * irpc + 1;
+    int pitchB = info.ywidth;
+    int iline = info.lineId;
+    int istrip = info.stripId;
+    for (int ibin = 0; ibin < pitchB; ++ibin) {
+      stripHistoB->AddBinContent(stripHistoB->GetBin(xbinOffsetBoard, ybinOffsetStrip + pitchB * (16 * iline + istrip) + ibin), wgt);
+      stripHistoB->SetEntries(stripHistoB->GetEntries() + wgt);
+    }
+    if (boardHisto) {
+      for (int ibin = 0; ibin < pitchB; ++ibin) {
+        boardHisto->AddBinContent(boardHisto->GetBin(xbinOffsetBoard, ybinOffsetBoard + pitchB * iline + ibin), wgt);
+        boardHisto->SetEntries(boardHisto->GetEntries() + wgt);
+      }
+    }
+  } else {
+    // NBP
+    int xbinOffsetStrip = 16 * (xbinOffsetBoard - 1) + 1;
+    int pitchNB = info.xwidth;
+    if (info.columnId == 6) {
+      pitchNB = 2;
+    }
+    if (o2::mid::geoparams::isShortRPC(info.deId) && info.columnId == 1) {
+      if (isRightSide) {
+        xbinOffsetStrip += 8;
+      }
+    }
+    if (lastLine != 2) {
+      lastLine = 3;
+    }
+    int binWidth = pitchNB / 2;
+    int istrip = info.stripId;
+    for (int iline = firstLine; iline <= lastLine; ++iline) {
+      for (int ibin = 0; ibin < binWidth; ++ibin) {
+        stripHistoNB->AddBinContent(stripHistoNB->GetBin(xbinOffsetStrip + binWidth * istrip + ibin, ybinOffsetBoard + iline), wgt);
+        stripHistoNB->SetEntries(stripHistoNB->GetEntries() + wgt);
+      }
+      if (boardHisto) {
+        boardHisto->AddBinContent(boardHisto->GetBin(xbinOffsetBoard, ybinOffsetBoard + iline), wgt);
+        boardHisto->SetEntries(boardHisto->GetEntries() + wgt);
+      }
+    }
+  }
+}
+
+void DigitsHelper::fillMapHistos(const TH1* stripHisto, std::array<std::unique_ptr<TH2F>, 4>& stripHistosB, std::array<std::unique_ptr<TH2F>, 4>& stripHistosNB, std::array<std::unique_ptr<TH2F>, 5>& boardHistos) const
+{
+  for (int ibin = 1, nBins = stripHisto->GetNbinsX(); ibin <= nBins; ++ibin) {
+    auto& info = mStripsInfo[ibin - 1];
+    int ch = o2::mid::detparams::getChamber(info.deId);
+    fillMapHistos(info, stripHistosB[ch].get(), stripHistosNB[ch].get(), boardHistos[ch].get(), stripHisto->GetBinContent(ibin));
+  }
+  boardHistos[4]->Reset();
+  for (size_t ich = 0; ich < 4; ++ich) {
+    boardHistos[4]->Add(boardHistos[ich].get());
+  }
+}
+
+void DigitsHelper::fillMapHistos(const TH1* stripHisto, std::array<std::unique_ptr<TH2F>, 4>& stripHistosB, std::array<std::unique_ptr<TH2F>, 4>& stripHistosNB) const
+{
+  for (int ibin = 1, nBins = stripHisto->GetNbinsX(); ibin <= nBins; ++ibin) {
+    auto& info = mStripsInfo[ibin - 1];
+    int ch = o2::mid::detparams::getChamber(info.deId);
+    fillMapHistos(info, stripHistosB[ch].get(), stripHistosNB[ch].get(), nullptr, stripHisto->GetBinContent(ibin));
+  }
+}
+
+void DigitsHelper::fillMapHistos(const TH1* stripHisto, TH2* stripHistosB, TH2* stripHistosNB, TH2* boardHistos, int chamber) const
+{
+  for (int ibin = 1, nBins = stripHisto->GetNbinsX(); ibin <= nBins; ++ibin) {
+    auto& info = mStripsInfo[ibin - 1];
+    int ch = o2::mid::detparams::getChamber(info.deId);
+    if (ch != chamber) {
+      continue;
+    }
+    fillMapHistos(info, stripHistosB, stripHistosNB, boardHistos, stripHisto->GetBinContent(ibin));
+  }
+}
+
+void DigitsHelper::fillStripHisto(const o2::mid::ColumnData& col, TH1* histo) const
+{
+  int idx = getColumnIdx(col.columnId, col.deId);
+  int firstLine = mColumnInfo[idx].firstLine;
+  int lastLine = mColumnInfo[idx].lastLine;
+  for (int iline = firstLine; iline <= lastLine; ++iline) {
+    for (int istrip = 0; istrip < 16; ++istrip) {
+      if (col.isBPStripFired(istrip, iline)) {
+        auto found = mStripsMap.find(o2::mid::getStripId(col.deId, col.columnId, iline, istrip, 0));
+        // The histogram bin corresponds to the strip index + 1
+        // Since we know the bin, we can use AddBinContent instead of Fill to save time
+        histo->AddBinContent(found->second + 1);
+        histo->SetEntries(histo->GetEntries() + 1);
+      }
+    }
+  }
+  int nStrips = mColumnInfo[idx].nStripsNB;
+  for (int istrip = 0; istrip < nStrips; ++istrip) {
+    if (col.isNBPStripFired(istrip)) {
+      auto found = mStripsMap.find(o2::mid::getStripId(col.deId, col.columnId, firstLine, istrip, 1));
+      // The histogram bin corresponds to the strip index + 1
+      // Since we know the bin, we can use AddBinContent instead of Fill to save time
+      histo->AddBinContent(found->second + 1);
+      histo->SetEntries(histo->GetEntries() + 1);
+    }
+  }
+}
+
+} // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/src/DigitsQcCheck.cxx
+++ b/Modules/MUON/MID/src/DigitsQcCheck.cxx
@@ -15,222 +15,115 @@
 ///
 
 #include "MID/DigitsQcCheck.h"
+#include "DataFormatsQualityControl/FlagReasons.h"
 #include "QualityControl/MonitorObject.h"
-#include "QualityControl/Quality.h"
 #include "QualityControl/QcInfoLogger.h"
 // ROOT
 #include <TStyle.h>
 #include <TColor.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TPaletteAxis.h>
-#include <TList.h>
-#include <TLatex.h>
-#include <TPaveText.h>
-
-using namespace std;
 
 namespace o2::quality_control_modules::mid
 {
 
 void DigitsQcCheck::configure()
-{ // default params ::
-  mMeanMultThreshold = 100.;
-  mMinMultThreshold = 0.;
-  mOrbTF = 32;
-  mLocalBoardScale = 100;     // kHz
-  mLocalBoardThreshold = 400; // kHz
-  mNbBadLocalBoard = 10;
-  mNbEmptyLocalBoard = 117; // 234/2
-
+{
   ILOG(Info, Devel) << "configure DigitsQcCheck" << ENDM;
   if (auto param = mCustomParameters.find("MeanMultThreshold"); param != mCustomParameters.end()) {
     ILOG(Info, Devel) << "Custom parameter - MeanMultThreshold: " << param->second << ENDM;
-    mMeanMultThreshold = stof(param->second);
+    mMeanMultThreshold = std::stof(param->second);
   }
   if (auto param = mCustomParameters.find("MinMultThreshold"); param != mCustomParameters.end()) {
     ILOG(Info, Devel) << "Custom parameter - MinMultThreshold: " << param->second << ENDM;
-    mMinMultThreshold = stof(param->second);
+    mMinMultThreshold = std::stof(param->second);
   }
   if (auto param = mCustomParameters.find("NbOrbitPerTF"); param != mCustomParameters.end()) {
-    ILOG(Info, Devel) << "Custom parameter - :NbOrbitPerTF " << param->second << ENDM;
-    mOrbTF = stof(param->second);
+    ILOG(Info, Devel) << "Custom parameter - NbOrbitPerTF: " << param->second << ENDM;
+    mHistoHelper.setNOrbitsPerTF(std::stol(param->second));
   }
   if (auto param = mCustomParameters.find("LocalBoardScale"); param != mCustomParameters.end()) {
-    ILOG(Info, Devel) << "Custom parameter - :LocalBoardScale " << param->second << ENDM;
-    mLocalBoardScale = stof(param->second);
+    ILOG(Info, Devel) << "Custom parameter - LocalBoardScale: " << param->second << ENDM;
+    mLocalBoardScale = std::stof(param->second);
   }
   if (auto param = mCustomParameters.find("LocalBoardThreshold"); param != mCustomParameters.end()) {
-    ILOG(Info, Devel) << "Custom parameter - :LocalBoardThreshold " << param->second << ENDM;
-    mLocalBoardThreshold = stof(param->second);
+    ILOG(Info, Devel) << "Custom parameter - LocalBoardThreshold: " << param->second << ENDM;
+    mLocalBoardThreshold = std::stof(param->second);
   }
   if (auto param = mCustomParameters.find("NbBadLocalBoard"); param != mCustomParameters.end()) {
-    ILOG(Info, Devel) << "Custom parameter - :NbBadLocalBoard " << param->second << ENDM;
-    mNbBadLocalBoard = stof(param->second);
+    ILOG(Info, Devel) << "Custom parameter - NbBadLocalBoard: " << param->second << ENDM;
+    mNbBadLocalBoard = std::stoi(param->second);
   }
   if (auto param = mCustomParameters.find("NbEmptyLocalBoard"); param != mCustomParameters.end()) {
-    ILOG(Info, Devel) << "Custom parameter - :NbEmptyLocalBoard " << param->second << ENDM;
-    mNbEmptyLocalBoard = stof(param->second);
+    ILOG(Info, Devel) << "Custom parameter - NbEmptyLocalBoard: " << param->second << ENDM;
+    mNbEmptyLocalBoard = std::stoi(param->second);
   }
-  // std::cout << " mLocalBoardThreshold  = "<<mLocalBoardThreshold << std::endl ;
-  // std::cout << " mNbBadLocalBoard  = "<<mNbBadLocalBoard << std::endl ;
-  mscale = 0;
 }
 
 Quality DigitsQcCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
-  // ILOG(Info, Devel) << "check DigitsQcCheck" << ENDM;
-
-  float mean = 0.;
-  float midThreshold = mMeanMultThreshold / 2;
+  Quality result = Quality::Null;
+  // This info must be available from the beginning
+  for (auto& item : *moMap) {
+    if (item.second->getName() == "NbDigitTF") {
+      mHistoHelper.setNTFs(static_cast<TH1F*>(item.second->getObject())->GetBinContent(1));
+      break;
+    }
+  }
 
   for (auto& [moName, mo] : *moMap) {
-    // Nb Time Frame ::
-    (void)moName;
-    if (mo->getName() == "NbDigitTF") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mDigitTF = h->GetBinContent(1);
-      // std::cout << " mDigitTF  = "<< mDigitTF << std::endl ;
-    }
-
-    (void)moName;
     if (mo->getName() == "MeanMultiHits") {
-      auto* hmult = dynamic_cast<TH1F*>(mo->getObject());
-      hmult->GetXaxis()->SetBinLabel(1, "MT11 Bend");
-      hmult->GetXaxis()->SetBinLabel(2, "MT12 Bend");
-      hmult->GetXaxis()->SetBinLabel(3, "MT21 Bend");
-      hmult->GetXaxis()->SetBinLabel(4, "MT22 Bend");
-      hmult->GetXaxis()->SetBinLabel(5, "MT11 NBend");
-      hmult->GetXaxis()->SetBinLabel(6, "MT12 NBend");
-      hmult->GetXaxis()->SetBinLabel(7, "MT21 NBend");
-      hmult->GetXaxis()->SetBinLabel(8, "MT22 NBend");
-      hmult->GetYaxis()->SetTitle("Min Hits Multiplicity");
-      hmult->SetStats(0);
+      int nGood = 0, nNull = 0, nBad = 0, nMedium = 0;
+      auto globalQual = Quality::Null;
+      for (int icath = 0; icath < 2; ++icath) {
+        for (int ich = 0; ich < 4; ++ich) {
+          int ibin = 1 + 4 * icath + ich;
+          auto histo = static_cast<TH1F*>(mo->getObject());
+          auto mean = histo->GetBinContent(ibin);
+          auto qual = Quality::Good;
+          if (mean == 0.) {
+            ++nNull;
+            qual = Quality::Null;
+          } else if (mean > mMeanMultThreshold || mean < mMinMultThreshold) {
+            qual = Quality::Bad;
+            result = qual;
+            ++nBad;
+          } else if (mean > mMeanMultThreshold / 2.) {
+            qual = Quality::Medium;
+            ++nMedium;
+          } else {
+            ++nGood;
+          }
+          std::string hName = "MultHit";
+          hName += histo->GetXaxis()->GetBinLabel(ibin);
+          mQualityMap[hName] = qual;
+        }
+      }
+      if (nBad > 0) {
+        globalQual = Quality::Bad;
+      } else if (nMedium > 0) {
+        globalQual = Quality::Medium;
+      } else if (nGood == 8) {
+        globalQual = Quality::Good;
+      }
+      mQualityMap[mo->getName()] = globalQual;
     }
-
-    (void)moName;
-    // Bend Multiplicity Histo ::
-    if (mo->getName() == "MultHitMT11B") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      resultBMT11 = Quality::Good;
-      mean = h->GetMean();
-      mMultTab[0] = mean;
-      if ((mean > mMeanMultThreshold) || (mean < mMinMultThreshold))
-        resultBMT11 = Quality::Bad;
-      else if (mean > midThreshold)
-        resultBMT11 = Quality::Medium;
-      // std::cout << "check :: resultBMT11 =>>  " <<resultBMT11 << std::endl;
-    } // end mMultHitMT11B check
-
-    if (mo->getName() == "MultHitMT12B") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      resultBMT12 = Quality::Good;
-      mean = h->GetMean();
-      mMultTab[1] = mean;
-      if ((mean > mMeanMultThreshold) || (mean < mMinMultThreshold))
-        resultBMT12 = Quality::Bad;
-      else if (mean > midThreshold)
-        resultBMT12 = Quality::Medium;
-    } // end mMultHitMT12B check
-
-    if (mo->getName() == "MultHitMT21B") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      resultBMT21 = Quality::Good;
-      mean = h->GetMean();
-      mMultTab[2] = mean;
-      if ((mean > mMeanMultThreshold) || (mean < mMinMultThreshold))
-        resultBMT21 = Quality::Bad;
-      else if (mean > midThreshold)
-        resultBMT21 = Quality::Medium;
-    } // end mMultHitMT21B check
-
-    if (mo->getName() == "MultHitMT22B") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      resultBMT22 = Quality::Good;
-      mean = h->GetMean();
-      mMultTab[3] = mean;
-      if ((mean > mMeanMultThreshold) || (mean < mMinMultThreshold))
-        resultBMT22 = Quality::Bad;
-      else if (mean > midThreshold)
-        resultBMT22 = Quality::Medium;
-    } // end mMultHitMT22B check
-
-    // Non-Bend Multiplicity Histo ::
-    if (mo->getName() == "MultHitMT11NB") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      resultNBMT11 = Quality::Good;
-      mean = h->GetMean();
-      mMultTab[4] = mean;
-      // std::cout << "check :: NBMT11 mean =>>  " << mean << std::endl;
-      if ((mean > mMeanMultThreshold) || (mean < mMinMultThreshold))
-        resultNBMT11 = Quality::Bad;
-      else if (mean > midThreshold)
-        resultNBMT11 = Quality::Medium;
-    } // end mMultHitMT11NB check
-
-    if (mo->getName() == "MultHitMT12NB") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      resultNBMT12 = Quality::Good;
-      mean = h->GetMean();
-      mMultTab[5] = mean;
-      if ((mean > mMeanMultThreshold) || (mean < mMinMultThreshold))
-        resultNBMT12 = Quality::Bad;
-      else if (mean > midThreshold)
-        resultNBMT12 = Quality::Medium;
-    } // end mMultHitMT12NB check
-
-    if (mo->getName() == "MultHitMT21NB") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      resultNBMT21 = Quality::Good;
-      mean = h->GetMean();
-      mMultTab[6] = mean;
-      if ((mean > mMeanMultThreshold) || (mean < mMinMultThreshold))
-        resultNBMT21 = Quality::Bad;
-      else if (mean > midThreshold)
-        resultNBMT21 = Quality::Medium;
-    } // end mMultHitMT21NB check
-
-    if (mo->getName() == "MultHitMT22NB") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      resultNBMT22 = Quality::Good;
-      mean = h->GetMean();
-      mMultTab[7] = mean;
-      if ((mean > mMeanMultThreshold) || (mean < mMinMultThreshold))
-        resultNBMT22 = Quality::Bad;
-      else if (mean > midThreshold)
-        resultNBMT22 = Quality::Medium;
-    } // end mMultHitMT22NB check
-
-    if ((resultBMT11 == Quality::Good) && (resultBMT12 == Quality::Good) &&
-        (resultBMT21 == Quality::Good) && (resultBMT22 == Quality::Good) &&
-        (resultNBMT11 == Quality::Good) && (resultNBMT12 == Quality::Good) &&
-        (resultNBMT21 == Quality::Good) && (resultNBMT22 == Quality::Good))
-      result = Quality::Good;
-    else if ((resultBMT11 == Quality::Bad) || (resultBMT12 == Quality::Bad) ||
-             (resultBMT21 == Quality::Bad) || (resultBMT22 == Quality::Bad) ||
-             (resultNBMT11 == Quality::Bad) || (resultNBMT12 == Quality::Bad) ||
-             (resultNBMT21 == Quality::Bad) || (resultNBMT22 == Quality::Bad))
-      result = Quality::Bad;
-    else
-      result = Quality::Medium;
 
     if (mo->getName() == "LocalBoardsMap") {
-      mBadLB = 0;
-      mEmptyLB = 0;
-      if (mDigitTF > 0) {
-        mscale = 1;
-        float scale = 1 / (mDigitTF * scaleTime * mOrbTF * 1000); // (kHz)
-        // std::cout << " scale = "<< scale << std::endl ;
-        auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-        h2->Scale(scale);
+      if (mHistoHelper.getNTFs() > 0) {
+        int nEmptyLB = 0;
+        int nBadLB = 0;
+        auto histo = static_cast<TH2F*>(mo->getObject());
+        mHistoHelper.normalizeHistoTokHz(histo);
         for (int bx = 1; bx < 15; bx++) {
           for (int by = 1; by < 37; by++) {
             if (!((bx > 6) && (bx < 9) && (by > 15) && (by < 22))) { // central zone empty
-              if (!(h2->GetBinContent(bx, by)))
-                mEmptyLB++;
-              else if (h2->GetBinContent(bx, by) > mLocalBoardThreshold)
-                mBadLB++;
-              // std::cout <<"        mBad:"<<mBadLB<<" ; mEmpt:"<<mEmptyLB<<" :: Board( " << bx <<";"<< by <<") ==> "<< h2->GetBinContent(bx,by) <<std::endl;
+              double val = histo->GetBinContent(bx, by);
+              if (val == 0) {
+                nEmptyLB++;
+              } else if (val > mLocalBoardThreshold) {
+                nBadLB++;
+              }
               if ((bx == 1) || (bx == 14) || (by == 1) || (by == 33))
                 by += 3; // zones 1 board
               else if (!((bx > 4) && (bx < 11) && (by > 12) && (by < 25)))
@@ -238,7 +131,24 @@ Quality DigitsQcCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
             }
           }
         }
-      } // if mDigitTF>0
+        auto qual = Quality::Good;
+        if (nBadLB > 0) {
+          qual = Quality::Medium;
+          if (nBadLB > mNbBadLocalBoard) {
+            qual = Quality::Bad;
+          }
+          auto flag = o2::quality_control::FlagReason();
+          qual.addReason(flag, fmt::format("{} boards > {} kHz", nBadLB, mLocalBoardThreshold));
+        } else if (nEmptyLB > 0) {
+          qual = Quality::Medium;
+          if (nEmptyLB > mNbEmptyLocalBoard) {
+            qual = Quality::Bad;
+          }
+          auto flag = o2::quality_control::FlagReason();
+          qual.addReason(flag, fmt::format("{} boards empty", nEmptyLB));
+        }
+        mQualityMap[mo->getName()] = qual;
+      } // if mNTFInSeconds > 0.
     }
   }
   return result;
@@ -246,450 +156,82 @@ Quality DigitsQcCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
 
 std::string DigitsQcCheck::getAcceptedType() { return "TH1"; }
 
-static void updateTitle(TH1* hist, std::string suffix)
-{
-  if (!hist) {
-    return;
-  }
-  TString title = hist->GetTitle();
-  title.Append(" ");
-  title.Append(suffix.c_str());
-  hist->SetTitle(title);
-}
-
-static std::string getCurrentTime()
-{
-  time_t t;
-  time(&t);
-
-  struct tm* tmp;
-  tmp = localtime(&t);
-
-  char timestr[500];
-  strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);
-
-  std::string result = timestr;
-  return result;
-}
-
-static TLatex* drawLatex(double xmin, double ymin, Color_t color, TString text)
-{
-
-  TLatex* tl = new TLatex(xmin, ymin, Form("%s", text.Data()));
-  tl->SetNDC();
-  tl->SetTextFont(22); // Normal 42
-  tl->SetTextSize(0.08);
-  tl->SetTextColor(color);
-
-  return tl;
-}
-
 void DigitsQcCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  // ILOG(Info, Devel) << "beautify DigitsQcCheck" << ENDM;
   gStyle->SetPalette(kRainBow);
 
-  TLatex* msg;
-  unsigned long mean = 0.;
-
-  // Bend Multiplicity Histo ::
-  if (mDigitTF > 5) {
-
-    if (mo->getName() == "MeanMultiHits") {
-      auto* hmult = dynamic_cast<TH1F*>(mo->getObject());
-      for (int i = 0; i < 8; i++) {
-        hmult->SetBinContent(i + 1, mMultTab[i]);
-        // std::cout <<"        binb: "<<i<<" ; meanMult:"<< mMultTab[i]  <<std::endl;
-      }
-      if (result == Quality::Good) {
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        hmult->GetListOfFunctions()->Add(msg);
-      } else if (result == Quality::Bad) {
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad");
-        hmult->GetListOfFunctions()->Add(msg);
-      } else {
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium");
-        hmult->GetListOfFunctions()->Add(msg);
-      }
-      updateTitle(hmult, Form("TF= %3.0f", mDigitTF));
-    }
-
-    if (mo->getName() == "MultHitMT11B") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mean = h->GetMean();
-      if (resultBMT11 == Quality::Good) {
-        // std::cout << "beautify :: BMT11 mean =>>  " << mean << std::endl;
-        h->SetFillColor(kGreen);
-        msg = drawLatex(.15, 0.82, kGreen, Form("Limit : [%4.2f;%4.1f]", mMinMultThreshold, mMeanMultThreshold));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.62, kGreen, Form("Mean=%4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT11 == Quality::Bad) {
-        h->SetFillColor(kRed);
-        msg = drawLatex(.2, 0.72, kRed, Form("Limit : [%4.2f;%4.1f]", mMinMultThreshold, mMeanMultThreshold));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.62, kRed, Form("Mean = %4.1f  ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad ");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT11 == Quality::Medium) {
-        h->SetFillColor(kOrange);
-        msg = drawLatex(.2, 0.72, kOrange, Form("Limit : [%4.2f;%4.1f]", mMinMultThreshold, mMeanMultThreshold / 2));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.62, kOrange, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium ");
-        h->GetListOfFunctions()->Add(msg);
-      }
-      h->SetTitleSize(0.04);
-      h->SetLineColor(kBlack);
-    }
-    if (mo->getName() == "MultHitMT12B") {
-      // std::cout << "beautify :: BMT12 =>>  " << resultBMT12 << std::endl;
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mean = h->GetMean();
-      if (resultBMT12 == Quality::Good) {
-        h->SetFillColor(kGreen);
-        msg = drawLatex(.3, 0.62, kGreen, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT12 == Quality::Bad) {
-        h->SetFillColor(kRed);
-        msg = drawLatex(.3, 0.62, kRed, Form("Mean = %4.1f  ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad ");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT12 == Quality::Medium) {
-        h->SetFillColor(kOrange);
-        msg = drawLatex(.3, 0.62, kOrange, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium ");
-        h->GetListOfFunctions()->Add(msg);
-      }
-      h->GetListOfFunctions()->Add(msg);
-      h->SetTitleSize(0.04);
-      h->SetLineColor(kBlack);
-    }
-    if (mo->getName() == "MultHitMT21B") {
-      // std::cout << "beautify :: BMT21 =>>  " << resultBMT21 << std::endl;
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mean = h->GetMean();
-      if (resultBMT21 == Quality::Good) {
-        h->SetFillColor(kGreen);
-        msg = drawLatex(.3, 0.62, kGreen, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT21 == Quality::Bad) {
-        h->SetFillColor(kRed);
-        msg = drawLatex(.3, 0.62, kRed, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad ");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT21 == Quality::Medium) {
-        h->SetFillColor(kOrange);
-        msg = drawLatex(.3, 0.62, kOrange, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium ");
-        h->GetListOfFunctions()->Add(msg);
-      }
-      h->GetListOfFunctions()->Add(msg);
-      h->SetTitleSize(0.04);
-      h->SetLineColor(kBlack);
-    }
-    if (mo->getName() == "MultHitMT22B") {
-      // std::cout << "beautify :: BMT22 =>>  " << resultBMT22 << std::endl;
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mean = h->GetMean();
-      if (resultBMT22 == Quality::Good) {
-        h->SetFillColor(kGreen);
-        msg = drawLatex(.3, 0.62, kGreen, Form("Mean = %4.1f  ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT22 == Quality::Bad) {
-        h->SetFillColor(kRed);
-        msg = drawLatex(.3, 0.62, kRed, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad ");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT22 == Quality::Medium) {
-        h->SetFillColor(kOrange);
-        msg = drawLatex(.3, 0.62, kOrange, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium ");
-        h->GetListOfFunctions()->Add(msg);
-      }
-      h->GetListOfFunctions()->Add(msg);
-      h->SetTitleSize(0.04);
-      h->SetLineColor(kBlack);
-    }
-    // Non-Bend Multiplicity Histo ::
-    if (mo->getName() == "MultHitMT11NB") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mean = h->GetMean();
-      if (resultNBMT11 == Quality::Good) {
-        h->SetFillColor(kGreen);
-        msg = drawLatex(.3, 0.62, kGreen, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT11 == Quality::Bad) {
-        h->SetFillColor(kRed);
-        msg = drawLatex(.3, 0.62, kRed, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad ");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT11 == Quality::Medium) {
-        h->SetFillColor(kOrange);
-        msg = drawLatex(.3, 0.62, kOrange, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium ");
-        h->GetListOfFunctions()->Add(msg);
-      }
-      h->GetListOfFunctions()->Add(msg);
-      h->SetTitleSize(0.04);
-      h->SetLineColor(kBlack);
-    }
-    if (mo->getName() == "MultHitMT12NB") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mean = h->GetMean();
-      if (resultNBMT12 == Quality::Good) {
-        h->SetFillColor(kGreen);
-        msg = drawLatex(.3, 0.62, kGreen, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT12 == Quality::Bad) {
-        h->SetFillColor(kRed);
-        msg = drawLatex(.3, 0.62, kRed, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad ");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT12 == Quality::Medium) {
-        h->SetFillColor(kOrange);
-        msg = drawLatex(.3, 0.62, kOrange, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium ");
-        h->GetListOfFunctions()->Add(msg);
-      }
-      h->GetListOfFunctions()->Add(msg);
-      h->SetTitleSize(0.04);
-      h->SetLineColor(kBlack);
-    }
-    if (mo->getName() == "MultHitMT21NB") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mean = h->GetMean();
-      if (resultNBMT21 == Quality::Good) {
-        h->SetFillColor(kGreen);
-        msg = drawLatex(.3, 0.62, kGreen, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT21 == Quality::Bad) {
-        h->SetFillColor(kRed);
-        msg = drawLatex(.3, 0.62, kRed, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad ");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT21 == Quality::Medium) {
-        h->SetFillColor(kOrange);
-        msg = drawLatex(.3, 0.62, kOrange, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium ");
-        h->GetListOfFunctions()->Add(msg);
-      }
-      h->GetListOfFunctions()->Add(msg);
-      h->SetTitleSize(0.04);
-      h->SetLineColor(kBlack);
-    }
-    if (mo->getName() == "MultHitMT22NB") {
-      auto* h = dynamic_cast<TH1F*>(mo->getObject());
-      mean = h->GetMean();
-      if (resultNBMT22 == Quality::Good) {
-        h->SetFillColor(kGreen);
-        msg = drawLatex(.3, 0.62, kGreen, Form("Mean = %4.1f ", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kGreen, "Quality::Good");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT22 == Quality::Bad) {
-        h->SetFillColor(kRed);
-        msg = drawLatex(.3, 0.62, kRed, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kRed, "Quality::Bad ");
-        h->GetListOfFunctions()->Add(msg);
-      } else if (resultBMT22 == Quality::Medium) {
-        h->SetFillColor(kOrange);
-        msg = drawLatex(.3, 0.62, kOrange, Form("Mean = %4.1f", h->GetMean()));
-        h->GetListOfFunctions()->Add(msg);
-        msg = drawLatex(.3, 0.52, kOrange, "Quality::Medium ");
-        h->GetListOfFunctions()->Add(msg);
-      }
-      h->GetListOfFunctions()->Add(msg);
-      h->SetTitleSize(0.04);
-      h->SetLineColor(kBlack);
-    }
-
-    /// Display Normalization (Hz)
-    Double_t zcontoursLoc[18] = { 0, 0.05, 0.1, 0.5, 1, 5, 8, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 400 };
-    Double_t zcontoursLoc4[18];
-    Double_t zcontoursStrip[18] = { 0, 0.02, 0.05, 0.08, 0.1, 0.3, 0.5, 0.8, 1, 3, 5, 8, 10, 12, 14, 16, 18, 20 };
-    for (int i = 0; i < 18; i++) {
-      zcontoursLoc[i] = zcontoursLoc[i] / 400 * mLocalBoardScale;
-      zcontoursLoc4[i] = zcontoursLoc[i] * 4;
-      zcontoursStrip[i] = zcontoursLoc[i] / 10;
-    }
-    int ncontours = 18;
-
-    /// Local Boards Display
-    float scale = 1 / (mDigitTF * scaleTime * mOrbTF * 1000); // (kHz)
-    if (mo->getName() == "LocalBoardsMap") {
-      if (mscale) {
-        auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-        // h2->GetZaxis()->SetTitleOffset(1.5);
-        // h2->GetZaxis()->SetTitleSize(0.05);
-        // h2->GetZaxis()->SetTitle("kHz");
-
-        // std::cout << " scale = "<< scale << std::endl ;
-        updateTitle(h2, "(kHz)");
-        updateTitle(h2, Form("- TF=%3.0f -", mDigitTF));
-        h2->SetMaximum(mLocalBoardScale);
-        h2->SetContour(ncontours, zcontoursLoc4);
-
-        if (mBadLB > mNbBadLocalBoard) {
-          msg = drawLatex(.12, 0.72, kRed, Form(" %d boards > %3.1f kHz", mBadLB, mLocalBoardThreshold));
-          h2->GetListOfFunctions()->Add(msg);
-          msg = drawLatex(.3, 0.32, kRed, "Quality::BAD ");
-          h2->GetListOfFunctions()->Add(msg);
-          QualLocBoards = Quality::Bad;
-        } else if (mBadLB >= 1) {
-          msg = drawLatex(.12, 0.72, kOrange, Form(" %d boards > %3.1f kHz", mBadLB, mLocalBoardThreshold));
-          h2->GetListOfFunctions()->Add(msg);
-          msg = drawLatex(.25, 0.32, kOrange, "Quality::MEDIUM ");
-          h2->GetListOfFunctions()->Add(msg);
-          QualLocBoards = Quality::Medium;
-        }
-        if (mEmptyLB > mNbEmptyLocalBoard) {
-          msg = drawLatex(.15, 0.62, kRed, Form(" %d boards empty", mEmptyLB));
-          h2->GetListOfFunctions()->Add(msg);
-          msg = drawLatex(.3, 0.32, kRed, "Quality::BAD ");
-          h2->GetListOfFunctions()->Add(msg);
-          QualLocBoards = Quality::Bad;
-        } else if (mEmptyLB >= mNbEmptyLocalBoard / 3) {
-          msg = drawLatex(.12, 0.62, kOrange, Form(" %d boards empty", mEmptyLB));
-          h2->GetListOfFunctions()->Add(msg);
-          msg = drawLatex(.25, 0.32, kOrange, "Quality::MEDIUM ");
-          h2->GetListOfFunctions()->Add(msg);
-          QualLocBoards = Quality::Medium;
-        } else if (mBadLB == 0) {
-          msg = drawLatex(.3, 0.32, kGreen, "Quality::GOOD ");
-          h2->GetListOfFunctions()->Add(msg);
-          QualLocBoards = Quality::Good;
-        }
-      }
-    }
-    if (mo->getName() == "LocalBoardsMap11") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursLoc);
-      h2->SetMaximum(mLocalBoardScale / 4);
-    }
-    if (mo->getName() == "LocalBoardsMap12") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursLoc);
-      h2->SetMaximum(mLocalBoardScale / 4);
-    }
-    if (mo->getName() == "LocalBoardsMap21") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursLoc);
-      h2->SetMaximum(mLocalBoardScale / 4);
-    }
-    if (mo->getName() == "LocalBoardsMap22") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursLoc);
-      h2->SetMaximum(mLocalBoardScale / 4);
-    }
-    /// Strips Display
-    if (mo->getName() == "BendHitsMap11") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursStrip);
-      h2->SetMaximum(mLocalBoardScale / 20);
-    }
-    if (mo->getName() == "BendHitsMap12") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursStrip);
-      h2->SetMaximum(mLocalBoardScale / 20);
-    }
-    if (mo->getName() == "BendHitsMap21") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursStrip);
-      h2->SetMaximum(mLocalBoardScale / 20);
-    }
-    if (mo->getName() == "BendHitsMap22") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursStrip);
-      h2->SetMaximum(mLocalBoardScale / 20);
-    }
-    if (mo->getName() == "NBendHitsMap11") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursStrip);
-      h2->SetMaximum(mLocalBoardScale / 20);
-    }
-    if (mo->getName() == "NBendHitsMap12") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursStrip);
-      h2->SetMaximum(mLocalBoardScale / 20);
-    }
-    if (mo->getName() == "NBendHitsMap21") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursStrip);
-      h2->SetMaximum(mLocalBoardScale / 20);
-    }
-    if (mo->getName() == "NBendHitsMap22") {
-      auto* h2 = dynamic_cast<TH2F*>(mo->getObject());
-      updateTitle(h2, "(kHz)");
-      updateTitle(h2, Form("TF= %3.0f", mDigitTF));
-      h2->Scale(scale);
-      h2->SetContour(ncontours, zcontoursStrip);
-      h2->SetMaximum(mLocalBoardScale / 20);
-    }
-    gStyle->SetPalette(kRainBow);
-    auto currentTime = getCurrentTime();
-    updateTitle(dynamic_cast<TH1*>(mo->getObject()), currentTime);
+  auto found = mQualityMap.find(mo->getName());
+  if (found != mQualityMap.end()) {
+    checkResult = found->second;
   }
-}
 
+  auto color = mHistoHelper.getColor(checkResult);
+
+  // Multiplicity Histograms
+  if (mo->getName().find("MultHitMT") != std::string::npos) {
+    // This matches "MultHitMT*"
+    if (mHistoHelper.getNTFs() > 0) {
+      auto histo = static_cast<TH1F*>(mo->getObject());
+      histo->SetFillColor(color);
+      mHistoHelper.addLatex(histo, 0.15, 0.82, color, Form("Limit : [%g;%g]", mMinMultThreshold, mMeanMultThreshold));
+      mHistoHelper.addLatex(histo, 0.3, 0.62, color, Form("Mean=%g ", histo->GetMean()));
+      mHistoHelper.addLatex(histo, 0.3, 0.52, color, fmt::format("Quality::{}", checkResult.getName()));
+      histo->SetTitleSize(0.04);
+      histo->SetLineColor(kBlack);
+    }
+  } else if (mo->getName() == "MeanMultiHits") {
+    auto histo = static_cast<TH1F*>(mo->getObject());
+    mHistoHelper.addLatex(histo, 0.3, 0.52, color, fmt::format("Quality::{}", checkResult.getName()));
+    mHistoHelper.updateTitleWithNTF(histo);
+    histo->SetStats(0);
+  } else {
+    // Change palette contours so that visibility of low-multiplicity strips or boards is improved
+    std::vector<double> zcontoursLoc{ 0, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100 };
+    std::vector<double> zcontoursLoc4, zcontoursStrip;
+    for (auto& con : zcontoursLoc) {
+      con *= mLocalBoardScale / zcontoursLoc.back();
+      zcontoursLoc4.emplace_back(con * 4);
+      zcontoursStrip.emplace_back(con / 10.);
+    }
+
+    // Local Boards Display
+    std::string lbHistoName = "LocalBoardsMap";
+    if (mo->getName().find(lbHistoName) != std::string::npos) {
+      // This matches "LocalBoardsMap*"
+      auto histo = static_cast<TH2F*>(mo->getObject());
+      if (mo->getName() == lbHistoName) {
+        // This is LocalBoardsMap and it was already scaled in the checker
+        if (!checkResult.getReasons().empty()) {
+          mHistoHelper.addLatex(histo, 0.12, 0.72, color, checkResult.getReasons().front().second.c_str());
+        }
+        mHistoHelper.addLatex(histo, 0.3, 0.32, color, fmt::format("Quality::{}", checkResult.getName()));
+        histo->SetMaximum(zcontoursLoc4.back());
+        histo->SetContour(zcontoursLoc4.size(), zcontoursLoc4.data());
+      } else {
+        mHistoHelper.normalizeHistoTokHz(histo);
+        histo->SetMaximum(zcontoursLoc.back());
+        histo->SetContour(zcontoursLoc.size(), zcontoursLoc.data());
+      }
+      mHistoHelper.updateTitleWithNTF(histo);
+      histo->SetStats(0);
+    } else {
+
+      // Strips Display
+      if (mo->getName().find("BendHitsMap") != std::string::npos) {
+        // This matches both [N]BendHitsMap*
+        int maxStrip = 20; // 20kHz Max Display
+        auto histo = static_cast<TH2F*>(mo->getObject());
+        mHistoHelper.normalizeHistoTokHz(histo);
+        histo->SetMaximum(zcontoursStrip.back());
+        histo->SetContour(zcontoursStrip.size(), zcontoursStrip.data());
+        histo->SetStats(0);
+      } else if (mo->getName() == "Hits") {
+        auto histo = static_cast<TH1F*>(mo->getObject());
+        mHistoHelper.normalizeHistoTokHz(histo);
+        histo->SetStats(0);
+      }
+    }
+  }
+  mHistoHelper.updateTitle(dynamic_cast<TH1*>(mo->getObject()), mHistoHelper.getCurrentTime());
+}
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/src/DigitsQcTask.cxx
+++ b/Modules/MUON/MID/src/DigitsQcTask.cxx
@@ -15,631 +15,206 @@
 /// \author Andrea Ferrero
 /// \author Valerie Ramillien
 
-#include <TCanvas.h>
-#include <TH1.h>
-#include <TH2.h>
-#include <TProfile.h>
-#include <TFile.h>
+#include "MID/DigitsQcTask.h"
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
 #include <string>
-#include <vector>
+#include <fmt/format.h>
 
 #include "QualityControl/QcInfoLogger.h"
-#include "MID/DigitsQcTask.h"
 #include <Framework/InputRecord.h>
-#include "Framework/DataRefUtils.h"
 #include "DataFormatsMID/ColumnData.h"
-#include "DataFormatsMID/ROBoard.h"
 #include "DataFormatsMID/ROFRecord.h"
-#include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/FEEIdConfig.h"
 #include "MIDBase/DetectorParameters.h"
 #include "MIDBase/GeometryParameters.h"
 #include "MIDWorkflow/ColumnDataSpecsUtils.h"
-
-#define MID_NDE 72
-#define MID_NCOL 7
-
-using namespace o2::quality_control_modules::muon;
+#include "MID/DigitsHelper.h"
 
 namespace o2::quality_control_modules::mid
 {
 
-DigitsQcTask::~DigitsQcTask()
-{
-}
-
 void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
-  ILOG(Info, Devel) << "initialize DigitsQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
-  // printf(" =================== > test initialize Digits \n");
-  if (auto param = mCustomParameters.find("DigitReset"); param != mCustomParameters.end()) {
-    mDigitReset = std::stof(param->second);
+  ILOG(Info, Devel) << "initialize DigitsQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will
+
+  if (auto param = mCustomParameters.find("ResetAtCycle"); param != mCustomParameters.end()) {
+    ILOG(Info, Devel) << "Custom parameter - ResetAtCycle: " << param->second << ENDM;
+    mResetAtCycle = (param->second == "True" || param->second == "TRUE" || param->second == "true") ? true : false;
   }
 
-  mNbDigitTF = std::make_shared<TH1F>("NbDigitTF", "NbTimeFrame", 1, 0, 1.);
+  mNbDigitTF = std::make_unique<TH1F>("NbDigitTF", "NbTimeFrame", 1, 0, 1.);
   getObjectsManager()->startPublishing(mNbDigitTF.get());
 
-  mHitsMapB = std::make_shared<TH2F>("HitsMapB", "Hits Map - bending plane", MID_NDE, 0, MID_NDE, MID_NCOL, 0, MID_NCOL);
-  getObjectsManager()->startPublishing(mHitsMapB.get());
-  mHitsMapB->GetXaxis()->SetTitle("DetectorElementID");
-  mHitsMapB->GetYaxis()->SetTitle("ColomnID");
-  mHitsMapB->SetOption("colz");
-  mHitsMapB->SetStats(0);
-
-  mHitsMapNB = std::make_shared<TH2F>("HitsMapNB", "Hits Map - non-bending plane", MID_NDE, 0, MID_NDE, MID_NCOL, 0, MID_NCOL);
-  getObjectsManager()->startPublishing(mHitsMapNB.get());
-  mHitsMapNB->GetXaxis()->SetTitle("DetectorElementID");
-  mHitsMapNB->GetYaxis()->SetTitle("ColomnID");
-  mHitsMapNB->SetOption("colz");
-  mHitsMapNB->SetStats(0);
-
-  mOrbitsMapB = std::make_shared<TH2F>("OrbitsMapB", "Orbits Map - bending plane", MID_NDE, 0, MID_NDE, MID_NCOL, 0, MID_NCOL);
-  getObjectsManager()->startPublishing(mOrbitsMapB.get());
-  mOrbitsMapB->GetXaxis()->SetTitle("DetectorElementID");
-  mOrbitsMapB->GetYaxis()->SetTitle("ColomnID");
-  mOrbitsMapB->SetOption("colz");
-  mOrbitsMapB->SetStats(0);
-  mOrbitsMapNB = std::make_shared<TH2F>("OrbitsMapNB", "Orbits Map - bending plane", MID_NDE, 0, MID_NDE, MID_NCOL, 0, MID_NCOL);
-  getObjectsManager()->startPublishing(mOrbitsMapNB.get());
-  mOrbitsMapNB->GetXaxis()->SetTitle("DetectorElementID");
-  mOrbitsMapNB->GetYaxis()->SetTitle("ColomnID");
-  mOrbitsMapNB->SetOption("colz");
-  mOrbitsMapNB->SetStats(0);
-
-  mROFSizeB = std::make_shared<TH1F>("ROFSizeB", "ROF size distribution - bending plane", 300, 0, 300);
-  getObjectsManager()->startPublishing(mROFSizeB.get());
-  mROFSizeNB = std::make_shared<TH1F>("ROFSizeNB", "ROF size distribution - non-bending plane", 300, 0, 300);
-  getObjectsManager()->startPublishing(mROFSizeNB.get());
-
-  mROFTimeDiff = std::make_shared<TH2F>("ROFTimeDiff", "ROF time difference vs. min. ROF size", 100, 0, 100, 100, 0, 100);
+  mROFTimeDiff = std::make_unique<TH2F>("ROFTimeDiff", "ROF time difference vs. min. ROF size", 100, 0, 100, 100, 0, 100);
   mROFTimeDiff->SetOption("colz");
   getObjectsManager()->startPublishing(mROFTimeDiff.get());
 
-  /////////////////
+  std::array<string, 4> chId{ "11", "12", "21", "22" };
 
-  mMultHitMT11B = std::make_shared<TH1F>("MultHitMT11B", "Multiplicity Hits - MT11 bending plane", 300, 0, 300);
-  mMultHitMT11NB = std::make_shared<TH1F>("MultHitMT11NB", "Multiplicity Hits - MT11 non-bending plane", 300, 0, 300);
-  mMultHitMT12B = std::make_shared<TH1F>("MultHitMT12B", "Multiplicity Hits - MT12 bending plane", 300, 0, 300);
-  mMultHitMT12NB = std::make_shared<TH1F>("MultHitMT12NB", "Multiplicity Hits - MT12 non-bending plane", 300, 0, 300);
-  mMultHitMT21B = std::make_shared<TH1F>("MultHitMT21B", "Multiplicity Hits - MT21 bending plane", 300, 0, 300);
-  mMultHitMT21NB = std::make_shared<TH1F>("MultHitMT21NB", "Multiplicity Hits - MT21 non-bending plane", 300, 0, 300);
-  mMultHitMT22B = std::make_shared<TH1F>("MultHitMT22B", "Multiplicity Hits - MT22 bending plane", 300, 0, 300);
-  mMultHitMT22NB = std::make_shared<TH1F>("MultHitMT22NB", "Multiplicity Hits - MT22 non-bending plane", 300, 0, 300);
-  getObjectsManager()->startPublishing(mMultHitMT11B.get());
-  getObjectsManager()->startPublishing(mMultHitMT11NB.get());
-  getObjectsManager()->startPublishing(mMultHitMT12B.get());
-  getObjectsManager()->startPublishing(mMultHitMT12NB.get());
-  getObjectsManager()->startPublishing(mMultHitMT21B.get());
-  getObjectsManager()->startPublishing(mMultHitMT21NB.get());
-  getObjectsManager()->startPublishing(mMultHitMT22B.get());
-  getObjectsManager()->startPublishing(mMultHitMT22NB.get());
+  for (size_t ich = 0; ich < 5; ++ich) {
+    std::string chName = "";
+    if (ich < 4) {
+      chName = "MT" + chId[ich];
+    }
+    mMultHitB[ich] = std::make_unique<TH1F>(fmt::format("MultHit{}B", chName).c_str(), fmt::format("Multiplicity Hits - {} bending plane", chName).c_str(), 300, 0, 300);
+    getObjectsManager()->startPublishing(mMultHitB[ich].get());
+    mMultHitNB[ich] = std::make_unique<TH1F>(fmt::format("MultHit{}NB", chName).c_str(), fmt::format("Multiplicity Hits - {} non-bending plane", chName).c_str(), 300, 0, 300);
+    getObjectsManager()->startPublishing(mMultHitNB[ich].get());
+  }
 
-  mMeanMultiHits = std::make_shared<TH1F>("MeanMultiHits", "MeanMultiHits", 8, 0, 8.);
+  mMeanMultiHits = std::make_unique<TH1F>("MeanMultiHits", "Min Hits Multiplicity", 8, 0, 8.);
+  for (int icath = 0; icath < 2; ++icath) {
+    std::string cathName = (icath == 0) ? "B" : "NB";
+    for (int ich = 0; ich < 4; ++ich) {
+      int ibin = 1 + 4 * icath + ich;
+      mMeanMultiHits->GetXaxis()->SetBinLabel(ibin, fmt::format("MT{}{}", chId[ich], cathName).c_str());
+    }
+  }
   getObjectsManager()->startPublishing(mMeanMultiHits.get());
 
-  mLocalBoardsMap = std::make_shared<TH2F>("LocalBoardsMap", "Local boards Occupancy Map", 14, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mLocalBoardsMap.get());
-  mLocalBoardsMap->GetXaxis()->SetTitle("Column");
-  mLocalBoardsMap->GetYaxis()->SetTitle("Line");
-  mLocalBoardsMap->SetOption("colz");
-  mLocalBoardsMap->SetStats(0);
+  for (int ich = 0; ich < 5; ++ich) {
+    std::string name = "LocalBoardsMap";
+    std::string title = "Local boards Occupancy Map";
+    if (ich < 4) {
+      name += chId[ich];
+      title += "MT" + chId[ich];
+    }
 
-  mLocalBoardsMap11 = std::make_shared<TH2F>("LocalBoardsMap11", "Local boards Occupancy Map MT11", 14, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mLocalBoardsMap11.get());
-  mLocalBoardsMap11->GetXaxis()->SetTitle("Column");
-  mLocalBoardsMap11->GetYaxis()->SetTitle("Line");
-  mLocalBoardsMap11->SetOption("colz");
-  mLocalBoardsMap11->SetStats(0);
+    mLocalBoardsMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeBoardMapHisto(name, title));
+    getObjectsManager()->startPublishing(mLocalBoardsMap[ich].get());
+    getObjectsManager()->setDefaultDrawOptions(mLocalBoardsMap[ich].get(), "COLZ");
+  }
 
-  mLocalBoardsMap12 = std::make_shared<TH2F>("LocalBoardsMap12", "Local boards Occupancy Map MT12", 14, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mLocalBoardsMap12.get());
-  mLocalBoardsMap12->GetXaxis()->SetTitle("Column");
-  mLocalBoardsMap12->GetYaxis()->SetTitle("Line");
-  mLocalBoardsMap12->SetOption("colz");
-  mLocalBoardsMap12->SetStats(0);
+  mHits = std::make_unique<TH1F>(mDigitsHelper.makeStripHisto("Hits", "Fired strips"));
+  getObjectsManager()->startPublishing(mHits.get());
 
-  mLocalBoardsMap21 = std::make_shared<TH2F>("LocalBoardsMap21", "Local boards Occupancy Map MT21", 14, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mLocalBoardsMap21.get());
-  mLocalBoardsMap21->GetXaxis()->SetTitle("Column");
-  mLocalBoardsMap21->GetYaxis()->SetTitle("Line");
-  mLocalBoardsMap21->SetOption("colz");
-  mLocalBoardsMap21->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mBendHitsMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("BendHitsMap{}", chId[ich]), fmt::format("Bending Hits Map MT{}", chId[ich]), 0));
+    getObjectsManager()->startPublishing(mBendHitsMap[ich].get());
+    getObjectsManager()->setDefaultDrawOptions(mBendHitsMap[ich].get(), "COLZ");
+  }
 
-  mLocalBoardsMap22 = std::make_shared<TH2F>("LocalBoardsMap22", "Local boards Occupancy Map MT22", 14, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mLocalBoardsMap22.get());
-  mLocalBoardsMap22->GetXaxis()->SetTitle("Column");
-  mLocalBoardsMap22->GetYaxis()->SetTitle("Line");
-  mLocalBoardsMap22->SetOption("colz");
-  mLocalBoardsMap22->SetStats(0);
+  for (int ich = 0; ich < 4; ++ich) {
+    mNBendHitsMap[ich] = std::make_unique<TH2F>(mDigitsHelper.makeStripMapHisto(fmt::format("NBendHitsMap{}", chId[ich]), fmt::format("Non-Bending Hits Map MT{}", chId[ich]), 1));
+    getObjectsManager()->startPublishing(mNBendHitsMap[ich].get());
+    getObjectsManager()->setDefaultDrawOptions(mNBendHitsMap[ich].get(), "COLZ");
+  }
 
-  mBendHitsMap11 = std::make_shared<TH2F>("BendHitsMap11", "Bending Hits Map MT11", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendHitsMap11.get());
-  mBendHitsMap11->GetXaxis()->SetTitle("Column");
-  mBendHitsMap11->GetYaxis()->SetTitle("Line");
-  mBendHitsMap11->SetOption("colz");
-  mBendHitsMap11->SetStats(0);
-  mBendHitsMap12 = std::make_shared<TH2F>("BendHitsMap12", "Bending Hits Map MT12", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendHitsMap12.get());
-  mBendHitsMap12->GetXaxis()->SetTitle("Column");
-  mBendHitsMap12->GetYaxis()->SetTitle("Line");
-  mBendHitsMap12->SetOption("colz");
-  mBendHitsMap12->SetStats(0);
-  mBendHitsMap21 = std::make_shared<TH2F>("BendHitsMap21", "Bending Hits Map MT21", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendHitsMap21.get());
-  mBendHitsMap21->GetXaxis()->SetTitle("Column");
-  mBendHitsMap21->GetYaxis()->SetTitle("Line");
-  mBendHitsMap21->SetOption("colz");
-  mBendHitsMap21->SetStats(0);
-  mBendHitsMap22 = std::make_shared<TH2F>("BendHitsMap22", "Bending Hits Map MT22", 14, -7, 7, 576, 0, 9);
-  getObjectsManager()->startPublishing(mBendHitsMap22.get());
-  mBendHitsMap22->GetXaxis()->SetTitle("Column");
-  mBendHitsMap22->GetYaxis()->SetTitle("Line");
-  mBendHitsMap22->SetOption("colz");
-  mBendHitsMap22->SetStats(0);
-
-  mNBendHitsMap11 = std::make_shared<TH2F>("NBendHitsMap11", "Non-Bending Hits Map MT11", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendHitsMap11.get());
-  mNBendHitsMap11->GetXaxis()->SetTitle("Column");
-  mNBendHitsMap11->GetYaxis()->SetTitle("Line");
-  mNBendHitsMap11->SetOption("colz");
-  mNBendHitsMap11->SetStats(0);
-
-  mNBendHitsMap12 = std::make_shared<TH2F>("NBendHitsMap12", "Non-Bending Hits Map MT12", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendHitsMap12.get());
-  mNBendHitsMap12->GetXaxis()->SetTitle("Column");
-  mNBendHitsMap12->GetYaxis()->SetTitle("Line");
-  mNBendHitsMap12->SetOption("colz");
-  mNBendHitsMap12->SetStats(0);
-
-  mNBendHitsMap21 = std::make_shared<TH2F>("NBendHitsMap21", "Non-Bending Hits Map MT21", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendHitsMap21.get());
-  mNBendHitsMap21->GetXaxis()->SetTitle("Column");
-  mNBendHitsMap21->GetYaxis()->SetTitle("Line");
-  mNBendHitsMap21->SetOption("colz");
-  mNBendHitsMap21->SetStats(0);
-
-  mNBendHitsMap22 = std::make_shared<TH2F>("NBendHitsMap22", "Non-Bending Hits Map MT22", 224, -7, 7, 36, 0, 9);
-  getObjectsManager()->startPublishing(mNBendHitsMap22.get());
-  mNBendHitsMap22->GetXaxis()->SetTitle("Column");
-  mNBendHitsMap22->GetYaxis()->SetTitle("Line");
-  mNBendHitsMap22->SetOption("colz");
-  mNBendHitsMap22->SetStats(0);
-
-  mDigitBCCounts = std::make_shared<TH1F>("DigitBCCounts", "Digits Bunch Crossing Counts", o2::constants::lhc::LHCMaxBunches, 0., o2::constants::lhc::LHCMaxBunches);
-  // mDigitBCCounts = std::make_shared<TProfile>("DigitBCCounts", "Mean Digits Bunch Crossing Counts", o2::constants::lhc::LHCMaxBunches, 0., o2::constants::lhc::LHCMaxBunches);
+  mDigitBCCounts = std::make_unique<TH1F>("DigitBCCounts", "Digits Bunch Crossing Counts", o2::constants::lhc::LHCMaxBunches, 0., o2::constants::lhc::LHCMaxBunches);
   getObjectsManager()->startPublishing(mDigitBCCounts.get());
   mDigitBCCounts->GetXaxis()->SetTitle("BC");
-  mDigitBCCounts->GetYaxis()->SetTitle("Entry (Ko)");
+  mDigitBCCounts->GetYaxis()->SetTitle("Number of digits");
 }
-/*
-static void DigitReset(){
-
-  mNbDigitTF->Reset();
-
-  mMultHitMT11B->Reset();
-  mMultHitMT11NB->Reset();
-  mMultHitMT12B->Reset();
-  mMultHitMT12NB->Reset();
-  mMultHitMT21B->Reset();
-  mMultHitMT21NB->Reset();
-  mMultHitMT22B->Reset();
-  mMultHitMT22NB->Reset();
-
-  mLocalBoardsMap->Reset();
-  mLocalBoardsMap11->Reset();
-  mLocalBoardsMap12->Reset();
-  mLocalBoardsMap21->Reset();
-  mLocalBoardsMap22->Reset();
-
-  mBendHitsMap11->Reset();
-  mBendHitsMap12->Reset();
-  mBendHitsMap21->Reset();
-  mBendHitsMap22->Reset();
-  mNBendHitsMap11->Reset();
-  mNBendHitsMap12->Reset();
-  mNBendHitsMap21->Reset();
-  mNBendHitsMap22->Reset();
-
-  mDigitBCCounts->Reset();
-}*/
 
 void DigitsQcTask::startOfActivity(Activity& /*activity*/)
 {
-  ILOG(Info, Devel) << "startOfActivity" << ENDM;
-  // printf(" =================== > test startOfActivity Digits \n");
 }
 
 void DigitsQcTask::startOfCycle()
 {
-  // ILOG(Info, Devel) << "startOfCycle" << ENDM;
-  // printf(" =================== > test startOfCycle Digits \n");
-}
-
-static int countColumnDataHits(const o2::mid::ColumnData& digit, int id)
-{
-  int nHits = 0;
-  int mask = 32768; // 1000000000000000
-  if (digit.patterns[id] != 0) {
-    for (int j = 0; j < 16; j++) {
-      if ((digit.patterns[id] & mask) != 0) {
-        nHits += 1;
-      }
-      mask >>= 1;
-    }
+  if (mResetAtCycle) {
+    reset();
   }
-  return nHits;
-}
-
-static int getBendingHits(const o2::mid::ColumnData& digit)
-{
-  int nHits = 0;
-  for (int i = 0; i < 4; i++) {
-    nHits += countColumnDataHits(digit, i);
-  }
-  return nHits;
-}
-
-static int getNonBendingHits(const o2::mid::ColumnData& digit)
-{
-  return countColumnDataHits(digit, 4);
-}
-
-bool isDigitEmpty(const o2::mid::ColumnData& digit)
-{
-  bool rep = 0;
-  for (int i = 0; i < 5; i++) {
-    if ((digit.patterns[i] != 0))
-      rep = 0;
-    else
-      rep = 1;
-  }
-  return rep;
-}
-
-static std::pair<uint32_t, uint32_t> getROFSize(const o2::mid::ROFRecord& rof, gsl::span<const o2::mid::ColumnData> digits)
-{
-  uint32_t nHitsB{ 0 };
-  uint32_t nHitsNB{ 0 };
-
-  auto lastEntry = rof.getEndIndex();
-  for (auto i = rof.firstEntry; i < lastEntry; i++) {
-    const auto& digit = digits[i];
-    nHitsB += getBendingHits(digit);
-    nHitsNB += getNonBendingHits(digit);
-  }
-
-  return std::make_pair(nHitsB, nHitsNB);
 }
 
 void DigitsQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  // printf(" =================== > test monitorData Digits \n");
-  //  auto digits = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("digits");
-  //  auto rofs = ctx.inputs().get<gsl::span<o2::mid::ROFRecord>>("digitrofs");
-  mDigitTF++;
   mNbDigitTF->Fill(0.5, 1.);
   auto digits = o2::mid::specs::getData(ctx, "digits", o2::mid::EventType::Standard);
   auto rofs = o2::mid::specs::getRofs(ctx, "digits", o2::mid::EventType::Standard);
 
-  int multHitMT11B = 0;
-  int multHitMT12B = 0;
-  int multHitMT21B = 0;
-  int multHitMT22B = 0;
-  int multHitMT11NB = 0;
-  int multHitMT12NB = 0;
-  int multHitMT21NB = 0;
-  int multHitMT22NB = 0;
+  std::array<unsigned long int, 4> evtSizeB{};
+  std::array<unsigned long int, 4> evtSizeNB{};
 
-  for (int i = 0; i < MID_NDE; i++) {
-    for (int j = 0; j < MID_NCOL; j++) {
-      mOrbitsMapB->Fill(i, j, 128);
-      mOrbitsMapNB->Fill(i, j, 128);
-    }
-  }
-
-  for (const auto& digit : digits) {
-    // total number of bending plane hits
-    int nHitsB = getBendingHits(digit);
-    mHitsMapB->Fill(digit.deId, digit.columnId, nHitsB);
-    // total number of non-bending plane hits
-    int nHitsNB = getNonBendingHits(digit);
-    mHitsMapNB->Fill(digit.deId, digit.columnId, nHitsNB);
-  }
-
-  std::pair<uint32_t, uint32_t> prevSize;
+  unsigned long int prevSize = 0;
   o2::InteractionRecord prevIr;
-  for (size_t i = 0; i < rofs.size(); i++) { // rofs.size() = Number of Events
-    const auto& rof = rofs[i];
-    auto rofSize = getROFSize(rof, digits);
-    mROFSizeB->Fill(rofSize.first);
-    mROFSizeNB->Fill(rofSize.second);
+  bool isFirst = true;
+  for (auto& rof : rofs) {
+    auto eventDigits = digits.subspan(rof.firstEntry, rof.nEntries);
+    evtSizeB.fill(0);
+    evtSizeNB.fill(0);
+    for (auto& col : eventDigits) {
+      auto ich = o2::mid::detparams::getChamber(col.deId);
+      evtSizeB[ich] = mDigitsHelper.countDigits(col, 0);
+      evtSizeNB[ich] = mDigitsHelper.countDigits(col, 1);
+      mDigitsHelper.fillStripHisto(col, mHits.get());
+    }
 
-    if (i > 0) {
-      uint32_t sizeTot = rofSize.first + rofSize.second;
-      uint32_t prevSizeTot = prevSize.first + prevSize.second;
-      uint32_t sizeMin = (sizeTot < prevSizeTot) ? sizeTot : prevSizeTot;
+    unsigned long int sizeTot = 0;
+    for (int ich = 0; ich < 4; ++ich) {
+      sizeTot += evtSizeB[ich];
+      sizeTot += evtSizeNB[ich];
+      mMultHitB[ich]->Fill(evtSizeB[ich]);
+      mMultHitB[4]->Fill(evtSizeB[4]);
+      mMultHitNB[ich]->Fill(evtSizeNB[ich]);
+      mMultHitNB[4]->Fill(evtSizeNB[4]);
+    }
 
+    if (!isFirst) {
+      unsigned long int sizeMin = (sizeTot < prevSize) ? sizeTot : prevSize;
       auto timeDiff = rof.interactionRecord.differenceInBC(prevIr);
-
       mROFTimeDiff->Fill(timeDiff, sizeMin);
     }
 
-    prevSize = rofSize;
+    isFirst = false;
+    prevSize = sizeTot;
     prevIr = rof.interactionRecord;
-  }
 
-  for (const auto& rofRecord : rofs) { // loop ROFRecords //
-    // printf("========================================================== \n");
-    // printf("Digits :: %05d ROF with first entry %05zu and nentries %02zu , BC %05d, ORB %05d , EventType %02d\n", nROF, rofRecord.firstEntry, rofRecord.nEntries, rofRecord.interactionRecord.bc, rofRecord.interactionRecord.orbit,rofRecord.eventType);
-    //  eventType::  Standard = 0, Calib = 1, FET = 2
-    mROF++;
-    multHitMT11B = 0;
-    multHitMT12B = 0;
-    multHitMT21B = 0;
-    multHitMT22B = 0;
-    multHitMT11NB = 0;
-    multHitMT12NB = 0;
-    multHitMT21NB = 0;
-    multHitMT22NB = 0;
-
-    mDigitBCCounts->Fill(rofRecord.interactionRecord.bc, float(rofRecord.nEntries) * 12. / 1000.); // 1 digit = 12 octets
-
-    // loadStripPatterns (ColumnData)
-    for (auto& digit : digits.subspan(rofRecord.firstEntry, rofRecord.nEntries)) { // loop DE //
-      int deIndex = digit.deId;
-      int colId = digit.columnId;
-      int rpcLine = o2::mid::detparams::getRPCLine(deIndex);
-      int ichamber = o2::mid::detparams::getChamber(deIndex);
-      auto isRightSide = o2::mid::detparams::isRightSide(deIndex);
-      auto detId = o2::mid::detparams::getDEId(isRightSide, ichamber, colId);
-
-      int nZoneHistoX = 1;
-      int nZoneHistoY = 4;
-      double stripYSize = 1. / 16;
-      double stripXSize = 0.25 / 16;
-      if (mMapping.getLastBoardBP(colId, deIndex) == 1) {
-        nZoneHistoX = 2;
-        stripXSize = 0.5 / 16;
-      } else if (mMapping.getLastBoardBP(colId, deIndex) == 0) {
-        nZoneHistoX = 4;
-        stripXSize = 1. / 16;
-      }
-
-      for (int board = mMapping.getFirstBoardBP(colId, deIndex), lastBoard = mMapping.getLastBoardBP(colId, deIndex); board <= lastBoard + 1; board++) {
-        // These are the existing bend boards for this column Id (board = n°board in the column) + 1 (for non-bend)
-        if ((lastBoard < 4) && (board == lastBoard + 1))
-          board = 4;                      // for Non-Bend digits
-        if (digit.patterns[board] != 0) { //  Bend + Non-Bend plane
-          //// Bend Local Boards Display ::
-          double linePos0 = rpcLine;
-          if (board < 4) {
-            linePos0 = rpcLine + 0.25 * board;
-            if ((nZoneHistoX == 2) && (board == 1))
-              linePos0 += 0.25;
-            for (int ib = 0; ib < nZoneHistoX; ib++) {
-              double linePos = linePos0 + (0.25 * ib);
-              if (isRightSide) {
-                mLocalBoardsMap->Fill(colId + 0.5, linePos, 1);
-                if (ichamber == 0)
-                  mLocalBoardsMap11->Fill(colId + 0.5, linePos, 1);
-                else if (ichamber == 1)
-                  mLocalBoardsMap12->Fill(colId + 0.5, linePos, 1);
-                else if (ichamber == 2)
-                  mLocalBoardsMap21->Fill(colId + 0.5, linePos, 1);
-                else if (ichamber == 3)
-                  mLocalBoardsMap22->Fill(colId + 0.5, linePos, 1);
-              } else {
-                mLocalBoardsMap->Fill(-colId - 0.5, linePos, 1);
-                if (ichamber == 0)
-                  mLocalBoardsMap11->Fill(-colId - 0.5, linePos, 1);
-                else if (ichamber == 1)
-                  mLocalBoardsMap12->Fill(-colId - 0.5, linePos, 1);
-                else if (ichamber == 2)
-                  mLocalBoardsMap21->Fill(-colId - 0.5, linePos, 1);
-                else if (ichamber == 3)
-                  mLocalBoardsMap22->Fill(-colId - 0.5, linePos, 1);
-              }
-            }    // board in line loop
-          }      // if board<4 :: Bend
-          else { // nen-Bend
-            double shift = 0;
-            if ((colId == 0) && ((rpcLine == 3) || (rpcLine == 5)))
-              nZoneHistoY = 3;
-            if ((colId == 0) && (rpcLine == 5))
-              shift = 0.25;
-            for (int ib = 0; ib < nZoneHistoY; ib++) {
-              if (isRightSide) {
-                mLocalBoardsMap->Fill(colId + 0.5, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                if (ichamber == 0)
-                  mLocalBoardsMap11->Fill(colId + 0.5, rpcLine + shift + (0.25 * ib), 1);
-                else if (ichamber == 1)
-                  mLocalBoardsMap12->Fill(colId + 0.5, rpcLine + shift + (0.25 * ib), 1);
-                else if (ichamber == 2)
-                  mLocalBoardsMap21->Fill(colId + 0.5, rpcLine + shift + (0.25 * ib), 1);
-                else if (ichamber == 3)
-                  mLocalBoardsMap22->Fill(colId + 0.5, rpcLine + shift + (0.25 * ib), 1);
-              } else {
-                mLocalBoardsMap->Fill(-colId - 0.5, rpcLine + shift + (0.25 * ib), 1);
-                if (ichamber == 0)
-                  mLocalBoardsMap11->Fill(-colId - 0.5, rpcLine + shift + (0.25 * ib), 1);
-                else if (ichamber == 1)
-                  mLocalBoardsMap12->Fill(-colId - 0.5, rpcLine + shift + (0.25 * ib), 1);
-                else if (ichamber == 2)
-                  mLocalBoardsMap21->Fill(-colId - 0.5, rpcLine + shift + (0.25 * ib), 1);
-                else if (ichamber == 3)
-                  mLocalBoardsMap22->Fill(-colId - 0.5, rpcLine + shift + (0.25 * ib), 1);
-              }
-            }
-          }
-          //// Strips Display ::
-          int mask = 1;
-
-          double shift = 0; // for central zone with only 3 loc boards
-          if ((colId == 0) && ((rpcLine == 3) || (rpcLine == 5)))
-            nZoneHistoY = 3;
-          if ((colId == 0) && (rpcLine == 5))
-            shift = 0.25;
-
-          for (int j = 0; j < 16; j++) {
-            if ((digit.patterns[board] & mask) != 0) {
-              double lineHitPos = linePos0 + (j * stripXSize);
-              int colj = j;
-              if (mMapping.getNStripsNBP(colId, deIndex) == 8)
-                colj = j * 2; // Bend with only 8 stripY
-              double colHitPos = colId + (colj * stripYSize);
-              // std::cout << " bit (j) =>>  " << j << "  stripXPos = "<< stripXPos <<"  lineHitPos = "<< lineHitPos << std::endl;
-              if (isRightSide) {
-                if (ichamber == 0) {
-                  if (board == 4) {
-                    for (int ib = 0; ib < nZoneHistoY; ib++)
-                      mNBendHitsMap11->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                  } else
-                    mBendHitsMap11->Fill(colId + 0.5, lineHitPos, 1); // Bend
-                } else if (ichamber == 1) {
-                  if (board == 4) {
-                    for (int ib = 0; ib < nZoneHistoY; ib++)
-                      mNBendHitsMap12->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                  } else
-                    mBendHitsMap12->Fill(colId + 0.5, lineHitPos, 1); // Bend
-                } else if (ichamber == 2) {
-                  if (board == 4) {
-                    for (int ib = 0; ib < nZoneHistoY; ib++)
-                      mNBendHitsMap21->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                  } else
-                    mBendHitsMap21->Fill(colId + 0.5, lineHitPos, 1); // Bend
-                } else if (ichamber == 3) {
-                  if (board == 4) {
-                    for (int ib = 0; ib < nZoneHistoY; ib++)
-                      mNBendHitsMap22->Fill(colHitPos + 0.01, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                  } else
-                    mBendHitsMap22->Fill(colId + 0.5, lineHitPos, 1); // Bend
-                }
-              } else {
-                if (ichamber == 0) {
-                  if (board == 4) {
-                    for (int ib = 0; ib < nZoneHistoY; ib++)
-                      mNBendHitsMap11->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                  } else
-                    mBendHitsMap11->Fill(-colId - 0.5, lineHitPos, 1); // Bend
-                } else if (ichamber == 1) {
-                  if (board == 4) {
-                    for (int ib = 0; ib < nZoneHistoY; ib++)
-                      mNBendHitsMap12->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                  } else
-                    mBendHitsMap12->Fill(-colId - 0.5, lineHitPos, 1); // Bend
-                } else if (ichamber == 2) {
-                  if (board == 4) {
-                    for (int ib = 0; ib < nZoneHistoY; ib++)
-                      mNBendHitsMap21->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                  } else
-                    mBendHitsMap21->Fill(-colId - 0.5, lineHitPos, 1); // Bend
-                } else if (ichamber == 3) {
-                  if (board == 4) {
-                    for (int ib = 0; ib < nZoneHistoY; ib++)
-                      mNBendHitsMap22->Fill(-colHitPos - 0.01, rpcLine + shift + (0.25 * ib), 1); // Non-Bend
-                  } else
-                    mBendHitsMap22->Fill(-colId - 0.5, lineHitPos, 1); // Bend
-                }
-              }
-            }
-            mask <<= 1;
-          }
-        } // digit.patterns[board] Bend or Non-Bend not empty
-      }
-
-      //  Hits Multiplicity ::
-      if (ichamber == 0) {
-        multHitMT11B += getBendingHits(digit);
-        multHitMT11NB += getNonBendingHits(digit);
-      } else if (ichamber == 1) {
-        multHitMT12B += getBendingHits(digit);
-        multHitMT12NB += getNonBendingHits(digit);
-      } else if (ichamber == 2) {
-        multHitMT21B += getBendingHits(digit);
-        multHitMT21NB += getNonBendingHits(digit);
-      } else if (ichamber == 3) {
-        multHitMT22B += getBendingHits(digit);
-        multHitMT22NB += getNonBendingHits(digit);
-      }
-
-    } // Histograms Hits Multiplicity ::
-    mMultHitMT11B->Fill(multHitMT11B);
-    mMultHitMT12B->Fill(multHitMT12B);
-    mMultHitMT21B->Fill(multHitMT21B);
-    mMultHitMT22B->Fill(multHitMT22B);
-    mMultHitMT11NB->Fill(multHitMT11NB);
-    mMultHitMT12NB->Fill(multHitMT12NB);
-    mMultHitMT21NB->Fill(multHitMT21NB);
-    mMultHitMT22NB->Fill(multHitMT22NB);
-  } //  ROFRecords //
-
-  // RESET Histo
-  if (mDigitTF > mDigitReset * 60 / 25.e-9) {
-    reset();
-    mDigitTF = 0;
-    // std::cout << "************************ Digit Reset  "<< std::endl;
+    mDigitBCCounts->Fill(rof.interactionRecord.bc, sizeTot);
   }
 }
 
 void DigitsQcTask::endOfCycle()
 {
-  // ILOG(Info, Devel) << "endOfCycle" << ENDM;
-  // printf(" =================== > test endOfCycle Digits \n");
+  // Fill here the 2D representation of the fired strips/boards
+  // First reset the old histograms
+  resetDisplayHistos();
+
+  // Then fill from the strip histogram
+  mDigitsHelper.fillMapHistos(mHits.get(), mBendHitsMap, mNBendHitsMap, mLocalBoardsMap);
+
+  // Fill the summary multiplicity histogram
+  for (int ich = 0; ich < 4; ++ich) {
+    mMeanMultiHits->SetBinContent(1 + ich, mMultHitB[ich]->GetMean());
+    mMeanMultiHits->SetBinContent(5 + ich, mMultHitNB[ich]->GetMean());
+  }
 }
 
 void DigitsQcTask::endOfActivity(Activity& /*activity*/)
 {
-  // ILOG(Info, Devel) << "endOfActivity" << ENDM;
-  // printf(" =================== > test endOfActivity Digits \n");
+}
+
+void DigitsQcTask::resetDisplayHistos()
+{
+  for (auto& histo : mBendHitsMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mNBendHitsMap) {
+    histo->Reset();
+  }
+  for (auto& histo : mLocalBoardsMap) {
+    histo->Reset();
+  }
 }
 
 void DigitsQcTask::reset()
 {
   // clean all the monitor objects here
 
-  // ILOG(Info, Devel) << "Resetting the histogram" << ENDM;
-  // printf(" =================== > test reset Digits \n");
-
-  // DigitReset();
   mNbDigitTF->Reset();
+  mROFTimeDiff->Reset();
 
-  mMultHitMT11B->Reset();
-  mMultHitMT11NB->Reset();
-  mMultHitMT12B->Reset();
-  mMultHitMT12NB->Reset();
-  mMultHitMT21B->Reset();
-  mMultHitMT21NB->Reset();
-  mMultHitMT22B->Reset();
-  mMultHitMT22NB->Reset();
+  for (auto& histo : mMultHitB) {
+    histo->Reset();
+  }
+  for (auto& histo : mMultHitNB) {
+    histo->Reset();
+  }
+  mMeanMultiHits->Reset();
 
-  mLocalBoardsMap->Reset();
-  mLocalBoardsMap11->Reset();
-  mLocalBoardsMap12->Reset();
-  mLocalBoardsMap21->Reset();
-  mLocalBoardsMap22->Reset();
-
-  mBendHitsMap11->Reset();
-  mBendHitsMap12->Reset();
-  mBendHitsMap21->Reset();
-  mBendHitsMap22->Reset();
-  mNBendHitsMap11->Reset();
-  mNBendHitsMap12->Reset();
-  mNBendHitsMap21->Reset();
-  mNBendHitsMap22->Reset();
+  mHits->Reset();
+  resetDisplayHistos();
 
   mDigitBCCounts->Reset();
-
-  mHitsMapB->Reset();
-  mHitsMapNB->Reset();
-  mOrbitsMapB->Reset();
-  mOrbitsMapNB->Reset();
-  mROFSizeB->Reset();
-  mROFSizeNB->Reset();
-  mROFTimeDiff->Reset();
 }
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/src/HistoHelper.cxx
+++ b/Modules/MUON/MID/src/HistoHelper.cxx
@@ -1,0 +1,108 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   HistoHelper.cxx
+/// \author Diego Stocco
+
+#include "MID/HistoHelper.h"
+
+#include "TH1.h"
+#include "TH2.h"
+#include "TString.h"
+#include "TLatex.h"
+#include "TList.h"
+
+namespace o2::quality_control_modules::mid
+{
+
+HistoHelper::HistoHelper()
+{
+  mColors[o2::quality_control::core::Quality::Null.getLevel()] = kWhite;
+  mColors[o2::quality_control::core::Quality::Good.getLevel()] = kGreen;
+  mColors[o2::quality_control::core::Quality::Medium.getLevel()] = kOrange;
+  mColors[o2::quality_control::core::Quality::Bad.getLevel()] = kRed;
+}
+
+bool HistoHelper::normalizeHisto(TH1* histo, double scale) const
+{
+  if (mNTFs > 0) {
+    histo->Scale(1. / (scale * getNTFsAsSeconds()));
+    return true;
+  }
+  return false;
+}
+
+void HistoHelper::normalizeHistoToHz(TH1* histo) const
+{
+  if (normalizeHisto(histo, 1.)) {
+    updateTitle(histo, "(Hz)");
+  }
+}
+
+void HistoHelper::normalizeHistoTokHz(TH1* histo) const
+{
+  if (normalizeHisto(histo, 1000.)) {
+    updateTitle(histo, "(kHz)");
+  }
+}
+
+void HistoHelper::updateTitle(TH1* histo, std::string suffix) const
+{
+  if (!histo) {
+    return;
+  }
+  TString title = histo->GetTitle();
+  title.Append(" ");
+  title.Append(suffix.c_str());
+  histo->SetTitle(title);
+}
+
+std::string HistoHelper::getCurrentTime() const
+{
+  time_t t;
+  time(&t);
+
+  struct tm* tmp;
+  tmp = localtime(&t);
+
+  char timestr[500];
+  strftime(timestr, sizeof(timestr), "(%x - %X)", tmp);
+
+  std::string result = timestr;
+  return result;
+}
+
+void HistoHelper::addLatex(TH1* histo, double xmin, double ymin, int color, std::string text) const
+{
+
+  TLatex* tl = new TLatex(xmin, ymin, Form("%s", text.c_str()));
+  tl->SetNDC();
+  tl->SetTextFont(22); // Normal 42
+  tl->SetTextSize(0.06);
+  tl->SetTextColor(color);
+  histo->GetListOfFunctions()->Add(tl);
+}
+
+int HistoHelper::getColor(const o2::quality_control::core::Quality& quality) const
+{
+  auto found = mColors.find(quality.getLevel());
+  if (found != mColors.end()) {
+    return found->second;
+  }
+  return 1;
+}
+
+void HistoHelper::updateTitleWithNTF(TH1* histo) const
+{
+  updateTitle(histo, Form("TF=%lu", mNTFs));
+}
+
+} // namespace o2::quality_control_modules::mid


### PR DESCRIPTION
The strip occupancy map provided directly a 2D representation which was meant to give a quick view of the actual position of the strips.
This representation is good for shifters, but it makes it difficult to pinpoint the ID of the problematic strip.
This PR introduces a 1D representation that can be more easily related to the strip ID for further analysis.
The 2D representation is kept for shifters, but, the conversion from 1D to 2D representation is entrusted to a separate class that can be used by different tasks which are handling MID digits.
The commits are meant to be atomic: please do not squash.