### PR TITLE
[FOCAL-8] Use dynamic pixel mapping

### DIFF
--- a/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
+++ b/Modules/FOCAL/include/FOCAL/TestbeamRawTask.h
@@ -27,7 +27,7 @@
 #include "FOCALReconstruction/PadDecoder.h"
 #include "FOCALReconstruction/PadMapper.h"
 #include "FOCALReconstruction/PixelDecoder.h"
-#include "FOCALReconstruction/PixelMapper.h"
+#include "FOCALReconstruction/PixelMapperV1.h"
 
 class TH1;
 class TH2;
@@ -86,15 +86,15 @@ class TestbeamRawTask final : public TaskInterface
   void processPadPayload(gsl::span<const o2::focal::PadGBTWord> gbtpayload);
   void processPixelPayload(gsl::span<const o2::itsmft::GBTWord> gbtpayload, uint16_t feeID);
   void processPadEvent(gsl::span<const o2::focal::PadGBTWord> gbtpayload);
-  std::pair<int, int> getNumberOfPixelSegments(o2::focal::PixelMapper::MappingType_t mappingtype) const;
-  std::pair<int, int> getPixelSegment(const o2::focal::PixelHit& hit, o2::focal::PixelMapper::MappingType_t mappingtype, const o2::focal::PixelMapping::ChipPosition& chipMapping) const;
+  std::pair<int, int> getNumberOfPixelSegments(o2::focal::PixelMapperV1::MappingType_t mappingtype) const;
+  std::pair<int, int> getPixelSegment(const o2::focal::PixelHit& hit, o2::focal::PixelMapperV1::MappingType_t mappingtype, const o2::focal::PixelMapperV1::ChipPosition& chipMapping) const;
 
   o2::focal::PadDecoder mPadDecoder;                                              ///< Decoder for pad data
   o2::focal::PadMapper mPadMapper;                                                ///< Mapping for Pads
   o2::focal::PixelDecoder mPixelDecoder;                                          ///< Decoder for pixel data
   o2::focal::PadPedestal* mPadPedestalHandler = nullptr;                          ///< Pedestal handler for pad pedestal subtraction
   o2::focal::PadBadChannelMap* mPadBadChannelMap = nullptr;                       ///< Bad channel map for pads
-  std::unique_ptr<o2::focal::PixelMapper> mPixelMapper;                           ///< Testbeam mapping for pixels
+  std::unique_ptr<o2::focal::PixelMapperV1> mPixelMapperV1;                       ///< Testbeam mapping for pixels
   std::unordered_map<o2::InteractionRecord, int> mPixelNHitsAll;                  ///< Number of hits / event all layers
   std::array<std::unordered_map<o2::InteractionRecord, int>, 2> mPixelNHitsLayer; ///< Number of hits / event layer
   std::vector<int> mHitSegmentCounter;                                            ///< Number of hits / segment


### PR DESCRIPTION
Pixel mapping was restructured in
https://github.com/AliceO2Group/AliceO2/pull/11350 from a hard coded mapping corresponding to
the Testbeams before to a dynamic mapping where
the correspondece of FEE and Chip in HIC to a global chip position in FOCAL is defined using config files (and later CCDB). New mapping is used in the QC as PixelMappingV1. Will be moved to PixelMapping once the commit in QC is merged into master.