### PR TITLE
Failure to retrieve MO and QO should produce a warning

### DIFF
--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -312,7 +312,7 @@ TObject* CcdbDatabase::retrieveTObject(std::string path, std::map<std::string, s
   // we try first to load a TFile
   auto* object = ccdbApi->retrieveFromTFileAny<TObject>(path, metadata, timestamp, headers);
   if (object == nullptr) {
-    ILOG(Error, Support) << "We could NOT retrieve the object " << path << " with timestamp " << timestamp << "." << ENDM;
+    ILOG(Warning, Support) << "We could NOT retrieve the object " << path << " with timestamp " << timestamp << "." << ENDM;
     return nullptr;
   }
   ILOG(Debug, Support) << "Retrieved object " << path << " with timestamp " << timestamp << ENDM;
@@ -323,7 +323,7 @@ void* CcdbDatabase::retrieveAny(const type_info& tinfo, const string& path, cons
 {
   auto* object = ccdbApi->retrieveFromTFile(tinfo, path, metadata, timestamp, headers, "", createdNotAfter, createdNotBefore);
   if (object == nullptr) {
-    ILOG(Error, Support) << "We could NOT retrieve the object " << path << " with timestamp " << timestamp << "." << ENDM;
+    ILOG(Warning, Support) << "We could NOT retrieve the object " << path << " with timestamp " << timestamp << "." << ENDM;
     return nullptr;
   }
   ILOG(Debug, Support) << "Retrieved object " << path << " with timestamp " << timestamp << ENDM;


### PR DESCRIPTION
Seeing how retrieveMO and retrieveQO are used by postprocessing tasks, it is sometimes fine if we do not manage to retrieve an object, thus we make it a warning.

cc @martenole 