### PR TITLE
Print clear error if config URI is missing

### DIFF
--- a/Framework/src/runQC.cxx
+++ b/Framework/src/runQC.cxx
@@ -28,6 +28,7 @@
 
 #include <vector>
 #include <utility>
+#include <regex>
 #include <boost/asio/ip/host_name.hpp>
 #include <DataSampling/DataSampling.h>
 #include <Configuration/ConfigurationFactory.h>
@@ -95,8 +96,12 @@ using namespace std::chrono;
 bool validateArguments(const ConfigContext& config)
 {
   const std::string qcConfigurationSource = config.options().get<std::string>("config");
+  std::regex configBackend(".+://.+$");
   if (qcConfigurationSource.empty()) {
     ILOG(Warning, Support) << "No configuration path specified, returning an empty workflow." << ENDM;
+    return false;
+  } else if (!std::regex_match(qcConfigurationSource, configBackend)) {
+    ILOG(Error, Support) << "The --config option expects a backend name (e.g. json:// or consul-json://) preceding the path. User specified: " << qcConfigurationSource << ENDM;
     return false;
   }
 


### PR DESCRIPTION
Hi @knopers8 
when trying to run some QC workflow locally I had wrongly put `o2-qc --config path/to/file.json` without anything preceding the file path. The help simply suggests "Absolute path to QC and Data Sampling configuration file.". The error I always got was not helping at all, because it just said
```
Fatal - Failed to build the workflow: Ill-formed URI
```
And I had no idea what URI was meant and was looking in my json file for any errors.. Now I understand that this error comes form the configuration package.

I would like to either merge this check or change the help message for the `--config` option to remind that a backend has to be specified. What do you think?
I tested with this that when I put a random backend name I get a proper error message from Configuration and when I put a wring file path Configuration also complains about a missing file.

Cheers,
Ole