### PR TITLE
ITS QC Checks: added FlagReasons for shifter plots

### DIFF
--- a/Modules/ITS/include/ITS/ITSFeeCheck.h
+++ b/Modules/ITS/include/ITS/ITSFeeCheck.h
@@ -64,6 +64,7 @@ class ITSFeeCheck : public o2::quality_control::checker::CheckInterface
 
     return result;
   }
+  bool checkReason(Quality checkResult, TString text);
 
  private:
   ClassDefOverride(ITSFeeCheck, 2);

--- a/Modules/ITS/include/ITS/ITSFhrCheck.h
+++ b/Modules/ITS/include/ITS/ITSFhrCheck.h
@@ -62,6 +62,7 @@ class ITSFhrCheck : public o2::quality_control::checker::CheckInterface
 
     return result;
   }
+  bool checkReason(Quality checkResult, TString text);
 
  private:
   int mNPixelPerStave[3] = { 4718592, 58720256, 102760448 }; // IB, ML, OL

--- a/Modules/ITS/itsQCQualitySummary.json
+++ b/Modules/ITS/itsQCQualitySummary.json
@@ -1,0 +1,421 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+            "ITSFEE": {
+                "active": "true",
+                "className": "o2::quality_control_modules::its::ITSFeeTask",
+                "moduleName": "QcITS",
+                "detectorName": "ITS",
+                "cycleDurationSeconds": "30",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "direct",
+                    "query": "filter:ITS/RAWDATA"
+                },
+                "location": "local",
+                "taskParameters": {
+                    "NPayloadSizeBins": "4096",
+                    "ResetLaneStatus": "1",
+                    "ResetPayload": "0"
+                }
+            },
+            "FHRTask": {
+                "active": "true",
+                "className": "o2::quality_control_modules::its::ITSFhrTask",
+                "moduleName": "QcITS",
+                "detectorName": "ITS",
+                "cycleDurationSeconds": "30",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "dataSamplingPolicy",
+                    "name": "RAWDATA"
+                },
+                "location": "remote",
+                "taskParameters": {
+                    "Layer": "3",
+		    "HitNumberCut": "0", 
+                    "decoderThreads": "8",
+                    "HitNumberCutForNoisyPixel": "0",
+                    "OccupancyNumberCutForNoisyPixel": "0.000001",
+          	    "MaxGeneralAxisRange": "-2",
+          	    "MinGeneralAxisRange": "-12",
+          	    "MaxGeneralNoisyAxisRange": "5000",
+                    "MinGeneralNoisyAxisRange": "0",
+		    "Etabins": "130",
+                    "Phibins": "240",
+		    "geomPath": "./",
+		    "CutSparseTF": "1",
+                    "DoHitmapFilter": "1",
+                    "PhysicalOccupancyIB": "1.7e-3",
+                    "PhysicalOccupancyOB": "4.3e-5"
+                },
+	        "grpGeomRequest" : {
+                    "geomRequest": "Aligned",
+                    "askGRPECS": "false",
+                    "askGRPLHCIF": "false",
+                    "askGRPMagField": "false",
+                    "askMatLUT": "false",
+                    "askTime": "false",
+                    "askOnceAllButField": "true",
+                    "needPropagatorD":  "false"
+                }
+            },
+ "ITSClusterTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSClusterTask",
+        "moduleName": "QcITS",
+        "detectorName": "ITS",
+        "cycleDurationSeconds": "180",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "compclus"
+        },
+        "location": "remote",
+        "taskParameters": {
+          "layer": "1111111",
+          "nThreads": "1",
+          "nBCbins": "103",
+          "dicttimestamp": "0",
+          "geomPath": "./",
+          "publishSummary1D": "0",
+          "publishDetailedSummary": "0"
+        },
+	"grpGeomRequest" : {
+          "geomRequest": "Aligned",
+          "askGRPECS": "false",
+          "askGRPLHCIF": "false",
+          "askGRPMagField": "false",
+          "askMatLUT": "false",
+          "askTime": "false",
+          "askOnceAllButField": "true",
+          "needPropagatorD":  "false"
+        }
+      },
+"ITSTrackTask" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::its::ITSTrackTask",
+        "moduleName" : "QcITS",
+        "detectorName" : "ITS",
+        "cycleDurationSeconds" : "30",
+        "maxNumberCycles" : "-1",
+        "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource" : {
+          "type" : "dataSamplingPolicy",
+          "name" : "tracks"
+        },
+        "location" : "remote",
+        "taskParameters" : {
+	        "vertexXYsize" : "0.5",
+	        "vertexZsize": "15",
+          "vertexRsize": "0.8",
+	  "NtracksMAX"  : "100",
+          "doTTree": "0",
+          "nBCbins": "103",
+          "dicttimestamp" : "0",
+          "doNorm" : "1"
+        }
+
+      }
+    },
+
+    "checks" : {
+      "ITSFeeCheck": {
+                "active": "true",
+                "className": "o2::quality_control_modules::its::ITSFeeCheck",
+                "moduleName": "QcITS",
+                "policy": "OnEachSeparately",
+                "detectorName": "ITS",
+                "checkParameters": {
+                  "skipbinstrg": "",
+                  "skipfeeids": "",
+                  "maxbadchipsIB": "2",
+                  "maxbadlanesML": "4",
+                  "maxbadlanesOL": "7",
+                  "maxfractionbadlanes": "0.1"
+                },
+                "dataSource": [
+                    {
+                        "type": "Task",
+                        "name": "ITSFEE",
+                        "MOs": [
+                            "LaneStatus/laneStatusFlagFAULT",
+                            "LaneStatus/laneStatusFlagERROR",
+                            "LaneStatus/laneStatusFlagWARNING",
+                            "LaneStatus/laneStatusOverviewFlagFAULT",
+                            "LaneStatus/laneStatusOverviewFlagERROR",
+                            "LaneStatus/laneStatusOverviewFlagWARNING",
+                            "LaneStatusSummary/LaneStatusSummaryGlobal",
+                            "RDHSummary",
+                            "TriggerVsFeeid",
+                            "PayloadSize"
+                        ]
+                    }
+                ]
+            }, 
+      "FHRCheck": {
+                "active": "true",
+                "className": "o2::quality_control_modules::its::ITSFhrCheck",
+                "moduleName": "QcITS",
+                "policy": "OnEachSeparately",
+                "detectorName": "ITS",
+                "checkParameters": {
+                    "fhrcutIB": "0.01",
+                    "fhrcutOB": "0.0001",
+                    "skipbins": ""
+                },
+                "dataSource": [{
+                    "type": "Task",
+                    "name": "FHRTask",
+                    "MOs": ["General/ErrorPlots","General/General_Occupancy","General/Noisy_Pixel","Occupancy/Layer0/Layer0ChipStave","Occupancy/Layer1/Layer1ChipStave","Occupancy/Layer2/Layer2ChipStave","Occupancy/Layer3/Layer3ChipStave","Occupancy/Layer4/Layer4ChipStave","Occupancy/Layer5/Layer5ChipStave","Occupancy/Layer6/Layer6ChipStave"]
+                }]
+       },
+      "ITSClusterCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSClusterCheck",
+        "moduleName": "QcITS",
+        "policy": "OnEachSeparately",
+        "detectorName": "ITS",
+        "checkParameters": {
+          "maxcluoccL0": "5",
+          "maxcluoccL1": "4",
+          "maxcluoccL2": "3",
+          "maxcluoccL3": "2",
+          "maxcluoccL4": "1",
+          "maxcluoccL5": "1",
+          "maxcluoccL6": "1",
+          "skipxbinsoccupancy": "",
+          "skipybinsoccupancy": ""
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "ITSClusterTask",
+            "MOs": [
+              "Layer0/AverageClusterSize",
+              "Layer1/AverageClusterSize",
+              "Layer2/AverageClusterSize",
+              "Layer3/AverageClusterSize",
+              "Layer4/AverageClusterSize",
+              "Layer5/AverageClusterSize",
+              "Layer6/AverageClusterSize",
+              "General/General_Occupancy"
+            ]
+          }
+        ]
+      },
+ 
+      "ITSTrackCheck" : {
+        "active" : "true",
+        "className" : "o2::quality_control_modules::its::ITSTrackCheck",
+        "moduleName" : "QcITS",
+        "policy" : "OnEachSeparately",
+        "detectorName" : "ITS",
+        "dataSource" : [ {
+          "type" : "Task",
+          "name" : "ITSTrackTask",
+          "MOs" : ["NClusters",
+                   "PhiDistribution",
+                   "AngularDistribution",
+                   "EtaDistribution",
+                   "VertexCoordinates",
+                   "VertexRvsZ",
+                   "VertexZ"
+                  ]
+        } ]
+      }
+
+
+
+    },
+    "postprocessing": {
+      "ITSQualityTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QualityControl",
+        "detectorName": "ITS",
+        "qualityGroups": [
+         {
+            "name" : "global",
+            "title" : "GLOBAL ITS QUALITY",
+            "path": "ITS/QO",
+            "ignoreQualitiesDetails" : ["Null", "Good", "Medium", "Bad"],
+            "inputObjects": [
+              {
+                "name" : "ITSQuality/ITSQuality",
+                "title" : "ITS Quality",
+                "messageBad" : "Inform on-call immediately",
+                "messageMedium": "Add bookkeeping entry",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty!!!"
+              }
+            ]
+          },
+
+        {
+            "name" : "details",
+            "title" : "ITS DETAILS",
+            "path": "ITS/QO",
+            "ignoreQualitiesDetails" : [],
+            "inputObjects": [
+              {
+                "name" : "FHRCheck/FHRTask/General/General_Occupancy",
+                "title" : "Hit Occupancy"
+              },
+              {
+                "name" : "FHRCheck/FHRTask/General/ErrorPlots",
+                "title" : "Decoding Errors"
+              },
+
+              {
+                "name" : "ITSFeeCheck/ITSFEE/LaneStatus/laneStatusOverviewFlagFAULT",
+                "title" : "Lanes into FAULT"
+              },
+              {
+                "name" : "ITSFeeCheck/ITSFEE/LaneStatus/laneStatusOverviewFlagERROR",
+                "title" : "Lanes into ERROR"
+              },
+               {
+                "name" : "ITSFeeCheck/ITSFEE/LaneStatus/laneStatusOverviewFlagWARNING",
+                "title" : "Lanes into WARNING"
+              },
+              {
+                "name" : "ITSFeeCheck/ITSFEE/LaneStatusSummary/LaneStatusSummaryGlobal",
+                "title" : "Lane status summary"
+              },     
+              {
+                "name" : "ITSFeeCheck/ITSFEE/TriggerVsFeeid",
+                "title" : "Trigger count Vs FeeID"
+              },
+              {
+                "name" : "ITSClusterCheck/ITSClusterTask/General/General_Occupancy",
+                "title" : "Cluster occupancy"
+              },
+              {
+                "name" : "ITSTrackCheck/ITSTrackTask/AngularDistribution",
+                "title" : "Track angular distribution"
+              },
+            {
+                "name" : "ITSTrackCheck/ITSTrackTask/NClusters",
+                "title" : "NClusters"
+            }            
+           ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "60 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol", "10 minutes"
+        ]
+      }
+    },
+    "aggregators": {
+      "ITSQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QualityControl",
+        "policy": "OnAny",
+        "detectorName": "ITS",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "FHRCheck",
+            "QOs" : ["FHRTask/General/General_Occupancy", "FHRTask/General/ErrorPlots" ]
+          },
+          {
+            "type": "Check",
+            "name": "ITSFeeCheck",
+            "QOs": ["ITSFEE/LaneStatus/laneStatusOverviewFlagFAULT", "ITSFEE/LaneStatus/laneStatusOverviewFlagERROR", "ITSFEE/LaneStatus/laneStatusOverviewFlagWarning", "ITSFEE/LaneStatusSummary/LaneStatusSummaryGlobal", "ITSFEE/TriggerVsFeeid" ]
+          },
+          {
+            "type": "Check",
+            "name": "ITSClusterCheck",
+             "QOs" : ["ITSClusterTask/General/General_Occupancy"]
+          },
+
+          {
+            "type": "Check",
+            "name": "ITSTrackCheck",
+             "QOs" : ["ITSTrackTask/AngularDistribution", "ITSTrackTask/NClusters" ]
+          }
+        ]
+     }
+    }
+
+
+  },
+           "dataSamplingPolicies" : [
+           {
+             "id" : "tracks",
+             "active" : "true",
+             "machines" : [],
+             "query" : "Verticesrof:ITS/VERTICESROF/0;Vertices:ITS/VERTICES/0;tracks:ITS/TRACKS/0;rofs:ITS/ITSTrackROF/0;clustersrof:ITS/CLUSTERSROF/0;compclus:ITS/COMPCLUSTERS/0;patterns:ITS/PATTERNS/0;clusteridx:ITS/TRACKCLSID/0",
+             "samplingConditions" : [
+               {
+                 "condition" : "random",
+                 "fraction" : "1",
+                 "seed" : "1441"
+               }
+             ],
+
+             "blocking" : "false"
+           },
+        {
+            "id": "RAWDATA",
+            "active": "true",
+            "machines": [],
+            "query": "filter:ITS/RAWDATA",
+            "samplingConditions": [
+                {
+                    "condition": "random",
+                    "fraction": "1",
+                    "seed": "1441"
+                }
+            ],
+            "blocking": "false"
+        },
+    {
+      "id": "compclus",
+      "active": "true",
+      "machines": [],
+      "query": "compclus:ITS/COMPCLUSTERS/0;clustersrof:ITS/CLUSTERSROF/0;patterns:ITS/PATTERNS/0",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    }
+         ]
+
+
+}

--- a/Modules/ITS/src/ITSFeeCheck.cxx
+++ b/Modules/ITS/src/ITSFeeCheck.cxx
@@ -66,6 +66,9 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
                 badStaveIB = true;
                 result.updateMetadata("IB", "medium");
                 countStave++;
+                TString text = "Medium:IB stave has many NOK chips;";
+                if (!checkReason(result, text))
+                  result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), text.Data());
               }
             } else if (ibin <= StaveBoundary[5]) {
               // Check if there are staves in the MLs with at least 4 lanes in Bad (bins are filled with %)
@@ -74,6 +77,9 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
                 badStaveML = true;
                 result.updateMetadata("ML", "medium");
                 countStave++;
+                TString text = "Medium:ML stave has many NOK chips;";
+                if (!checkReason(result, text))
+                  result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), text.Data());
               }
             } else if (ibin <= StaveBoundary[7]) {
               // Check if there are staves in the OLs with at least 7 lanes in Bad (bins are filled with %)
@@ -82,6 +88,9 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
                 badStaveOL = true;
                 result.updateMetadata("OL", "medium");
                 countStave++;
+                TString text = "Medium:OL stave has many NOK chips;";
+                if (!checkReason(result, text))
+                  result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), text.Data());
               }
             }
           } // end loop bins (staves)
@@ -91,6 +100,7 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
           if (countStave > 0.25 * NStaves[ilayer]) {
             badStaveCount = true;
             result.updateMetadata(Form("Layer%d", ilayer), "bad");
+            result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("BAD:Layer%d has many NOK staves;", ilayer));
           }
         } // end loop over layers
         if (badStaveIB || badStaveML || badStaveOL) {
@@ -110,6 +120,7 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
       if (h->GetBinContent(1) + h->GetBinContent(2) + h->GetBinContent(3) > maxfractionbadlanes) {
         result.updateMetadata("SummaryGlobal", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("BAD:>%.0f %% of the lanes are bad", (h->GetBinContent(1) + h->GetBinContent(2) + h->GetBinContent(3)) * 100));
       }
     } // end summary loop
     if (mo->getName() == Form("RDHSummary")) {
@@ -141,13 +152,19 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
         if (std::find(skipbins.begin(), skipbins.end(), itrg + 1) != skipbins.end()) {
           continue;
         }
+        bool badTrigger = false;
         if ((itrg == 0 || itrg == 1 || itrg == 4 || itrg == 9 || itrg == 11) && counttrgflags[itrg] < cutvalue[itrg] - (int)skipfeeid.size()) {
           result.updateMetadata(h->GetYaxis()->GetBinLabel(itrg + 1), "bad");
           result.set(Quality::Bad);
+          badTrigger = true;
         } else if ((itrg == 2 || itrg == 3 || itrg == 5 || itrg == 6 || itrg == 7 || itrg == 8 || itrg == 10 || itrg == 12) && counttrgflags[itrg] > cutvalue[itrg]) {
           result.updateMetadata(h->GetYaxis()->GetBinLabel(itrg + 1), "bad");
           result.set(Quality::Bad);
+          badTrigger = true;
         }
+        std::string extraText = (!strcmp(h->GetYaxis()->GetBinLabel(itrg + 1), "PHYSICS")) ? "(OK if it's COSMICS/SYNTHETIC)" : "";
+        if (badTrigger)
+          result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("BAD:Trigger flag %s of bad quality %s", h->GetYaxis()->GetBinLabel(itrg + 1), extraText.c_str()));
       }
     }
 
@@ -282,9 +299,9 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
           } // end check result over layer
         }   // end of loop over layers
       }
-      tInfo = std::make_shared<TLatex>(0.12, 0.835, Form("#bf{%s}", status.Data()));
+      tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
       tInfo->SetTextColor(textColor);
-      tInfo->SetTextSize(0.03);
+      tInfo->SetTextSize(0.06);
       tInfo->SetTextFont(43);
       tInfo->SetNDC();
       hp->GetListOfFunctions()->Add(tInfo->Clone());
@@ -310,9 +327,9 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
         h->GetListOfFunctions()->Add(tInfoSummary->Clone());
       }
     }
-    tInfo = std::make_shared<TLatex>(0.12, 0.835, Form("#bf{%s}", status.Data()));
+    tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
     tInfo->SetTextColor(textColor);
-    tInfo->SetTextSize(0.04);
+    tInfo->SetTextSize(0.06);
     tInfo->SetTextFont(43);
     tInfo->SetNDC();
     h->GetListOfFunctions()->Add(tInfo->Clone());
@@ -328,9 +345,9 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
       status = "Quality::BAD (call expert)";
       textColor = kRed;
     }
-    tInfo = std::make_shared<TLatex>(0.12, 0.835, Form("#bf{%s}", status.Data()));
+    tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
     tInfo->SetTextColor(textColor);
-    tInfo->SetTextSize(0.04);
+    tInfo->SetTextSize(0.06);
     tInfo->SetTextFont(43);
     tInfo->SetNDC();
     h->GetListOfFunctions()->Add(tInfo->Clone());
@@ -360,9 +377,9 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
         }
       }
     }
-    tInfo = std::make_shared<TLatex>(0.12, 0.835, Form("#bf{%s}", status.Data()));
+    tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
     tInfo->SetTextColor(textColor);
-    tInfo->SetTextSize(0.04);
+    tInfo->SetTextSize(0.06);
     tInfo->SetTextFont(43);
     tInfo->SetNDC();
     h->GetListOfFunctions()->Add(tInfo->Clone());
@@ -396,15 +413,25 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
         h->GetListOfFunctions()->Add(tInfoPL[1]->Clone());
       }
     }
-    tInfo = std::make_shared<TLatex>(0.12, 0.75, Form("#bf{%s}", status.Data()));
+    tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
     tInfo->SetTextColor(textColor);
-    tInfo->SetTextSize(0.04);
+    tInfo->SetTextSize(0.06);
     tInfo->SetTextFont(43);
     tInfo->SetNDC();
     h->GetListOfFunctions()->Add(tInfo->Clone());
     if (ShifterInfoText[mo->getName()] != "")
       h->GetListOfFunctions()->Add(tShifterInfo->Clone());
   }
+}
+
+bool ITSFeeCheck::checkReason(Quality checkResult, TString text)
+{
+  auto reasons = checkResult.getReasons();
+  for (int i = 0; i < int(reasons.size()); i++) {
+    if (text.Contains(reasons[i].second.c_str()))
+      return true;
+  }
+  return false;
 }
 
 } // namespace o2::quality_control_modules::its

--- a/Modules/ITS/src/ITSTrackCheck.cxx
+++ b/Modules/ITS/src/ITSTrackCheck.cxx
@@ -51,26 +51,32 @@ Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
 
         result.updateMetadata("CheckMean", "medium");
         result.set(Quality::Medium);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), Form("Medium: Mean (%.1f) is outside 5.2-5.9, ignore for COSMICS and TECHNICALS", h->GetMean()));
       }
       if (h->GetBinContent(h->FindBin(4)) < 1e-15) {
         result.updateMetadata("CheckTracks4", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), "BAD: no tracks with 4 clusters");
       }
       if (h->GetBinContent(h->FindBin(5)) < 1e-15) {
         result.updateMetadata("CheckTracks5", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), "BAD: no tracks with 5 clusters");
       }
       if (h->GetBinContent(h->FindBin(6)) < 1e-15) {
         result.updateMetadata("CheckTracks6", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), "BAD: no tracks with 6 clusters");
       }
       if (h->GetBinContent(h->FindBin(7)) < 1e-15) {
         result.updateMetadata("CheckTracks7", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), "BAD: no tracks with 7 clusters");
       }
       if (h->GetEntries() < 1e-15) {
         result.updateMetadata("CheckEmpty", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), "BAD: no tracks!");
       }
     }
 
@@ -87,14 +93,17 @@ Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
       if (hAngular->GetEntries() < 1e-15) {
         result.updateMetadata("CheckAngEmpty", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), "BAD: no tracks!");
       }
       if (ratioEta > 0.3) {
         result.updateMetadata("CheckAsymmEta", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), "BAD: Eta asymmetry");
       }
       if (ratioPhi > 0.3) {
         result.updateMetadata("CheckAsymmPhi", "bad");
         result.set(Quality::Bad);
+        result.addReason(o2::quality_control::FlagReasonFactory::Unknown(), "BAD: Phi asymmetry");
       }
     }
 
@@ -256,9 +265,9 @@ void ITSTrackCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
       }
     }
 
-    tInfo = std::make_shared<TLatex>(0.12, 0.65, Form("#bf{%s}", status.Data()));
+    tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
     tInfo->SetTextFont(43);
-    tInfo->SetTextSize(0.04);
+    tInfo->SetTextSize(0.06);
     tInfo->SetTextColor(textColor);
     tInfo->SetNDC();
     h->GetListOfFunctions()->Add(tInfo->Clone());
@@ -301,9 +310,9 @@ void ITSTrackCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
       }
     }
 
-    tInfo = std::make_shared<TLatex>(0.12, 0.75, Form("#bf{%s}", status.Data()));
+    tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
     tInfo->SetTextFont(43);
-    tInfo->SetTextSize(0.04);
+    tInfo->SetTextSize(0.06);
     tInfo->SetTextColor(textColor);
     tInfo->SetNDC();
     h->GetListOfFunctions()->Add(tInfo->Clone());


### PR DESCRIPTION
- Added text with QC check information to QualityReason list. In future, it will be used instead of text on top of plots
- Improved readability of QC info messages