### PR TITLE
[QC-429] Introduce Timekeeper to track validity of objects

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -88,7 +88,10 @@ add_library(O2QualityControl
   src/SliceTrendingTaskConfig.cxx
   src/Bookkeeping.cxx
   src/CustomParameters.cxx
-  src/runnerUtils.cxx)
+  src/runnerUtils.cxx
+  src/Timekeeper.cxx
+  src/TimekeeperSynchronous.cxx
+  src/TimekeeperAsynchronous.cxx)
 
 
 target_include_directories(
@@ -228,6 +231,7 @@ add_executable(o2-qc-test-core
                test/testQuality.cxx
                test/testQualityObject.cxx
                test/testTaskInterface.cxx
+               test/testTimekeeper.cxx
                test/testTriggerHelpers.cxx
                test/testVersion.cxx
                )

--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -48,6 +48,7 @@ class ProcessingContext;
 namespace o2::quality_control::core
 {
 
+class Timekeeper;
 class TaskInterface;
 class ObjectsManager;
 
@@ -137,6 +138,7 @@ class TaskRunner : public framework::Task
   std::shared_ptr<monitoring::Monitoring> mCollector;
   std::shared_ptr<TaskInterface> mTask;
   std::shared_ptr<ObjectsManager> mObjectsManager;
+  std::shared_ptr<Timekeeper> mTimekeeper;
   int mRunNumber;
 
   void updateMonitoringStats(framework::ProcessingContext& pCtx);

--- a/Framework/include/QualityControl/Timekeeper.h
+++ b/Framework/include/QualityControl/Timekeeper.h
@@ -1,0 +1,79 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Timekeeper.h
+/// \author Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_TIMEKEEPER_H
+#define QUALITYCONTROL_TIMEKEEPER_H
+
+#include "QualityControl/ValidityInterval.h"
+
+namespace o2::framework
+{
+struct ProcessingContext;
+struct TimingInfo;
+} // namespace o2::framework
+
+namespace o2::quality_control::core
+{
+
+// could be moved to a separate file
+using TimeframeIdRange = o2::math_utils::detail::Bracket<uint32_t>;
+const static TimeframeIdRange gInvalidTimeframeIdRange{
+  std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::min()
+};
+
+class Timekeeper
+{
+ public:
+  explicit Timekeeper(uint64_t nOrbitsPerTF);
+  virtual ~Timekeeper() = default;
+
+  /// \brief sets activity (run) duration
+  void setActivityDuration(ValidityInterval);
+  /// \brief sets start of activity (run), but prioritises the source of information according to the class implementation
+  void setStartOfActivity(validity_time_t ecsTimestamp = 0, validity_time_t configTimestamp = 0, validity_time_t currentTimestamp = 0);
+  /// \brief sets end of activity (run), but prioritises the source of information according to the class implementation
+  void setEndOfActivity(validity_time_t ecsTimestamp = 0, validity_time_t configTimestamp = 0, validity_time_t currentTimestamp = 0);
+
+  /// \brief updates the validity based on the provided timestamp (ms since epoch)
+  virtual void updateByCurrentTimestamp(validity_time_t timestampMs) = 0;
+  /// \brief updates the validity based on the provided TF ID
+  virtual void updateByTimeFrameID(uint32_t tfID) = 0;
+
+  /// \brief resets the state of the mCurrent* counters
+  virtual void reset() = 0;
+
+  ValidityInterval getValidity() const;
+  ValidityInterval getSampleTimespan() const;
+  TimeframeIdRange getTimerangeIdRange() const;
+  ValidityInterval getActivityDuration() const;
+
+ protected:
+  /// \brief defines how a class implementation chooses the activity (run) boundaries
+  virtual validity_time_t activityBoundarySelectionStrategy(validity_time_t ecsTimestamp,
+                                                            validity_time_t configTimestamp,
+                                                            validity_time_t currentTimestamp) = 0;
+
+ protected:
+  ValidityInterval mActivityDuration = gInvalidValidityInterval;        // from O2StartTime to O2EndTime or current timestamp
+  ValidityInterval mCurrentValidityTimespan = gInvalidValidityInterval; // since the last reset time until `update()` call
+  ValidityInterval mCurrentSampleTimespan = gInvalidValidityInterval;   // since the last reset
+  TimeframeIdRange mCurrentTimeframeIdRange = gInvalidTimeframeIdRange; // since the last reset
+
+  uint64_t mNOrbitsPerTF = 0;
+};
+
+} // namespace o2::quality_control::core
+#endif // QUALITYCONTROL_TIMEKEEPER_H

--- a/Framework/include/QualityControl/TimekeeperAsynchronous.h
+++ b/Framework/include/QualityControl/TimekeeperAsynchronous.h
@@ -1,0 +1,46 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TimekeeperAsynchronous.h
+/// \author Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_TIMEKEEPERASYNCHRONOUS_H
+#define QUALITYCONTROL_TIMEKEEPERASYNCHRONOUS_H
+
+#include "Timekeeper.h"
+
+namespace o2::quality_control::core
+{
+
+class TimekeeperAsynchronous : public Timekeeper
+{
+ public:
+  explicit TimekeeperAsynchronous(uint64_t nOrbitsPerTF, validity_time_t windowLengthMs = 0);
+  ~TimekeeperAsynchronous() = default;
+
+  void updateByCurrentTimestamp(validity_time_t timestampMs) override;
+  void updateByTimeFrameID(uint32_t tfID) override;
+  void reset() override;
+
+ protected:
+  validity_time_t activityBoundarySelectionStrategy(validity_time_t ecsTimestamp,
+                                                    validity_time_t configTimestamp,
+                                                    validity_time_t currentTimestamp) override;
+
+ private:
+  validity_time_t mWindowLengthMs = 0;
+};
+
+} // namespace o2::quality_control::core
+
+#endif // QUALITYCONTROL_TIMEKEEPERASYNCHRONOUS_H

--- a/Framework/include/QualityControl/TimekeeperSynchronous.h
+++ b/Framework/include/QualityControl/TimekeeperSynchronous.h
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TimekeeperSynchronous.h
+/// \author Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_TIMEKEEPERSYNCHRONOUS_H
+#define QUALITYCONTROL_TIMEKEEPERSYNCHRONOUS_H
+
+#include "Timekeeper.h"
+
+namespace o2::quality_control::core
+{
+
+class TimekeeperSynchronous : public Timekeeper
+{
+ public:
+  explicit TimekeeperSynchronous(uint64_t nOrbitsPerTF);
+  ~TimekeeperSynchronous() = default;
+
+  void updateByCurrentTimestamp(validity_time_t timestampMs) override;
+  void updateByTimeFrameID(uint32_t tfID) override;
+
+  void reset() override;
+
+ protected:
+  validity_time_t activityBoundarySelectionStrategy(validity_time_t ecsTimestamp,
+                                                    validity_time_t configTimestamp,
+                                                    validity_time_t currentTimestamp) override;
+
+ private:
+  bool mWarnedAboutDataWithoutSOR = false;
+};
+
+} // namespace o2::quality_control::core
+
+#endif // QUALITYCONTROL_TIMEKEEPERSYNCHRONOUS_H

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -30,6 +30,8 @@
 #include <Framework/InputSpan.h>
 #include <Framework/DataRefUtils.h>
 #include <Framework/EndOfStreamContext.h>
+#include <Framework/TimingInfo.h>
+#include <Framework/DataTakingContext.h>
 #include <CommonUtils/ConfigurableParam.h>
 #include <DetectorsBase/GRPGeomHelper.h>
 
@@ -41,6 +43,8 @@
 #include "QualityControl/ConfigParamGlo.h"
 #include "QualityControl/ObjectsManager.h"
 #include "QualityControl/Bookkeeping.h"
+#include "QualityControl/TimekeeperSynchronous.h"
+#include "QualityControl/TimekeeperAsynchronous.h"
 
 #include <string>
 #include <TFile.h>
@@ -107,8 +111,7 @@ void TaskRunner::refreshConfig(InitContext& iCtx)
     ILOG(Warning, Devel) << "Could not get updated config tree in TaskRunner::init() - `qcConfiguration` could not be retrieved" << ENDM;
   } catch (...) {
     // we catch here because we don't know where it will get lost in dpl, and also we don't care if this part has failed.
-    ILOG(Warning, Devel) << "Error caught in refreshConfig() : "
-                         << current_diagnostic(true) << ENDM;
+    ILOG(Warning, Devel) << "Error caught in refreshConfig() : " << current_diagnostic(true) << ENDM;
   }
 }
 
@@ -160,6 +163,15 @@ void TaskRunner::init(InitContext& iCtx)
   // setup publisher
   mObjectsManager = std::make_shared<ObjectsManager>(mTaskConfig.taskName, mTaskConfig.className, mTaskConfig.detectorName, mTaskConfig.consulUrl, mTaskConfig.parallelTaskID);
 
+  // setup timekeeping
+  // fixme: use DataTakingContext.deployment once we can get it during initialization
+  // fixme: use DataTakingContext.nOrbitsPerTF once we can get it during initialization
+  if (mTaskConfig.fallbackActivity.mProvenance == "qc") {
+    mTimekeeper = std::make_shared<TimekeeperSynchronous>(32);
+  } else {
+    mTimekeeper = std::make_shared<TimekeeperAsynchronous>(32);
+  }
+
   // setup user's task
   mTask.reset(TaskFactory::create(mTaskConfig, mObjectsManager));
   mTask->setMonitoring(mCollector);
@@ -201,14 +213,17 @@ void TaskRunner::run(ProcessingContext& pCtx)
   auto [dataReady, timerReady] = validateInputs(pCtx.inputs());
 
   if (dataReady) {
+    mTimekeeper->updateByTimeFrameID(pCtx.services().get<TimingInfo>().tfCounter);
     mTask->monitorData(pCtx);
     updateMonitoringStats(pCtx);
   }
 
   if (timerReady) {
+    mTimekeeper->updateByCurrentTimestamp(pCtx.services().get<TimingInfo>().timeslice / 1000);
     finishCycle(pCtx.outputs());
     if (mTaskConfig.resetAfterCycles > 0 && (mCycleNumber % mTaskConfig.resetAfterCycles == 0)) {
       mTask->reset();
+      mTimekeeper->reset();
     }
     if (mTaskConfig.maxNumberCycles < 0 || mCycleNumber < mTaskConfig.maxNumberCycles) {
       startCycle();
@@ -322,6 +337,8 @@ void TaskRunner::endOfStream(framework::EndOfStreamContext& eosContext)
   if (!mCycleOn && mCycleNumber == 0) {
     ILOG(Error, Support) << "An EndOfStream was received before TaskRunner could start the first cycle, probably the device was not started. Something is wrong, doing nothing." << ENDM;
   } else {
+    ILOG(Info, Trace) << "Updating timekeeper with a current timestamp upon receiving an EoS message" << ENDM;
+    mTimekeeper->updateByCurrentTimestamp(getCurrentTimestamp());
     ILOG(Info, Support) << "Received an EndOfStream, finishing the current cycle" << ENDM;
     finishCycle(eosContext.outputs());
   }
@@ -374,6 +391,7 @@ void TaskRunner::reset()
     mTask.reset();
     mCollector.reset();
     mObjectsManager.reset();
+    mTimekeeper.reset();
     mRunNumber = 0;
   } catch (...) {
     // we catch here because we don't know where it will go in DPL's CallbackService
@@ -431,6 +449,12 @@ void TaskRunner::startOfActivity()
   Activity activity = mTaskConfig.fallbackActivity;
   Bookkeeping::getInstance().populateActivity(activity, mRunNumber);
   mObjectsManager->setActivity(activity);
+
+  auto now = getCurrentTimestamp();
+  mTimekeeper->setStartOfActivity(activity.mValidity.getMin(), mTaskConfig.fallbackActivity.mValidity.getMin(), now);
+  mTimekeeper->updateByCurrentTimestamp(mTimekeeper->getActivityDuration().getMin());
+  mTimekeeper->setEndOfActivity(activity.mValidity.getMax(), mTaskConfig.fallbackActivity.mValidity.getMax(), now);
+
   mCollector->setRunNumber(mRunNumber);
   mTask->startOfActivity(activity);
   mObjectsManager->updateServiceDiscovery();
@@ -438,10 +462,13 @@ void TaskRunner::startOfActivity()
 
 void TaskRunner::endOfActivity()
 {
-  Activity activity = mTaskConfig.fallbackActivity;
-  activity.mId = mRunNumber;
   ILOG(Info, Support) << "Stopping run " << mRunNumber << ENDM;
-  mTask->endOfActivity(activity);
+
+  auto now = getCurrentTimestamp();
+  mTimekeeper->updateByCurrentTimestamp(now);
+  mTimekeeper->setEndOfActivity(0, mTaskConfig.fallbackActivity.mValidity.getMax(), now); // TODO: get end of run from ECS/BK if possible
+
+  mTask->endOfActivity(mObjectsManager->getActivity());
   mObjectsManager->removeAllFromServiceDiscovery();
 
   double rate = mTotalNumberObjectsPublished / mTimerTotalDurationActivity.getTime();
@@ -462,8 +489,13 @@ void TaskRunner::startCycle()
 void TaskRunner::finishCycle(DataAllocator& outputs)
 {
   ILOG(Debug, Support) << "Finish cycle " << mCycleNumber << ENDM;
+  ILOG(Info, Devel) << "According to new validity rules, the objects validity is "
+                    << "(" << mTimekeeper->getValidity().getMin() << ", " << mTimekeeper->getValidity().getMax() << "), "
+                    << "(" << mTimekeeper->getSampleTimespan().getMin() << ", " << mTimekeeper->getSampleTimespan().getMax() << "), "
+                    << "(" << mTimekeeper->getTimerangeIdRange().getMin() << ", " << mTimekeeper->getTimerangeIdRange().getMax() << ")" << ENDM;
   mTask->endOfCycle();
 
+  // this stays until we move to using mTimekeeper.
   auto nowMs = getCurrentTimestamp();
   mObjectsManager->setValidity(ValidityInterval{ nowMs, nowMs + 1000l * 60 * 60 * 24 * 365 * 10 });
   mNumberObjectsPublishedInCycle += publish(outputs);

--- a/Framework/src/TaskRunnerFactory.cxx
+++ b/Framework/src/TaskRunnerFactory.cxx
@@ -70,7 +70,7 @@ TaskRunnerConfig TaskRunnerFactory::extractConfig(const CommonSpec& globalConfig
   // 1. simple, old, way: cycleDurationSeconds is the duration in seconds for all cycles
   // 2. complex, new, way: cycleDurations: a list of tuples specifying different durations to be applied for a certain time
   if (taskSpec.cycleDurationSeconds > 0 && taskSpec.multipleCycleDurations.size() > 0) {
-    throw std::runtime_error("Both cycleDurationSeconds and cycleDurations have been defined. Pick one. Sheepishly bailing out.");
+    throw std::runtime_error("Both cycleDurationSeconds and cycleDurations have been defined for task '" + taskSpec.taskName + "'. Pick one. Sheepishly bailing out.");
   }
   auto multipleCycleDurations = taskSpec.multipleCycleDurations; // this is the new style
   if (taskSpec.cycleDurationSeconds > 0) {                       // if it was actually the old style, then we convert it to the new style

--- a/Framework/src/Timekeeper.cxx
+++ b/Framework/src/Timekeeper.cxx
@@ -1,0 +1,69 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   Timekeeper.cxx
+/// \author Piotr Konopka
+///
+
+#include "QualityControl/Timekeeper.h"
+#include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/runnerUtils.h"
+
+namespace o2::quality_control::core
+{
+
+Timekeeper::Timekeeper(uint64_t nOrbitsPerTF)
+  : mNOrbitsPerTF(nOrbitsPerTF)
+{
+  if (nOrbitsPerTF == 0) {
+    ILOG(Warning, Support) << "nOrbitsPerTF was set to 0, object validity may be incorrectly marked" << ENDM;
+  }
+}
+
+void Timekeeper::setActivityDuration(ValidityInterval validity)
+{
+  mActivityDuration = validity;
+}
+
+ValidityInterval Timekeeper::getValidity() const
+{
+  return mCurrentValidityTimespan;
+}
+
+ValidityInterval Timekeeper::getSampleTimespan() const
+{
+  return mCurrentSampleTimespan;
+}
+
+TimeframeIdRange Timekeeper::getTimerangeIdRange() const
+{
+  return mCurrentTimeframeIdRange;
+}
+
+void Timekeeper::setStartOfActivity(validity_time_t ecsTimestamp, validity_time_t configTimestamp,
+                                    validity_time_t currentTimestamp)
+{
+  mActivityDuration.setMin(activityBoundarySelectionStrategy(ecsTimestamp, configTimestamp, currentTimestamp));
+}
+
+void Timekeeper::setEndOfActivity(validity_time_t ecsTimestamp, validity_time_t configTimestamp,
+                                  validity_time_t currentTimestamp)
+{
+  mActivityDuration.setMax(activityBoundarySelectionStrategy(ecsTimestamp, configTimestamp, currentTimestamp));
+}
+
+ValidityInterval Timekeeper::getActivityDuration() const
+{
+  return mActivityDuration;
+}
+
+} // namespace o2::quality_control::core

--- a/Framework/src/TimekeeperAsynchronous.cxx
+++ b/Framework/src/TimekeeperAsynchronous.cxx
@@ -1,0 +1,104 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TimekeeperAsynchronous.cxx
+/// \author Piotr Konopka
+///
+
+#include "QualityControl/TimekeeperAsynchronous.h"
+#include "QualityControl/QcInfoLogger.h"
+
+#include <CommonConstants/LHCConstants.h>
+
+namespace o2::quality_control::core
+{
+
+TimekeeperAsynchronous::TimekeeperAsynchronous(uint64_t nOrbitsPerTF, validity_time_t windowLengthMs)
+  : Timekeeper(nOrbitsPerTF), mWindowLengthMs(windowLengthMs)
+{
+}
+
+void TimekeeperAsynchronous::updateByCurrentTimestamp(validity_time_t timestampMs)
+{
+  // async QC should ignore current timestamp
+}
+
+void TimekeeperAsynchronous::updateByTimeFrameID(uint32_t tfid)
+{
+  // fixme: We might want to use this once we know how to get orbitResetTime:
+  //  std::ceil((timingInfo.firstTForbit * o2::constants::lhc::LHCOrbitNS / 1000 + orbitResetTime) / 1000);
+  //  Until then, we use a less precise method:
+  if (mActivityDuration.isInvalid()) {
+    ILOG(Warning, Support)
+      << "trying to update the validity range with TF ID without having set the activity duration, returning" << ENDM;
+    return;
+  }
+  auto tfLengthMs = constants::lhc::LHCOrbitNS / 1000000 * mNOrbitsPerTF;
+  auto tfStart = static_cast<validity_time_t>(mActivityDuration.getMin() + tfLengthMs * tfid);
+  auto tfEnd = static_cast<validity_time_t>(mActivityDuration.getMin() + tfLengthMs * (tfid + 1) - 1); // todo ints!
+  mCurrentSampleTimespan.update(tfStart);
+  mCurrentSampleTimespan.update(tfEnd);
+
+  mCurrentTimeframeIdRange.update(tfid);
+
+  if (mActivityDuration.isOutside(tfStart)) {
+    ILOG(Warning, Support) << "Timestamp " << tfStart << " is outside of the assumed run duration ("
+                           << mActivityDuration.getMin() << ", " << mActivityDuration.getMax() << ")" << ENDM;
+    return;
+  }
+
+  if (mWindowLengthMs == 0) {
+    mCurrentValidityTimespan = mActivityDuration;
+  } else {
+    size_t subdivisionIdx = (tfStart - mActivityDuration.getMin()) / mWindowLengthMs;
+    size_t fullSubdivisions = mActivityDuration.delta() / mWindowLengthMs;
+    if (subdivisionIdx < fullSubdivisions - 1) {
+      mCurrentValidityTimespan.update(mActivityDuration.getMin() + subdivisionIdx * mWindowLengthMs);
+      mCurrentValidityTimespan.update(mActivityDuration.getMin() + (subdivisionIdx + 1) * mWindowLengthMs);
+    } else if (subdivisionIdx == fullSubdivisions - 1) {
+      mCurrentValidityTimespan.update(mActivityDuration.getMin() + subdivisionIdx * mWindowLengthMs);
+      mCurrentValidityTimespan.update(mActivityDuration.getMax());
+    } else { // subdivisionIdx == fullSubdivisions
+      mCurrentValidityTimespan.update(mActivityDuration.getMin() + (subdivisionIdx - 1) * mWindowLengthMs);
+      mCurrentValidityTimespan.update(mActivityDuration.getMax());
+    }
+  }
+}
+
+void TimekeeperAsynchronous::reset()
+{
+  mCurrentSampleTimespan = gInvalidValidityInterval;
+  mCurrentValidityTimespan = gInvalidValidityInterval;
+  mCurrentTimeframeIdRange = gInvalidTimeframeIdRange;
+}
+
+validity_time_t
+  TimekeeperAsynchronous::activityBoundarySelectionStrategy(validity_time_t ecsTimestamp, validity_time_t configTimestamp,
+                                                            validity_time_t currentTimestamp)
+{
+  auto notOnLimit = [](validity_time_t value) {
+    return value != std::numeric_limits<validity_time_t>::min() && value != std::numeric_limits<validity_time_t>::max();
+  };
+  validity_time_t selected = 0;
+  if (notOnLimit(ecsTimestamp)) {
+    selected = ecsTimestamp;
+  } else if (notOnLimit(configTimestamp)) {
+    selected = configTimestamp;
+  } else {
+    // an exception could be thrown here once the values above are set correctly in production
+  }
+  ILOG(Info, Devel) << "Received the following activity boundary propositions: " << ecsTimestamp
+                    << ", " << configTimestamp << ", " << currentTimestamp << ". Selected: " << selected << ENDM;
+  return selected;
+}
+
+} // namespace o2::quality_control::core

--- a/Framework/src/TimekeeperSynchronous.cxx
+++ b/Framework/src/TimekeeperSynchronous.cxx
@@ -1,0 +1,86 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TimekeeperSynchronous.cxx
+/// \author Piotr Konopka
+///
+
+#include "QualityControl/TimekeeperSynchronous.h"
+#include "QualityControl/QcInfoLogger.h"
+
+#include <CommonConstants/LHCConstants.h>
+
+namespace o2::quality_control::core
+{
+
+TimekeeperSynchronous::TimekeeperSynchronous(uint64_t nOrbitsPerTF) : Timekeeper(nOrbitsPerTF)
+{
+}
+
+void TimekeeperSynchronous::updateByCurrentTimestamp(validity_time_t timestampMs)
+{
+  mCurrentValidityTimespan.update(timestampMs);
+  mActivityDuration.update(timestampMs);
+}
+
+void TimekeeperSynchronous::updateByTimeFrameID(uint32_t tfid)
+{
+  if (mActivityDuration.getMin() == gInvalidValidityInterval.getMin() || mActivityDuration.isInvalid()) {
+    if (!mWarnedAboutDataWithoutSOR) {
+      ILOG(Warning, Devel)
+        << "Data arrived before SOR time was set, cannot proceed with creating sample timespan. Will not warn further."
+        << ENDM;
+      mWarnedAboutDataWithoutSOR = true;
+    }
+  } else {
+    // fixme: We might want to use this once we know how to get orbitResetTime:
+    //  std::ceil((timingInfo.firstTForbit * o2::constants::lhc::LHCOrbitNS / 1000 + orbitResetTime) / 1000);
+    //  Until then, we use a less precise method:
+    auto tfStart = mActivityDuration.getMin() + constants::lhc::LHCOrbitNS / 1000000 * mNOrbitsPerTF * tfid;
+    auto tfEnd = tfStart + constants::lhc::LHCOrbitNS / 1000000 * mNOrbitsPerTF - 1;
+    mCurrentSampleTimespan.update(tfStart);
+    mCurrentSampleTimespan.update(tfEnd);
+  }
+
+  mCurrentTimeframeIdRange.update(tfid);
+}
+
+void TimekeeperSynchronous::reset()
+{
+  mCurrentSampleTimespan = gInvalidValidityInterval;
+  if (mCurrentValidityTimespan.isValid()) {
+    mCurrentValidityTimespan.set(mCurrentValidityTimespan.getMax(), mCurrentValidityTimespan.getMax());
+  }
+  mCurrentTimeframeIdRange = gInvalidTimeframeIdRange;
+}
+
+validity_time_t
+  TimekeeperSynchronous::activityBoundarySelectionStrategy(validity_time_t ecsTimestamp, validity_time_t configTimestamp,
+                                                           validity_time_t currentTimestamp)
+{
+  auto notOnLimit = [](validity_time_t value) {
+    return value != std::numeric_limits<validity_time_t>::min() && value != std::numeric_limits<validity_time_t>::max();
+  };
+  validity_time_t selected = 0;
+  if (notOnLimit(ecsTimestamp)) {
+    selected = ecsTimestamp;
+  } else if (notOnLimit(currentTimestamp)) {
+    selected = currentTimestamp;
+  } else {
+    selected = configTimestamp;
+  }
+  ILOG(Info, Devel) << "Received the following activity boundary propositions: " << ecsTimestamp
+                    << ", " << configTimestamp << ", " << currentTimestamp << ". Selected: " << selected << ENDM;
+  return selected;
+}
+
+} // namespace o2::quality_control::core

--- a/Framework/test/testTimekeeper.cxx
+++ b/Framework/test/testTimekeeper.cxx
@@ -1,0 +1,307 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    testTimekeeper.cxx
+/// \author  Piotr Konopka
+///
+
+#include "QualityControl/Timekeeper.h"
+#include "QualityControl/TimekeeperSynchronous.h"
+#include "QualityControl/TimekeeperAsynchronous.h"
+#include <Framework/TimingInfo.h>
+
+#include <catch_amalgamated.hpp>
+
+using namespace o2::quality_control::core;
+using namespace o2::framework;
+
+TEST_CASE("timekeeper_synchronous")
+{
+  SECTION("defaults")
+  {
+    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+
+    tk->reset();
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+  }
+
+  SECTION("one_data_point_no_timer")
+  {
+    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    tk->updateByTimeFrameID(5);
+
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 5, 5 });
+
+    tk->reset();
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+  }
+
+  SECTION("no_data_one_timer")
+  {
+    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    tk->updateByCurrentTimestamp(1653000000000);
+
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000000000 });
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+
+    tk->reset();
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000000000 });
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+  }
+
+  SECTION("one_data_point_sor_timer")
+  {
+    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    tk->setActivityDuration(ValidityInterval{ 1653000000000, 1653000000000 });
+    tk->updateByTimeFrameID(5);
+
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    // we need at least one update with timestamp for a valid validity
+    tk->updateByCurrentTimestamp(1653000000000);
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000000000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000014, 1653000000016 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 5, 5 });
+  }
+
+  SECTION("one_data_point_one_timer")
+  {
+    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    tk->updateByCurrentTimestamp(1653000000000);
+    tk->updateByTimeFrameID(5);
+
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000000000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000014, 1653000000016 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 5, 5 });
+
+    tk->reset();
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000000000 });
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+  }
+
+  SECTION("no_data_many_timers")
+  {
+    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    tk->updateByCurrentTimestamp(1655000000000);
+    tk->updateByCurrentTimestamp(1656000000000);
+    tk->updateByCurrentTimestamp(1654000000000); // a timer from the past is rather unexpected, but it should not break anything
+
+    CHECK(tk->getValidity() == ValidityInterval{ 1654000000000, 1656000000000 });
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+
+    tk->reset();
+    tk->updateByCurrentTimestamp(1655000000000); // again, we try with a timestamp which is before the beginning of this window
+    CHECK(tk->getValidity() == ValidityInterval{ 1655000000000, 1656000000000 });
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+  }
+
+  SECTION("many_data_points_many_timers")
+  {
+    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    tk->updateByCurrentTimestamp(1653000000000);
+    tk->updateByTimeFrameID(5);
+    tk->updateByTimeFrameID(7);
+    tk->updateByTimeFrameID(3);
+    tk->updateByTimeFrameID(10);
+    tk->updateByCurrentTimestamp(1653500000000);
+
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653500000000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000008, 1653000000030 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 3, 10 });
+
+    tk->reset();
+    CHECK(tk->getValidity() == ValidityInterval{ 1653500000000, 1653500000000 });
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+
+    tk->updateByTimeFrameID(12);
+    tk->updateByTimeFrameID(54);
+    tk->updateByCurrentTimestamp(1653600000000);
+
+    CHECK(tk->getValidity() == ValidityInterval{ 1653500000000, 1653600000000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000034, 1653000000155 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 12, 54 });
+  }
+
+  SECTION("boundary_selection")
+  {
+    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+
+    // ECS first
+    tk->setStartOfActivity(1, 2, 3);
+    tk->setEndOfActivity(4, 5, 6);
+    CHECK(tk->getActivityDuration().getMin() == 1);
+    CHECK(tk->getActivityDuration().getMax() == 4);
+
+    // current timestamp second
+    tk->setStartOfActivity(0, 2, 3);
+    tk->setEndOfActivity(0, 5, 6);
+    CHECK(tk->getActivityDuration().getMin() == 3);
+    CHECK(tk->getActivityDuration().getMax() == 6);
+    tk->setStartOfActivity(-1, 2, 3);
+    tk->setEndOfActivity(-1, 5, 6);
+    CHECK(tk->getActivityDuration().getMin() == 3);
+    CHECK(tk->getActivityDuration().getMax() == 6);
+
+    // config as the last resort
+    tk->setStartOfActivity(0, 2, 0);
+    tk->setEndOfActivity(0, 5, 0);
+    CHECK(tk->getActivityDuration().getMin() == 2);
+    CHECK(tk->getActivityDuration().getMax() == 5);
+    tk->setStartOfActivity(-1, 2, 0);
+    tk->setEndOfActivity(-1, 5, 0);
+    CHECK(tk->getActivityDuration().getMin() == 2);
+    CHECK(tk->getActivityDuration().getMax() == 5);
+  }
+}
+
+TEST_CASE("timekeeper_asynchronous")
+{
+  SECTION("defaults")
+  {
+    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+
+    tk->reset();
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+  }
+
+  SECTION("timers_have_no_effect")
+  {
+    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    tk->setActivityDuration(ValidityInterval{ 1653000000000, 1655000000000 });
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    tk->updateByCurrentTimestamp(1654000000000);
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+  }
+
+  SECTION("sor_eor_not_set")
+  {
+    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    // duration not set
+    tk->updateByTimeFrameID(1234);
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+
+    // sor set, not eor - not enough
+    tk->setActivityDuration(ValidityInterval{ 1653000000000, 0 });
+    tk->updateByTimeFrameID(1234);
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+
+    // make sure nothing weird happens after reset
+    tk->reset();
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+  }
+
+  SECTION("data_no_moving_window")
+  {
+    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    tk->setActivityDuration(ValidityInterval{ 1653000000000, 1655000000000 });
+
+    tk->updateByTimeFrameID(3);
+    tk->updateByTimeFrameID(10);
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1655000000000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000008, 1653000000030 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 3, 10 });
+
+    tk->reset();
+    CHECK(tk->getValidity() == gInvalidValidityInterval);
+    CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
+    CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
+
+    tk->updateByTimeFrameID(12);
+    tk->updateByTimeFrameID(54);
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1655000000000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000034, 1653000000155 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 12, 54 });
+  }
+
+  SECTION("data_moving_window")
+  {
+    // for "simplicity" assuming TF length of 11246 orbits, which gives us 1.0005 second TF duration
+    auto tk = std::make_shared<TimekeeperAsynchronous>(11246, 30 * 1000);
+    tk->setActivityDuration(ValidityInterval{ 1653000000000, 1653000095000 }); // 95 seconds: 0-30, 30-60, 60-95
+
+    // hitting only the 1st window
+    tk->updateByTimeFrameID(1);
+    tk->updateByTimeFrameID(9);
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000030000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000001000, 1653000009999 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 1, 9 });
+
+    // hitting the 1st and 2nd window
+    tk->reset();
+    tk->updateByTimeFrameID(1);
+    tk->updateByTimeFrameID(55);
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000060000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000001000, 1653000056001 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 1, 55 });
+
+    // hitting the 3rd, extended window in the main part.
+    // there is no 4th window, since we merge the last two to avoid having the last one with too little statistics
+    tk->reset();
+    tk->updateByTimeFrameID(80);
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000060000, 1653000095000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000080003, 1653000081002 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 80, 80 });
+
+    // hitting the 3rd window with a sample which is in the extended part.
+    tk->reset();
+    tk->updateByTimeFrameID(93);
+    CHECK(tk->getValidity() == ValidityInterval{ 1653000060000, 1653000095000 });
+    CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000093004, 1653000094003 });
+    CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 93, 93 });
+  }
+
+  SECTION("boundary_selection")
+  {
+    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+
+    // ECS first
+    tk->setStartOfActivity(1, 2, 3);
+    tk->setEndOfActivity(4, 5, 6);
+    CHECK(tk->getActivityDuration().getMin() == 1);
+    CHECK(tk->getActivityDuration().getMax() == 4);
+
+    // config as the last resort
+    tk->setStartOfActivity(0, 2, 0);
+    tk->setEndOfActivity(0, 5, 0);
+    CHECK(tk->getActivityDuration().getMin() == 2);
+    CHECK(tk->getActivityDuration().getMax() == 5);
+    tk->setStartOfActivity(-1, 2, 0);
+    tk->setEndOfActivity(-1, 5, 0);
+    CHECK(tk->getActivityDuration().getMin() == 2);
+    CHECK(tk->getActivityDuration().getMax() == 5);
+  }
+}


### PR DESCRIPTION
We do not propagate its results to QC objects yet, but log them instead. Once we see the logged values make sense in different setups, we can switch.

Until we can access DataTakingContext during initialization, we are using a naive workaround for determining the deployment mode. We are also assuming that tf has 32 orbits, which does not apply for old data.