### PR TITLE
Pulse Height from matched tracks optimised

### DIFF
--- a/Modules/TRD/TRDQC.json
+++ b/Modules/TRD/TRDQC.json
@@ -114,6 +114,28 @@
         "location": "remote",
         "saveObjectsToFile": "qcpulseheight.root"
       },
+      "PulseHeightTrackMatch": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::PulseHeightTrackMatch",
+        "moduleName": "QcTRD",
+        "detectorName": "TRD",
+        "cycleDurationSeconds": "15",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "no comment",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD;tracks:TRD/MATCH_ITSTPC;trigrectrk:TRD/TRGREC_ITSTPC"
+        },
+        "taskParameters": {
+          "pileupCut": "0.7",
+          "peakregionstart": "7.0",
+          "peakregionend": "20.0",
+          "pulseheightpeaklower": "1.0",
+          "pulseheightpeakupper": "5.0"
+        },
+        "location": "remote",
+        "saveObjectsToFile": "qcpulseheightitstpc.root"
+      },
       "TrackingTask": {
         "active": "true",
         "className": "o2::quality_control_modules::trd::TrackingTask",

--- a/Modules/TRD/include/TRD/PulseHeightTrackMatch.h
+++ b/Modules/TRD/include/TRD/PulseHeightTrackMatch.h
@@ -52,16 +52,18 @@ class PulseHeightTrackMatch final : public TaskInterface
   void startOfActivity(Activity& activity) override;
   void startOfCycle() override;
   void monitorData(o2::framework::ProcessingContext& ctx) override;
+  void drawLinesOnPulseHeight(TH1F* h);
   void endOfCycle() override;
   void endOfActivity(Activity& activity) override;
   void reset() override;
   void buildHistograms();
   void retrieveCCDBSettings();
-  void drawLinesOnPulseHeight(TH1F* h);
+  void drawLinesOnPulseHeight(TProfile* h);
 
  private:
   // limits
   bool mSkipSharedDigits;
+  double mPileupCut = 0.0;
   unsigned int mPulseHeightThreshold;
   std::pair<float, float> mDriftRegion;
   std::pair<float, float> mPulseHeightPeakRegion;

--- a/Modules/TRD/include/TRD/PulseHeightTrackMatch.h
+++ b/Modules/TRD/include/TRD/PulseHeightTrackMatch.h
@@ -52,7 +52,6 @@ class PulseHeightTrackMatch final : public TaskInterface
   void startOfActivity(Activity& activity) override;
   void startOfCycle() override;
   void monitorData(o2::framework::ProcessingContext& ctx) override;
-  void drawLinesOnPulseHeight(TH1F* h);
   void endOfCycle() override;
   void endOfActivity(Activity& activity) override;
   void reset() override;

--- a/Modules/TRD/src/PulseHeightCheck.cxx
+++ b/Modules/TRD/src/PulseHeightCheck.cxx
@@ -99,7 +99,7 @@ Quality PulseHeightCheck::check(std::map<std::string, std::shared_ptr<MonitorObj
   for (auto& [moName, mo] : *moMap) {
 
     (void)moName;
-    if (mo->getName() == "PulseHeight/mPulseHeight") {
+    if ((mo->getName() == "PulseHeight/mPulseHeight") || (mo->getName() == "PulseHeight/mPulseHeightpro")) {
       auto* h = dynamic_cast<TH1F*>(mo->getObject());
 
       result = Quality::Good;
@@ -123,7 +123,7 @@ Quality PulseHeightCheck::check(std::map<std::string, std::shared_ptr<MonitorObj
         return result;
       }
 
-      // check the drift region is suffuciently below the lefth hand peak.
+      // check the drift region is sufficiently below the left hand peak.
       if (average > 0) {
         if (max / average > mPulseHeightRatio) {
           // peak is sufficiently high relative to the drift region.
@@ -158,7 +158,7 @@ std::string PulseHeightCheck::getAcceptedType() { return "TH1"; }
 
 void PulseHeightCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  if (mo->getName() == "PulseHeight/mPulseHeight") {
+  if ((mo->getName() == "PulseHeight/mPulseHeight") || (mo->getName() == "PulseHeight/mPulseHeightpro")) {
     auto* h = dynamic_cast<TH1F*>(mo->getObject());
     TPaveText* msg = new TPaveText(0.3, 0.9, 0.7, 0.95, "NDC");
     h->GetListOfFunctions()->Add(msg);

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -148,7 +148,7 @@ void TrackletsTask::buildHistograms()
   getObjectsManager()->startPublishing(mTrackletPositionRaw);
   mTrackletsPerEvent = new TH1F("trackletsperevent", "Number of Tracklets per event;Tracklets in Event;Counts", 25000, 0, 25000);
   getObjectsManager()->startPublishing(mTrackletsPerEvent);
-  mTrackletsPerEvent2D = new TH2F("trackletsperevent2d", "Number of Tracklets per event;Sector_Side;Stack_Side", 36, 0, 36, 30, 0, 30);
+  mTrackletsPerEvent2D = new TH2F("trackletsperevent2d", "Tracklets distribution in half-chambers;Sector_Side;Stack_Side;Number of tracklets per half-chamber", 36, 0, 36, 30, 0, 30);
   getObjectsManager()->startPublishing(mTrackletsPerEvent2D);
   getObjectsManager()->setDefaultDrawOptions("trackletsperevent2d", "COLZ");
   getObjectsManager()->setDisplayHint(mTrackletsPerEvent2D->GetName(), "logz");


### PR DESCRIPTION
- Added pileup cut to the json with the default value of 0.7
- Added red lines similar to the standalone PH
- Changed the y-axis label to 'ADC Counts'
- Added everything above to the example json
- Additionally, in trackletstask, for the new 2D plot, changes the title and z-axis label.