### PR TITLE
Use template type for DPLRawParser iterator, since that will become templated in O2

### DIFF
--- a/Modules/Daq/src/DaqTask.cxx
+++ b/Modules/Daq/src/DaqTask.cxx
@@ -222,7 +222,8 @@ void DaqTask::monitorInputRecord(InputRecord& inputRecord)
   mNumberInputs->Fill(inputRecord.countValidInputs());
 }
 
-void printPage(const DPLRawParser::Iterator<const DataRef>& data)
+template <class T>
+void printPage(const T& data)
 {
   auto const* raw = data.raw();         // retrieving the raw pointer of the page
   auto const* rawPayload = data.data(); // retrieving payload pointer of the page


### PR DESCRIPTION
@Barthelemy : Could we have this in a tag next week? It is needed for AliceO2Group/AliceO2#11390