### PR TITLE
[QC-972] Notify if aggregator name is more than 16 characters. 

### DIFF
--- a/Framework/basic-functional.json.in
+++ b/Framework/basic-functional.json.in
@@ -23,7 +23,7 @@
       }
     },
     "tasks": {
-      "FunctionalTest@UNIQUE_ID@": {
+      "FuncTest@UNIQUE_ID@": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonTask",
         "moduleName": "QcSkeleton",
@@ -42,7 +42,7 @@
       }
     },
     "checks": {
-      "FunctionalTest@UNIQUE_ID@": {
+      "FuncTestCheck@UNIQUE_ID@": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
         "moduleName": "QcSkeleton",
@@ -50,7 +50,7 @@
         "detectorName": "TST",
         "dataSource": [{
           "type": "Task",
-          "name": "FunctionalTest@UNIQUE_ID@",
+          "name": "FuncTest@UNIQUE_ID@",
           "MOs": ["example"]
         }]
       }

--- a/Framework/include/QualityControl/InfrastructureSpecReader.h
+++ b/Framework/include/QualityControl/InfrastructureSpecReader.h
@@ -24,6 +24,7 @@
 #include "QualityControl/PostProcessingTaskSpec.h"
 #include "QualityControl/RecoRequestSpecs.h"
 #include <boost/property_tree/ptree_fwd.hpp>
+#include <unordered_set>
 
 namespace o2::quality_control::core
 {
@@ -77,6 +78,9 @@ std::vector<T> readSectionSpec(const boost::property_tree::ptree& wholeTree, con
 }
 
 std::string validateDetectorName(std::string name);
+static void validateName(const std::string& name);
+
+static std::unordered_set<std::string> deviceNamesCache;
 
 } // namespace InfrastructureSpecReader
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/InfrastructureSpecReader.h
+++ b/Framework/include/QualityControl/InfrastructureSpecReader.h
@@ -80,7 +80,7 @@ std::vector<T> readSectionSpec(const boost::property_tree::ptree& wholeTree, con
 std::string validateDetectorName(std::string name);
 static void validateName(const std::string& name);
 
-static std::unordered_set<std::string> deviceNamesCache;
+static std::unordered_set<std::string> sDeviceNamesCache;
 
 } // namespace InfrastructureSpecReader
 } // namespace o2::quality_control::core

--- a/Framework/multinode-test.json.in
+++ b/Framework/multinode-test.json.in
@@ -23,7 +23,7 @@
       }
     },
     "tasks": {
-      "MultiNodeLocalTest@UNIQUE_PORT_1@": {
+      "MNLocalTest@UNIQUE_PORT_1@": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonTask",
         "moduleName": "QcSkeleton",
@@ -44,7 +44,7 @@
         "remotePort": "@UNIQUE_PORT_1@",
         "mergingMode": "delta"
       },
-      "MultiNodeRemoteTest@UNIQUE_PORT_2@": {
+      "MNRemoteTest@UNIQUE_PORT_2@": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonTask",
         "moduleName": "QcSkeleton",
@@ -62,7 +62,7 @@
       }
     },
     "checks": {
-      "MultiNodeLocalTest": {
+      "MNLocalTest": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
         "moduleName": "QcSkeleton",
@@ -70,11 +70,11 @@
         "detectorName": "TST",
         "dataSource": [{
           "type": "Task",
-          "name": "MultiNodeLocalTest@UNIQUE_PORT_1@",
+          "name": "MNLocalTest@UNIQUE_PORT_1@",
           "MOs": ["example"]
         }]
       },
-      "MultiNodeRemoteTest": {
+      "MNRemoteTest": {
         "active": "true",
         "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
         "moduleName": "QcSkeleton",
@@ -82,7 +82,7 @@
         "detectorName": "TST",
         "dataSource": [{
           "type": "Task",
-          "name": "MultiNodeRemoteTest@UNIQUE_PORT_2@",
+          "name": "MNRemoteTest@UNIQUE_PORT_2@",
           "MOs": ["example"]
         }]
       }

--- a/Framework/script/o2-qc-functional-test.sh
+++ b/Framework/script/o2-qc-functional-test.sh
@@ -29,8 +29,8 @@ else
 fi
 
 # delete data
-curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/MO/FunctionalTest${UNIQUE_ID}*
-curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/QO/FunctionalTest${UNIQUE_ID}*
+curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/MO/FuncTest${UNIQUE_ID}*
+curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/QO/FuncTestCheck${UNIQUE_ID}*
 
 # store data
 DIR="$(dirname "${BASH_SOURCE[0]}")"  # get the directory name
@@ -39,7 +39,7 @@ o2-qc-run-producer --message-amount 10 -b | o2-qc --config json://${JSON_DIR}/ba
 
 # check MonitorObject
 # first the return code must be 200
-code=$(curl -L ccdb-test.cern.ch:8080/qc/TST/MO/FunctionalTest${UNIQUE_ID}/example/`date +%s`999 --write-out %{http_code} --silent --output /tmp/output${UNIQUE_ID}.root)
+code=$(curl -L ccdb-test.cern.ch:8080/qc/TST/MO/FuncTest${UNIQUE_ID}/example/`date +%s`999 --write-out %{http_code} --silent --output /tmp/output${UNIQUE_ID}.root)
 if (( $code != 200 )); then
   echo "Error, monitor object could not be found."
   exit 2
@@ -49,7 +49,7 @@ root -b -l -q -e 'TFile f("/tmp/output${UNIQUE_ID}.root"); f.Print();'
 
 # check QualityObject
 # first the return code must be 200
-code=$(curl -L ccdb-test.cern.ch:8080/qc/TST/QO/FunctionalTest${UNIQUE_ID}/`date +%s`999 --write-out %{http_code} --silent --output /tmp/output${UNIQUE_ID}.root)
+code=$(curl -L ccdb-test.cern.ch:8080/qc/TST/QO/FuncTestCheck${UNIQUE_ID}/`date +%s`999 --write-out %{http_code} --silent --output /tmp/output${UNIQUE_ID}.root)
 if (( $code != 200 )); then
   echo "Error, data not found."
   exit 2
@@ -58,5 +58,5 @@ fi
 root -b -l -q -e 'TFile f("/tmp/output${UNIQUE_ID}.root"); f.Print();'
 
 # delete the data
-curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/MO/FunctionalTest${UNIQUE_ID}*
-curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/QO/FunctionalTest${UNIQUE_ID}*
+curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/MO/FuncTest${UNIQUE_ID}*
+curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/QO/FuncTestCheck${UNIQUE_ID}*

--- a/Framework/script/o2-qc-multinode-test.sh
+++ b/Framework/script/o2-qc-multinode-test.sh
@@ -44,10 +44,10 @@ function check_if_port_in_use() {
 }
 
 function delete_data() {
-  curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/MO/MultiNodeLocalTest${UNIQUE_PORT_1}*
-  curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/MO/MultiNodeRemoteTest${UNIQUE_PORT_2}*
-  curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/QO/MultiNodeLocalTest
-  curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/QO/MultiNodeRemoteTest
+  curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/MO/MNLocalTest${UNIQUE_PORT_1}*
+  curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/MO/MNRemoteTest${UNIQUE_PORT_2}*
+  curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/QO/MNLocalTest
+  curl -i -L ccdb-test.cern.ch:8080/truncate/qc/TST/QO/MNRemoteTest
 
   cd /tmp
   # mv in /tmp is guaranteed to be atomic
@@ -89,7 +89,7 @@ wait
 
 # check MonitorObject
 # first the return code must be 200
-code=$(curl -L ccdb-test.cern.ch:8080/qc/TST/MO/MultiNodeLocalTest${UNIQUE_PORT_1}/example/`date +%s`999 --write-out %{http_code} --silent --output /tmp/${UNIQUE_TEST_NAME}/multinode_test_obj${UNIQUE_PORT_1}.root)
+code=$(curl -L ccdb-test.cern.ch:8080/qc/TST/MO/MNLocalTest${UNIQUE_PORT_1}/example/`date +%s`999 --write-out %{http_code} --silent --output /tmp/${UNIQUE_TEST_NAME}/multinode_test_obj${UNIQUE_PORT_1}.root)
 if (( $code != 200 )); then
   echo "Error, monitor object of the local QC Task could not be found."
   delete_data
@@ -113,7 +113,7 @@ fi
 
 # check MonitorObject
 # first the return code must be 200
-code=$(curl -L ccdb-test.cern.ch:8080/qc/TST/MO/MultiNodeRemoteTest${UNIQUE_PORT_2}/example/`date +%s`999 --write-out %{http_code} --silent --output /tmp/${UNIQUE_TEST_NAME}/multinode_test_obj${UNIQUE_PORT_2}.root)
+code=$(curl -L ccdb-test.cern.ch:8080/qc/TST/MO/MNRemoteTest${UNIQUE_PORT_2}/example/`date +%s`999 --write-out %{http_code} --silent --output /tmp/${UNIQUE_TEST_NAME}/multinode_test_obj${UNIQUE_PORT_2}.root)
 if (( $code != 200 )); then
   echo "Error, monitor object of the remote QC Task could not be found."
   delete_data

--- a/Framework/src/AggregatorRunner.cxx
+++ b/Framework/src/AggregatorRunner.cxx
@@ -133,6 +133,9 @@ header::DataDescription AggregatorRunner::createAggregatorRunnerDataDescription(
   if (aggregatorName.empty()) {
     BOOST_THROW_EXCEPTION(FatalException() << errinfo_details("Empty taskName for task's data description"));
   }
+  if (aggregatorName.length() > header::DataDescription::size) {
+    ILOG(Warning, Devel) << "Aggregator name \"" << aggregatorName << "\" is longer than " << (int)header::DataDescription::size << ", it might cause name clashes in the DPL workflow" << ENDM;
+  }
   o2::header::DataDescription description;
   description.runtimeInit(std::string(aggregatorName.substr(0, header::DataDescription::size)).c_str());
   return description;

--- a/Framework/src/InfrastructureSpecReader.cxx
+++ b/Framework/src/InfrastructureSpecReader.cxx
@@ -91,6 +91,7 @@ TaskSpec InfrastructureSpecReader::readSpecEntry<TaskSpec>(const std::string& ta
   TaskSpec ts;
 
   ts.taskName = taskTree.get<std::string>("taskName", taskID);
+  validateName(ts.taskName); // bail if the 16 first characters of the name match another device
   ts.className = taskTree.get<std::string>("className");
   ts.moduleName = taskTree.get<std::string>("moduleName");
   ts.detectorName = taskTree.get<std::string>("detectorName");
@@ -259,6 +260,7 @@ CheckSpec InfrastructureSpecReader::readSpecEntry<CheckSpec>(const std::string& 
   CheckSpec cs;
 
   cs.checkName = checkTree.get<std::string>("checkName", checkID);
+  validateName(cs.checkName); // bail if the 16 first characters of the name match another device
   cs.className = checkTree.get<std::string>("className");
   cs.moduleName = checkTree.get<std::string>("moduleName");
   cs.detectorName = checkTree.get<std::string>("detectorName", cs.detectorName);
@@ -290,6 +292,7 @@ AggregatorSpec InfrastructureSpecReader::readSpecEntry<AggregatorSpec>(const std
   AggregatorSpec as;
 
   as.aggregatorName = aggregatorTree.get<std::string>("checkName", aggregatorID);
+  validateName(as.aggregatorName); // bail if the 16 first characters of the name match another device
   as.className = aggregatorTree.get<std::string>("className");
   as.moduleName = aggregatorTree.get<std::string>("moduleName");
   as.detectorName = aggregatorTree.get<std::string>("detectorName", as.detectorName);
@@ -322,6 +325,7 @@ PostProcessingTaskSpec
 
   ppts.id = ppTaskId;
   ppts.taskName = ppTaskTree.get<std::string>("taskName", ppts.id);
+  validateName(ppts.taskName); // bail if the 16 first characters of the name match another device
   ppts.active = ppTaskTree.get<bool>("active", ppts.active);
   ppts.detectorName = ppTaskTree.get<std::string>("detectorName", ppts.detectorName);
   ppts.tree = wholeTree;
@@ -400,6 +404,21 @@ template <typename T>
 T InfrastructureSpecReader::readSpecEntry(const std::string&, const boost::property_tree::ptree&, const boost::property_tree::ptree&)
 {
   throw std::runtime_error("Unknown entry type: " + std::string(typeid(T).name()));
+}
+
+void InfrastructureSpecReader::validateName(const std::string& name)
+{
+  std::string const trunc = name.substr( 0, 16 );
+  auto test = deviceNamesCache.emplace(trunc);
+  if(!test.second) { // the second of the pair indicates if there was an insertion, i.e. it was not already there
+    std::string errorMessage = std::string("Multiple devices share the same first 16 characters of their names: ") + trunc + "[" + name.substr(16) + "]. Probable cause: name was longer than 16 characters and was truncated. Disable one of the faulty tasks/aggregator/postprocessing or call the detector expert to change the name.";
+    if (getenv("QUALITYCONTROL_NO_FATAL_16_CHARS") == nullptr) { // if this sysenv is set to anything we don't quit
+      ILOG(Fatal, Ops) << errorMessage << " Set QUALITYCONTROL_NO_FATAL_16_CHARS to anything to avoid quitting." << ENDM;
+      throw new std::runtime_error("Duplicate device names");
+    } else {
+      ILOG(Error, Devel) << errorMessage << " QUALITYCONTROL_NO_FATAL_16_CHARS is set, we carry on" << ENDM;
+    }
+  }
 }
 
 } // namespace o2::quality_control::core

--- a/Framework/src/InfrastructureSpecReader.cxx
+++ b/Framework/src/InfrastructureSpecReader.cxx
@@ -409,9 +409,9 @@ T InfrastructureSpecReader::readSpecEntry(const std::string&, const boost::prope
 
 void InfrastructureSpecReader::validateName(const std::string& name)
 {
-  std::string const trunc = name.substr( 0, 16 );
+  std::string const trunc = name.substr(0, 16);
   auto test = sDeviceNamesCache.emplace(trunc);
-  if(!test.second) { // the second of the pair indicates if there was an insertion, i.e. it was not already there
+  if (!test.second) { // the second of the pair indicates if there was an insertion, i.e. it was not already there
     std::string errorMessage = std::string("Multiple devices share the same first 16 characters of their names: ") + trunc + "[" + name.substr(16) + "]. Probable cause: name was longer than 16 characters and was truncated. Disable one of the faulty tasks/aggregator/postprocessing or call the detector expert to change the name.";
     if (getenv("QUALITYCONTROL_NO_FATAL_16_CHARS") == nullptr) { // if this sysenv is set to anything we don't quit
       ILOG(Fatal, Ops) << errorMessage << " Set QUALITYCONTROL_NO_FATAL_16_CHARS to anything to avoid quitting." << ENDM;

--- a/Framework/src/InfrastructureSpecReader.cxx
+++ b/Framework/src/InfrastructureSpecReader.cxx
@@ -34,6 +34,7 @@ namespace o2::quality_control::core
 InfrastructureSpec InfrastructureSpecReader::readInfrastructureSpec(const boost::property_tree::ptree& wholeTree)
 {
   InfrastructureSpec spec;
+  sDeviceNamesCache.clear();
   const auto& qcTree = wholeTree.get_child("qc");
   if (qcTree.find("config") != qcTree.not_found()) {
     spec.common = readSpecEntry<CommonSpec>("", qcTree.get_child("config"), wholeTree);
@@ -409,7 +410,7 @@ T InfrastructureSpecReader::readSpecEntry(const std::string&, const boost::prope
 void InfrastructureSpecReader::validateName(const std::string& name)
 {
   std::string const trunc = name.substr( 0, 16 );
-  auto test = deviceNamesCache.emplace(trunc);
+  auto test = sDeviceNamesCache.emplace(trunc);
   if(!test.second) { // the second of the pair indicates if there was an insertion, i.e. it was not already there
     std::string errorMessage = std::string("Multiple devices share the same first 16 characters of their names: ") + trunc + "[" + name.substr(16) + "]. Probable cause: name was longer than 16 characters and was truncated. Disable one of the faulty tasks/aggregator/postprocessing or call the detector expert to change the name.";
     if (getenv("QUALITYCONTROL_NO_FATAL_16_CHARS") == nullptr) { // if this sysenv is set to anything we don't quit

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -70,6 +70,14 @@ To enable debug messages, edit your config file :
 ```
 There are more options in the "Advanced" section of this guide. 
 
+### Why do I get an error about multiple devices sharing the same first 16 characters of their names ? 
+
+The O2 software imposes that the device names do not exceed 16 characters. As a consequence we truncate. This can cause
+issues as it might seem that the names are different but in the end they are not. 
+
+If two or more devices share the 16 first characters in their names, we issue and error and we quit. 
+If you want to proceed and run despite the error, set the env var `QUALITYCONTROL_NO_FATAL_16_CHARS` to anything.
+
 ## QCDB
 
 ### How to see which objects are stored in the CCDB ?


### PR DESCRIPTION
Raise an error if two devices share the 16 first characters as it will clash. Provide the env var QUALITYCONTROL_NO_FATAL_16_CHARS to carry on despite the error.