### PR TITLE
[QC-429] Correct validity information in NewObject and Periodic Triggers

### DIFF
--- a/Framework/include/QualityControl/Triggers.h
+++ b/Framework/include/QualityControl/Triggers.h
@@ -66,8 +66,8 @@ struct Trigger {
 
   TriggerType triggerType;
   bool last;
-  core::Activity activity;
-  uint64_t timestamp;
+  core::Activity activity; // if tracking an object, it contains also its validity start and end
+  uint64_t timestamp;      // if tracking an object, it is the validity start (validFrom)
   std::string config{};
 };
 


### PR DESCRIPTION
This will allow TrendingTask and similar ones to use the validity end as timestamps on trends. If they were to use validFrom of objects with correct validity, all the points would land in the same timestamp. Using validUntil instead makes sense, as it basically indicates the last update of an object.

There will be a separate PR changing the code in Trending-like tasks, since that one may take longer to pass reviews of all module owners.