### PR TITLE
[QC-429] Require nOrbitPerTF at each update by TFID

### DIFF
--- a/Framework/include/QualityControl/Timekeeper.h
+++ b/Framework/include/QualityControl/Timekeeper.h
@@ -37,7 +37,7 @@ const static TimeframeIdRange gInvalidTimeframeIdRange{
 class Timekeeper
 {
  public:
-  explicit Timekeeper(uint64_t nOrbitsPerTF);
+  Timekeeper();
   virtual ~Timekeeper() = default;
 
   /// \brief sets activity (run) duration
@@ -50,7 +50,7 @@ class Timekeeper
   /// \brief updates the validity based on the provided timestamp (ms since epoch)
   virtual void updateByCurrentTimestamp(validity_time_t timestampMs) = 0;
   /// \brief updates the validity based on the provided TF ID
-  virtual void updateByTimeFrameID(uint32_t tfID) = 0;
+  virtual void updateByTimeFrameID(uint32_t tfID, uint64_t nOrbitsPerTF) = 0;
 
   /// \brief resets the state of the mCurrent* counters
   virtual void reset() = 0;
@@ -71,8 +71,6 @@ class Timekeeper
   ValidityInterval mCurrentValidityTimespan = gInvalidValidityInterval; // since the last reset time until `update()` call
   ValidityInterval mCurrentSampleTimespan = gInvalidValidityInterval;   // since the last reset
   TimeframeIdRange mCurrentTimeframeIdRange = gInvalidTimeframeIdRange; // since the last reset
-
-  uint64_t mNOrbitsPerTF = 0;
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/TimekeeperAsynchronous.h
+++ b/Framework/include/QualityControl/TimekeeperAsynchronous.h
@@ -25,11 +25,11 @@ namespace o2::quality_control::core
 class TimekeeperAsynchronous : public Timekeeper
 {
  public:
-  explicit TimekeeperAsynchronous(uint64_t nOrbitsPerTF, validity_time_t windowLengthMs = 0);
+  explicit TimekeeperAsynchronous(validity_time_t windowLengthMs = 0);
   ~TimekeeperAsynchronous() = default;
 
   void updateByCurrentTimestamp(validity_time_t timestampMs) override;
-  void updateByTimeFrameID(uint32_t tfID) override;
+  void updateByTimeFrameID(uint32_t tfID, uint64_t nOrbitsPerTF) override;
   void reset() override;
 
  protected:

--- a/Framework/include/QualityControl/TimekeeperSynchronous.h
+++ b/Framework/include/QualityControl/TimekeeperSynchronous.h
@@ -25,11 +25,11 @@ namespace o2::quality_control::core
 class TimekeeperSynchronous : public Timekeeper
 {
  public:
-  explicit TimekeeperSynchronous(uint64_t nOrbitsPerTF);
+  TimekeeperSynchronous();
   ~TimekeeperSynchronous() = default;
 
   void updateByCurrentTimestamp(validity_time_t timestampMs) override;
-  void updateByTimeFrameID(uint32_t tfID) override;
+  void updateByTimeFrameID(uint32_t tfID, uint64_t nOrbitsPerTF) override;
 
   void reset() override;
 

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -167,9 +167,9 @@ void TaskRunner::init(InitContext& iCtx)
   // fixme: use DataTakingContext.deployment once we can get it during initialization
   // fixme: use DataTakingContext.nOrbitsPerTF once we can get it during initialization
   if (mTaskConfig.fallbackActivity.mProvenance == "qc") {
-    mTimekeeper = std::make_shared<TimekeeperSynchronous>(32);
+    mTimekeeper = std::make_shared<TimekeeperSynchronous>();
   } else {
-    mTimekeeper = std::make_shared<TimekeeperAsynchronous>(32);
+    mTimekeeper = std::make_shared<TimekeeperAsynchronous>();
   }
 
   // setup user's task
@@ -213,7 +213,7 @@ void TaskRunner::run(ProcessingContext& pCtx)
   auto [dataReady, timerReady] = validateInputs(pCtx.inputs());
 
   if (dataReady) {
-    mTimekeeper->updateByTimeFrameID(pCtx.services().get<TimingInfo>().tfCounter);
+    mTimekeeper->updateByTimeFrameID(pCtx.services().get<TimingInfo>().tfCounter, pCtx.services().get<DataTakingContext>().nOrbitsPerTF);
     mTask->monitorData(pCtx);
     updateMonitoringStats(pCtx);
   }

--- a/Framework/src/Timekeeper.cxx
+++ b/Framework/src/Timekeeper.cxx
@@ -21,12 +21,8 @@
 namespace o2::quality_control::core
 {
 
-Timekeeper::Timekeeper(uint64_t nOrbitsPerTF)
-  : mNOrbitsPerTF(nOrbitsPerTF)
+Timekeeper::Timekeeper()
 {
-  if (nOrbitsPerTF == 0) {
-    ILOG(Warning, Support) << "nOrbitsPerTF was set to 0, object validity may be incorrectly marked" << ENDM;
-  }
 }
 
 void Timekeeper::setActivityDuration(ValidityInterval validity)

--- a/Framework/src/TimekeeperAsynchronous.cxx
+++ b/Framework/src/TimekeeperAsynchronous.cxx
@@ -22,8 +22,8 @@
 namespace o2::quality_control::core
 {
 
-TimekeeperAsynchronous::TimekeeperAsynchronous(uint64_t nOrbitsPerTF, validity_time_t windowLengthMs)
-  : Timekeeper(nOrbitsPerTF), mWindowLengthMs(windowLengthMs)
+TimekeeperAsynchronous::TimekeeperAsynchronous(validity_time_t windowLengthMs)
+  : Timekeeper(), mWindowLengthMs(windowLengthMs)
 {
 }
 
@@ -32,7 +32,7 @@ void TimekeeperAsynchronous::updateByCurrentTimestamp(validity_time_t timestampM
   // async QC should ignore current timestamp
 }
 
-void TimekeeperAsynchronous::updateByTimeFrameID(uint32_t tfid)
+void TimekeeperAsynchronous::updateByTimeFrameID(uint32_t tfid, uint64_t nOrbitsPerTF)
 {
   // fixme: We might want to use this once we know how to get orbitResetTime:
   //  std::ceil((timingInfo.firstTForbit * o2::constants::lhc::LHCOrbitNS / 1000 + orbitResetTime) / 1000);
@@ -50,7 +50,7 @@ void TimekeeperAsynchronous::updateByTimeFrameID(uint32_t tfid)
     return;
   }
 
-  auto tfDurationMs = constants::lhc::LHCOrbitNS / 1000000 * mNOrbitsPerTF;
+  auto tfDurationMs = constants::lhc::LHCOrbitNS / 1000000 * nOrbitsPerTF;
   auto tfStart = static_cast<validity_time_t>(mActivityDuration.getMin() + tfDurationMs * (tfid - 1));
   auto tfEnd = static_cast<validity_time_t>(mActivityDuration.getMin() + tfDurationMs * tfid - 1);
   mCurrentSampleTimespan.update(tfStart);

--- a/Framework/src/TimekeeperSynchronous.cxx
+++ b/Framework/src/TimekeeperSynchronous.cxx
@@ -22,7 +22,7 @@
 namespace o2::quality_control::core
 {
 
-TimekeeperSynchronous::TimekeeperSynchronous(uint64_t nOrbitsPerTF) : Timekeeper(nOrbitsPerTF)
+TimekeeperSynchronous::TimekeeperSynchronous() : Timekeeper()
 {
 }
 
@@ -32,7 +32,7 @@ void TimekeeperSynchronous::updateByCurrentTimestamp(validity_time_t timestampMs
   mActivityDuration.update(timestampMs);
 }
 
-void TimekeeperSynchronous::updateByTimeFrameID(uint32_t tfid)
+void TimekeeperSynchronous::updateByTimeFrameID(uint32_t tfid, uint64_t nOrbitsPerTF)
 {
   if (tfid == 0) {
     if (!mWarnedAboutTfIdZero) {
@@ -56,7 +56,7 @@ void TimekeeperSynchronous::updateByTimeFrameID(uint32_t tfid)
   // fixme: We might want to use this once we know how to get orbitResetTime:
   //  std::ceil((timingInfo.firstTForbit * o2::constants::lhc::LHCOrbitNS / 1000 + orbitResetTime) / 1000);
   //  Until then, we use a less precise method:
-  auto tfDuration = constants::lhc::LHCOrbitNS / 1000000 * mNOrbitsPerTF;
+  auto tfDuration = constants::lhc::LHCOrbitNS / 1000000 * nOrbitsPerTF;
   auto tfStart = mActivityDuration.getMin() + tfDuration * (tfid - 1);
   auto tfEnd = tfStart + tfDuration - 1;
   mCurrentSampleTimespan.update(tfStart);

--- a/Framework/test/testTimekeeper.cxx
+++ b/Framework/test/testTimekeeper.cxx
@@ -28,7 +28,7 @@ TEST_CASE("timekeeper_synchronous")
 {
   SECTION("defaults")
   {
-    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    auto tk = std::make_shared<TimekeeperSynchronous>();
     CHECK(tk->getValidity() == gInvalidValidityInterval);
     CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
     CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
@@ -41,8 +41,8 @@ TEST_CASE("timekeeper_synchronous")
 
   SECTION("one_data_point_no_timer")
   {
-    auto tk = std::make_shared<TimekeeperSynchronous>(32);
-    tk->updateByTimeFrameID(5);
+    auto tk = std::make_shared<TimekeeperSynchronous>();
+    tk->updateByTimeFrameID(5, 32);
 
     CHECK(tk->getValidity() == gInvalidValidityInterval);
     CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
@@ -56,7 +56,7 @@ TEST_CASE("timekeeper_synchronous")
 
   SECTION("no_data_one_timer")
   {
-    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    auto tk = std::make_shared<TimekeeperSynchronous>();
     tk->updateByCurrentTimestamp(1653000000000);
 
     CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000000000 });
@@ -71,9 +71,9 @@ TEST_CASE("timekeeper_synchronous")
 
   SECTION("one_data_point_sor_timer")
   {
-    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    auto tk = std::make_shared<TimekeeperSynchronous>();
     tk->setActivityDuration(ValidityInterval{ 1653000000000, 1653000000000 });
-    tk->updateByTimeFrameID(5);
+    tk->updateByTimeFrameID(5, 32);
 
     CHECK(tk->getValidity() == gInvalidValidityInterval);
     // we need at least one update with timestamp for a valid validity
@@ -85,9 +85,9 @@ TEST_CASE("timekeeper_synchronous")
 
   SECTION("one_data_point_one_timer")
   {
-    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    auto tk = std::make_shared<TimekeeperSynchronous>();
     tk->updateByCurrentTimestamp(1653000000000);
-    tk->updateByTimeFrameID(5);
+    tk->updateByTimeFrameID(5, 32);
 
     CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000000000 });
     CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000011, 1653000000013 });
@@ -101,7 +101,7 @@ TEST_CASE("timekeeper_synchronous")
 
   SECTION("no_data_many_timers")
   {
-    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    auto tk = std::make_shared<TimekeeperSynchronous>();
     tk->updateByCurrentTimestamp(1655000000000);
     tk->updateByCurrentTimestamp(1656000000000);
     tk->updateByCurrentTimestamp(1654000000000); // a timer from the past is rather unexpected, but it should not break anything
@@ -119,12 +119,12 @@ TEST_CASE("timekeeper_synchronous")
 
   SECTION("many_data_points_many_timers")
   {
-    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    auto tk = std::make_shared<TimekeeperSynchronous>();
     tk->updateByCurrentTimestamp(1653000000000);
-    tk->updateByTimeFrameID(5);
-    tk->updateByTimeFrameID(7);
-    tk->updateByTimeFrameID(3);
-    tk->updateByTimeFrameID(10);
+    tk->updateByTimeFrameID(5, 32);
+    tk->updateByTimeFrameID(7, 32);
+    tk->updateByTimeFrameID(3, 32);
+    tk->updateByTimeFrameID(10, 32);
     tk->updateByCurrentTimestamp(1653500000000);
 
     CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653500000000 });
@@ -136,8 +136,8 @@ TEST_CASE("timekeeper_synchronous")
     CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
     CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
 
-    tk->updateByTimeFrameID(12);
-    tk->updateByTimeFrameID(54);
+    tk->updateByTimeFrameID(12, 32);
+    tk->updateByTimeFrameID(54, 32);
     tk->updateByCurrentTimestamp(1653600000000);
 
     CHECK(tk->getValidity() == ValidityInterval{ 1653500000000, 1653600000000 });
@@ -147,7 +147,7 @@ TEST_CASE("timekeeper_synchronous")
 
   SECTION("boundary_selection")
   {
-    auto tk = std::make_shared<TimekeeperSynchronous>(32);
+    auto tk = std::make_shared<TimekeeperSynchronous>();
 
     // ECS first
     tk->setStartOfActivity(1, 2, 3);
@@ -181,7 +181,7 @@ TEST_CASE("timekeeper_asynchronous")
 {
   SECTION("defaults")
   {
-    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    auto tk = std::make_shared<TimekeeperAsynchronous>();
     CHECK(tk->getValidity() == gInvalidValidityInterval);
     CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
     CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
@@ -194,7 +194,7 @@ TEST_CASE("timekeeper_asynchronous")
 
   SECTION("timers_have_no_effect")
   {
-    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    auto tk = std::make_shared<TimekeeperAsynchronous>();
     tk->setActivityDuration(ValidityInterval{ 1653000000000, 1655000000000 });
     CHECK(tk->getValidity() == gInvalidValidityInterval);
     tk->updateByCurrentTimestamp(1654000000000);
@@ -203,16 +203,16 @@ TEST_CASE("timekeeper_asynchronous")
 
   SECTION("sor_eor_not_set")
   {
-    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    auto tk = std::make_shared<TimekeeperAsynchronous>();
     // duration not set
-    tk->updateByTimeFrameID(1234);
+    tk->updateByTimeFrameID(1234, 32);
     CHECK(tk->getValidity() == gInvalidValidityInterval);
     CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
     CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
 
     // sor set, not eor - not enough
     tk->setActivityDuration(ValidityInterval{ 1653000000000, 0 });
-    tk->updateByTimeFrameID(1234);
+    tk->updateByTimeFrameID(1234, 32);
     CHECK(tk->getValidity() == gInvalidValidityInterval);
     CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
     CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
@@ -226,11 +226,11 @@ TEST_CASE("timekeeper_asynchronous")
 
   SECTION("data_no_moving_window")
   {
-    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    auto tk = std::make_shared<TimekeeperAsynchronous>();
     tk->setActivityDuration(ValidityInterval{ 1653000000000, 1655000000000 });
 
-    tk->updateByTimeFrameID(3);
-    tk->updateByTimeFrameID(10);
+    tk->updateByTimeFrameID(3, 32);
+    tk->updateByTimeFrameID(10, 32);
     CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1655000000000 });
     CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000005, 1653000000027 });
     CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 3, 10 });
@@ -240,8 +240,8 @@ TEST_CASE("timekeeper_asynchronous")
     CHECK(tk->getSampleTimespan() == gInvalidValidityInterval);
     CHECK(tk->getTimerangeIdRange() == gInvalidTimeframeIdRange);
 
-    tk->updateByTimeFrameID(12);
-    tk->updateByTimeFrameID(54);
+    tk->updateByTimeFrameID(12, 32);
+    tk->updateByTimeFrameID(54, 32);
     CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1655000000000 });
     CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000031, 1653000000152 });
     CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 12, 54 });
@@ -250,20 +250,21 @@ TEST_CASE("timekeeper_asynchronous")
   SECTION("data_moving_window")
   {
     // for "simplicity" assuming TF length of 11246 orbits, which gives us 1.0005 second TF duration
-    auto tk = std::make_shared<TimekeeperAsynchronous>(11246, 30 * 1000);
+    const auto nOrbitPerTF = 11246;
+    auto tk = std::make_shared<TimekeeperAsynchronous>(30 * 1000);
     tk->setActivityDuration(ValidityInterval{ 1653000000000, 1653000095000 }); // 95 seconds: 0-30, 30-60, 60-95
 
     // hitting only the 1st window
-    tk->updateByTimeFrameID(1);
-    tk->updateByTimeFrameID(10);
+    tk->updateByTimeFrameID(1, nOrbitPerTF);
+    tk->updateByTimeFrameID(10, nOrbitPerTF);
     CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000030000 });
     CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000000, 1653000009999 });
     CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 1, 10 });
 
     // hitting the 1st and 2nd window
     tk->reset();
-    tk->updateByTimeFrameID(1);
-    tk->updateByTimeFrameID(55);
+    tk->updateByTimeFrameID(1, nOrbitPerTF);
+    tk->updateByTimeFrameID(55, nOrbitPerTF);
     CHECK(tk->getValidity() == ValidityInterval{ 1653000000000, 1653000060000 });
     CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000000000, 1653000055001 });
     CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 1, 55 });
@@ -271,14 +272,14 @@ TEST_CASE("timekeeper_asynchronous")
     // hitting the 3rd, extended window in the main part.
     // there is no 4th window, since we merge the last two to avoid having the last one with too little statistics
     tk->reset();
-    tk->updateByTimeFrameID(80);
+    tk->updateByTimeFrameID(80, nOrbitPerTF);
     CHECK(tk->getValidity() == ValidityInterval{ 1653000060000, 1653000095000 });
     CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000079003, 1653000080002 });
     CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 80, 80 });
 
     // hitting the 3rd window with a sample which is in the extended part.
     tk->reset();
-    tk->updateByTimeFrameID(93);
+    tk->updateByTimeFrameID(93, nOrbitPerTF);
     CHECK(tk->getValidity() == ValidityInterval{ 1653000060000, 1653000095000 });
     CHECK(tk->getSampleTimespan() == ValidityInterval{ 1653000092004, 1653000093003 });
     CHECK(tk->getTimerangeIdRange() == TimeframeIdRange{ 93, 93 });
@@ -286,7 +287,7 @@ TEST_CASE("timekeeper_asynchronous")
 
   SECTION("boundary_selection")
   {
-    auto tk = std::make_shared<TimekeeperAsynchronous>(32);
+    auto tk = std::make_shared<TimekeeperAsynchronous>();
 
     // ECS first
     tk->setStartOfActivity(1, 2, 3);


### PR DESCRIPTION
because it is not accessible during initialization.