### PR TITLE
CPV, PHS: update tasks and checks

### DIFF
--- a/Modules/CPV/CMakeLists.txt
+++ b/Modules/CPV/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcCPV PUBLIC O2QualityControl O2::CPVBase ROOT::Spectrum)
+target_link_libraries(O2QcCPV PUBLIC O2QualityControl O2QcPHOS O2::DataFormatsQualityControl O2::CPVBase ROOT::Spectrum)
 
 install(TARGETS O2QcCPV
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/CPV/etc/cpv-physics-qcmn-epn.json
+++ b/Modules/CPV/etc/cpv-physics-qcmn-epn.json
@@ -1,0 +1,460 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ali-qcdb.cern.ch:8083",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "monitoring": {
+        "url": "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul": {
+        "url": "http://localhost:8500"
+      },
+      "conditionDB": {
+        "url": "o2-ccdb.internal"
+      },
+      "bookkeeping": {
+        "url": "ali-bookkeeping:4001"
+      }
+    },
+    "tasks": {
+      "PhysicsOnEPNs": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsTask",
+        "moduleName": "QcCPV",
+        "detectorName": "CPV",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:CPV/DIGITS/0;dtrigrec:CPV/DIGITTRIGREC/0;clusters:CPV/CLUSTERS/0;ctrigrec:CPV/CLUSTERTRIGRECS/0;calibdigits:CPV/CALIBDIGITS/0;rawerrors:CPV/RAWHWERRORS/0;peds:CPV/CPV_Pedestals;badmap:CPV/CPV_BadMap;gains:CPV/CPV_Gains",
+          "#query": "digits:CPV/DIGITS/0;dtrigrec:CPV/DIGITTRIGREC/0;clusters:CPV/CLUSTERS/0;ctrigrec:CPV/CLUSTERTRIGRECS/0;calibdigits:CPV/CALIBDIGITS/0"
+        },
+        "taskParameters": {
+          "": ""
+        },
+        "location": "local",
+        "localMachines": [
+          "localhost"
+        ],
+        "remoteMachine": "alio2-cr1-qme07.cern.ch",
+        "remotePort": "47768",
+        "mergingMode": "delta",
+        "localControl": "odc",
+        "": ""
+      }
+    },
+    "checks": {
+      "IncreasingEntriesClusterCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "checkParameters": {
+          "mustIncrease": "true"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "ClusterMapM2",
+              "ClusterMapM3",
+              "ClusterMapM4"
+            ]
+          }
+        ]
+      },
+      "IncreasingEntriesDigitCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "checkParameters": {
+          "mustIncrease": "true"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "DigitMapM2",
+              "DigitMapM3",
+              "DigitMapM4"
+            ]
+          }
+        ]
+      },
+      "DigitsCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsCheck",
+        "moduleName": "QcCPV",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "DigitMapM2",
+              "DigitMapM3",
+              "DigitMapM4"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "mMinEventsToCheckDigitMap2": "10000",
+          "mMinEventsToCheckDigitMap3": "10000",
+          "mMinEventsToCheckDigitMap4": "10000",
+          "mStripPopulationDeviationAllowed2": "1.5",
+          "mStripPopulationDeviationAllowed3": "1.5",
+          "mStripPopulationDeviationAllowed4": "1.5",
+          "mNBadStripsPerQuarterAllowed2": "10",
+          "mNBadStripsPerQuarterAllowed3": "10",
+          "mNBadStripsPerQuarterAllowed4": "10",
+          "mNCold3GassiplexAllowed2": "30",
+          "mNCold3GassiplexAllowed3": "10",
+          "mNCold3GassiplexAllowed4": "17",
+          "mNHot3GassiplexAllowed2": "10",
+          "mNHot3GassiplexAllowed3": "10",
+          "mNHot3GassiplexAllowed4": "14",
+          "mHot3GassiplexCriterium2": "2.5",
+          "mHot3GassiplexCriterium3": "2.5",
+          "mHot3GassiplexCriterium4": "2.5",
+          "mCold3GassiplexCriterium2": "0.3",
+          "mCold3GassiplexCriterium3": "0.3",
+          "mCold3GassiplexCriterium4": "0.3"
+        }
+      },
+      "ClusterSizeCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsCheck",
+        "moduleName": "QcCPV",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "NDigitsInClusterM2",
+              "NDigitsInClusterM3",
+              "NDigitsInClusterM4"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "mMinClusterSize2": "1.7",
+          "mMinClusterSize3": "1.7",
+          "mMinClusterSize4": "1.7",
+          "mMaxClusterSize2": "10",
+          "mMaxClusterSize3": "10",
+          "mMaxClusterSize4": "10"
+        }
+      },
+      "CalibDigitsCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsCheck",
+        "moduleName": "QcCPV",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "CalibDigitEnergyM2",
+              "CalibDigitEnergyM3",
+              "CalibDigitEnergyM4"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "mAmplitudeRangeL2": "100",
+          "mAmplitudeRangeL3": "100",
+          "mAmplitudeRangeL4": "100",
+          "mAmplitudeRangeR2": "1000",
+          "mAmplitudeRangeR3": "1000",
+          "mAmplitudeRangeR4": "1000",
+          "mMinEventsToFit2": "10000",
+          "mMinEventsToFit3": "10000",
+          "mMinEventsToFit4": "10000",
+          "mMinAmplification2": "10",
+          "mMinAmplification3": "10",
+          "mMinAmplification4": "10",
+          "mMaxAmplification2": "700",
+          "mMaxAmplification3": "700",
+          "mMaxAmplification4": "700"
+        }
+      }
+    },
+    "postprocessing": {
+      "PhysicsTrending": {
+        "active": "true",
+        "#taskName": "PhysicsOnEPNs",
+        "": "use the taskName in order to post output to CPV/MO/TaskName",
+        "className": "o2::quality_control::postprocessing::TrendingTask",
+        "moduleName": "QualityControl",
+        "detectorName": "CPV",
+        "resumeTrend": "false",
+        "producePlotsOnUpdate": "true",
+        "initTrigger": [
+          "once"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:CPV/MO/PhysicsOnEPNs/NDigitsInEventM2M3M4"
+        ],
+        "stopTrigger": [
+          "usercontrol"
+        ],
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "CPV/MO/PhysicsOnEPNs",
+            "names": [
+              "NDigitsInEventM2M3M4",
+              "NClustersInEventM2M3M4",
+              "ClusterTotEnergyM2",
+              "ClusterTotEnergyM3",
+              "ClusterTotEnergyM4",
+              "CalibDigitEnergyM2",
+              "CalibDigitEnergyM3",
+              "CalibDigitEnergyM4",
+              "DigitEnergyM2",
+              "DigitEnergyM3",
+              "DigitEnergyM4",
+              "NDigitsInClusterM2",
+              "NDigitsInClusterM3",
+              "NDigitsInClusterM4"
+            ],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcCommon"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mean_of_n_digits",
+            "title": "Trend of mean number of digits per event",
+            "varexp": "NDigitsInEventM2M3M4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean number of digits:time",
+            "graphYRange": "0:300"
+          },
+          {
+            "name": "mean_of_n_clusters",
+            "title": "Trend of mean number of clusters per event",
+            "varexp": "NClustersInEventM2M3M4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean number of clusters:time",
+            "graphYRange": "0:50"
+          },
+          {
+            "name": "mean_of_cluEnergyM2",
+            "title": "Trend of mean cluster energy M2",
+            "varexp": "ClusterTotEnergyM2.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster energy:time",
+            "graphYRange": "0:150"
+          },
+          {
+            "name": "mean_of_cluEnergyM3",
+            "title": "Trend of mean cluster energy M3",
+            "varexp": "ClusterTotEnergyM3.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster energy:time",
+            "graphYRange": "0:150"
+          },
+          {
+            "name": "mean_of_cluEnergyM4",
+            "title": "Trend of mean cluster energy M4",
+            "varexp": "ClusterTotEnergyM4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster energy:time",
+            "graphYRange": "0:150"
+          },
+          {
+            "name": "mean_of_calibDigEnergyM2",
+            "title": "Trend of mean calib digit energy M2",
+            "varexp": "CalibDigitEnergyM2.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:300"
+          },
+          {
+            "name": "mean_of_calibDigEnergyM3",
+            "title": "Trend of mean calib digit energy M3",
+            "varexp": "CalibDigitEnergyM3.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:300"
+          },
+          {
+            "name": "mean_of_calibDigEnergyM4",
+            "title": "Trend of mean calib digit energy M4",
+            "varexp": "CalibDigitEnergyM4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:300"
+          },
+          {
+            "name": "mean_of_digEnergyM2",
+            "title": "Trend of mean digit energy M2",
+            "varexp": "DigitEnergyM2.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:100"
+          },
+          {
+            "name": "mean_of_digEnergyM3",
+            "title": "Trend of mean digit energy M3",
+            "varexp": "DigitEnergyM3.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:100"
+          },
+          {
+            "name": "mean_of_digEnergyM4",
+            "title": "Trend of mean digit energy M4",
+            "varexp": "DigitEnergyM4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:100"
+          },
+          {
+            "name": "mean_of_cluSizeM2",
+            "title": "Trend of mean cluster size M2",
+            "varexp": "NDigitsInClusterM2.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster size:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluSizeM3",
+            "title": "Trend of mean cluster size M3",
+            "varexp": "NDigitsInClusterM3.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster size:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluSizeM4",
+            "title": "Trend of mean cluster size M4",
+            "varexp": "NDigitsInClusterM4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster size:time",
+            "graphYRange": "0:10"
+          }
+        ]
+      },
+      "QualityTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QualityControl",
+        "detectorName": "CPV",
+        "qualityGroups": [
+          {
+            "name": "global",
+            "title": "GLOBAL CPV QUALITY",
+            "path": "CPV/QO/GlobalQuality",
+            "ignoreQualitiesDetails": [
+              "Null",
+              "Good",
+              "Medium",
+              "Bad"
+            ],
+            "inputObjects": [
+              {
+                "name": "GlobalQuality",
+                "title": "Global CPV Quality",
+                "messageBad": "Inform CPV on-call",
+                "messageMedium": "Not enough statistics in some histograms",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty!!!"
+              }
+            ]
+          },
+          {
+            "name": "details",
+            "title": "CPV DETAILS",
+            "path": "CPV/QO",
+            "ignoreQualitiesDetails": [],
+            "inputObjects": [
+              {
+                "name": "IncreasingEntriesDigitCheck",
+                "title": "Number of digits increases",
+                "messageBad": "Entries are not increasing in last cycle",
+                "messageNull": ""
+              },
+              {
+                "name": "IncreasingEntriesClusterCheck",
+                "title": "Number of clusters increases",
+                "messageBad": "Entries are not increasing in last cycle",
+                "messageNull": ""
+              },
+              {
+                "name": "DigitsCheck",
+                "title": "Digit occupancy check",
+                "messageBad": "Inform CPV on-call",
+                "messageGood": "",
+                "messageNull": ""
+              }
+            ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "60 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    },
+    "aggregators": {
+      "GlobalQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QualityControl",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "IncreasingEntriesDigitCheck"
+          },
+          {
+            "type": "Check",
+            "name": "IncreasingEntriesClusterCheck"
+          },
+          {
+            "type": "Check",
+            "name": "DigitsCheck"
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": []
+}

--- a/Modules/CPV/etc/physics-full-no-sampling.json
+++ b/Modules/CPV/etc/physics-full-no-sampling.json
@@ -1,0 +1,536 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "PhysicsOnEPNs": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsTask",
+        "moduleName": "QcCPV",
+        "detectorName": "CPV",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:CPV/DIGITS/0;dtrigrec:CPV/DIGITTRIGREC/0;clusters:CPV/CLUSTERS/0;ctrigrec:CPV/CLUSTERTRIGRECS/0;calibdigits:CPV/CALIBDIGITS/0;rawerrors:CPV/RAWHWERRORS/0;peds:CPV/CPV_Pedestals;badmap:CPV/CPV_BadMap;gains:CPV/CPV_Gains"
+        },
+        "taskParameters": {
+          "ccdbCheckInterval": "1000",
+          "isAsyncMode": "0"
+        },
+        "location": "remote",
+        "saveObjectsToFile": "MOs.root"
+      }
+    },
+    "checks": {
+      "ClustersIncrease": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "checkParameters": {
+          "mustIncrease": "true"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "ClusterMapM2",
+              "ClusterMapM3",
+              "ClusterMapM4"
+            ]
+          }
+        ]
+      },
+      "DigitsIncrease": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "checkParameters": {
+          "mustIncrease": "true"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "DigitMapM2",
+              "DigitMapM3",
+              "DigitMapM4"
+            ]
+          }
+        ]
+      },
+      "DigitsCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsCheck",
+        "moduleName": "QcCPV",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "DigitsInEventM2",
+              "DigitsInEventM3",
+              "DigitsInEventM4",
+              "DigitMapM2",
+              "DigitMapM3",
+              "DigitMapM4",
+              "DigitOccuranceM2",
+              "DigitOccuranceM3",
+              "DigitOccuranceM4"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "mMinEventsToCheckDigitMap2": "10000",
+          "mMinEventsToCheckDigitMap3": "10000",
+          "mMinEventsToCheckDigitMap4": "10000",
+          "mNCold3GassiplexAllowed2": "30",
+          "mNCold3GassiplexAllowed3": "10",
+          "mNCold3GassiplexAllowed4": "17",
+          "mNHot3GassiplexAllowed2": "10",
+          "mNHot3GassiplexAllowed3": "10",
+          "mNHot3GassiplexAllowed4": "14",
+          "mHot3GassiplexCriterium2": "2.5",
+          "mHot3GassiplexCriterium3": "2.5",
+          "mHot3GassiplexCriterium4": "2.5",
+          "mCold3GassiplexCriterium2": "0.3",
+          "mCold3GassiplexCriterium3": "0.3",
+          "mCold3GassiplexCriterium4": "0.3",
+          "mMinDigitsPerEvent2": "50",
+          "mMinDigitsPerEvent3": "50",
+          "mMinDigitsPerEvent4": "50",
+          "mMaxDigitsPerEvent2": "100",
+          "mMaxDigitsPerEvent3": "100",
+          "mMaxDigitsPerEvent4": "100",
+          "mHot3GassiplexOccurance2": "0.05",
+          "mHot3GassiplexOccurance3": "0.05",
+          "mHot3GassiplexOccurance4": "0.05",
+          "mCold3GassiplexOccurance2": "0.000001",
+          "mCold3GassiplexOccurance3": "0.000001",
+          "mCold3GassiplexOccurance4": "0.000001"
+        }
+      },
+      "ClustersCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsCheck",
+        "moduleName": "QcCPV",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "NDigitsInClusterM2",
+              "NDigitsInClusterM3",
+              "NDigitsInClusterM4",
+              "ClusterTotEnergyM2",
+              "ClusterTotEnergyM3",
+              "ClusterTotEnergyM4"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "mMinEventsToCheckClusters2": "10000",
+          "mMinEventsToCheckClusters3": "10000",
+          "mMinEventsToCheckClusters4": "10000",
+          "mCluEnergyRangeL2": "100",
+          "mCluEnergyRangeL3": "100",
+          "mCluEnergyRangeL4": "100",
+          "mCluEnergyRangeR2": "2000",
+          "mCluEnergyRangeR3": "2000",
+          "mCluEnergyRangeR4": "2000",
+          "mMinCluEnergyMean2": "50",
+          "mMinCluEnergyMean3": "50",
+          "mMinCluEnergyMean4": "50",
+          "mMaxCluEnergyMean2": "400",
+          "mMaxCluEnergyMean3": "400",
+          "mMaxCluEnergyMean4": "400",
+          "mMinClusterSize2": "1.5",
+          "mMinClusterSize3": "1.7",
+          "mMinClusterSize4": "1.7",
+          "mMaxClusterSize2": "2.5",
+          "mMaxClusterSize3": "2.5",
+          "mMaxClusterSize4": "2.5"
+        }
+      },
+      "CalibDigitsCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsCheck",
+        "moduleName": "QcCPV",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "CalibDigitEnergyM2",
+              "CalibDigitEnergyM3",
+              "CalibDigitEnergyM4"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "mAmplitudeRangeL2": "100",
+          "mAmplitudeRangeL3": "100",
+          "mAmplitudeRangeL4": "100",
+          "mAmplitudeRangeR2": "1000",
+          "mAmplitudeRangeR3": "1000",
+          "mAmplitudeRangeR4": "1000",
+          "mMinEventsToCheckAmplitude2": "10000",
+          "mMinEventsToCheckAmplitude3": "10000",
+          "mMinEventsToCheckAmplitude4": "10000",
+          "mMinAmplitudeMean2": "50",
+          "mMinAmplitudeMean3": "50",
+          "mMinAmplitudeMean4": "50",
+          "mMaxAmplitudeMean2": "400",
+          "mMaxAmplitudeMean3": "400",
+          "mMaxAmplitudeMean4": "400"
+        }
+      },
+      "ErrorsCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::cpv::PhysicsCheck",
+        "moduleName": "QcCPV",
+        "policy": "OnAny",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "PhysicsOnEPNs",
+            "MOs": [
+              "ErrorTypeOccurance"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "mErrorOccuranceThreshold18": "0.1"
+        }
+      }
+    },
+    "postprocessing": {
+      "PhysicsTrending": {
+        "active": "true",
+        "#taskName": "PhysicsOnEPNs",
+        "": "use the taskName in order to post output to CPV/MO/TaskName",
+        "className": "o2::quality_control::postprocessing::TrendingTask",
+        "moduleName": "QcCommon",
+        "detectorName": "CPV",
+        "resumeTrend": "false",
+        "producePlotsOnUpdate": "true",
+        "initTrigger": [
+          "newobject:qcdb:CPV/MO/PhysicsOnEPNs/NDigitsInEventM2M3M4"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:CPV/MO/PhysicsOnEPNs/NDigitsInEventM2M3M4"
+        ],
+        "stopTrigger": [
+          "usercontrol"
+        ],
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "CPV/MO/PhysicsOnEPNs",
+            "names": [
+              "NDigitsInEventM2M3M4",
+              "NClustersInEventM2M3M4",
+              "ClusterTotEnergyM2",
+              "ClusterTotEnergyM3",
+              "ClusterTotEnergyM4",
+              "CalibDigitEnergyM2",
+              "CalibDigitEnergyM3",
+              "CalibDigitEnergyM4",
+              "DigitEnergyM2",
+              "DigitEnergyM3",
+              "DigitEnergyM4",
+              "NDigitsInClusterM2",
+              "NDigitsInClusterM3",
+              "NDigitsInClusterM4"
+            ],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcCommon"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mean_of_n_digits",
+            "title": "Trend of mean number of digits per event",
+            "varexp": "NDigitsInEventM2M3M4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean number of digits:time",
+            "graphYRange": "0:300"
+          },
+          {
+            "name": "mean_of_n_clusters",
+            "title": "Trend of mean number of clusters per event",
+            "varexp": "NClustersInEventM2M3M4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean number of clusters:time",
+            "graphYRange": "0:50"
+          },
+          {
+            "name": "mean_of_cluEnergyM2",
+            "title": "Trend of mean cluster energy M2",
+            "varexp": "ClusterTotEnergyM2.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster energy:time",
+            "graphYRange": "0:150"
+          },
+          {
+            "name": "mean_of_cluEnergyM3",
+            "title": "Trend of mean cluster energy M3",
+            "varexp": "ClusterTotEnergyM3.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster energy:time",
+            "graphYRange": "0:150"
+          },
+          {
+            "name": "mean_of_cluEnergyM4",
+            "title": "Trend of mean cluster energy M4",
+            "varexp": "ClusterTotEnergyM4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster energy:time",
+            "graphYRange": "0:150"
+          },
+          {
+            "name": "mean_of_calibDigEnergyM2",
+            "title": "Trend of mean calib digit energy M2",
+            "varexp": "CalibDigitEnergyM2.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:300"
+          },
+          {
+            "name": "mean_of_calibDigEnergyM3",
+            "title": "Trend of mean calib digit energy M3",
+            "varexp": "CalibDigitEnergyM3.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:300"
+          },
+          {
+            "name": "mean_of_calibDigEnergyM4",
+            "title": "Trend of mean calib digit energy M4",
+            "varexp": "CalibDigitEnergyM4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:300"
+          },
+          {
+            "name": "mean_of_digEnergyM2",
+            "title": "Trend of mean digit energy M2",
+            "varexp": "DigitEnergyM2.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:100"
+          },
+          {
+            "name": "mean_of_digEnergyM3",
+            "title": "Trend of mean digit energy M3",
+            "varexp": "DigitEnergyM3.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:100"
+          },
+          {
+            "name": "mean_of_digEnergyM4",
+            "title": "Trend of mean digit energy M4",
+            "varexp": "DigitEnergyM4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean digit energy:time",
+            "graphYRange": "0:100"
+          },
+          {
+            "name": "mean_of_cluSizeM2",
+            "title": "Trend of mean cluster size M2",
+            "varexp": "NDigitsInClusterM2.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster size:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluSizeM3",
+            "title": "Trend of mean cluster size M3",
+            "varexp": "NDigitsInClusterM3.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster size:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluSizeM4",
+            "title": "Trend of mean cluster size M4",
+            "varexp": "NDigitsInClusterM4.mean:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Mean cluster size:time",
+            "graphYRange": "0:10"
+          }
+        ]
+      },
+      "QualityTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QcCommon",
+        "detectorName": "CPV",
+        "qualityGroups": [
+          {
+            "name": "global",
+            "title": "GLOBAL CPV QUALITY",
+            "path": "CPV/QO/GlobalQuality",
+            "ignoreQualitiesDetails": [
+              "Null",
+              "Good",
+              "Medium",
+              "Bad"
+            ],
+            "inputObjects": [
+              {
+                "name": "GlobalQuality",
+                "title": "Global CPV Quality",
+                "messageBad": "Inform CPV on-call",
+                "messageMedium": "Not enough statistics in some histograms",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty!!!"
+              }
+            ]
+          },
+          {
+            "name": "details",
+            "title": "CPV DETAILS",
+            "path": "CPV/QO",
+            "ignoreQualitiesDetails": [],
+            "inputObjects": [
+              {
+                "name": "DigitsIncrease",
+                "title": "Number of digits increases",
+                "messageBad": "Entries are not increasing in last cycle",
+                "messageNull": ""
+              },
+              {
+                "name": "ClustersIncrease",
+                "title": "Number of clusters increases",
+                "messageBad": "Entries are not increasing in last cycle",
+                "messageNull": ""
+              },
+              {
+                "name": "DigitsCheck",
+                "title": "Digit occupancy check",
+                "messageBad": "Inform CPV on-call",
+                "messageGood": "Ok",
+                "messageNull": ""
+              },
+              {
+                "name": "ClustersCheck",
+                "title": "Cluster size check",
+                "messageBad": "Inform CPV on-call",
+                "messageMedium": "Inform CPV on-call",
+                "messageNull": ""
+              },
+              {
+                "name": "CalibDigitsCheck",
+                "title": "CalibDigit amplitude check",
+                "messageBad": "Inform CPV on-call",
+                "messageMedium": "Inform CPV on-call",
+                "messageNull": ""
+              },
+              {
+                "name": "ErrorsCheck",
+                "title": "Errors presence check",
+                "messageBad": "Inform CPV on-call",
+                "messageMedium": "Inform CPV on-call",
+                "messageNull": ""
+              }
+            ]
+          }
+        ],
+        "initTrigger": [
+          "newobject:qcdb:CPV/QO/GlobalQuality/GlobalQuality"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:CPV/QO/GlobalQuality/GlobalQuality"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    },
+    "aggregators": {
+      "GlobalQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QcCommon",
+        "policy": "OnAll",
+        "detectorName": "CPV",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "DigitsIncrease"
+          },
+          {
+            "type": "Check",
+            "name": "ClustersIncrease"
+          },
+          {
+            "type": "Check",
+            "name": "DigitsCheck"
+          },
+          {
+            "type": "Check",
+            "name": "ClustersCheck"
+          },
+          {
+            "type": "Check",
+            "name": "CalibDigitsCheck"
+          },
+          {
+            "type": "Check",
+            "name": "ErrorsCheck"
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": []
+}

--- a/Modules/CPV/include/CPV/PhysicsCheck.h
+++ b/Modules/CPV/include/CPV/PhysicsCheck.h
@@ -42,26 +42,79 @@ class PhysicsCheck : public o2::quality_control::checker::CheckInterface
  private:
   int getRunNumberFromMO(std::shared_ptr<MonitorObject> mo);
 
-  // configurable parameters and their default values
-  // see config example in Modules/CPV/etc/Physics-task-no-sampling.json
+  // amplitude check parameters
   float mAmplitudeRangeL[3] = { 20., 20., 20. };
   float mAmplitudeRangeR[3] = { 1000., 1000., 1000. };
-  float mMinEventsToFit[3] = { 100, 100, 100 };
-  float mMinAmplification[3] = { 5., 5., 5. };
-  float mMaxAmplification[3] = { 200., 200., 200. };
+  float mMinEventsToCheckAmplitude[3] = { 100, 100, 100 };
+  float mMinAmplitudeMean[3] = { 5., 5., 5. };
+  float mMaxAmplitudeMean[3] = { 200., 200., 200. };
+  // cluster check parameters
+  float mMinEventsToCheckClusters[3] = { 10., 10., 10. };
   float mMinClusterSize[3] = { 2., 2., 2. };
   float mMaxClusterSize[3] = { 5., 5., 5. };
+  float mCluEnergyRangeL[3] = { 20., 20., 20. };
+  float mCluEnergyRangeR[3] = { 1000., 1000., 1000. };
+  float mMinCluEnergyMean[3] = { 5., 5., 5. };
+  float mMaxCluEnergyMean[3] = { 200., 200., 200. };
+  // digits check parameters
   int mMinEventsToCheckDigitMap[3] = { 10000, 10000, 10000 };
-  float mStripPopulationDeviationAllowed[3] = { 10., 10., 10. };
-  int mNBadStripsPerQuarterAllowed[3] = { 10, 10, 10 };
   int mNCold3GassiplexAllowed[3] = { 10, 10, 10 };
   int mNHot3GassiplexAllowed[3] = { 10, 10, 10 };
   float mHot3GassiplexCriterium[3] = { 10., 10., 10. };
   float mCold3GassiplexCriterium[3] = { 0.1, 0.1, 0.1 };
+  float mHot3GassiplexOccurance[3] = { 0.1, 0.1, 0.1 };
+  float mCold3GassiplexOccurance[3] = { 1.e-6, 1.e-6, 1.e-6 };
+  float mMinDigitsPerEvent[3] = { 0., 0., 0 };
+  float mMaxDigitsPerEvent[3] = { 300., 300., 300 };
+  // errors check parameters
+  float mErrorOccuranceThreshold[20] = {
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.,
+    0.
+  };
+  const char* mErrorLabel[20] = {
+    "ok",
+    "no payload",
+    "rdh decod",
+    "rdh invalid",
+    "not cpv rdh",
+    "no stopbit",
+    "page not found",
+    "0 offset to next",
+    "payload incomplete",
+    "no cpv header",
+    "no cpv trailer",
+    "cpv header invalid",
+    "cpv trailer invalid",
+    "segment header err",
+    "row header error",
+    "EOE header error",
+    "pad error",
+    "unknown word",
+    "pad address",
+    "wrong data format"
+  };
 
   bool mIsConfigured = false; // had configure() been called already?
 
-  ClassDefOverride(PhysicsCheck, 1);
+  ClassDefOverride(PhysicsCheck, 2);
 };
 
 } // namespace o2::quality_control_modules::cpv

--- a/Modules/CPV/include/CPV/PhysicsTask.h
+++ b/Modules/CPV/include/CPV/PhysicsTask.h
@@ -18,6 +18,8 @@
 #define QC_MODULE_CPV_CPVPHYSICSTASK_H
 
 #include "QualityControl/TaskInterface.h"
+#include "PHOS/TH1Fraction.h"
+#include "PHOS/TH2Fraction.h"
 #include <Mergers/MergeInterface.h>
 #include <memory>
 #include <array>
@@ -81,6 +83,8 @@ class IntensiveTH2F : public TH2F, public o2::mergers::MergeInterface
 /// \brief Task for CPV Physics monitoring
 /// \author Sergey Evdokimov
 using Geometry = o2::cpv::Geometry;
+using TH1Fraction = o2::quality_control_modules::phos::TH1Fraction;
+using TH2Fraction = o2::quality_control_modules::phos::TH2Fraction;
 class PhysicsTask final : public TaskInterface
 {
  public:
@@ -134,16 +138,13 @@ class PhysicsTask final : public TaskInterface
                   H1DNDigitsInClusterM4
   };
 
-  static constexpr short kNHist2D = 12;
+  static constexpr short kNHist2D = 9;
   enum Histos2D { H2DDigitMapM2,
                   H2DDigitMapM3,
                   H2DDigitMapM4,
                   H2DCalibDigitMapM2,
                   H2DCalibDigitMapM3,
                   H2DCalibDigitMapM4,
-                  H2DDigitFreqM2,
-                  H2DDigitFreqM3,
-                  H2DDigitFreqM4,
                   H2DClusterMapM2,
                   H2DClusterMapM3,
                   H2DClusterMapM4
@@ -162,6 +163,14 @@ class PhysicsTask final : public TaskInterface
                            H2DGainsM3,
                            H2DGainsM4
   };
+  static constexpr short kNfractions1D = 1;
+  enum fractions1D { F1DErrorTypeOccurance };
+
+  static constexpr short kNfractions2D = 3;
+  enum fractions2D { F2DDigitFreqM2,
+                     F2DDigitFreqM3,
+                     F2DDigitFreqM4
+  };
 
   static constexpr short kNModules = 3;
   static constexpr short kNChannels = 23040;
@@ -173,6 +182,8 @@ class PhysicsTask final : public TaskInterface
   std::array<TH1F*, kNHist1D> mHist1D = { nullptr };                            ///< Array of 1D histograms
   std::array<TH2F*, kNHist2D> mHist2D = { nullptr };                            ///< Array of 2D histograms
   std::array<IntensiveTH2F*, kNIntensiveHist2D> mIntensiveHist2D = { nullptr }; ///< Array of IntensiveTH2F histograms
+  std::array<TH1Fraction*, kNfractions1D> mFractions1D = { nullptr };           ///< Array of TH1Fraction histograms
+  std::array<TH2Fraction*, kNfractions2D> mFractions2D = { nullptr };           ///< Array of TH1Fraction histograms
 };
 
 } // namespace o2::quality_control_modules::cpv

--- a/Modules/CPV/src/PedestalCheck.cxx
+++ b/Modules/CPV/src/PedestalCheck.cxx
@@ -14,11 +14,15 @@
 /// \author Sergey Evdokimov
 ///
 
+// QC
 #include "CPV/PedestalCheck.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/ObjectMetadataKeys.h"
+// O2
+#include <DataFormatsQualityControl/FlagReasons.h>
+#include <DataFormatsQualityControl/FlagReasonFactory.h>
 // ROOT
 #include <TH1.h>
 #include <TH2.h>
@@ -26,6 +30,7 @@
 #include <TList.h>
 
 using namespace std;
+using namespace o2::quality_control;
 using namespace o2::quality_control::repository;
 
 namespace o2::quality_control_modules::cpv
@@ -148,6 +153,7 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
     configure();
   }
 
+  // default
   Quality result = Quality::Good;
 
   for (auto& [moName, mo] : *moMap) {
@@ -162,16 +168,18 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
           ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1F*, skipping" << ENDM;
           continue;
         }
-        result = Quality::Good; // default
         TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
-        msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
+        // msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
         // count number of too small pedestals + too big pedestals
         int nOfBadPedestalValues = h->Integral(0, mMinGoodPedestalValueM[iMod]) + h->GetBinContent(h->GetNbinsX() + 1); // underflow + small pedestals + overflow
         if (nOfBadPedestalValues > mToleratedBadPedestalValueChannelsM[iMod]) {
-          result = Quality::Bad;
+          if (result.isBetterThan(Quality::Bad)) {
+            result = Quality::Bad;
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("bad ped values M%d", iMod));
           msg->AddText(Form("Too many bad ped values: %d", nOfBadPedestalValues));
           msg->AddText(Form("Tolerated bad ped values: %d", mToleratedBadPedestalValueChannelsM[iMod]));
           msg->SetFillColor(kRed);
@@ -181,7 +189,10 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
         // count number of bad pedestals (double peaked and so)
         int nOfBadPedestals = 7680 - h->GetEntries();
         if (nOfBadPedestals > mToleratedBadChannelsM[iMod]) {
-          result = Quality::Bad;
+          if (result.isBetterThan(Quality::Bad)) {
+            result.set(Quality::Bad);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("bad pedestals M%d", iMod));
           msg->AddText(Form("Too many bad channels: %d", nOfBadPedestals));
           msg->AddText(Form("Tolerated bad channels: %d", mToleratedBadChannelsM[iMod]));
           msg->SetFillColor(kRed);
@@ -202,19 +213,21 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
           ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1F*, skipping" << ENDM;
           continue;
         }
-        result = Quality::Good; // default
         TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
-        msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
+        // msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
         // count number of too small pedestals + too big pedestals
         float binWidth = h->GetBinWidth(1);
         int nOfBadPedestalSigmas = h->Integral(mMaxGoodPedestalSigmaM[iMod] / binWidth + 1,
                                                h->GetNbinsX() + 1); // big sigmas + overflow
 
         if (nOfBadPedestalSigmas > mToleratedBadPedestalSigmaChannelsM[iMod]) {
-          result = Quality::Bad;
+          if (result.isBetterThan(Quality::Bad)) {
+            result.set(Quality::Bad);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("bad ped sigmas M%d", iMod));
           msg->AddText(Form("Too many bad ped sigmas: %d", nOfBadPedestalSigmas));
           msg->AddText(Form("Tolerated bad ped sigmas: %d", mToleratedBadPedestalSigmaChannelsM[iMod]));
 
@@ -239,7 +252,7 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
-        msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
+        // msg->AddText(Form("Run %d", getRunNumberFromMO(mo)));
         // count number of too small pedestals + too big pedestals
         float binWidth = h->GetBinWidth(1);
         int nOfBadPedestalEfficiencies = 7680 -
@@ -247,7 +260,10 @@ Quality PedestalCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
                                                      mMaxGoodPedestalEfficiencyM[iMod] / binWidth); // big sigmas + overflow
 
         if (nOfBadPedestalEfficiencies > mToleratedBadPedestalEfficiencyChannelsM[iMod]) {
-          result = Quality::Bad;
+          if (result.isBetterThan(Quality::Bad)) {
+            result.set(Quality::Bad);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("bad ped efficiencies M%d", iMod));
           msg->AddText(Form("Too many bad ped efficiencies: %d", nOfBadPedestalEfficiencies));
           msg->AddText(Form("Tolerated bad ped efficiencies: %d",
                             mToleratedBadPedestalEfficiencyChannelsM[iMod]));

--- a/Modules/CPV/src/PhysicsCheck.cxx
+++ b/Modules/CPV/src/PhysicsCheck.cxx
@@ -14,20 +14,30 @@
 /// \author Sergey Evdokimov
 ///
 
+// QC
 #include "CPV/PhysicsCheck.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/ObjectMetadataKeys.h"
+#include "PHOS/TH1Fraction.h"
+#include "PHOS/TH2Fraction.h"
+// O2
+#include <DataFormatsQualityControl/FlagReasons.h>
+#include <DataFormatsQualityControl/FlagReasonFactory.h>
 // ROOT
 #include <TF1.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TPaveText.h>
 #include <TList.h>
+#include <TLatex.h>
 
 using namespace std;
+using namespace o2::quality_control;
 using namespace o2::quality_control::repository;
+using TH1Fraction = o2::quality_control_modules::phos::TH1Fraction;
+using TH2Fraction = o2::quality_control_modules::phos::TH2Fraction;
 
 namespace o2::quality_control_modules::cpv
 {
@@ -56,31 +66,72 @@ void PhysicsCheck::configure()
                          << param->second << ENDM;
       mAmplitudeRangeR[mod] = stof(param->second);
     }
-    // mMinEventsToFit
-    if (auto param = mCustomParameters.find(Form("mMinEventsToFit%d", mod + 2));
+    // mMinEventsToChaeckAmplitude
+    if (auto param = mCustomParameters.find(Form("mMinEventsToCheckAmplitude%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Debug, Devel) << "configure() : Custom parameter "
-                         << Form("mMinEventsToFit%d = ", mod + 2)
+                         << Form("mMinEventsToCheckAmplitude%d = ", mod + 2)
                          << param->second << ENDM;
-      mMinEventsToFit[mod] = stof(param->second);
+      mMinEventsToCheckAmplitude[mod] = stof(param->second);
     }
 
-    // mMinAmplification
-    if (auto param = mCustomParameters.find(Form("mMinAmplification%d", mod + 2));
+    // mMinAmplitudeMean
+    if (auto param = mCustomParameters.find(Form("mMinAmplitudeMean%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Debug, Devel) << "configure() : Custom parameter "
-                         << Form("mMinAmplification%d = ", mod + 2)
+                         << Form("mMinAmplitudeMean%d = ", mod + 2)
                          << param->second << ENDM;
-      mMinAmplification[mod] = stof(param->second);
+      mMinAmplitudeMean[mod] = stof(param->second);
     }
-    // mMaxAmplification
-    if (auto param = mCustomParameters.find(Form("mMaxAmplification%d", mod + 2));
+    // mMaxAmplitudeMean
+    if (auto param = mCustomParameters.find(Form("mMaxAmplitudeMean%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Debug, Devel) << "configure() : Custom parameter "
-                         << Form("mMaxAmplification%d = ", mod + 2)
+                         << Form("mMaxAmplitudeMean%d = ", mod + 2)
                          << param->second << ENDM;
-      mMaxAmplification[mod] = stof(param->second);
+      mMaxAmplitudeMean[mod] = stof(param->second);
     }
+    // mMinEventsToCheckClusters
+    if (auto param = mCustomParameters.find(Form("mMinEventsToCheckClusters%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mMinEventsToCheckClusters%d = ", mod + 2)
+                         << param->second << ENDM;
+      mMinEventsToCheckClusters[mod] = stoi(param->second);
+    }
+    // mCluEnergyRangeL
+    if (auto param = mCustomParameters.find(Form("mCluEnergyRangeL%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mCluEnergyRangeL%d = ", mod + 2)
+                         << param->second << ENDM;
+      mCluEnergyRangeL[mod] = stof(param->second);
+    }
+    // mCluEnergyRangeR
+    if (auto param = mCustomParameters.find(Form("mCluEnergyRangeR%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mCluEnergyRangeR%d = ", mod + 2)
+                         << param->second << ENDM;
+      mCluEnergyRangeR[mod] = stof(param->second);
+    }
+    // mMinCluEnergyMean
+    if (auto param = mCustomParameters.find(Form("mMinCluEnergyMean%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mMinCluEnergyMean%d = ", mod + 2)
+                         << param->second << ENDM;
+      mMinCluEnergyMean[mod] = stof(param->second);
+    }
+    // mMaxCluEnergyMean
+    if (auto param = mCustomParameters.find(Form("mMaxCluEnergyMean%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mMaxCluEnergyMean%d = ", mod + 2)
+                         << param->second << ENDM;
+      mMaxCluEnergyMean[mod] = stof(param->second);
+    }
+
     // mMinClusterSize
     if (auto param = mCustomParameters.find(Form("mMinClusterSize%d", mod + 2));
         param != mCustomParameters.end()) {
@@ -97,30 +148,13 @@ void PhysicsCheck::configure()
                          << param->second << ENDM;
       mMaxClusterSize[mod] = stof(param->second);
     }
-
-    // mMinEventsToCheckTrip
+    // mMinEventsToCheckDigitMap
     if (auto param = mCustomParameters.find(Form("mMinEventsToCheckDigitMap%d", mod + 2));
         param != mCustomParameters.end()) {
       ILOG(Debug, Devel) << "configure() : Custom parameter "
                          << Form("mMinEventsToCheckDigitMap%d = ", mod + 2)
                          << param->second << ENDM;
       mMinEventsToCheckDigitMap[mod] = stoi(param->second);
-    }
-    // mStripPopulationDeviationAllowed
-    if (auto param = mCustomParameters.find(Form("mStripPopulationDeviationAllowed%d", mod + 2));
-        param != mCustomParameters.end()) {
-      ILOG(Debug, Devel) << "configure() : Custom parameter "
-                         << Form("mStripPopulationDeviationAllowed%d = ", mod + 2)
-                         << param->second << ENDM;
-      mStripPopulationDeviationAllowed[mod] = stof(param->second);
-    }
-    // mNBadStripsPerQuarterAllowed
-    if (auto param = mCustomParameters.find(Form("mNBadStripsPerQuarterAllowed%d", mod + 2));
-        param != mCustomParameters.end()) {
-      ILOG(Debug, Devel) << "configure() : Custom parameter "
-                         << Form("mNBadStripsPerQuarterAllowed%d = ", mod + 2)
-                         << param->second << ENDM;
-      mNBadStripsPerQuarterAllowed[mod] = stoi(param->second);
     }
     // mNCold3GassiplexAllowed
     if (auto param = mCustomParameters.find(Form("mNCold3GassiplexAllowed%d", mod + 2));
@@ -154,7 +188,50 @@ void PhysicsCheck::configure()
                          << param->second << ENDM;
       mCold3GassiplexCriterium[mod] = stof(param->second);
     }
+    // mHot3GassiplexOccurance
+    if (auto param = mCustomParameters.find(Form("mHot3GassiplexOccurance%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mHot3GassiplexOccurance%d = ", mod + 2)
+                         << param->second << ENDM;
+      mHot3GassiplexOccurance[mod] = stof(param->second);
+    }
+    // mCold3GassilexOccurance
+    if (auto param = mCustomParameters.find(Form("mCold3GassiplexOccurance%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mCold3GassiplexOccurance%d = ", mod + 2)
+                         << param->second << ENDM;
+      mCold3GassiplexOccurance[mod] = stof(param->second);
+    }
+    // mMinDigitsPerEvent
+    if (auto param = mCustomParameters.find(Form("mMinDigitsPerEvent%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mMinDigitsPerEvent%d = ", mod + 2)
+                         << param->second << ENDM;
+      mMinDigitsPerEvent[mod] = stof(param->second);
+    }
+    // mMaxDigitsPerEvent
+    if (auto param = mCustomParameters.find(Form("mMaxDigitsPerEvent%d", mod + 2));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mMaxDigitsPerEvent%d = ", mod + 2)
+                         << param->second << ENDM;
+      mMaxDigitsPerEvent[mod] = stof(param->second);
+    }
   }
+  // error occurance
+  for (int i = 0; i < 20; i++) {
+    if (auto param = mCustomParameters.find(Form("mErrorOccuranceThreshold%d", i));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mErrorOccuranceThreshold%d = ", i)
+                         << param->second << "for the " << mErrorLabel[i] << ENDM;
+      mErrorOccuranceThreshold[i] = stof(param->second);
+    }
+  }
+
   ILOG(Info, Support) << "PhysicsCheck::configure() : configuring is done." << ENDM;
   mIsConfigured = true;
 }
@@ -166,11 +243,13 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
     configure();
   }
 
+  // default value
   Quality result = Quality::Good;
 
   for (auto& [moName, mo] : *moMap) {
     (void)moName;                          // trick the compiler about not used variable
     for (int iMod = 0; iMod < 3; iMod++) { // loop modules
+      // ========================= CALIBDIGIT ENERGY =========================
       if (mo->getName() == Form("CalibDigitEnergyM%d", iMod + 2)) {
         bool isGoodMO = true;
 
@@ -179,51 +258,107 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
           ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1F*, skipping" << ENDM;
           continue;
         }
-        result = Quality::Good; // default
-        TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
+        TPaveText* msg = new TPaveText(0.6, 0.5, 1.0, 0.75, "NDC");
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
-        float binWidth = h->GetBinWidth(1);
-        float amplification;
-        auto nEventsToFit = h->Integral(mAmplitudeRangeL[iMod] / binWidth + 1, mAmplitudeRangeR[iMod] / binWidth + 1);
-        if (nEventsToFit < mMinEventsToFit[iMod]) {
-          result = Quality::Medium;
-          msg->AddText("Not enough data in fit range");
+
+        auto nEvents = h->GetEntries();
+        if (nEvents < mMinEventsToCheckAmplitude[iMod]) {
+          if (result.isBetterThan(Quality::Null)) {
+            result.set(Quality::Null);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("not enough statistics M%d", iMod + 2));
+          msg->AddText("Not enough data to check");
           msg->SetFillColor(kOrange);
           isGoodMO = false;
         } else {
-          // fit with Landau function
-          TF1* fLandau = new TF1("fLandau", "landau", mAmplitudeRangeL[iMod], mAmplitudeRangeR[iMod]);
-          fLandau->SetParLimits(0, 0., 1.E100);
-          fLandau->SetParLimits(1, 0., 1.E3);
-          fLandau->SetParLimits(2, 0., 1.E3);
-          fLandau->SetParameters(1000., 100., 60.);
-          h->Fit(fLandau, "Q0N", "", mAmplitudeRangeL[iMod], mAmplitudeRangeR[iMod]);
-          amplification = fLandau->GetParameter(1);
-          if (amplification < mMinAmplification[iMod]) {
-            result = Quality::Bad;
-            msg->AddText(Form("Amplification is too small: %f", amplification));
-            msg->AddText(Form("Lowest allowed amplification: %f", mMinAmplification[iMod]));
+          h->GetXaxis()->SetRangeUser(mAmplitudeRangeL[iMod], mAmplitudeRangeR[iMod]);
+          auto mean = h->GetMean();
+          if (mean < mMinAmplitudeMean[iMod]) {
+            if (result.isBetterThan(Quality::Medium)) {
+              result.set(Quality::Medium);
+            }
+            result.addReason(FlagReasonFactory::Unknown(), Form("too small mean M%d", iMod + 2));
+            msg->AddText(Form("Mean is too small: %f", mean));
+            msg->AddText(Form("Min allowed mean: %f", mMinAmplitudeMean[iMod]));
             msg->SetFillColor(kRed);
             h->SetFillColor(kRed);
             isGoodMO = false;
-          } else if (amplification > mMaxAmplification[iMod]) {
-            result = Quality::Bad;
-            msg->AddText(Form("Amplification is too big: %f", amplification));
-            msg->AddText(Form("Largest allowed amplification: %f", mMaxAmplification[iMod]));
+          } else if (mean > mMaxAmplitudeMean[iMod]) {
+            if (result.isBetterThan(Quality::Medium)) {
+              result.set(Quality::Medium);
+            }
+            result.addReason(FlagReasonFactory::Unknown(), Form("too big mean M%d", iMod + 2));
+            msg->AddText(Form("Mean is too big: %f", mean));
+            msg->AddText(Form("Max allowed mean: %f", mMaxAmplitudeMean[iMod]));
             msg->SetFillColor(kRed);
             h->SetFillColor(kRed);
             isGoodMO = false;
           }
         }
         if (isGoodMO) {
-          msg->AddText(Form("amplification %4.1f: OK", amplification));
+          msg->AddText("OK");
+          msg->SetFillColor(kGreen);
+        }
+        break; // exit modules loop for this particular object
+      }
+      // ========================= CLUSTER ENERGY =========================
+      if (mo->getName() == Form("ClusterTotEnergyM%d", iMod + 2)) {
+        bool isGoodMO = true;
+
+        auto* h = dynamic_cast<TH1F*>(mo->getObject());
+        if (h == nullptr) {
+          ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1F*, skipping" << ENDM;
+          continue;
+        }
+        TPaveText* msg = new TPaveText(0.6, 0.5, 1.0, 0.75, "NDC");
+        h->GetListOfFunctions()->Add(msg);
+        msg->SetName(Form("%s_msg", mo->GetName()));
+        msg->Clear();
+
+        auto nEvents = h->GetEntries();
+        if (nEvents < mMinEventsToCheckClusters[iMod]) {
+          if (result.isBetterThan(Quality::Null)) {
+            result.set(Quality::Null);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("not enough statistics M%d", iMod + 2));
+          msg->AddText("Not enough data to check");
+          msg->SetFillColor(kOrange);
+          isGoodMO = false;
+        } else {
+          h->GetXaxis()->SetRangeUser(mCluEnergyRangeL[iMod], mCluEnergyRangeR[iMod]);
+          auto mean = h->GetMean();
+          if (mean < mMinCluEnergyMean[iMod]) {
+            if (result.isBetterThan(Quality::Medium)) {
+              result.set(Quality::Medium);
+            }
+            result.addReason(FlagReasonFactory::Unknown(), Form("too small mean energy M%d", iMod + 2));
+            msg->AddText(Form("Mean is too small: %f", mean));
+            msg->AddText(Form("Min allowed mean: %f", mMinCluEnergyMean[iMod]));
+            msg->SetFillColor(kRed);
+            h->SetFillColor(kRed);
+            isGoodMO = false;
+          } else if (mean > mMaxCluEnergyMean[iMod]) {
+            if (result.isBetterThan(Quality::Medium)) {
+              result.set(Quality::Medium);
+            }
+            result.addReason(FlagReasonFactory::Unknown(), Form("too big mean energy M%d", iMod + 2));
+            msg->AddText(Form("Mean is too big: %f", mean));
+            msg->AddText(Form("Max allowed mean: %f", mMaxCluEnergyMean[iMod]));
+            msg->SetFillColor(kRed);
+            h->SetFillColor(kRed);
+            isGoodMO = false;
+          }
+        }
+        if (isGoodMO) {
+          msg->AddText("OK");
           msg->SetFillColor(kGreen);
         }
         break; // exit modules loop for this particular object
       }
 
+      // ====================== CLUSTER SIZE =============================
       if (mo->getName() == Form("NDigitsInClusterM%d", iMod + 2)) {
 
         auto* h = dynamic_cast<TH1F*>(mo->getObject());
@@ -231,23 +366,33 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
           ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1F*, skipping" << ENDM;
           continue;
         }
-        result = Quality::Good; // default
-        TPaveText* msg = new TPaveText(0.5, 0.5, 0.9, 0.75, "NDC");
+        TPaveText* msg = new TPaveText(0.6, 0.5, 1.0, 0.75, "NDC");
         h->GetListOfFunctions()->Add(msg);
         msg->SetName(Form("%s_msg", mo->GetName()));
         msg->Clear();
-        msg->SetMargin(0.005);
+        if (h->GetEntries() < mMinEventsToCheckClusters[iMod]) {
+          result.addReason(FlagReasonFactory::Unknown(), Form("not enough statistics M%d", iMod));
+          msg->AddText("Not enough data to check");
+          msg->SetFillColor(kOrange);
+          break;
+        }
         auto meanClusterSize = h->GetMean();
         if (meanClusterSize < mMinClusterSize[iMod]) {
-          result = Quality::Bad;
-          msg->AddText(Form("Too small mean cluster size: %f", meanClusterSize));
-          msg->AddText(Form("Tolerated mean cluster size: %f", mMinClusterSize[iMod]));
+          if (result.isBetterThan(Quality::Medium)) {
+            result.set(Quality::Medium);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("too big mean size M%d", iMod + 2));
+          msg->AddText(Form("Mean is too small: %f", meanClusterSize));
+          msg->AddText(Form("Min allowed mean: %f", mMinClusterSize[iMod]));
           msg->SetFillColor(kRed);
           h->SetFillColor(kRed);
         } else if (meanClusterSize > mMaxClusterSize[iMod]) {
-          result = Quality::Bad;
-          msg->AddText(Form("Too big mean cluster size: %f", meanClusterSize));
-          msg->AddText(Form("Tolerated mean cluster size: %f", mMaxClusterSize[iMod]));
+          if (result.isBetterThan(Quality::Medium)) {
+            result.set(Quality::Medium);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("too big mean size M%d", iMod + 2));
+          msg->AddText(Form("Mean is too big: %f", meanClusterSize));
+          msg->AddText(Form("Max allowed mean: %f", mMaxClusterSize[iMod]));
           msg->SetFillColor(kRed);
           h->SetFillColor(kRed);
         } else {
@@ -257,23 +402,18 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
         break; // exit modules loop for this particular object
       }
 
+      // ======================= DIGIT MAP =========================
       if (mo->getName() == Form("DigitMapM%d", iMod + 2)) {
 
         auto* h = dynamic_cast<TH2F*>(mo->getObject());
         if (h == nullptr) {
           ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH2F*, skipping" << ENDM;
-          continue;
+          break;
         }
-        result = Quality::Good; // default
-
         if (h->GetEntries() < mMinEventsToCheckDigitMap[iMod]) {
-          continue;
+          break;
         }
-        TPaveText* msg = new TPaveText(0.6, 0.0, 1., 0.3, "NDC");
-        msg->SetName(Form("%s_msg", mo->GetName()));
-        msg->Clear();
-        msg->SetMargin(0.005);
-
+        bool isObjectGood = true;
         // check Cold and hot 3gassiplex cards
         int nHot3Gassiplexes = 0, nCold3Gassiplexes = 0;
         TH2* h3GassiplexMap = (TH2*)h->Clone("h3GassiplexMap");
@@ -296,56 +436,34 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
           }
         }
         if (nHot3Gassiplexes > mNHot3GassiplexAllowed[iMod]) {
-          result = Quality::Bad;
-          msg->AddText(Form("hot 3Gassiplex cards (%d/%d)", nHot3Gassiplexes, mNHot3GassiplexAllowed[iMod]));
-          msg->SetTextSize(20);
+          if (result.isBetterThan(Quality::Bad)) {
+            result.set(Quality::Bad);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("many hot cards M%d", iMod + 2));
+          TPaveText* msg = new TPaveText(0.0, 0.0, 0.2, 0.1, "NDC");
+          msg->SetName(Form("%s_msgHot3G", mo->GetName()));
+          msg->Clear();
+          msg->AddText(Form("hot 3G cards (%d/%d)", nHot3Gassiplexes, mNHot3GassiplexAllowed[iMod]));
           msg->SetFillColor(kRed);
           h->GetListOfFunctions()->Add(msg);
+          isObjectGood = false;
         }
         if (nCold3Gassiplexes > mNCold3GassiplexAllowed[iMod]) {
-          result = Quality::Bad;
-          msg->AddText(Form("cold 3Gassiplex cards (%d/%d)", nCold3Gassiplexes, mNCold3GassiplexAllowed[iMod]));
-          msg->SetFillColor(kRed);
-          msg->SetTextSize(20);
-          h->GetListOfFunctions()->Add(msg);
-        }
-        h3GassiplexMap->Delete();
-
-        // check quarters for HV trip
-        bool isHVTrip = false;
-        int tripQ = 0, nTripQ = 0;
-        TH1* projectionX = h->ProjectionX();
-        TF1 pol0("constant", "pol0", 0., 128.);
-        for (int q = 0; q < 4; q++) {
-          int firstBin = 1 + q * 32;
-          int lastBin = (q + 1) * 32;
-          projectionX->Fit(&pol0, "Q0N", "", firstBin - 1, lastBin);
-          double mean = pol0.GetParameter(0);
-          int nBadStrips = 0;
-          for (int iBin = firstBin; iBin < lastBin; iBin++) {
-            if (projectionX->GetBinContent(iBin) > 0 && (projectionX->GetBinContent(iBin) > mean * mStripPopulationDeviationAllowed[iMod] ||
-                                                         projectionX->GetBinContent(iBin) < mean / mStripPopulationDeviationAllowed[iMod])) {
-              nBadStrips++;
-            }
+          if (result.isBetterThan(Quality::Bad)) {
+            result.set(Quality::Bad);
           }
-          if (nBadStrips > mNBadStripsPerQuarterAllowed[iMod]) {
-            tripQ = (q + 1) + 10 * tripQ;
-            nTripQ++;
-            isHVTrip = true;
-          }
-        }
-        projectionX->Delete();
-        if (isHVTrip) {
-          result = Quality::Bad;
-          msg->AddText(Form("HV Trip in Q%d ?", tripQ));
-          msg->SetTextSize(20);
+          result.addReason(FlagReasonFactory::Unknown(), Form("many cold cards M%d", iMod + 2));
+          TPaveText* msg = new TPaveText(0.0, 0.9, 0.2, 1.0, "NDC");
+          msg->AddText(Form("cold 3G cards (%d/%d)", nCold3Gassiplexes, mNCold3GassiplexAllowed[iMod]));
           msg->SetFillColor(kRed);
           h->GetListOfFunctions()->Add(msg);
+          isObjectGood = false;
         }
+        delete h3GassiplexMap;
 
         // show OK message if everything is OK
-        if (result == Quality::Good) {
-          TPaveText* msgOk = new TPaveText(0.9, 0.0, 1., 0.1, "NDC");
+        if (isObjectGood) {
+          TPaveText* msgOk = new TPaveText(0.9, 0.9, 1.0, 1.0, "NDC");
           msgOk->SetName(Form("%s_msg", mo->GetName()));
           msgOk->Clear();
           msgOk->AddText("OK");
@@ -354,9 +472,153 @@ Quality PhysicsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>
         }
         break; // exit modules loop for this particular object
       }
+      // ======================= DIGIT OCCURANCE =========================
+      if (mo->getName() == Form("DigitOccuranceM%d", iMod + 2)) {
 
+        auto* h = dynamic_cast<TH2D*>(mo->getObject());
+        if (h == nullptr) {
+          ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH2D*, skipping" << ENDM;
+          break;
+        }
+        auto* hFraction = dynamic_cast<TH2Fraction*>(mo->getObject());
+        if (hFraction->getEventCounter() < mMinEventsToCheckDigitMap[iMod]) {
+          break;
+        }
+        bool isObjectGood = true;
+        // check Cold and hot 3gassiplex cards
+        int nHot3Gassiplexes = 0, nCold3Gassiplexes = 0;
+        TH2* h3GassiplexOccurance = (TH2*)h->Clone("h3GassiplexOccurance");
+        h3GassiplexOccurance->Rebin2D(8, 6);
+        h3GassiplexOccurance->Scale(1. / 48.);
+        float meanOcc = 0;
+        for (int iX = 1; iX <= h3GassiplexOccurance->GetNbinsX(); iX++) {
+          for (int iY = 1; iY <= h3GassiplexOccurance->GetNbinsY(); iY++) {
+            if (h3GassiplexOccurance->GetBinContent(iX, iY) > mHot3GassiplexOccurance[iMod]) {
+              nHot3Gassiplexes++;
+            }
+            if (h3GassiplexOccurance->GetBinContent(iX, iY) < mCold3GassiplexOccurance[iMod]) {
+              nCold3Gassiplexes++;
+            }
+          }
+        }
+        if (nHot3Gassiplexes > mNHot3GassiplexAllowed[iMod]) {
+          if (result.isBetterThan(Quality::Bad)) {
+            result.set(Quality::Bad);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("many hot cards M%d", iMod + 2));
+          TPaveText* msg = new TPaveText(0.0, 0.0, 0.2, 0.1, "NDC");
+          msg->SetName(Form("%s_msgHot3G", mo->GetName()));
+          msg->Clear();
+          msg->AddText(Form("hot 3G cards (%d/%d)", nHot3Gassiplexes, mNHot3GassiplexAllowed[iMod]));
+          msg->SetFillColor(kRed);
+          h->GetListOfFunctions()->Add(msg);
+          isObjectGood = false;
+        }
+        if (nCold3Gassiplexes > mNCold3GassiplexAllowed[iMod]) {
+          if (result.isBetterThan(Quality::Bad)) {
+            result.set(Quality::Bad);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("many cold cards M%d", iMod + 2));
+          TPaveText* msg = new TPaveText(0.0, 0.9, 0.2, 1.0, "NDC");
+          msg->AddText(Form("cold 3G cards (%d/%d)", nCold3Gassiplexes, mNCold3GassiplexAllowed[iMod]));
+          msg->SetFillColor(kRed);
+          h->GetListOfFunctions()->Add(msg);
+          isObjectGood = false;
+        }
+        delete h3GassiplexOccurance;
+
+        // show OK message if everything is OK
+        if (isObjectGood) {
+          TPaveText* msgOk = new TPaveText(0.9, 0.9, 1.0, 1.0, "NDC");
+          msgOk->SetName(Form("%s_msg", mo->GetName()));
+          msgOk->Clear();
+          msgOk->AddText("OK");
+          msgOk->SetFillColor(kGreen);
+          h->GetListOfFunctions()->Add(msgOk);
+        }
+        break; // exit modules loop for this particular object
+      }
+      // ======================= PER EVENT COUNTS ===========================
+      if (mo->getName() == Form("DigitsInEventM%d", iMod + 2)) {
+
+        auto* h = dynamic_cast<TH1F*>(mo->getObject());
+        if (h == nullptr) {
+          ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1F*, skipping" << ENDM;
+          break;
+        }
+        auto mean = h->GetMean();
+        if (mean > mMaxDigitsPerEvent[iMod]) {
+          if (result.isBetterThan(Quality::Medium)) {
+            result.set(Quality::Medium);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("too many digits per event M%d", iMod + 2));
+          TPaveText* msg = new TPaveText(0.6, 0.6, 1.0, 0.8, "NDC");
+          msg->AddText(Form("Mean is too big: %f", mean));
+          msg->AddText(Form("Max allowed mean: %f", mMaxDigitsPerEvent[iMod]));
+          msg->SetFillColor(kRed);
+          h->GetListOfFunctions()->Add(msg);
+        } else if (mean < mMinDigitsPerEvent[iMod]) {
+          if (result.isBetterThan(Quality::Medium)) {
+            result.set(Quality::Medium);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("too few digits per event M%d", iMod + 2));
+          TPaveText* msg = new TPaveText(0.6, 0.6, 1.0, 0.8, "NDC");
+          msg->AddText(Form("Mean is too small: %f", mean));
+          msg->AddText(Form("Min allowed mean: %f", mMinDigitsPerEvent[iMod]));
+          msg->SetFillColor(kRed);
+          h->GetListOfFunctions()->Add(msg);
+        } else {
+          TPaveText* msgOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+          msgOk->SetName(Form("%s_msg", mo->GetName()));
+          msgOk->Clear();
+          msgOk->AddText("OK");
+          msgOk->SetFillColor(kGreen);
+          h->GetListOfFunctions()->Add(msgOk);
+        }
+      }
     } // iMod cycle
-  }   // moMap cycle
+    // ======================= HW ERRORS CHECK ============================
+    if (mo->getName() == "ErrorTypeOccurance") {
+      auto* h = dynamic_cast<TH1Fraction*>(mo->getObject());
+      if (h == nullptr) {
+        ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1Fraction*, skipping" << ENDM;
+        break;
+      }
+      bool isGoodMO = true;
+      for (int i = 1; i <= h->GetXaxis()->GetNbins(); i++) {
+        if (h->GetBinContent(i) > mErrorOccuranceThreshold[i - 1]) {
+          isGoodMO = false;
+          if (result.isBetterThan(Quality::Medium)) {
+            result.set(Quality::Medium);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("too many %s errors", mErrorLabel[i - 1]));
+          TLatex* msg = new TLatex(0.12 + (0.2 * (i % 2)), 0.2 + (i / 2) * 0.06, Form("#color[2]{Too many %s errors}", mErrorLabel[i - 1]));
+          msg->SetNDC();
+          msg->SetTextSize(16);
+          msg->SetTextFont(43);
+          h->GetListOfFunctions()->Add(msg);
+          msg->Draw();
+          h->SetFillColor(kOrange);
+          h->SetOption("hist");
+          h->SetDrawOption("hist");
+          h->SetMarkerStyle(21);
+          h->SetLineWidth(2);
+        }
+      }
+      if (isGoodMO) {
+        TPaveText* msgOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+        msgOk->SetName(Form("%s_msg", mo->GetName()));
+        msgOk->Clear();
+        msgOk->AddText("OK");
+        msgOk->SetFillColor(kGreen);
+        h->GetListOfFunctions()->Add(msgOk);
+        h->SetFillColor(kGreen);
+        h->SetOption("hist");
+        h->SetDrawOption("hist");
+      }
+    }
+
+  } // moMap cycle
 
   return result;
 } // namespace o2::quality_control_modules::cpv

--- a/Modules/CPV/src/PhysicsTask.cxx
+++ b/Modules/CPV/src/PhysicsTask.cxx
@@ -153,10 +153,20 @@ void PhysicsTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
 
   // 2. Using get("<binding>")
+  // HW Raw Errors
+  if (hasRawErrors) {
+    auto rawErrors = ctx.inputs().get<gsl::span<o2::cpv::RawDecoderError>>("rawerrors");
+    for (const auto& rawError : rawErrors) {
+      mHist1D[H1DRawErrors]->Fill(rawError.errortype);
+      mFractions1D[F1DErrorTypeOccurance]->fillUnderlying(rawError.errortype);
+    }
+  }
+
   // digits
   if (hasDigits) {
     auto digits = ctx.inputs().get<gsl::span<o2::cpv::Digit>>("digits");
     auto digitsTR = ctx.inputs().get<gsl::span<o2::cpv::TriggerRecord>>("dtrigrec");
+    mFractions1D[F1DErrorTypeOccurance]->increaseEventCounter(digitsTR.size());
     mHist1D[H1DNDigitsPerInput]->Fill(digits.size());
     unsigned short nDigPerEvent[3];
     for (const auto& trigRecord : digitsTR) {
@@ -173,18 +183,17 @@ void PhysicsTask::monitorData(o2::framework::ProcessingContext& ctx)
             // reminder: relId[3]={Module, phi col, z row} where Module=2..4, phi col=0..127, z row=0..59
             mHist2D[H2DDigitMapM2 + relId[0] - 2]->Fill(relId[1], relId[2]);
             mHist1D[H1DDigitEnergyM2 + relId[0] - 2]->Fill(digits[iDig].getAmplitude());
+            mFractions2D[F2DDigitFreqM2 + relId[0] - 2]->fillUnderlying(relId[1], relId[2]);
             nDigPerEvent[relId[0] - 2]++;
           }
         }
       }
+      for (int i = 0; i < 3; i++) {
+        mHist1D[H1DDigitsInEventM2 + i]->Fill(nDigPerEvent[i]);
+      }
     }
     for (int iMod = 0; iMod < kNModules; iMod++) {
-      mHist1D[H1DDigitsInEventM2 + iMod]->Fill(nDigPerEvent[iMod]);
-      for (int iZ = 1; iZ <= 60; iZ++) {
-        for (int iX = 1; iX <= 128; iX++) {
-          mHist2D[H2DDigitFreqM2 + iMod]->SetBinContent(iX, iZ, mHist2D[H2DDigitMapM2 + iMod]->GetBinContent(iX, iZ) / mNEventsTotal);
-        }
-      }
+      mFractions2D[F2DDigitFreqM2 + iMod]->increaseEventCounter(digitsTR.size());
     }
   }
 
@@ -232,14 +241,6 @@ void PhysicsTask::monitorData(o2::framework::ProcessingContext& ctx)
     }
   }
 
-  // HW Raw Errors
-  if (hasRawErrors) {
-    auto rawErrors = ctx.inputs().get<gsl::span<o2::cpv::RawDecoderError>>("rawerrors");
-    for (const auto& rawError : rawErrors) {
-      mHist1D[H1DRawErrors]->Fill(rawError.errortype);
-    }
-  }
-
   // 3. Access CCDB. If it is enough to retrieve it once, do it in initialize().
   // Remember to delete the object when the pointer goes out of scope or it is no longer needed.
 
@@ -247,20 +248,20 @@ void PhysicsTask::monitorData(o2::framework::ProcessingContext& ctx)
   // we need somehow to extract timestamp from data when there are no ccdb dpl fetcher inputs available
   // however most of the time ccdb dpl fetcher is present. take care of it later
 
-  static auto startTime = std::chrono::system_clock::now();                  // remember time when we first time checked ccdb
-  static int minutesPassed = 0;                                              // count how much minutes passed from 1st ccdb check
-  bool checkCcdbEntries = (isFirstTime || mJustWasReset) && (!mIsAsyncMode); // check at first time or when  mCcdbCheckIntervalInMinutes passed
+  static auto startTime = std::chrono::system_clock::now(); // remember time when we first time checked ccdb
+  static int minutesPassed = 0;                             // count how much minutes passed from 1st ccdb check
+  bool checkCcdbEntries = isFirstTime && (!mIsAsyncMode);   // check at first time or when  mCcdbCheckIntervalInMinutes passed
   auto now = std::chrono::system_clock::now();
   if (((now - startTime) / std::chrono::minutes(1)) > minutesPassed) {
     minutesPassed = (now - startTime) / std::chrono::minutes(1);
     LOG(info) << "minutes passed since first monitorData() call: " << minutesPassed;
     if (minutesPassed % mCcdbCheckIntervalInMinutes == 0) {
       checkCcdbEntries = true;
+      LOG(info) << "checking CCDB objects";
     }
   }
 
   if (checkCcdbEntries) {
-    mJustWasReset = false;
     // retrieve gains
     const o2::cpv::CalibParams* gains = nullptr;
     if (hasGains) {
@@ -357,6 +358,12 @@ void PhysicsTask::monitorData(o2::framework::ProcessingContext& ctx)
 void PhysicsTask::endOfCycle()
 {
   ILOG(Debug, Devel) << "endOfCycle" << ENDM;
+  for (int i = 0; i < kNfractions1D; i++) {
+    mFractions1D[i]->update();
+  }
+  for (int i = 0; i < kNfractions2D; i++) {
+    mFractions2D[i]->update();
+  }
 }
 
 void PhysicsTask::endOfActivity(Activity& /*activity*/)
@@ -447,14 +454,6 @@ void PhysicsTask::initHistograms()
     mHist1D[H1DDigitsInEventM2M3M4]->Reset();
   }
 
-  // if (!mHist1D[H1DCalibDigitsInEventM2M3M4]) {
-  //   mHist1D[H1DCalibDigitsInEventM2M3M4] =
-  //     new TH1F("NCalibDigitsInEventM2M3M4", "Number of CalibDigits per event", 23040, 0., 23040.);
-  //   getObjectsManager()->startPublishing(mHist1D[H1DCalibDigitsInEventM2M3M4]);
-  // } else {
-  //   mHist1D[H1DCalibDigitsInEventM2M3M4]->Reset();
-  // }
-
   if (!mHist1D[H1DClustersInEventM2M3M4]) {
     mHist1D[H1DClustersInEventM2M3M4] =
       new TH1F("NClustersInEventM2M3M4", "Number of clusters per event", 23040, 0., 23040.);
@@ -469,6 +468,41 @@ void PhysicsTask::initHistograms()
     getObjectsManager()->startPublishing(mHist1D[H1DRawErrors]);
   } else {
     mHist1D[H1DRawErrors]->Reset();
+  }
+
+  if (!mFractions1D[F1DErrorTypeOccurance]) {
+    mFractions1D[F1DErrorTypeOccurance] = new TH1Fraction("ErrorTypeOccurance", "Errors of differen types per event", 20, 0, 20);
+    mFractions1D[F1DErrorTypeOccurance]->GetXaxis()->SetTitle("Error Type");
+    mFractions1D[F1DErrorTypeOccurance]->SetStats(0);
+    mFractions1D[F1DErrorTypeOccurance]->GetYaxis()->SetTitle("Occurance (event^{-1})");
+    const char* errorLabel[] = {
+      "ok",
+      "no payload",
+      "rdh decod",
+      "rdh invalid",
+      "not cpv rdh",
+      "no stopbit",
+      "page not found",
+      "0 offset to next",
+      "payload incomplete",
+      "no cpv header",
+      "no cpv trailer",
+      "cpv header invalid",
+      "cpv trailer invalid",
+      "segment header err",
+      "row header error",
+      "EOE header error",
+      "pad error",
+      "unknown word",
+      "pad address",
+      "wrong data format"
+    };
+    for (int i = 1; i <= 20; i++) {
+      mFractions1D[F1DErrorTypeOccurance]->GetXaxis()->SetBinLabel(i, errorLabel[i - 1]);
+    }
+    getObjectsManager()->startPublishing(mFractions1D[F1DErrorTypeOccurance]);
+  } else {
+    mFractions1D[F1DErrorTypeOccurance]->Reset();
   }
 
   int nPadsX = Geometry::kNumberOfCPVPadsPhi;
@@ -515,19 +549,6 @@ void PhysicsTask::initHistograms()
     } else {
       mHist1D[H1DDigitsInEventM2 + mod]->Reset();
     }
-
-    // N CalibDigits per event
-    // if (!mHist1D[H1DCalibDigitsInEventM2 + mod]) {
-    //  mHist1D[H1DCalibDigitsInEventM2 + mod] =
-    //    new TH1F(
-    //      Form("CalibDigitsInEventM%d", mod + 2),
-    //      Form("CalibDigits per event in M%d", mod + 2),
-    //      Geometry::kNCHANNELS / 3, 0., float(Geometry::kNCHANNELS / 3));
-    //  mHist1D[H1DCalibDigitsInEventM2 + mod]->GetXaxis()->SetTitle("Number of CalibDigits");
-    //  getObjectsManager()->startPublishing(mHist1D[H1DCalibDigitsInEventM2 + mod]);
-    // } else {
-    //  mHist1D[H1DCalibDigitsInEventM2 + mod]->Reset();
-    // }
 
     // Total cluster energy
     if (!mHist1D[H1DClusterTotEnergyM2 + mod]) {
@@ -601,22 +622,6 @@ void PhysicsTask::initHistograms()
       mHist2D[H2DCalibDigitMapM2 + mod]->Reset();
     }
 
-    // digit frequency
-    if (!mHist2D[H2DDigitFreqM2 + mod]) {
-      mHist2D[H2DDigitFreqM2 + mod] =
-        new TH2F(
-          Form("DigitFreqM%d", 2 + mod),
-          Form("Digit Frequency in M%d", mod + 2),
-          nPadsX, -0.5, nPadsX - 0.5,
-          nPadsZ, -0.5, nPadsZ - 0.5);
-      mHist2D[H2DDigitFreqM2 + mod]->GetXaxis()->SetTitle("x, pad");
-      mHist2D[H2DDigitFreqM2 + mod]->GetYaxis()->SetTitle("z, pad");
-      mHist2D[H2DDigitFreqM2 + mod]->SetStats(0);
-      getObjectsManager()->startPublishing(mHist2D[H2DDigitFreqM2 + mod]);
-    } else {
-      mHist2D[H2DDigitFreqM2 + mod]->Reset();
-    }
-
     // cluster map
     if (!mHist2D[H2DClusterMapM2 + mod]) {
       mHist2D[H2DClusterMapM2 + mod] =
@@ -648,7 +653,6 @@ void PhysicsTask::initHistograms()
     } else {
       mIntensiveHist2D[H2DPedestalValueM2 + mod]->Reset();
       mIntensiveHist2D[H2DPedestalValueM2 + mod]->setCycleNumber(0);
-      mJustWasReset = true;
     }
 
     // pedestal sigma map
@@ -666,7 +670,6 @@ void PhysicsTask::initHistograms()
     } else {
       mIntensiveHist2D[H2DPedestalSigmaM2 + mod]->Reset();
       mIntensiveHist2D[H2DPedestalSigmaM2 + mod]->setCycleNumber(0);
-      mJustWasReset = true;
     }
 
     // bad channel map
@@ -684,7 +687,6 @@ void PhysicsTask::initHistograms()
     } else {
       mIntensiveHist2D[H2DBadChannelMapM2 + mod]->Reset();
       mIntensiveHist2D[H2DBadChannelMapM2 + mod]->setCycleNumber(0);
-      mJustWasReset = true;
     }
 
     // gains map
@@ -702,7 +704,22 @@ void PhysicsTask::initHistograms()
     } else {
       mIntensiveHist2D[H2DGainsM2 + mod]->Reset();
       mIntensiveHist2D[H2DGainsM2 + mod]->setCycleNumber(0);
-      mJustWasReset = true;
+    }
+
+    // digit occurance per event
+    if (!mFractions2D[F2DDigitFreqM2 + mod]) {
+      mFractions2D[F2DDigitFreqM2 + mod] =
+        new TH2Fraction(
+          Form("DigitOccuranceM%d", 2 + mod),
+          Form("Digit occurance per event in M%d", mod + 2),
+          nPadsX, -0.5, nPadsX - 0.5,
+          nPadsZ, -0.5, nPadsZ - 0.5);
+      mFractions2D[F2DDigitFreqM2 + mod]->GetXaxis()->SetTitle("x, pad");
+      mFractions2D[F2DDigitFreqM2 + mod]->GetYaxis()->SetTitle("z, pad");
+      mFractions2D[F2DDigitFreqM2 + mod]->SetStats(0);
+      getObjectsManager()->startPublishing(mFractions2D[F2DDigitFreqM2 + mod]);
+    } else {
+      mFractions2D[F2DDigitFreqM2 + mod]->Reset();
     }
   }
 }
@@ -732,7 +749,16 @@ void PhysicsTask::resetHistograms()
       mIntensiveHist2D[itIntHist2D]->setCycleNumber(0);
     }
   }
-  mJustWasReset = true;
+  for (int i = 0; i < kNfractions1D; i++) {
+    if (mFractions1D[i]) {
+      mFractions1D[i]->Reset();
+    }
+  }
+  for (int i = 0; i < kNfractions2D; i++) {
+    if (mFractions2D[i]) {
+      mFractions2D[i]->Reset();
+    }
+  }
 }
 
 } // namespace o2::quality_control_modules::cpv

--- a/Modules/PHOS/CMakeLists.txt
+++ b/Modules/PHOS/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 add_library(O2QcPHOS)
 
-target_sources(O2QcPHOS PRIVATE src/TH2FMean.cxx
+target_sources(O2QcPHOS PRIVATE src/TH1Fraction.cxx
+                                src/TH2Fraction.cxx
+                                src/TH2FMean.cxx
                                 src/TH2SBitmask.cxx
                                 src/RawQcTask.cxx
                                 src/RawCheck.cxx
@@ -16,13 +18,15 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_link_libraries(O2QcPHOS PUBLIC O2QualityControl O2::PHOSBase O2::PHOSReconstruction ROOT::Spectrum)
+target_link_libraries(O2QcPHOS PUBLIC O2QualityControl O2::DataFormatsQualityControl O2::PHOSBase O2::PHOSReconstruction ROOT::Spectrum)
 
 add_root_dictionary(O2QcPHOS
-                    HEADERS include/PHOS/TH2FMean.h
+                    HEADERS include/PHOS/TH1Fraction.h
+                            include/PHOS/TH2Fraction.h
+                            include/PHOS/TH2FMean.h
                             include/PHOS/TH2SBitmask.h
                             include/PHOS/ClusterQcTask.h
-		            include/PHOS/ClusterCheck.h
+		                        include/PHOS/ClusterCheck.h
                             include/PHOS/RawQcTask.h
                             include/PHOS/RawCheck.h
                             include/PHOS/CalibQcTask.h

--- a/Modules/PHOS/etc/phos-raw-clusters-epn.json
+++ b/Modules/PHOS/etc/phos-raw-clusters-epn.json
@@ -1,0 +1,212 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ali-qcdb.cern.ch:8083",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "monitoring": {
+        "url": "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul": {
+        "url": "http://localhost:8500"
+      },
+      "conditionDB": {
+        "url": "o2-ccdb.internal"
+      },
+      "bookkeeping": {
+        "url": "ali-bookkeeping:4001"
+      }
+    },
+    "tasks": {
+      "RawTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::phos::RawQcTask",
+        "moduleName": "QcPHOS",
+        "detectorName": "PHS",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "phosraw"
+        },
+        "taskParameters": {
+          "physics": "on"
+        },
+        "location": "local",
+        "localMachines": [
+          "localhost"
+        ],
+        "remoteMachine": "alio2-cr1-qme06.cern.ch",
+        "remotePort": "47757",
+        "mergingMode": "delta",
+        "localControl": "odc"
+      },
+      "ClusterTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::phos::ClusterQcTask",
+        "moduleName": "QcPHOS",
+        "detectorName": "PHS",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "phosclu"
+        },
+        "taskParameters": {
+          "": ""
+        },
+        "location": "local",
+        "localMachines": [
+          "localhost"
+        ],
+        "remoteMachine": "alio2-cr1-qme06.cern.ch",
+        "remotePort": "47758",
+        "mergingMode": "delta",
+        "localControl": "odc"
+      }
+    },
+    "checks": {
+      "IncreasingEntriesCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnAny",
+        "detectorName": "PHS",
+        "checkParameters": {
+          "mustIncrease": "true"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "RawTask",
+            "MOs": [
+              "CellHGOccupancyM1",
+              "CellHGOccupancyM2",
+              "CellHGOccupancyM3",
+              "CellHGOccupancyM4"
+            ]
+          }
+        ]
+      }
+    },
+    "postprocessing": {
+      "PhysicsTrending": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::SliceTrendingTask",
+        "moduleName": "QualityControl",
+        "detectorName": "PHS",
+        "resumeTrend": "false",
+        "producePlotsOnUpdate": "true",
+        "initTrigger": [
+          "once"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:PHS/MO/ClusterTask/SpectrumM1"
+        ],
+        "stopTrigger": [
+          "usercontrol"
+        ],
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "PHS/MO/ClusterTask",
+            "names": [
+              "SpectrumM1",
+              "SpectrumM2",
+              "SpectrumM3",
+              "SpectrumM4"
+            ],
+            "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
+            "axisDivision": [
+              [
+                "1.",
+                "10."
+              ]
+            ],
+            "moduleName": "QcCommon"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mean_of_cluEnergyM1",
+            "title": "Trend of mean energy of >1GeV clusters",
+            "varexp": "SpectrumM1.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.",
+            "graphAxisLabel": "Mean energy:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluEnergyM2",
+            "title": "Trend of mean energy of >1GeV clusters",
+            "varexp": "SpectrumM2.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.",
+            "graphAxisLabel": "Mean energy:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluEnergyM3",
+            "title": "Trend of mean energy of >1GeV clusters",
+            "varexp": "SpectrumM3.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.",
+            "graphAxisLabel": "Mean energy:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluEnergyM4",
+            "title": "Trend of mean energy of >1GeV clusters",
+            "varexp": "SpectrumM4.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.",
+            "graphAxisLabel": "Mean energy:time",
+            "graphYRange": "0:10"
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "phosraw",
+      "active": "true",
+      "machines": [
+        "localhost"
+      ],
+      "query": "rawerr:PHS/RAWHWERRORS;cells:PHS/CELLS;cellstr:PHS/CELLTRIGREC",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1.",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    },
+    {
+      "id": "phosclu",
+      "active": "true",
+      "machines": [
+        "localhost"
+      ],
+      "query": "clusters:PHS/CLUSTERS/0;clustertr:PHS/CLUSTERTRIGREC/0",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1.",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/Modules/PHOS/etc/phosRawClu.json
+++ b/Modules/PHOS/etc/phosRawClu.json
@@ -1,62 +1,377 @@
 {
-    "qc": {
-        "config": {
-            "database": {
-                "implementation": "CCDB",
-                "host": "ccdb-test.cern.ch:8080",
-                "username": "not_applicable",
-                "password": "not_applicable",
-                "name": "not_applicable"
-            },
-            "Activity": {
-                "number": "42",
-                "type": "2"
-            },
-            "monitoring": {
-                "url": "infologger:///debug?qc"
-            },
-            "consul": {
-                "url": ""
-            },
-            "conditionDB": {
-                "url": "ccdb-test.cern.ch:8080"
-            }
-        },
-       "tasks": {
-        "QcTask": {
-          "active": "true",
-          "className": "o2::quality_control_modules::phos::RawQcTask",
-          "moduleName": "QcPHOS",
-          "detectorName": "PHS",
-          "cycleDurationSeconds": "10",
-          "maxNumberCycles": "-1",
-          "dataSource": {
-            "type": "direct",
-            "query": "rawerr:PHS/RAWHWERRORS;fitquality:PHS/CELLFITQA;cells:PHS/CELLS/0;cellstr:PHS/CELLTRIGREC/0"
-          },
-          "taskParameters": {
-            "physics": "on"    
-          },
-          "location": "remote"
-        },
-        "PHOSClusters": {
-          "active": "true",
-          "className": "o2::quality_control_modules::phos::ClusterQcTask",
-          "moduleName": "QcPHOS",
-          "detectorName": "PHS",
-          "cycleDurationSeconds": "100",
-          "maxNumberCycles": "-1",
-          "dataSource": {
-            "type": "direct",
-            "query": "clusters:PHS/CLUSTERS;clustertr:PHS/CLUSTERTRIGREC"
-          },
-          "taskParameters": {
-            "": ""    
-          },
-          "location": "remote"
-        }        
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "#conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      },
+      "conditionDB": {
+        "url": "alice-ccdb.cern.ch"
       }
     },
-    "dataSamplingPolicies": [
-    ]
+    "tasks": {
+      "RawTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::phos::RawQcTask",
+        "moduleName": "QcPHOS",
+        "detectorName": "PHS",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "rawerr:PHS/RAWHWERRORS;cells:PHS/CELLS/0;cellstr:PHS/CELLTRIGREC/0",
+          "#query": "rawerr:PHS/RAWHWERRORS;fitquality:PHS/CELLFITQA;cells:PHS/CELLS/0;cellstr:PHS/CELLTRIGREC/0"
+        },
+        "taskParameters": {
+          "physics": "on"
+        },
+        "location": "remote"
+      },
+      "ClusterTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::phos::ClusterQcTask",
+        "moduleName": "QcPHOS",
+        "detectorName": "PHS",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query": "clusters:PHS/CLUSTERS;clustertr:PHS/CLUSTERTRIGREC"
+        },
+        "taskParameters": {
+          "": ""
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "CellsIncrease": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnAny",
+        "detectorName": "PHS",
+        "checkParameters": {
+          "mustIncrease": "true"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "RawTask",
+            "MOs": [
+              "CellHGOccupancyM1",
+              "CellHGOccupancyM2",
+              "CellHGOccupancyM3",
+              "CellHGOccupancyM4"
+            ]
+          }
+        ]
+      },
+      "ClustersIncrease": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnAny",
+        "detectorName": "PHS",
+        "checkParameters": {
+          "mustIncrease": "true"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "ClusterTask",
+            "MOs": [
+              "SpectrumM1",
+              "SpectrumM2",
+              "SpectrumM3",
+              "SpectrumM4"
+            ]
+          }
+        ]
+      },
+      "ErrorsCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::phos::RawCheck",
+        "moduleName": "QcPHOS",
+        "policy": "OnAny",
+        "detectorName": "PHS",
+        "checkParameters": {
+          "mErrorOccuranceThreshold0": "0.1",
+          "mErrorOccuranceThreshold1": "0.1",
+          "mErrorOccuranceThreshold2": "0.1",
+          "mErrorOccuranceThreshold3": "0.1",
+          "mErrorOccuranceThreshold4": "0.1"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "RawTask",
+            "MOs": [
+              "ErrorTypeOccurance"
+            ]
+          }
+        ]
+      },
+      "CellsCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::phos::RawCheck",
+        "moduleName": "QcPHOS",
+        "policy": "OnAny",
+        "detectorName": "PHS",
+        "checkParameters": {
+          "mToleratedBadChannelsM1": "1",
+          "mToleratedBadChannelsM2": "1",
+          "mToleratedBadChannelsM3": "1",
+          "mToleratedBadChannelsM4": "1"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "RawTask",
+            "MOs": [
+              "BadMapSummary",
+              "CellHGOccupancyM1",
+              "CellHGOccupancyM2",
+              "CellHGOccupancyM3",
+              "CellHGOccupancyM4"
+            ]
+          }
+        ]
+      },
+      "ClustersCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::phos::ClusterCheck",
+        "moduleName": "QcPHOS",
+        "policy": "OnAny",
+        "detectorName": "PHS",
+        "checkParameters": {
+          "mMaxCluEnergyMean2": "1.0",
+          "mMinCluEnergyMean1": "9.0"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "ClusterTask",
+            "MOs": [
+              "SpectrumM1",
+              "SpectrumM2",
+              "SpectrumM3",
+              "SpectrumM4"
+            ]
+          }
+        ]
+      }
+    },
+    "postprocessing": {
+      "PhysicsTrending": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::SliceTrendingTask",
+        "moduleName": "QualityControl",
+        "detectorName": "PHS",
+        "resumeTrend": "false",
+        "producePlotsOnUpdate": "true",
+        "initTrigger": [
+          "once"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:PHS/MO/ClusterTask/SpectrumM1"
+        ],
+        "stopTrigger": [
+          "usercontrol"
+        ],
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "PHS/MO/ClusterTask",
+            "names": [
+              "SpectrumM1",
+              "SpectrumM2",
+              "SpectrumM3",
+              "SpectrumM4"
+            ],
+            "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
+            "axisDivision": [
+              [
+                "1.",
+                "10."
+              ]
+            ],
+            "moduleName": "QcCommon"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mean_of_cluEnergyM1",
+            "title": "Trend of mean energy of >1GeV clusters",
+            "varexp": "SpectrumM1.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.",
+            "graphAxisLabel": "Mean energy:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluEnergyM2",
+            "title": "Trend of mean energy of >1GeV clusters",
+            "varexp": "SpectrumM2.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.",
+            "graphAxisLabel": "Mean energy:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluEnergyM3",
+            "title": "Trend of mean energy of >1GeV clusters",
+            "varexp": "SpectrumM3.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.",
+            "graphAxisLabel": "Mean energy:time",
+            "graphYRange": "0:10"
+          },
+          {
+            "name": "mean_of_cluEnergyM4",
+            "title": "Trend of mean energy of >1GeV clusters",
+            "varexp": "SpectrumM4.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.",
+            "graphAxisLabel": "Mean energy:time",
+            "graphYRange": "0:10"
+          }
+        ]
+      },
+      "QualityTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QcCommon",
+        "detectorName": "PHS",
+        "qualityGroups": [
+          {
+            "name": "global",
+            "title": "GLOBAL PHS QUALITY",
+            "path": "PHS/QO/GlobalQuality",
+            "ignoreQualitiesDetails": [
+              "Null",
+              "Good",
+              "Medium",
+              "Bad"
+            ],
+            "inputObjects": [
+              {
+                "name": "GlobalQuality",
+                "title": "Global PHS Quality",
+                "messageBad": "Inform PHS on-call",
+                "messageMedium": "Inform the PHS on-call",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty!!!"
+              }
+            ]
+          },
+          {
+            "name": "details",
+            "title": "PHS DETAILS",
+            "path": "PHS/QO",
+            "ignoreQualitiesDetails": [],
+            "inputObjects": [
+              {
+                "name": "CellsIncrease",
+                "title": "Number of cells increases",
+                "messageBad": "Entries are not increasing in last cycle",
+                "messageNull": ""
+              },
+              {
+                "name": "ClustersIncrease",
+                "title": "Number of clusters increases",
+                "messageBad": "Entries are not increasing in last cycle",
+                "messageNull": ""
+              },
+              {
+                "name": "CellsCheck",
+                "title": "Cells check",
+                "messageBad": "Inform PHS on-call",
+                "messageMedium": "Inform the PHS on-call",
+                "messageGood": "",
+                "messageNull": ""
+              },
+              {
+                "name": "ClustersCheck",
+                "title": "Clusters check",
+                "messageBad": "Inform PHS on-call",
+                "messageMedium": "Inform the PHS on-call",
+                "messageGood": "",
+                "messageNull": "Not enough stat"
+              },
+              {
+                "name": "ErrorsCheck",
+                "title": "Errors check",
+                "messageBad": "Inform PHS on-call",
+                "messageMedium": "Inform the PHS on-call",
+                "messageGood": "",
+                "messageNull": ""
+              }
+            ]
+          }
+        ],
+        "initTrigger": [
+          "newobject:qcdb:PHS/QO/GlobalQuality/GlobalQuality"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:PHS/QO/GlobalQuality/GlobalQuality"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    },
+    "aggregators": {
+      "GlobalQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QcCommon",
+        "policy": "OnAll",
+        "detectorName": "PHS",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "CellsIncrease"
+          },
+          {
+            "type": "Check",
+            "name": "ClustersIncrease"
+          },
+          {
+            "type": "Check",
+            "name": "CellsCheck"
+          },
+          {
+            "type": "Check",
+            "name": "ClustersCheck"
+          },
+          {
+            "type": "Check",
+            "name": "ErrorsCheck"
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": []
 }

--- a/Modules/PHOS/include/PHOS/ClusterCheck.h
+++ b/Modules/PHOS/include/PHOS/ClusterCheck.h
@@ -43,11 +43,15 @@ class ClusterCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  protected:
-  static constexpr int kDeadThreshold = 10;   /// Number of new dead channels per module to decalre bad
-  static constexpr int kNoisyThreshold = 2;   /// Number of new noisy channels per module to send warning
-  static constexpr int kMaxUccupancyCut = 10; /// occupancy in noisy channel wrt mean over module
+  int mDeadThreshold[5] = { 10, 10, 10, 10, 10 };   /// Number of new dead channels per module to decalre bad
+  int mNoisyThreshold[5] = { 2, 2, 2, 2, 2 };       /// Number of new noisy channels per module to send warning
+  int mMaxOccupancyCut[5] = { 10, 10, 10, 10, 10 }; /// occupancy in noisy channel wrt mean over module
+  float mCluEnergyRangeL[5] = { 1., 1., 1., 1., 1. };
+  float mCluEnergyRangeR[5] = { 10., 10., 10., 10., 10. };
+  float mMinCluEnergyMean[5] = { 2., 2., 2., 2., 2 };
+  float mMaxCluEnergyMean[5] = { 4., 4., 4., 4., 4 };
 
-  std::unique_ptr<o2::phos::BadChannelsMap> mBadMap; /// bad map
+  const o2::phos::BadChannelsMap* mBadMap; /// bad map
   ClassDefOverride(ClusterCheck, 2);
 };
 

--- a/Modules/PHOS/include/PHOS/LinkDef.h
+++ b/Modules/PHOS/include/PHOS/LinkDef.h
@@ -3,6 +3,10 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::quality_control_modules::phos::TH1Fraction + ;
+
+#pragma link C++ class o2::quality_control_modules::phos::TH2Fraction + ;
+
 #pragma link C++ class o2::quality_control_modules::phos::TH2SBitmask + ;
 
 #pragma link C++ class o2::quality_control_modules::phos::TH2FMean + ;

--- a/Modules/PHOS/include/PHOS/RawCheck.h
+++ b/Modules/PHOS/include/PHOS/RawCheck.h
@@ -61,6 +61,11 @@ class RawCheck final : public o2::quality_control::checker::CheckInterface
 
   int mToleratedBadChannelsM[5] = { 0, 10, 20, 20, 20 }; // Nuber of channels beyond bad map
   int mBadMap[5] = { 0 };
+  float mErrorOccuranceThreshold[5] = { 0., 0., 0., 0., 0. };
+  const char* mErrorLabel[5] = { "wrong ALTRO", "mapping", "ch. header",
+                                 "ch. payload", "wrond hw addr" };
+  float mBranchOccupancyDeviationAllowed[5] = { 1.5, 1.5, 1.5, 1.5, 1.5 };
+  int mToleratedDeviatedBranches[5] = { 0, 0, 0, 0, 0 };
   Quality mCheckResult = Quality::Null;
   ClassDefOverride(RawCheck, 2);
 };

--- a/Modules/PHOS/include/PHOS/RawQcTask.h
+++ b/Modules/PHOS/include/PHOS/RawQcTask.h
@@ -31,6 +31,7 @@ class TH2F;
 #include <TSpectrum.h>
 #include "PHOS/TH2FMean.h"
 #include "PHOS/TH2SBitmask.h"
+#include "PHOS/TH1Fraction.h"
 
 using namespace o2::quality_control::core;
 
@@ -160,6 +161,9 @@ class RawQcTask final : public TaskInterface
   static constexpr short kNhist2DBitmask = 1;
   enum histos2DBitmask { kErrorType };
 
+  static constexpr short kNratio1D = 1;
+  enum ratios1D { kErrorTypeOccurance };
+
   void InitHistograms();
 
   void CreatePhysicsHistograms();
@@ -181,11 +185,13 @@ class RawQcTask final : public TaskInterface
   bool mFinalized = false; ///< if final histograms calculated
   bool mCheckChi2 = false; ///< scan Chi2 distributions
   bool mTrNoise = false;   ///< check mathing of trigger summary tables and tr.digits
+  unsigned long long eventCounter = 0;
 
   std::array<TH1F*, kNhist1D> mHist1D = { nullptr };                      ///< Array of 1D histograms
   std::array<TH2F*, kNhist2D> mHist2D = { nullptr };                      ///< Array of 2D histograms
   std::array<TH2FMean*, kNhist2DMean> mHist2DMean = { nullptr };          ///< Array of 2D mean histograms
   std::array<TH2SBitmask*, kNhist2DBitmask> mHist2DBitmask = { nullptr }; ///< Array of 2D mean histograms
+  std::array<TH1Fraction*, kNratio1D> mFractions1D = { nullptr };         ///< Array of mergeable 1D fractions
 
   bool mInitBadMap = true;                           //! BadMap had to be initialized
   const o2::phos::BadChannelsMap* mBadMap = nullptr; //! Bad map for comparison

--- a/Modules/PHOS/include/PHOS/TH1Fraction.h
+++ b/Modules/PHOS/include/PHOS/TH1Fraction.h
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TH1Fraction.h
+/// \author Sergey Evdokimov
+///
+
+#ifndef QC_MODULE_PHOS_TH1FRACTION_H
+#define QC_MODULE_PHOS_TH1FRACTION_H
+
+#include "QualityControl/TaskInterface.h"
+#include <TH1.h>
+#include "Mergers/MergeInterface.h"
+
+namespace o2::quality_control_modules::phos
+{
+
+/// \brief Custom TH2F class with special merger
+
+class TH1Fraction : public TH1D, public o2::mergers::MergeInterface
+{
+ public:
+  /// \brief Constructor.
+  TH1Fraction() = default;
+  TH1Fraction(const char* name, const char* title, Int_t nbinsx, Double_t xlow, Double_t xup);
+  TH1Fraction(TH1Fraction const& copymerge);
+  /// \brief Destructor
+  virtual ~TH1Fraction()
+  {
+    delete mUnderlyingCounts;
+  }
+
+  void increaseEventCounter(int increment) { mEventCounter += increment; }
+  void fillUnderlying(double x) { mUnderlyingCounts->Fill(x); }
+  void update();
+  TH1D* getUnderlyingCounts() const { return mUnderlyingCounts; }
+  unsigned long long getEventCounter() const { return mEventCounter; }
+  void Reset(Option_t* option = "") override;
+
+  void merge(MergeInterface* const other) override;
+
+ private:
+  std::string mTreatMeAs = "TH1F";      // the name of the class this object should be considered as when drawing in QCG.
+  unsigned long long mEventCounter = 0; // event counter
+  TH1D* mUnderlyingCounts{ nullptr };   // underlying histogram with counts
+
+  ClassDefOverride(TH1Fraction, 1);
+};
+
+} // namespace o2::quality_control_modules::phos
+
+#endif // QC_MODULE_PHOS_TH1FRACTION_H

--- a/Modules/PHOS/include/PHOS/TH2Fraction.h
+++ b/Modules/PHOS/include/PHOS/TH2Fraction.h
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TH2Fraction.h
+/// \author Sergey Evdokimov
+///
+
+#ifndef QC_MODULE_PHOS_TH2FRACTION_H
+#define QC_MODULE_PHOS_TH2FRACTION_H
+
+#include "QualityControl/TaskInterface.h"
+#include <TH2.h>
+#include "Mergers/MergeInterface.h"
+
+namespace o2::quality_control_modules::phos
+{
+
+/// \brief Custom TH2F class with special merger
+
+class TH2Fraction : public TH2D, public o2::mergers::MergeInterface
+{
+ public:
+  /// \brief Constructor.
+  TH2Fraction() = default;
+  TH2Fraction(const char* name, const char* title, Int_t nbinsx, Double_t xlow, Double_t xup, Int_t nbinsy, Double_t ylow, Double_t yup);
+  TH2Fraction(TH2Fraction const& copymerge);
+  /// \brief Destructor
+  virtual ~TH2Fraction()
+  {
+    delete mUnderlyingCounts;
+  }
+
+  void increaseEventCounter(int increment) { mEventCounter += increment; }
+  void fillUnderlying(double x, double y) { mUnderlyingCounts->Fill(x, y); }
+  void update();
+  TH2D* getUnderlyingCounts() const { return mUnderlyingCounts; }
+  unsigned long long getEventCounter() const { return mEventCounter; }
+  void Reset(Option_t* option = "") override;
+
+  void merge(MergeInterface* const other) override;
+
+ private:
+  std::string mTreatMeAs = "TH2F";      // the name of the class this object should be considered as when drawing in QCG.
+  unsigned long long mEventCounter = 0; // event counter
+  TH2D* mUnderlyingCounts{ nullptr };   // underlying histogram with counts
+
+  ClassDefOverride(TH2Fraction, 1);
+};
+
+} // namespace o2::quality_control_modules::phos
+
+#endif // QC_MODULE_PHOS_TH2FRACTION_H

--- a/Modules/PHOS/src/ClusterCheck.cxx
+++ b/Modules/PHOS/src/ClusterCheck.cxx
@@ -11,7 +11,7 @@
 
 ///
 /// \file   ClusterCheck.cxx
-/// \author Cristina Terrevoli
+/// \author Dmitri Peressounko
 ///
 
 #include "PHOS/ClusterCheck.h"
@@ -22,74 +22,239 @@
 #include <TH1.h>
 #include <TH2.h>
 #include <TPaveText.h>
+#include <TLatex.h>
 #include <TList.h>
 #include <iostream>
+// O2
+#include <DataFormatsQualityControl/FlagReasons.h>
+#include <DataFormatsQualityControl/FlagReasonFactory.h>
 
 using namespace std;
+using namespace o2::quality_control::core;
+using namespace o2::quality_control;
 
 namespace o2::quality_control_modules::phos
 {
 
 void ClusterCheck::configure()
 {
-  //TODO: configure reading bad map from CCDB
-  mBadMap.reset(new o2::phos::BadChannelsMap());
+  for (int mod = 1; mod < 5; mod++) {
+    // mDeadThreshold
+    if (auto param = mCustomParameters.find(Form("mDeadThreshold%d", mod));
+        param != mCustomParameters.end()) {
+      mDeadThreshold[mod] = stoi(param->second);
+      ILOG(Debug, Support) << "configure() : Custom parameter "
+                           << Form("mDeadThreshold%d", mod)
+                           << mDeadThreshold[mod] << ENDM;
+    }
+    // mNoisyThreshold
+    if (auto param = mCustomParameters.find(Form("mNoisyThreshold%d", mod));
+        param != mCustomParameters.end()) {
+      mNoisyThreshold[mod] = stoi(param->second);
+      ILOG(Debug, Support) << "configure() : Custom parameter "
+                           << Form("mNoisyThreshold%d", mod)
+                           << mNoisyThreshold[mod] << ENDM;
+    }
+    // mMaxOccupancyCut
+    if (auto param = mCustomParameters.find(Form("mMaxOccupancyCut%d", mod));
+        param != mCustomParameters.end()) {
+      mMaxOccupancyCut[mod] = stoi(param->second);
+      ILOG(Debug, Support) << "configure() : Custom parameter "
+                           << Form("mMaxOccupancyCut%d", mod)
+                           << mMaxOccupancyCut[mod] << ENDM;
+    }
+
+    // mCluEnergyRangeL
+    if (auto param = mCustomParameters.find(Form("mCluEnergyRangeL%d", mod));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mCluEnergyRangeL%d = ", mod)
+                         << param->second << ENDM;
+      mCluEnergyRangeL[mod] = stof(param->second);
+    }
+    // mCluEnergyRangeR
+    if (auto param = mCustomParameters.find(Form("mCluEnergyRangeR%d", mod));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mCluEnergyRangeR%d = ", mod)
+                         << param->second << ENDM;
+      mCluEnergyRangeR[mod] = stof(param->second);
+    }
+    // mMinCluEnergyMean
+    if (auto param = mCustomParameters.find(Form("mMinCluEnergyMean%d", mod));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mMinCluEnergyMean%d = ", mod)
+                         << param->second << ENDM;
+      mMinCluEnergyMean[mod] = stof(param->second);
+    }
+    // mMaxCluEnergyMean
+    if (auto param = mCustomParameters.find(Form("mMaxCluEnergyMean%d", mod));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mMaxCluEnergyMean%d = ", mod)
+                         << param->second << ENDM;
+      mMaxCluEnergyMean[mod] = stof(param->second);
+    }
+  }
 }
 
 Quality ClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
-  auto mo = moMap->begin()->second;
+  Quality result = Quality::Good;
+  for (auto& [moName, mo] : *moMap) {
+    //check occupancy
+    if (mo->getName().find("ClusterOccupancyM") != std::string::npos) {
+      // the problem here is that CcdbUrl must be setted via setCcdbUrl() method
+      // otherwise it tries to open empty url
+      // but how to access global qc config here?
+      // for the timebeing don't include "ClusterOccupancyM" in list of objects to check
+      if (!mBadMap) {
+        mBadMap = UserCodeInterface::retrieveConditionAny<o2::phos::BadChannelsMap>("PHS/Calib/BadMap");
+      }
 
-  //check occupancy
-  if (mo->getName().find("ClusterOccupancyM") != std::string::npos) {
-    auto* h = dynamic_cast<TH2*>(mo->getObject());
-    if (h->GetEntries() == 0) {
-      return Quality::Bad;
-    }
-    //get module number:
-    int m = mo->getName()[mo->getName().find_first_of("1234")] - '0';
-    //Compare with current bad map: check for new bad regions
-    float mean = 0;
-    int entries = 0, nDead = 0, nNoisy = 0;
-    for (int ix = 1; ix <= 64; ix++) {
-      for (int iz = 1; iz <= 56; iz++) {
-        float cont = h->GetBinContent(ix, iz);
-        char relid[3] = { char(m), char(ix), char(iz) };
-        short absId;
-        o2::phos::Geometry::relToAbsNumbering(relid, absId);
-
-        if (cont > 0) {
-          mean += cont;
-          entries++;
-        } else {
-          if (mBadMap->isChannelGood(absId)) { //new bad channel
-            nDead++;
+      auto* h = dynamic_cast<TH2*>(mo->getObject());
+      if (h->GetEntries() == 0) {
+        continue;
+      }
+      //get module number:
+      int m = mo->getName()[mo->getName().find_first_of("1234")] - '0';
+      //Compare with current bad map: check for new bad regions
+      float mean = 0;
+      int entries = 0, nDead = 0, nNoisy = 0;
+      for (int ix = 1; ix <= 64; ix++) {
+        for (int iz = 1; iz <= 56; iz++) {
+          float cont = h->GetBinContent(ix, iz);
+          char relid[3] = { char(m), char(ix), char(iz) };
+          short absId;
+          o2::phos::Geometry::relToAbsNumbering(relid, absId);
+          if (cont > 0) {
+            mean += cont;
+            entries++;
+          } else {
+            if (mBadMap->isChannelGood(absId)) { //new bad channel
+              nDead++;
+            }
           }
         }
       }
-    }
-    if (entries) {
-      mean /= entries;
-    }
-    //scan noisy channels
-    for (int ix = 1; ix <= 64; ix++) {
-      for (int iz = 1; iz <= 56; iz++) {
-        float cont = h->GetBinContent(ix, iz);
-        if (cont > kMaxUccupancyCut * mean) {
-          nNoisy++;
+      if (entries) {
+        mean /= entries;
+      }
+      //scan noisy channels
+      for (int ix = 1; ix <= 64; ix++) {
+        for (int iz = 1; iz <= 56; iz++) {
+          float cont = h->GetBinContent(ix, iz);
+          if (cont > mMaxOccupancyCut[m] * mean) {
+            nNoisy++;
+          }
         }
       }
+      // check quality
+      // dead channels
+      if (nDead > mDeadThreshold[m]) {
+        if (result.isBetterThan(Quality::Bad)) {
+          result.set(Quality::Bad);
+        }
+        result.addReason(FlagReasonFactory::Unknown(), Form("too many dead channels M%d", m));
+        TLatex* msg = new TLatex(0.2, 0.2, Form("#color[2]{Too many new dead channels: %d}", nDead));
+        msg->SetNDC();
+        msg->SetTextSize(16);
+        msg->SetTextFont(43);
+        h->GetListOfFunctions()->Add(msg);
+        msg->Draw();
+        TPaveText* msgNotOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+        msgNotOk->SetName(Form("%s_msg", mo->GetName()));
+        msgNotOk->Clear();
+        msgNotOk->AddText("Not OK");
+        msgNotOk->SetFillColor(kRed);
+        h->GetListOfFunctions()->Add(msgNotOk);
+      } else if (nNoisy > mNoisyThreshold[m]) { // noisy channels
+        if (result.isBetterThan(Quality::Medium)) {
+          result.set(Quality::Medium);
+        }
+        result.addReason(FlagReasonFactory::Unknown(), Form("too many noisy channels M%d", m));
+        TLatex* msg = new TLatex(0.2, 0.2, Form("#color[2]{Too many noisy channels: %d}", nNoisy));
+        msg->SetNDC();
+        msg->SetTextSize(16);
+        msg->SetTextFont(43);
+        h->GetListOfFunctions()->Add(msg);
+        msg->Draw();
+        TPaveText* msgNotOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+        msgNotOk->SetName(Form("%s_msg", mo->GetName()));
+        msgNotOk->Clear();
+        msgNotOk->AddText("Not OK");
+        msgNotOk->SetFillColor(kRed);
+        h->GetListOfFunctions()->Add(msgNotOk);
+      } else {
+        TPaveText* msgOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+        msgOk->SetName(Form("%s_msg", mo->GetName()));
+        msgOk->Clear();
+        msgOk->AddText("OK");
+        msgOk->SetFillColor(kGreen);
+        h->GetListOfFunctions()->Add(msgOk);
+        h->SetFillColor(kGreen);
+      }
     }
-    if (nDead > kDeadThreshold) {
-      return Quality::Bad;
+    // check energy spectrum
+    if (mo->getName().find("SpectrumM") != std::string::npos) {
+      LOG(info) << "I checking " << mo->getName();
+
+      //get module number:
+      int iMod = mo->getName()[mo->getName().find_first_of("1234")] - '0';
+      bool isGoodMO = true;
+      auto* h = dynamic_cast<TH1F*>(mo->getObject());
+      if (h == nullptr) {
+        ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1F*, skipping" << ENDM;
+        continue;
+      }
+      TPaveText* msg = new TPaveText(0.6, 0.5, 1.0, 0.75, "NDC");
+      h->GetListOfFunctions()->Add(msg);
+      msg->SetName(Form("%s_msg", mo->GetName()));
+      msg->Clear();
+
+      auto nEvents = h->GetEntries();
+      if (nEvents == 0) {
+        if (result.isBetterThan(Quality::Null)) {
+          result.set(Quality::Null);
+        }
+        result.addReason(FlagReasonFactory::Unknown(), Form("not enough statistics M%d", iMod));
+        msg->AddText("Not enough data to check");
+        msg->SetFillColor(kOrange);
+        isGoodMO = false;
+      } else {
+        h->GetXaxis()->SetRangeUser(mCluEnergyRangeL[iMod], mCluEnergyRangeR[iMod]);
+        auto mean = h->GetMean();
+        if (mean < mMinCluEnergyMean[iMod]) {
+          if (result.isBetterThan(Quality::Medium)) {
+            result.set(Quality::Medium);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("too small mean energy M%d", iMod));
+          msg->AddText(Form("Mean is too small: %f", mean));
+          msg->AddText(Form("Min allowed mean: %f", mMinCluEnergyMean[iMod]));
+          msg->SetFillColor(kRed);
+          h->SetFillColor(kRed);
+          isGoodMO = false;
+        } else if (mean > mMaxCluEnergyMean[iMod]) {
+          if (result.isBetterThan(Quality::Medium)) {
+            result.set(Quality::Medium);
+          }
+          result.addReason(FlagReasonFactory::Unknown(), Form("too big mean energy M%d", iMod));
+          msg->AddText(Form("Mean is too big: %f", mean));
+          msg->AddText(Form("Max allowed mean: %f", mMaxCluEnergyMean[iMod]));
+          msg->SetFillColor(kRed);
+          h->SetFillColor(kRed);
+          isGoodMO = false;
+        }
+      }
+      if (isGoodMO) {
+        msg->AddText("OK");
+        msg->SetFillColor(kGreen);
+      }
     }
-    if (nNoisy > kNoisyThreshold) {
-      return Quality::Medium;
-    }
-    return Quality::Good;
   }
-  return Quality::Good;
-}
+  return result;
+} // namespace o2::quality_control_modules::phos
 
 std::string ClusterCheck::getAcceptedType() { return "TH1"; }
 

--- a/Modules/PHOS/src/RawCheck.cxx
+++ b/Modules/PHOS/src/RawCheck.cxx
@@ -19,14 +19,20 @@
 #include <TH2.h>
 #include <TPaveText.h>
 #include <TList.h>
+#include <TLatex.h>
 
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include <fairlogger/Logger.h>
 #include "PHOS/RawCheck.h"
+#include "PHOS/TH1Fraction.h"
+
+#include <DataFormatsQualityControl/FlagReasons.h>
+#include <DataFormatsQualityControl/FlagReasonFactory.h>
 
 using namespace std;
+using namespace o2::quality_control;
 
 namespace o2::quality_control_modules::phos
 {
@@ -83,8 +89,8 @@ void RawCheck::configure()
                          << mMaxLGPedestalRMS << ENDM;
   }
 
-  // mToleratedBadPedestalValueChannelsM
   for (int mod = 1; mod < 5; mod++) {
+    // mToleratedBadPedestalValueChannelsM
     param = mCustomParameters.find(Form("mToleratedBadChannelsM%d", mod));
     if (param != mCustomParameters.end()) {
       mToleratedBadChannelsM[mod] = stoi(param->second);
@@ -92,12 +98,39 @@ void RawCheck::configure()
                            << Form("mToleratedBadChannelsM%d", mod)
                            << mToleratedBadChannelsM[mod] << ENDM;
     }
+    // mToleratedDeviatedBranches
+    param = mCustomParameters.find(Form("mToleratedDeviatedBranchesM%d", mod));
+    if (param != mCustomParameters.end()) {
+      mToleratedDeviatedBranches[mod] = stoi(param->second);
+      ILOG(Debug, Support) << "configure() : Custom parameter "
+                           << Form("mToleratedDeviatedBranchesM%d", mod)
+                           << mToleratedDeviatedBranches[mod] << ENDM;
+    }
+    // mBranchOccupancyDeviationAllowed
+    param = mCustomParameters.find(Form("mBranchOccupancyDeviationAllowedM%d", mod));
+    if (param != mCustomParameters.end()) {
+      mBranchOccupancyDeviationAllowed[mod] = stof(param->second);
+      ILOG(Debug, Support) << "configure() : Custom parameter "
+                           << Form("mBranchOccupancyDeviationAllowedM%d", mod)
+                           << mBranchOccupancyDeviationAllowed[mod] << ENDM;
+    }
   }
+  // error occurance
+  for (int i = 0; i < 5; i++) {
+    if (auto param = mCustomParameters.find(Form("mErrorOccuranceThreshold%d", i));
+        param != mCustomParameters.end()) {
+      ILOG(Debug, Devel) << "configure() : Custom parameter "
+                         << Form("mErrorOccuranceThreshold%d = ", i)
+                         << param->second << "for the " << mErrorLabel[i] << ENDM;
+      mErrorOccuranceThreshold[i] = stof(param->second);
+    }
+  }
+  mBadMap[0] = 0;
 }
 
 Quality RawCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
-  mCheckResult = Quality::Null;
+  mCheckResult = Quality::Good;
   for (auto& [moName, mo] : *moMap) {
     (void)moName; // trick the compiler about not used variable
     if (checkErrHistograms(mo.get())) {
@@ -120,16 +153,6 @@ bool RawCheck::checkErrHistograms(MonitorObject* mo)
   // Return true if mo found and handled
   // else return false to search further
 
-  if (mo->getName().find("BadMapSummary") != std::string::npos) {                   // HG mean summary 100, 0., 100.
-    if (mBadMap[1] != 0 || mBadMap[2] != 0 || mBadMap[3] != 0 || mBadMap[4] != 0) { // already set
-      return true;
-    }
-    TH1F* h = dynamic_cast<TH1F*>(mo->getObject());
-    for (int mod = 1; mod < 5; mod++) {
-      mBadMap[mod] = h->GetBinContent(mod);
-    }
-    return true;
-  }
   if (mo->getName().find("ErrorTypePerDDL") != std::string::npos) { // HG mean summary 100, 0., 100.
     TH2S* h = dynamic_cast<TH2S*>(mo->getObject());
     if (h->Integral() == 0) {
@@ -153,20 +176,80 @@ bool RawCheck::checkErrHistograms(MonitorObject* mo)
     }
     return true;
   }
+  if (mo->getName().find("ErrorTypeOccurance") != std::string::npos) {
+    auto* h = dynamic_cast<TH1Fraction*>(mo->getObject());
+    if (h == nullptr) {
+      ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1Fraction*, skipping" << ENDM;
+    } else {
+      h->SetOption("hist");
+      h->SetDrawOption("hist");
+      bool isGoodMO = true;
+      for (int i = 1; i <= h->GetXaxis()->GetNbins(); i++) {
+        if (h->GetBinContent(i) > mErrorOccuranceThreshold[i - 1]) {
+          isGoodMO = false;
+          if (mCheckResult.isBetterThan(Quality::Medium)) {
+            mCheckResult.set(Quality::Medium);
+          }
+          mCheckResult.addReason(FlagReasonFactory::Unknown(), Form("too many %s errors", mErrorLabel[i - 1]));
+          TLatex* msg = new TLatex(0.2, 0.2 + i * 0.125, Form("#color[2]{Too many %s errors}", mErrorLabel[i - 1]));
+          msg->SetNDC();
+          msg->SetTextSize(16);
+          msg->SetTextFont(43);
+          h->GetListOfFunctions()->Add(msg);
+          msg->Draw();
+          TPaveText* msgNotOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+          msgNotOk->SetName(Form("%s_msg", mo->GetName()));
+          msgNotOk->Clear();
+          msgNotOk->AddText("Not OK");
+          msgNotOk->SetFillColor(kRed);
+          h->GetListOfFunctions()->Add(msgNotOk);
+          h->SetMarkerStyle(21);
+          h->SetFillColor(kOrange);
+        }
+      }
+      if (isGoodMO) {
+        TPaveText* msgOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+        msgOk->SetName(Form("%s_msg", mo->GetName()));
+        msgOk->Clear();
+        msgOk->AddText("OK");
+        msgOk->SetFillColor(kGreen);
+        h->GetListOfFunctions()->Add(msgOk);
+        h->SetFillColor(kGreen);
+      }
+    }
+  }
   return false;
 }
 bool RawCheck::checkPhysicsHistograms(MonitorObject* mo)
 {
+  // get number of bad channels in each module. do it only once
+  if (mo->getName().find("BadMapSummary") != std::string::npos) {
+    if (mBadMap[0]) { // do it only once
+      return true;
+    }
+    TH1F* h = dynamic_cast<TH1F*>(mo->getObject());
+    for (int mod = 1; mod < 5; mod++) {
+      mBadMap[mod] = h->GetBinContent(mod);
+    }
+    mBadMap[0] = 1;
+    return true;
+  }
   // Check occupancy histograms: if statistics is sufficient?
   // if yes - check number of dead channels wrt bad map
-  if (mo->getName().find("CellOccupancyM") != std::string::npos) { // HG mean summary 100, 0., 100.
-    int mod = atoi(&mo->getName()[mo->getName().find("CellOccupancyM") + 14]);
+  if (mo->getName().find("CellHGOccupancyM") != std::string::npos) { // HG mean summary 100, 0., 100.
+    int mod = atoi(&mo->getName()[mo->getName().find("CellHGOccupancyM") + 16]);
     TH2F* h = dynamic_cast<TH2F*>(mo->getObject());
     float nCounts = h->Integral();
     if ((mod == 1 && nCounts < 17920.) || (mod > 1 && nCounts < 35840.)) {
-      mCheckResult = Quality::Null;
+      TPaveText* msg = new TPaveText(0.0, 0.0, 0.3, 0.1, "NDC");
+      msg->SetName(Form("%s_msg", mo->GetName()));
+      msg->Clear();
+      msg->AddText("Not enough stat");
+      msg->SetFillColor(kGreen);
+      h->GetListOfFunctions()->Add(msg);
       return true;
     }
+    // calculate dead channels
     int nDead = 0;
     for (int ix = 1; ix <= 64; ix++) {
       for (int iz = 1; iz <= 56; iz++) {
@@ -178,25 +261,70 @@ bool RawCheck::checkPhysicsHistograms(MonitorObject* mo)
     if (mod == 1) {
       nDead -= 1792;
     }
-    if (nDead > mBadMap[mod] + mToleratedBadChannelsM[mod]) {
-      mCheckResult = Quality::Bad;
-      TPaveText* msg = new TPaveText(0.6, 0.6, 0.9, 0.75, "NDC");
-      msg->SetName(Form("%s_msg", mo->GetName()));
-      msg->Clear();
-      mCheckResult = Quality::Bad;
-      msg->AddText(Form("Too many new bad channels"));
-      msg->AddText(Form(" %d in bad map: %d ", nDead, mBadMap[mod]));
-      msg->SetFillColor(kRed);
+    // calculate deviated branches
+    TH2F* hBranches = (TH2F*)h->Clone("hBranches");
+    hBranches->Rebin2D(16, 28);
+    double mean = 0;
+    int nDeviatedBranches = 0;
+    for (int ix = 1; ix <= 4; ix++) {
+      mean += hBranches->GetBinContent(ix, 1);
+      mean += hBranches->GetBinContent(ix, 2);
+    }
+    if (mod == 1) {
+      mean /= 4.;
+    } else {
+      mean /= 8.;
+    }
+    for (int ix = (mod == 1) ? 3 : 1; ix <= 4; ix++) {
+      for (int iz = 1; iz <= 2; iz++) {
+        if (hBranches->GetBinContent(ix, iz) > mean * mBranchOccupancyDeviationAllowed[mod] ||
+            hBranches->GetBinContent(ix, iz) < mean / mBranchOccupancyDeviationAllowed[mod])
+          nDeviatedBranches++;
+      }
+    }
+    // define quality
+    if (mBadMap[0] && (nDead > mBadMap[mod] + mToleratedBadChannelsM[mod])) {
+      if (mCheckResult.isBetterThan(Quality::Bad)) {
+        mCheckResult.set(Quality::Bad);
+      }
+      mCheckResult.addReason(FlagReasonFactory::Unknown(), Form("too many dead channels M%d", mod));
+      TLatex* msg = new TLatex(0.2, 0.2, Form("#color[2]{Too many dead channels: %d; but bad map has %d channels}", nDead, mToleratedBadChannelsM[mod]));
+      msg->SetNDC();
+      msg->SetTextSize(16);
+      msg->SetTextFont(43);
       h->GetListOfFunctions()->Add(msg);
-      h->SetFillColor(kRed);
+      msg->Draw();
+      TPaveText* msgNotOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+      msgNotOk->SetName(Form("%s_msg", mo->GetName()));
+      msgNotOk->Clear();
+      msgNotOk->AddText("Not OK");
+      msgNotOk->SetFillColor(kRed);
+      h->GetListOfFunctions()->Add(msgNotOk);
+    } else if (nDeviatedBranches > mToleratedDeviatedBranches[mod]) {
+      if (mCheckResult.isBetterThan(Quality::Medium)) {
+        mCheckResult.set(Quality::Medium);
+      }
+      mCheckResult.addReason(FlagReasonFactory::Unknown(), Form("Branch oocupancy deviated M%d", mod));
+      TLatex* msg = new TLatex(0.2, 0.4, Form("#color[2]{%d deviated branches; but %d allowed}", nDeviatedBranches, mToleratedDeviatedBranches[mod]));
+      msg->SetNDC();
+      msg->SetTextSize(16);
+      msg->SetTextFont(43);
+      h->GetListOfFunctions()->Add(msg);
+      msg->Draw();
+      TPaveText* msgNotOk = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
+      msgNotOk->SetName(Form("%s_msg", mo->GetName()));
+      msgNotOk->Clear();
+      msgNotOk->AddText("Not OK");
+      msgNotOk->SetFillColor(kRed);
+      h->GetListOfFunctions()->Add(msgNotOk);
+
     } else { // OK
-      TPaveText* msg = new TPaveText(0.6, 0.8, 0.9, 0.9, "NDC");
+      TPaveText* msg = new TPaveText(0.0, 0.0, 0.1, 0.1, "NDC");
       msg->SetName(Form("%s_msg", mo->GetName()));
       msg->Clear();
       msg->AddText("OK");
       msg->SetFillColor(kGreen);
       h->GetListOfFunctions()->Add(msg);
-      mCheckResult = Quality::Good;
     }
     return true;
   }

--- a/Modules/PHOS/src/TH1Fraction.cxx
+++ b/Modules/PHOS/src/TH1Fraction.cxx
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TH1Fraction.cxx
+/// \author Sergey Evdokimov
+///
+
+#include "PHOS/TH1Fraction.h"
+
+namespace o2::quality_control_modules::phos
+{
+TH1Fraction::TH1Fraction(const char* name, const char* title, Int_t nbinsx, Double_t xlow, Double_t xup) : TH1D(name, title, nbinsx, xlow, xup)
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mUnderlyingCounts = new TH1D(Form("%s_underlying", name), title, nbinsx, xlow, xup);
+  TH1::AddDirectory(bStatus);
+
+  if (!mUnderlyingCounts) {
+    return;
+  }
+  mUnderlyingCounts->Sumw2();
+}
+
+TH1Fraction::TH1Fraction(TH1Fraction const& copymerge) : TH1D(copymerge.GetName(), copymerge.GetTitle(),
+                                                              copymerge.GetXaxis()->GetNbins(),
+                                                              copymerge.GetXaxis()->GetXmin(),
+                                                              copymerge.GetXaxis()->GetXmax()),
+                                                         o2::mergers::MergeInterface(),
+                                                         mEventCounter(copymerge.getEventCounter())
+{
+  Bool_t bStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  mUnderlyingCounts = (TH1D*)copymerge.getUnderlyingCounts()->Clone();
+  TH1::AddDirectory(bStatus);
+
+  if (!mUnderlyingCounts) {
+    return;
+  }
+  mUnderlyingCounts->Sumw2();
+  update();
+}
+
+void TH1Fraction::update()
+{
+  if (mEventCounter) {
+    for (int i = 1; i <= GetXaxis()->GetNbins(); i++) {
+      SetBinContent(i, mUnderlyingCounts->GetBinContent(i) / mEventCounter);
+      SetBinError(i, mUnderlyingCounts->GetBinError(i) / mEventCounter);
+    }
+  }
+}
+
+void TH1Fraction::merge(MergeInterface* const other)
+{
+  // special merge method to approximately combine two histograms
+  auto otherHisto = dynamic_cast<const TH1Fraction* const>(other);
+  if (otherHisto) {
+    if (mUnderlyingCounts->Add(otherHisto->getUnderlyingCounts())) {
+      mEventCounter += otherHisto->getEventCounter();
+    }
+  }
+  update();
+}
+
+void TH1Fraction::Reset(Option_t* option)
+{
+  if (mUnderlyingCounts) {
+    mUnderlyingCounts->Reset(option);
+  }
+  mEventCounter = 0;
+  TH1D::Reset(option);
+}
+
+} // namespace o2::quality_control_modules::phos

--- a/Modules/PHOS/src/TH2Fraction.cxx
+++ b/Modules/PHOS/src/TH2Fraction.cxx
@@ -1,0 +1,90 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TH2Fraction.cxx
+/// \author Sergey Evdokimov
+///
+
+#include "PHOS/TH2Fraction.h"
+
+namespace o2::quality_control_modules::phos
+{
+TH2Fraction::TH2Fraction(const char* name, const char* title, Int_t nbinsx, Double_t xlow, Double_t xup,
+                         Int_t nbinsy, Double_t ylow, Double_t yup) : TH2D(name, title, nbinsx, xlow, xup, nbinsy, ylow, yup)
+{
+  Bool_t bStatus = TH2::AddDirectoryStatus();
+  TH2::AddDirectory(kFALSE);
+  mUnderlyingCounts = new TH2D(Form("%s_underlying", name), title, nbinsx, xlow, xup, nbinsy, ylow, yup);
+  TH2::AddDirectory(bStatus);
+
+  if (!mUnderlyingCounts) {
+    return;
+  }
+  mUnderlyingCounts->Sumw2();
+}
+
+TH2Fraction::TH2Fraction(TH2Fraction const& copymerge) : TH2D(copymerge.GetName(), copymerge.GetTitle(),
+                                                              copymerge.GetXaxis()->GetNbins(),
+                                                              copymerge.GetXaxis()->GetXmin(),
+                                                              copymerge.GetXaxis()->GetXmax(),
+                                                              copymerge.GetYaxis()->GetNbins(),
+                                                              copymerge.GetYaxis()->GetXmin(),
+                                                              copymerge.GetYaxis()->GetXmax()),
+                                                         o2::mergers::MergeInterface(),
+                                                         mEventCounter(copymerge.getEventCounter())
+{
+  Bool_t bStatus = TH2::AddDirectoryStatus();
+  TH2::AddDirectory(kFALSE);
+  mUnderlyingCounts = (TH2D*)copymerge.getUnderlyingCounts()->Clone();
+  TH2::AddDirectory(bStatus);
+
+  if (!mUnderlyingCounts) {
+    return;
+  }
+  mUnderlyingCounts->Sumw2();
+  update();
+}
+
+void TH2Fraction::update()
+{
+  if (mEventCounter) {
+    for (int i = 1; i <= GetXaxis()->GetNbins(); i++) {
+      for (int j = 1; j <= GetYaxis()->GetNbins(); j++) {
+        SetBinContent(i, j, mUnderlyingCounts->GetBinContent(i, j) / mEventCounter);
+        SetBinError(i, j, mUnderlyingCounts->GetBinError(i, j) / mEventCounter);
+      }
+    }
+  }
+}
+
+void TH2Fraction::merge(MergeInterface* const other)
+{
+  // special merge method to approximately combine two histograms
+  auto otherHisto = dynamic_cast<const TH2Fraction* const>(other);
+  if (otherHisto) {
+    if (mUnderlyingCounts->Add(otherHisto->getUnderlyingCounts())) {
+      mEventCounter += otherHisto->getEventCounter();
+    }
+  }
+  update();
+}
+
+void TH2Fraction::Reset(Option_t* option)
+{
+  if (mUnderlyingCounts) {
+    mUnderlyingCounts->Reset(option);
+  }
+  mEventCounter = 0;
+  TH2D::Reset(option);
+}
+
+} // namespace o2::quality_control_modules::phos


### PR DESCRIPTION
Hello! In this PR there are updates for CPV and PHS tasks and checks:
added mergable TH1 and TH2 Fraction objects;
introduced ErrorTypeOccupancy MOs;
modified checkers (CPV/PhysicsCheck, PHS/RawCheck and PHS/ClusterCheck)
added example jsons to run standalone.