### PR TITLE
Fix checks of MID calibration objects

### DIFF
--- a/Modules/MUON/MID/include/MID/CalibMQcCheck.h
+++ b/Modules/MUON/MID/include/MID/CalibMQcCheck.h
@@ -19,6 +19,8 @@
 
 #include "QualityControl/CheckInterface.h"
 
+#include "MID/HistoHelper.h"
+
 namespace o2::quality_control_modules::mid
 {
 
@@ -37,9 +39,8 @@ class CalibMQcCheck : public o2::quality_control::checker::CheckInterface
 
  private:
   ///////////////////////////
-  int mIsEmpty = 0;
-  int mCalibTF = 0;
-  ClassDefOverride(CalibMQcCheck, 2);
+  HistoHelper mHistoHelper; ///! Histogram helper
+  ClassDefOverride(CalibMQcCheck, 3);
 };
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/include/MID/CalibMQcTask.h
+++ b/Modules/MUON/MID/include/MID/CalibMQcTask.h
@@ -55,6 +55,8 @@ class CalibMQcTask final : public TaskInterface
   void resetDisplayHistos();
   DigitsHelper mDigitsHelper; ///! Digits helper
 
+  std::unique_ptr<TH1F> mNbBadChannelTF{ nullptr };
+
   std::unique_ptr<TH1F> mNoise{ nullptr };
   std::array<std::unique_ptr<TH2F>, 4> mBendNoiseMap{};
   std::array<std::unique_ptr<TH2F>, 4> mNBendNoiseMap{};

--- a/Modules/MUON/MID/include/MID/CalibQcCheck.h
+++ b/Modules/MUON/MID/include/MID/CalibQcCheck.h
@@ -19,6 +19,8 @@
 
 #include "QualityControl/CheckInterface.h"
 
+#include "MID/HistoHelper.h"
+
 namespace o2::quality_control_modules::mid
 {
 
@@ -37,15 +39,10 @@ class CalibQcCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
-  ///////////////////////////
-  float mTF = 0;
-  int mOrbTF = 32;
-  float mNoiseRof = 0;
   float mDeadRof = 0;
-  // float scaleTime = 0.0114048; // 128 orb/TF * 3564 BC/orb * 25ns
-  float scaleTime = 0.0000891; // 3564 BC/orb * 25ns
+  HistoHelper mHistoHelper; ///! Histogram helper
 
-  ClassDefOverride(CalibQcCheck, 2);
+  ClassDefOverride(CalibQcCheck, 3);
 };
 
 } // namespace o2::quality_control_modules::mid

--- a/Modules/MUON/MID/src/CalibMQcTask.cxx
+++ b/Modules/MUON/MID/src/CalibMQcTask.cxx
@@ -38,6 +38,9 @@ void CalibMQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   std::array<string, 4> chId{ "11", "12", "21", "22" };
 
+  mNbBadChannelTF = std::make_unique<TH1F>("NbBadChannelTF", "Anaylyzed timeframes", 1, 0, 1.);
+  getObjectsManager()->startPublishing(mNbBadChannelTF.get());
+
   mNoise = std::make_unique<TH1F>(mDigitsHelper.makeStripHisto("MNoiseStrips", "Noise strips"));
   getObjectsManager()->startPublishing(mNoise.get());
 
@@ -88,6 +91,8 @@ void CalibMQcTask::startOfCycle()
 
 void CalibMQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
+  mNbBadChannelTF->Fill(0.5);
+
   auto noises = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("noisych");
   auto deads = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("deadch");
   auto bads = ctx.inputs().get<gsl::span<o2::mid::ColumnData>>("badch");
@@ -143,6 +148,7 @@ void CalibMQcTask::resetDisplayHistos()
 
 void CalibMQcTask::reset()
 {
+  mNbBadChannelTF->Reset();
   mNoise->Reset();
   mDead->Reset();
   mBad->Reset();


### PR DESCRIPTION
The last PR: https://github.com/AliceO2Group/QualityControl/pull/1770 introduced a bug in the check of calibration objects, leading to a crash at P2. I temporarily disabled the QC check at P2.
This PR should solve the issue.