### PR TITLE
[QC-974] Introduce mergeable histogram ratios

### DIFF
--- a/Modules/Common/CMakeLists.txt
+++ b/Modules/Common/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TEST_SRCS
         test/testMeanIsAbove.cxx
         test/testNonEmpty.cxx
         test/testCommonReductors.cxx
+        test/testCommonHistRatios.cxx
         test/testWorstOfAllAggregator.cxx)
 
 foreach(test ${TEST_SRCS})

--- a/Modules/Common/CMakeLists.txt
+++ b/Modules/Common/CMakeLists.txt
@@ -45,6 +45,8 @@ add_root_dictionary(O2QcCommon
                             include/Common/TRFCollectionTask.h
                             include/Common/QualityTask.h
                             include/Common/MeanIsAbove.h
+                            include/Common/TH1Ratio.h
+                            include/Common/TH2Ratio.h
                             include/Common/TH1Reductor.h
                             include/Common/TH2Reductor.h
                             include/Common/THnSparse5Reductor.h

--- a/Modules/Common/include/Common/LinkDef.h
+++ b/Modules/Common/include/Common/LinkDef.h
@@ -5,10 +5,10 @@
 
 #pragma link C++ class o2::quality_control_modules::common::NonEmpty + ;
 #pragma link C++ class o2::quality_control_modules::common::MeanIsAbove + ;
-#pragma link C++ class o2::quality_control_modules::common::TH1Ratio<TH1F> + ;
-#pragma link C++ class o2::quality_control_modules::common::TH1Ratio<TH1D> + ;
-#pragma link C++ class o2::quality_control_modules::common::TH2Ratio<TH2F> + ;
-#pragma link C++ class o2::quality_control_modules::common::TH2Ratio<TH2D> + ;
+#pragma link C++ class o2::quality_control_modules::common::TH1Ratio < TH1F> + ;
+#pragma link C++ class o2::quality_control_modules::common::TH1Ratio < TH1D> + ;
+#pragma link C++ class o2::quality_control_modules::common::TH2Ratio < TH2F> + ;
+#pragma link C++ class o2::quality_control_modules::common::TH2Ratio < TH2D> + ;
 #pragma link C++ class o2::quality_control_modules::common::TH1Reductor + ;
 #pragma link C++ class o2::quality_control_modules::common::TH2Reductor + ;
 #pragma link C++ class o2::quality_control_modules::common::THnSparse5Reductor + ;

--- a/Modules/Common/include/Common/LinkDef.h
+++ b/Modules/Common/include/Common/LinkDef.h
@@ -5,6 +5,10 @@
 
 #pragma link C++ class o2::quality_control_modules::common::NonEmpty + ;
 #pragma link C++ class o2::quality_control_modules::common::MeanIsAbove + ;
+#pragma link C++ class o2::quality_control_modules::common::TH1Ratio<TH1F> + ;
+#pragma link C++ class o2::quality_control_modules::common::TH1Ratio<TH1D> + ;
+#pragma link C++ class o2::quality_control_modules::common::TH2Ratio<TH2F> + ;
+#pragma link C++ class o2::quality_control_modules::common::TH2Ratio<TH2D> + ;
 #pragma link C++ class o2::quality_control_modules::common::TH1Reductor + ;
 #pragma link C++ class o2::quality_control_modules::common::TH2Reductor + ;
 #pragma link C++ class o2::quality_control_modules::common::THnSparse5Reductor + ;

--- a/Modules/Common/include/Common/TH1Ratio.h
+++ b/Modules/Common/include/Common/TH1Ratio.h
@@ -62,8 +62,6 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
   Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1, Double_t c2 = 1) override;
   Bool_t Add(const TH1* h1, Double_t c1 = 1) override;
   void SetBins(Int_t nx, Double_t xmin, Double_t xmax) override;
-  void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax) override;
-  void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz, Double_t zmin, Double_t zmax) override;
 
  private:
   T* mHistoNum{ nullptr };

--- a/Modules/Common/include/Common/TH1Ratio.h
+++ b/Modules/Common/include/Common/TH1Ratio.h
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TH1Ratio.h
+/// \brief A generic TH1Ratio inheriting MergeInterface
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch, Andrea Ferrero
+
+#ifndef QUALITYCONTROL_TH1RATIO_H
+#define QUALITYCONTROL_TH1RATIO_H
+
+#include "Mergers/MergeInterface.h"
+#include <TH1F.h>
+#include <TH1D.h>
+
+namespace o2::quality_control_modules::common
+{
+
+template <class T>
+class TH1Ratio : public T, public o2::mergers::MergeInterface
+{
+ public:
+  TH1Ratio() = default;
+  TH1Ratio(TH1Ratio const& copymerge);
+  TH1Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, bool uniformScaling = false);
+  TH1Ratio(const char* name, const char* title, bool uniformScaling = false);
+
+  ~TH1Ratio();
+
+  void init();
+
+  void merge(MergeInterface* const other) override;
+
+  T* getNum() const
+  {
+    return mHistoNum;
+  }
+
+  T* getDen() const
+  {
+    return mHistoDen;
+  }
+
+  bool hasUniformScaling() const
+  {
+    return mUniformScaling;
+  }
+
+  void update();
+
+  // functions inherited from TH1x
+  void Reset(Option_t* option = "") override;
+  void Copy(TObject& obj) const override;
+  Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1, Double_t c2 = 1) override;
+  Bool_t Add(const TH1* h1, Double_t c1 = 1) override;
+  void SetBins(Int_t nx, Double_t xmin, Double_t xmax) override;
+  void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax) override;
+  void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz, Double_t zmin, Double_t zmax) override;
+
+ private:
+  T* mHistoNum{ nullptr };
+  T* mHistoDen{ nullptr };
+  bool mUniformScaling{ true };
+  std::string mTreatMeAs{ T::Class_Name() };
+
+  ClassDefOverride(TH1Ratio, 1);
+};
+
+typedef TH1Ratio<TH1F> TH1FRatio;
+typedef TH1Ratio<TH1D> TH1DRatio;
+
+} // namespace o2::quality_control_modules::common
+
+#include "Common/TH1Ratio.inl"
+
+#endif // QUALITYCONTROL_TH1RATIO_H

--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -1,0 +1,235 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TH1Ratio.inl
+/// \brief An generic TH1Ratio inheriting MergeInterface
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch, Andrea Ferrero
+
+#include "QualityControl/QcInfoLogger.h"
+
+namespace o2::quality_control_modules::common
+{
+
+template<class T>
+TH1Ratio<T>::TH1Ratio(TH1Ratio const& copymerge)
+  : T(copymerge.GetName(), copymerge.GetTitle(),
+         copymerge.getNum()->GetXaxis()->GetNbins(), copymerge.getNum()->GetXaxis()->GetXmin(), copymerge.getNum()->GetXaxis()->GetXmax()),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(copymerge.hasUniformScaling())
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = (T*)copymerge.getNum()->Clone();
+  mHistoDen = (T*)copymerge.getDen()->Clone();
+  TH1::AddDirectory(bStatus);
+
+  init();
+}
+
+template<class T>
+TH1Ratio<T>::TH1Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, bool uniformScaling)
+  : T(name, title, nbinsx, xmin, xmax),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = new T("num", "num", nbinsx, xmin, xmax);
+  if (mUniformScaling) {
+    mHistoDen = new T("den", "den", 1, -1, 1);
+  } else {
+    mHistoDen = new T("den", "den", nbinsx, xmin, xmax);
+  }
+  TH1::AddDirectory(bStatus);
+
+  init();
+}
+
+template<class T>
+TH1Ratio<T>::TH1Ratio(const char* name, const char* title, bool uniformScaling)
+  : T(name, title, 10, 0, 10),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = new T("num", "num", 10, 0, 10);
+  if (mUniformScaling) {
+    mHistoDen = new T("den", "den", 1, -1, 1);
+  } else {
+    mHistoDen = new T("den", "den", 10, 0, 10);
+  }
+  TH1::AddDirectory(bStatus);
+
+  init();
+}
+
+template<class T>
+TH1Ratio<T>::~TH1Ratio()
+{
+  if (mHistoNum) {
+    delete mHistoNum;
+  }
+
+  if (mHistoDen) {
+    delete mHistoDen;
+  }
+}
+
+template<class T>
+void TH1Ratio<T>::init()
+{
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+  mHistoNum->Sumw2();
+  mHistoDen->Sumw2();
+  T::Sumw2();
+
+  update();
+}
+
+template<class T>
+void TH1Ratio<T>::merge(MergeInterface* const other)
+{
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
+  mHistoNum->Add(dynamic_cast<const TH1Ratio* const>(other)->getNum());
+  mHistoDen->Add(dynamic_cast<const TH1Ratio* const>(other)->getDen());
+  update();
+}
+
+template<class T>
+void TH1Ratio<T>::update()
+{
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
+  const char* name = this->GetName();
+  const char* title = this->GetTitle();
+
+  T::Reset();
+
+  T::SetNameTitle(name, title);
+  T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
+  T::SetBinsLength();
+
+  T::Add(mHistoNum);
+
+  if (mUniformScaling) {
+    double entries = mHistoDen->GetBinContent(1);
+    double norm = (entries > 0) ? 1.0 / entries : 0;
+    T::Scale(norm);
+  } else {
+    T::Divide(mHistoDen);
+  }
+}
+
+template<class T>
+void TH1Ratio<T>::Reset(Option_t* option)
+{
+  if (mHistoNum) {
+    mHistoNum->Reset(option);
+  }
+
+  if (mHistoDen) {
+    mHistoDen->Reset(option);
+  }
+
+  T::Reset(option);
+}
+
+template<class T>
+void TH1Ratio<T>::Copy(TObject& obj) const
+{
+  auto dest = dynamic_cast<TH1Ratio*>(&obj);
+  if (!dest) {
+    return;
+  }
+
+  getNum()->Copy(*(dest->getNum()));
+  getDen()->Copy(*(dest->getDen()));
+  T::Copy(obj);
+
+  dest->update();
+}
+
+template<class T>
+Bool_t TH1Ratio<T>::Add(const TH1* h1, const TH1* h2, Double_t c1, Double_t c2)
+{
+  auto m1 = dynamic_cast<const TH1Ratio*>(h1);
+  if (!m1) {
+    return kFALSE;
+  }
+
+  auto m2 = dynamic_cast<const TH1Ratio*>(h2);
+  if (!m2) {
+    return kFALSE;
+  }
+
+  if (!getNum()->Add(m1->getNum(), m2->getNum(), c1, c2)) {
+    return kFALSE;
+  }
+  if (!getDen()->Add(m1->getDen(), m2->getDen(), c1, c2)) {
+    return kFALSE;
+  }
+
+  update();
+  return kTRUE;
+}
+
+template<class T>
+Bool_t TH1Ratio<T>::Add(const TH1* h1, Double_t c1)
+{
+  auto m1 = dynamic_cast<const TH1Ratio*>(h1);
+  if (!m1) {
+    return kFALSE;
+  }
+
+  if (!getNum()->Add(m1->getNum(), c1)) {
+    return kFALSE;
+  }
+  if (!getDen()->Add(m1->getDen(), c1)) {
+    return kFALSE;
+  }
+
+  update();
+  return kTRUE;
+}
+
+template<class T>
+void TH1Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax)
+{
+  getNum()->SetBins(nx, xmin, xmax);
+  getDen()->SetBins(nx, xmin, xmax);
+  T::SetBins(nx, xmin, xmax);
+}
+
+template<class T>
+void TH1Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
+                       Int_t ny, Double_t ymin, Double_t ymax)
+{
+  ILOG(Debug, Devel) << "SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax) not valid for MergeableTH2Ratio" << ENDM;
+}
+
+template<class T>
+void TH1Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
+                       Int_t ny, Double_t ymin, Double_t ymax,
+                       Int_t nz, Double_t zmin, Double_t zmax)
+{
+  ILOG(Debug, Devel) << "SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz, Double_t zmin, Double_t zmax) not valid for MergeableTH2Ratio" << ENDM;
+}
+
+} // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -217,19 +217,4 @@ void TH1Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax)
   T::SetBins(nx, xmin, xmax);
 }
 
-template<class T>
-void TH1Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
-                       Int_t ny, Double_t ymin, Double_t ymax)
-{
-  ILOG(Debug, Devel) << "SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax) not valid for MergeableTH2Ratio" << ENDM;
-}
-
-template<class T>
-void TH1Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
-                       Int_t ny, Double_t ymin, Double_t ymax,
-                       Int_t nz, Double_t zmin, Double_t zmax)
-{
-  ILOG(Debug, Devel) << "SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz, Double_t zmin, Double_t zmax) not valid for MergeableTH2Ratio" << ENDM;
-}
-
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/TH2Ratio.h
+++ b/Modules/Common/include/Common/TH2Ratio.h
@@ -61,9 +61,7 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
   void Copy(TObject& obj) const override;
   Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1, Double_t c2 = 1) override;
   Bool_t Add(const TH1* h1, Double_t c1 = 1) override;
-  void SetBins(Int_t nx, Double_t xmin, Double_t xmax) override;
   void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax) override;
-  void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz, Double_t zmin, Double_t zmax) override;
 
  private:
   T* mHistoNum{ nullptr };

--- a/Modules/Common/include/Common/TH2Ratio.h
+++ b/Modules/Common/include/Common/TH2Ratio.h
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TH2Ratio.h
+/// \brief A generic TH2Ratio inheriting MergeInterface
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch, Sebastien Perrin, Andrea Ferrero
+
+#ifndef QUALITYCONTROL_TH2RATIO_H
+#define QUALITYCONTROL_TH2RATIO_H
+
+#include "Mergers/MergeInterface.h"
+#include <TH2F.h>
+#include <TH2D.h>
+
+namespace o2::quality_control_modules::common
+{
+
+template <class T>
+class TH2Ratio : public T, public o2::mergers::MergeInterface
+{
+ public:
+  TH2Ratio() = default;
+  TH2Ratio(TH2Ratio const& copymerge);
+  TH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, bool uniformScaling = false);
+  TH2Ratio(const char* name, const char* title, bool uniformScaling = false);
+
+  ~TH2Ratio();
+
+  void init();
+
+  void merge(MergeInterface* const other) override;
+
+  T* getNum() const
+  {
+    return mHistoNum;
+  }
+
+  T* getDen() const
+  {
+    return mHistoDen;
+  }
+
+  bool hasUniformScaling() const
+  {
+    return mUniformScaling;
+  }
+
+  void update();
+
+  // functions inherited from TH2x
+  void Reset(Option_t* option = "") override;
+  void Copy(TObject& obj) const override;
+  Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1, Double_t c2 = 1) override;
+  Bool_t Add(const TH1* h1, Double_t c1 = 1) override;
+  void SetBins(Int_t nx, Double_t xmin, Double_t xmax) override;
+  void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax) override;
+  void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz, Double_t zmin, Double_t zmax) override;
+
+ private:
+  T* mHistoNum{ nullptr };
+  T* mHistoDen{ nullptr };
+  bool mUniformScaling{ true };
+  std::string mTreatMeAs{ T::Class_Name() };
+
+  ClassDefOverride(TH2Ratio, 1);
+};
+
+typedef TH2Ratio<TH2F> TH2FRatio;
+typedef TH2Ratio<TH2D> TH2DRatio;
+
+} // namespace o2::quality_control_modules::common
+
+#include "Common/TH2Ratio.inl"
+
+#endif // QUALITYCONTROL_TH2RATIO_H

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -1,0 +1,236 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TH2Ratio.inl
+/// \brief An generic TH2Ratio inheriting MergeInterface
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch, Andrea Ferrero
+
+#include "QualityControl/QcInfoLogger.h"
+
+namespace o2::quality_control_modules::common
+{
+
+template<class T>
+TH2Ratio<T>::TH2Ratio(TH2Ratio const& copymerge)
+  : T(copymerge.GetName(), copymerge.GetTitle(),
+         copymerge.getNum()->GetXaxis()->GetNbins(), copymerge.getNum()->GetXaxis()->GetXmin(), copymerge.getNum()->GetXaxis()->GetXmax(),
+         copymerge.getNum()->GetYaxis()->GetNbins(), copymerge.getNum()->GetYaxis()->GetXmin(), copymerge.getNum()->GetYaxis()->GetXmax()),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(copymerge.hasUniformScaling())
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = (T*)copymerge.getNum()->Clone();
+  mHistoDen = (T*)copymerge.getDen()->Clone();
+  TH1::AddDirectory(bStatus);
+
+  init();
+}
+
+template<class T>
+TH2Ratio<T>::TH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, bool uniformScaling)
+  : T(name, title, nbinsx, xmin, xmax, nbinsy, ymin, ymax),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = new T("num", "num", nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+  if (mUniformScaling) {
+    mHistoDen = new T("den", "den", 1, -1, 1, 1, -1, 1);
+  } else {
+    mHistoDen = new T("den", "den", nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+  }
+  TH1::AddDirectory(bStatus);
+
+  init();
+}
+
+template<class T>
+TH2Ratio<T>::TH2Ratio(const char* name, const char* title, bool uniformScaling)
+  : T(name, title, 10, 0, 10, 10, 0, 10),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mHistoNum = new T("num", "num", 10, 0, 10, 10, 0, 10);
+  if (mUniformScaling) {
+    mHistoDen = new T("den", "den", 1, -1, 1, 1, -1, 1);
+  } else {
+    mHistoDen = new T("den", "den", 10, 0, 10, 10, 0, 10);
+  }
+  TH1::AddDirectory(bStatus);
+
+  init();
+}
+
+template<class T>
+TH2Ratio<T>::~TH2Ratio()
+{
+  if (mHistoNum) {
+    delete mHistoNum;
+  }
+
+  if (mHistoDen) {
+    delete mHistoDen;
+  }
+}
+
+template<class T>
+void TH2Ratio<T>::init()
+{
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+  mHistoNum->Sumw2();
+  mHistoDen->Sumw2();
+  T::Sumw2();
+
+  update();
+}
+
+template<class T>
+void TH2Ratio<T>::merge(MergeInterface* const other)
+{
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
+  mHistoNum->Add(dynamic_cast<const TH2Ratio* const>(other)->getNum());
+  mHistoDen->Add(dynamic_cast<const TH2Ratio* const>(other)->getDen());
+  update();
+}
+
+template<class T>
+void TH2Ratio<T>::update()
+{
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
+  const char* name = this->GetName();
+  const char* title = this->GetTitle();
+
+  T::Reset();
+  T::SetNameTitle(name, title);
+  T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
+  T::GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXmin(), mHistoNum->GetYaxis()->GetXmax());
+  T::SetBinsLength();
+
+  T::Add(mHistoNum);
+
+  if (mUniformScaling) {
+    double entries = mHistoDen->GetBinContent(1, 1);
+    double norm = (entries > 0) ? 1.0 / entries : 0;
+    T::Scale(norm);
+  } else {
+    T::Divide(mHistoDen);
+  }
+}
+
+template<class T>
+void TH2Ratio<T>::Reset(Option_t* option)
+{
+  if (mHistoNum) {
+    mHistoNum->Reset(option);
+  }
+
+  if (mHistoDen) {
+    mHistoDen->Reset(option);
+  }
+
+  T::Reset(option);
+}
+
+template<class T>
+void TH2Ratio<T>::Copy(TObject& obj) const
+{
+  auto dest = dynamic_cast<TH2Ratio*>(&obj);
+  if (!dest) {
+    return;
+  }
+
+  getNum()->Copy(*(dest->getNum()));
+  getDen()->Copy(*(dest->getDen()));
+  T::Copy(obj);
+
+  dest->update();
+}
+
+template<class T>
+Bool_t TH2Ratio<T>::Add(const TH1* h1, const TH1* h2, Double_t c1, Double_t c2)
+{
+  auto m1 = dynamic_cast<const TH2Ratio*>(h1);
+  if (!m1) {
+    return kFALSE;
+  }
+
+  auto m2 = dynamic_cast<const TH2Ratio*>(h2);
+  if (!m2) {
+    return kFALSE;
+  }
+
+  if (!getNum()->Add(m1->getNum(), m2->getNum(), c1, c2)) {
+    return kFALSE;
+  }
+  if (!getDen()->Add(m1->getDen(), m2->getDen(), c1, c2)) {
+    return kFALSE;
+  }
+
+  update();
+  return kTRUE;
+}
+
+template<class T>
+Bool_t TH2Ratio<T>::Add(const TH1* h1, Double_t c1)
+{
+  auto m1 = dynamic_cast<const TH2Ratio*>(h1);
+  if (!m1) {
+    return kFALSE;
+  }
+
+  if (!getNum()->Add(m1->getNum(), c1)) {
+    return kFALSE;
+  }
+  if (!getDen()->Add(m1->getDen(), c1)) {
+    return kFALSE;
+  }
+
+  update();
+  return kTRUE;
+}
+
+template<class T>
+void TH2Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax)
+{
+  ILOG(Debug, Devel) << "SetBins(Int_t nx, Double_t xmin, Double_t xmax) not valid for TH2Ratio" << ENDM;
+}
+
+template<class T>
+void TH2Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
+                       Int_t ny, Double_t ymin, Double_t ymax)
+{
+  getNum()->SetBins(nx, xmin, xmax, ny, ymin, ymax);
+  getDen()->SetBins(nx, xmin, xmax, ny, ymin, ymax);
+  T::SetBins(nx, xmin, xmax, ny, ymin, ymax);
+}
+
+template<class T>
+void TH2Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
+                       Int_t ny, Double_t ymin, Double_t ymax,
+                       Int_t nz, Double_t zmin, Double_t zmax)
+{
+  ILOG(Debug, Devel) << "SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz, Double_t zmin, Double_t zmax) not valid for TH2Ratio" << ENDM;
+}
+
+} // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -211,26 +211,12 @@ Bool_t TH2Ratio<T>::Add(const TH1* h1, Double_t c1)
 }
 
 template<class T>
-void TH2Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax)
-{
-  ILOG(Debug, Devel) << "SetBins(Int_t nx, Double_t xmin, Double_t xmax) not valid for TH2Ratio" << ENDM;
-}
-
-template<class T>
 void TH2Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
                        Int_t ny, Double_t ymin, Double_t ymax)
 {
   getNum()->SetBins(nx, xmin, xmax, ny, ymin, ymax);
   getDen()->SetBins(nx, xmin, xmax, ny, ymin, ymax);
   T::SetBins(nx, xmin, xmax, ny, ymin, ymax);
-}
-
-template<class T>
-void TH2Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
-                       Int_t ny, Double_t ymin, Double_t ymax,
-                       Int_t nz, Double_t zmin, Double_t zmax)
-{
-  ILOG(Debug, Devel) << "SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz, Double_t zmin, Double_t zmax) not valid for TH2Ratio" << ENDM;
 }
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/test/testCommonHistRatios.cxx
+++ b/Modules/Common/test/testCommonHistRatios.cxx
@@ -1,0 +1,144 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    testCommonReductors.cxx
+/// \author  Piotr Konopka
+///
+
+#include "QualityControl/Reductor.h"
+#include "QualityControl/QualityObject.h"
+#include "Common/TH1Ratio.h"
+#include "Common/TH2Ratio.h"
+
+#define BOOST_TEST_MODULE CommonHistRatios test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+using namespace o2::quality_control;
+using namespace o2::quality_control::core;
+using namespace o2::quality_control::postprocessing;
+using namespace o2::quality_control_modules::common;
+
+BOOST_AUTO_TEST_CASE(test_TH1FRatioUniform)
+{
+  auto histo1 = std::make_unique<TH1FRatio>("test1", "test1", 10, 0, 10.0, true);
+  auto histo2 = std::make_unique<TH1FRatio>("test2", "test2", 10, 0, 10.0, true);
+  auto histoMerged = std::make_unique<TH1FRatio>("testMerged", "testMerged", 10, 0, 10.0, true);
+
+  for (int bin = 1; bin <= 10; bin++) {
+    histo1->getNum()->SetBinContent(bin, bin * 4);
+    histo2->getNum()->SetBinContent(bin, bin * 5);
+  }
+
+  histo1->getDen()->SetBinContent(1, 2);
+  histo2->getDen()->SetBinContent(1, 3);
+
+  histo1->update();
+  histo2->update();
+
+  histoMerged->merge(histo1.get());
+  histoMerged->merge(histo2.get());
+
+  for (int bin = 1; bin <= 10; bin++) {
+    float value = 9.0 * bin / 5.0;
+    BOOST_REQUIRE_EQUAL(histoMerged->GetBinContent(bin), value);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_TH1FRatio)
+{
+  auto histo1 = std::make_unique<TH1FRatio>("test1", "test1", 10, 0, 10.0, false);
+  auto histo2 = std::make_unique<TH1FRatio>("test2", "test2", 10, 0, 10.0, false);
+  auto histoMerged = std::make_unique<TH1FRatio>("testMerged", "testMerged", 10, 0, 10.0, false);
+
+  for (int bin = 1; bin <= 10; bin++) {
+    histo1->getNum()->SetBinContent(bin, bin * bin * 4);
+    histo1->getDen()->SetBinContent(bin, bin * 3);
+
+    histo2->getNum()->SetBinContent(bin, bin * bin * 5);
+    histo2->getDen()->SetBinContent(bin, bin * 4);
+  }
+
+  histo1->update();
+  histo2->update();
+
+  histoMerged->merge(histo1.get());
+  histoMerged->merge(histo2.get());
+
+  for (int bin = 1; bin <= 10; bin++) {
+    float value = 9.0 * bin / 7.0;
+    BOOST_REQUIRE_EQUAL(histoMerged->GetBinContent(bin), value);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_TH2FRatioUniform)
+{
+  auto histo1 = std::make_unique<TH2FRatio>("test1", "test1", 10, 0, 10.0, 10, 0, 10.0, true);
+  auto histo2 = std::make_unique<TH2FRatio>("test2", "test2", 10, 0, 10.0, 10, 0, 10.0, true);
+  auto histoMerged = std::make_unique<TH2FRatio>("testMerged", "testMerged", 10, 0, 10.0, 10, 0, 10.0, true);
+
+  for (int ybin = 1; ybin <= 10; ybin++) {
+    for (int xbin = 1; xbin <= 10; xbin++) {
+      histo1->getNum()->SetBinContent(xbin, ybin, xbin * ybin * 4);
+      histo2->getNum()->SetBinContent(xbin, ybin, xbin * ybin * 5);
+    }
+  }
+
+  histo1->getDen()->SetBinContent(1, 1, 2);
+  histo2->getDen()->SetBinContent(1, 1, 3);
+
+  histo1->update();
+  histo2->update();
+
+  histoMerged->merge(histo1.get());
+  histoMerged->merge(histo2.get());
+
+  for (int ybin = 1; ybin <= 10; ybin++) {
+    for (int xbin = 1; xbin <= 10; xbin++) {
+      float value = 9.0 * xbin * ybin / 5.0;
+      BOOST_REQUIRE_EQUAL(histoMerged->GetBinContent(xbin, ybin), value);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_TH2FRatio)
+{
+  auto histo1 = std::make_unique<TH2FRatio>("test1", "test1", 10, 0, 10.0, 10, 0, 10.0, false);
+  auto histo2 = std::make_unique<TH2FRatio>("test2", "test2", 10, 0, 10.0, 10, 0, 10.0, false);
+  auto histoMerged = std::make_unique<TH2FRatio>("testMerged", "testMerged", 10, 0, 10.0, 10, 0, 10.0, false);
+
+  for (int ybin = 1; ybin <= 10; ybin++) {
+    for (int xbin = 1; xbin <= 10; xbin++) {
+      histo1->getNum()->SetBinContent(xbin, ybin, xbin * ybin * xbin * ybin * 4);
+      histo1->getDen()->SetBinContent(xbin, ybin, xbin * ybin * 3);
+
+      histo2->getNum()->SetBinContent(xbin, ybin, xbin * ybin * xbin * ybin * 5);
+      histo2->getDen()->SetBinContent(xbin, ybin, xbin * ybin * 4);
+    }
+  }
+
+  histo1->update();
+  histo2->update();
+
+  histoMerged->merge(histo1.get());
+  histoMerged->merge(histo2.get());
+
+  for (int ybin = 1; ybin <= 10; ybin++) {
+    for (int xbin = 1; xbin <= 10; xbin++) {
+      float value = 9.0 * xbin * ybin / 7.0;
+      BOOST_REQUIRE_EQUAL(histoMerged->GetBinContent(xbin, ybin), value);
+    }
+  }
+}
+

--- a/Modules/Common/test/testCommonHistRatios.cxx
+++ b/Modules/Common/test/testCommonHistRatios.cxx
@@ -141,4 +141,3 @@ BOOST_AUTO_TEST_CASE(test_TH2FRatio)
     }
   }
 }
-


### PR DESCRIPTION
This PR introduces two generic classes that allow to create and publish histogram ratios in QC tasks.
The classes derive from MergeInterface, such that histogram rations from multiple sources can be properly combined on the merger nodes.
One class introduces ratios of TH1D histograms, and the other of TH2F histograms.

The classes can be conveniently used to normalize plots to the number of processed TFs or orbits, or to compute efficiencies.

The `uniformScaling` constructor parameter controls whether the denominator is a single constant (practically implemented as a 1-bin histogram) or if each bin has its own denominator value (in which case the numerator and denominator histograms have the same number of bins).
The first option allows to save memory and is appropriate for global histogram normalization, while the second is more flexible and appropriate for efficiency-like histograms.