### PR TITLE
Set Activity in Check Runner again

### DIFF
--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -150,14 +150,14 @@ class CheckRunner : public framework::Task
    *
    * @param qualityObjects QOs to be stored in DB.
    */
-  void store(QualityObjectsType& qualityObjects);
+  void store(QualityObjectsType& qualityObjects, long validFrom);
 
   /**
    * \brief Store the MonitorObjects in the database.
    *
    * @param monitorObjects MOs to be stored in DB.
    */
-  void store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects);
+  void store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects, long validFrom);
 
   /**
    * \brief Send the QualityObjects on the DataProcessor output channel.

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -238,12 +238,13 @@ void CcdbDatabase::storeMO(std::shared_ptr<const o2::quality_control::core::Moni
   auto from = static_cast<long>(validity.getMin());
   auto to = static_cast<long>(validity.getMax());
 
-  if (from == -1 || validity.getMin() == gInvalidValidityInterval.getMin()) {
+  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
     from = getCurrentTimestamp();
   }
-  if (to == -1 || validity.getMax() == gInvalidValidityInterval.getMax()) {
+  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
     to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
   }
+
   if (from >= to) {
     ILOG(Error, Support) << "The start validity of '" << mo->GetName() << "' is not earlier than the end (" << from << ", " << to << "). The object will not be stored" << ENDM;
     return;
@@ -279,10 +280,10 @@ void CcdbDatabase::storeQO(std::shared_ptr<const o2::quality_control::core::Qual
   auto from = static_cast<long>(validity.getMin());
   auto to = static_cast<long>(validity.getMax());
 
-  if (from == -1 || validity.getMin() == gInvalidValidityInterval.getMin()) {
+  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
     from = getCurrentTimestamp();
   }
-  if (to == -1 || validity.getMax() == gInvalidValidityInterval.getMax()) {
+  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
     to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
   }
   if (from >= to) {

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -240,14 +240,27 @@ void CheckRunner::init(framework::InitContext& iCtx)
   }
 }
 
+long getCurrentTimestamp()
+{
+  auto now = std::chrono::system_clock::now();
+  auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+  auto epoch = now_ms.time_since_epoch();
+  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
+  return value.count();
+}
+
 void CheckRunner::run(framework::ProcessingContext& ctx)
 {
   prepareCacheData(ctx.inputs());
 
   auto qualityObjects = check();
 
-  store(qualityObjects);
-  store(mMonitorObjectStoreVector);
+  // we want all objects that we are going to store to have the same validFrom values.
+  // ideally it should be SOR or the moving window start, but before GUI allows for this,
+  // we have to put the current timestamp.
+  auto now = getCurrentTimestamp();
+  store(qualityObjects, now);
+  store(mMonitorObjectStoreVector, now);
 
   send(qualityObjects, ctx.outputs());
 
@@ -360,11 +373,13 @@ QualityObjectsType CheckRunner::check()
   return allQOs;
 }
 
-void CheckRunner::store(QualityObjectsType& qualityObjects)
+void CheckRunner::store(QualityObjectsType& qualityObjects, long validFrom)
 {
   ILOG(Debug, Devel) << "Storing " << qualityObjects.size() << " QualityObjects" << ENDM;
   try {
     for (auto& qo : qualityObjects) {
+      qo->setActivity(*mActivity);
+      qo->getActivity().mValidity.setMin(validFrom);
       mDatabase->storeQO(qo);
       mTotalNumberQOStored++;
       mNumberQOStored++;
@@ -374,11 +389,13 @@ void CheckRunner::store(QualityObjectsType& qualityObjects)
   }
 }
 
-void CheckRunner::store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects)
+void CheckRunner::store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects, long validFrom)
 {
   ILOG(Debug, Devel) << "Storing " << monitorObjects.size() << " MonitorObjects" << ENDM;
   try {
     for (auto& mo : monitorObjects) {
+      mo->setActivity(*mActivity);
+      mo->getActivity().mValidity.setMin(validFrom);
       mDatabase->storeMO(mo);
       mTotalNumberMOStored++;
       mNumberMOStored++;


### PR DESCRIPTION
this rolls back the changes of the commit below without having to revert a lot of intertwined commits. https://github.com/AliceO2Group/QualityControl/commit/82be5ff2700eed311483ace20d29dd284e4e4b3e

we need to think how aggregators should behave in the new scenario for a proper fix