### PR TITLE
ITS Fee + Track: nicer plot for GlobalLaneFraction + new ranges for nClusters per Track

### DIFF
--- a/Modules/ITS/include/ITS/ITSFeeTask.h
+++ b/Modules/ITS/include/ITS/ITSFeeTask.h
@@ -32,6 +32,9 @@
 #include <TLine.h>
 #include <TText.h>
 #include <TLatex.h>
+#include <TLine.h>
+#include <TLegend.h>
+#include <TCanvas.h>
 
 class TH2I;
 class TH1I;
@@ -137,6 +140,7 @@ class ITSFeeTask final : public TaskInterface
   TH1D* mLaneStatusSummaryML;
   TH1D* mLaneStatusSummaryOL;
   TH1D* mLaneStatusSummaryGlobal;
+  TCanvas* mLaneStatusSummaryGlobalCanvas;
   TH1I* mProcessingTime;
   TH2F* mPayloadSize; // average payload size vs linkID
   // TH1D* mInfoCanvas;//TODO: default, not implemented yet

--- a/Modules/ITS/include/ITS/ITSTrackCheck.h
+++ b/Modules/ITS/include/ITS/ITSTrackCheck.h
@@ -60,6 +60,7 @@ class ITSTrackCheck : public o2::quality_control::checker::CheckInterface
   }
 
  private:
+  float mEtaRatio = 0.1, mPhiRatio = 0.1;
   std::shared_ptr<TLatex> tInfo;
   std::shared_ptr<TLatex> tMessage[10];
   ClassDefOverride(ITSTrackCheck, 2);

--- a/Modules/ITS/itsTrack.json
+++ b/Modules/ITS/itsTrack.json
@@ -58,7 +58,9 @@
         "detectorName" : "ITS",
                 "checkParameters": {
                       "plotWithTextMessage": "",
-                      "textMessage": ""
+                      "textMessage": "",
+                      "EtaRatio": "0.3",
+                      "PhiRatio": "0.3"
         },
         "dataSource" : [ {
           "type" : "Task",

--- a/Modules/ITS/src/ITSFeeTask.cxx
+++ b/Modules/ITS/src/ITSFeeTask.cxx
@@ -109,6 +109,9 @@ void ITSFeeTask::createFeePlots()
     getObjectsManager()->startPublishing(mLaneStatusSummary[i]); // mLaneStatusSummary
   }
 
+  mLaneStatusSummaryGlobalCanvas = new TCanvas("LaneStatusSummary/SummaryCanvas", "SummaryCanvas",800,600);
+  getObjectsManager()->startPublishing(mLaneStatusSummaryGlobalCanvas);
+
   mLaneStatusSummaryIB = new TH1D("LaneStatusSummary/LaneStatusSummaryIB", "Lane Status Summary IB", 3, 0, 3);
   getObjectsManager()->startPublishing(mLaneStatusSummaryIB); // mLaneStatusSummaryIB
   mLaneStatusSummaryML = new TH1D("LaneStatusSummary/LaneStatusSummaryML", "Lane Status Summary ML", 3, 0, 3);
@@ -116,10 +119,9 @@ void ITSFeeTask::createFeePlots()
   mLaneStatusSummaryOL = new TH1D("LaneStatusSummary/LaneStatusSummaryOL", "Lane Status Summary OL", 3, 0, 3);
   getObjectsManager()->startPublishing(mLaneStatusSummaryOL); // mLaneStatusSummaryOL
   mLaneStatusSummaryGlobal = new TH1D("LaneStatusSummary/LaneStatusSummaryGlobal", "Lane Status Summary Global", 4, 0, 4);
+  mLaneStatusSummaryGlobal->SetMaximum(1);
+  mLaneStatusSummaryGlobal->SetBit(TObject::kCanDelete);
   getObjectsManager()->startPublishing(mLaneStatusSummaryGlobal); // mLaneStatusSummaryGlobal
-
-  mLaneStatusSummaryGlobalCanvas = new TCanvas("LaneStatusSummary/SummaryCanvas", "SummaryCanvas");
-  getObjectsManager()->startPublishing(mLaneStatusSummaryGlobalCanvas);
 
   mFlag1Check = new TH2I("Flag1Check", "Flag 1 Check", NFees, 0, NFees, 3, 0, 3); // Row 1 : transmission_timeout, Row 2 : packet_overflow, Row 3 : lane_starts_violation
   getObjectsManager()->startPublishing(mFlag1Check);                              // mFlag1Check
@@ -476,21 +478,31 @@ void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
   }
 
   mLaneStatusSummaryGlobal->SetBinContent(4, 1. * (counterSummary[0][0] + counterSummary[0][1] + counterSummary[0][2]) / NLanesTotal);
-  mLaneStatusSummaryGlobalCanvas->cd();
-  mLaneStatusSummaryGlobal->SetMaximum(1);
-  mLaneStatusSummaryGlobal->Draw("histo");
-  TLine* line = new TLine(0, 0.1, 4, 0.1);
-  line->SetLineStyle(9);
-  line->SetLineColor(kRed);
-  line->Draw("same");
-  TLatex* tInfo = new TLatex(0.1, 0.11, Form("#bf{%s}", "Threshold value"));
-  tInfo->SetTextSize(0.04);
-  tInfo->SetTextFont(43);
-  tInfo->SetTextColor(kRed);
-  tInfo->Draw("same");
-  delete line;
-  delete tInfo;
 
+
+ //-------------------------------------------  canvas for GlobalSummaryPlot
+  mLaneStatusSummaryGlobalCanvas->cd();
+  mLaneStatusSummaryGlobalCanvas->Clear();
+
+  TLine* mLaneStatusSummaryLine = new TLine(0, 0.1, 4, 0.1);
+  mLaneStatusSummaryLine->SetLineStyle(9);
+  mLaneStatusSummaryLine->SetLineColor(kRed);
+  mLaneStatusSummaryLine->SetBit(TObject::kCanDelete);
+  
+  TLatex* mLaneStatusSummaryInfo = new TLatex(0.1, 0.11, Form("#bf{%s}", "Threshold value"));
+  mLaneStatusSummaryInfo->SetTextSize(0.05);
+  mLaneStatusSummaryInfo->SetTextFont(43);
+  mLaneStatusSummaryInfo->SetTextColor(kRed);
+  mLaneStatusSummaryInfo->SetBit(TObject::kCanDelete);
+
+  TH1F *  mLaneStatusCanvasMember = (TH1F*) mLaneStatusSummaryGlobal->Clone("mLaneStatusCanvasMember");
+  mLaneStatusCanvasMember->SetBit(TObject::kCanDelete);
+
+  mLaneStatusCanvasMember->Draw("histo");
+  mLaneStatusSummaryLine->Draw("same");  
+  mLaneStatusSummaryInfo->Draw("same"); 
+//------end of canvas settings
+ 
   for (int i = 0; i < NFees; i++) {
     if (nStops[i]) {
       float payloadAvg = (float)payloadTot[i] / nStops[i];

--- a/Modules/ITS/src/ITSFeeTask.cxx
+++ b/Modules/ITS/src/ITSFeeTask.cxx
@@ -109,7 +109,7 @@ void ITSFeeTask::createFeePlots()
     getObjectsManager()->startPublishing(mLaneStatusSummary[i]); // mLaneStatusSummary
   }
 
-  mLaneStatusSummaryGlobalCanvas = new TCanvas("LaneStatusSummary/SummaryCanvas", "SummaryCanvas",800,600);
+  mLaneStatusSummaryGlobalCanvas = new TCanvas("LaneStatusSummary/SummaryCanvas", "SummaryCanvas", 800, 600);
   getObjectsManager()->startPublishing(mLaneStatusSummaryGlobalCanvas);
 
   mLaneStatusSummaryIB = new TH1D("LaneStatusSummary/LaneStatusSummaryIB", "Lane Status Summary IB", 3, 0, 3);
@@ -479,8 +479,7 @@ void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
 
   mLaneStatusSummaryGlobal->SetBinContent(4, 1. * (counterSummary[0][0] + counterSummary[0][1] + counterSummary[0][2]) / NLanesTotal);
 
-
- //-------------------------------------------  canvas for GlobalSummaryPlot
+  //-------------------------------------------  canvas for GlobalSummaryPlot
   mLaneStatusSummaryGlobalCanvas->cd();
   mLaneStatusSummaryGlobalCanvas->Clear();
 
@@ -488,21 +487,21 @@ void ITSFeeTask::monitorData(o2::framework::ProcessingContext& ctx)
   mLaneStatusSummaryLine->SetLineStyle(9);
   mLaneStatusSummaryLine->SetLineColor(kRed);
   mLaneStatusSummaryLine->SetBit(TObject::kCanDelete);
-  
+
   TLatex* mLaneStatusSummaryInfo = new TLatex(0.1, 0.11, Form("#bf{%s}", "Threshold value"));
   mLaneStatusSummaryInfo->SetTextSize(0.05);
   mLaneStatusSummaryInfo->SetTextFont(43);
   mLaneStatusSummaryInfo->SetTextColor(kRed);
   mLaneStatusSummaryInfo->SetBit(TObject::kCanDelete);
 
-  TH1F *  mLaneStatusCanvasMember = (TH1F*) mLaneStatusSummaryGlobal->Clone("mLaneStatusCanvasMember");
+  TH1F* mLaneStatusCanvasMember = (TH1F*)mLaneStatusSummaryGlobal->Clone("mLaneStatusCanvasMember");
   mLaneStatusCanvasMember->SetBit(TObject::kCanDelete);
 
   mLaneStatusCanvasMember->Draw("histo");
-  mLaneStatusSummaryLine->Draw("same");  
-  mLaneStatusSummaryInfo->Draw("same"); 
-//------end of canvas settings
- 
+  mLaneStatusSummaryLine->Draw("same");
+  mLaneStatusSummaryInfo->Draw("same");
+  //------end of canvas settings
+
   for (int i = 0; i < NFees; i++) {
     if (nStops[i]) {
       float payloadAvg = (float)payloadTot[i] / nStops[i];

--- a/Modules/ITS/src/ITSTrackCheck.cxx
+++ b/Modules/ITS/src/ITSTrackCheck.cxx
@@ -47,7 +47,7 @@ Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
       result.addMetadata("CheckTracks7", "good");
       result.addMetadata("CheckEmpty", "good");
       result.addMetadata("CheckMean", "good");
-      if (h->GetMean() < 5.2 || h->GetMean() > 5.8) {
+      if (h->GetMean() < 5.2 || h->GetMean() > 6.2) {
 
         result.updateMetadata("CheckMean", "medium");
         result.set(Quality::Medium);
@@ -247,7 +247,7 @@ void ITSTrackCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
         h->GetListOfFunctions()->Add(tMessage[4]->Clone());
       }
       if (strcmp(checkResult.getMetadata("CheckMean").c_str(), "medium") == 0) {
-        tMessage[5] = std::make_shared<TLatex>(0.12, 0.76, Form("#splitline{Mean (%.1f) is outside 5.2-5.9}{ignore for COSMICS and TECHNICALS}", h->GetMean()));
+        tMessage[5] = std::make_shared<TLatex>(0.12, 0.76, Form("#splitline{Mean (%.1f) is outside 5.2-6.2}{ignore for COSMICS and TECHNICALS}", h->GetMean()));
         tMessage[5]->SetTextFont(43);
         tMessage[5]->SetTextSize(0.04);
         tMessage[5]->SetTextColor(kOrange);

--- a/Modules/ITS/src/ITSTrackCheck.cxx
+++ b/Modules/ITS/src/ITSTrackCheck.cxx
@@ -33,6 +33,9 @@ namespace o2::quality_control_modules::its
 
 Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
+  mEtaRatio = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "EtaRatio", mEtaRatio);
+  mPhiRatio = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "PhiRatio", mPhiRatio);
+
   Quality result = 0;
   Int_t id = 0;
   std::map<std::string, std::shared_ptr<MonitorObject>>::iterator iter;
@@ -88,11 +91,11 @@ Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
         result.updateMetadata("CheckAngEmpty", "bad");
         result.set(Quality::Bad);
       }
-      if (ratioEta > 0.3) {
+      if (ratioEta > mEtaRatio) {
         result.updateMetadata("CheckAsymmEta", "bad");
         result.set(Quality::Bad);
       }
-      if (ratioPhi > 0.3) {
+      if (ratioPhi > mPhiRatio) {
         result.updateMetadata("CheckAsymmPhi", "bad");
         result.set(Quality::Bad);
       }


### PR DESCRIPTION
1) changed plot of GlobalFractionLanesSummary -> added 4th bin to show TOTAL number of lanes in NOK, ranges fixed from 1 to 0
2) Added canvas with GlobalFractionLanesSummary to demonstrate threshold for bad run
3) Limits for QC check of nClusterPerTrack changed from 5.2 - 5.9 to 5.2 - 6.2
