### PR TITLE
[QC-429] Trending tasks should use End Of Validity for point timestamps

### DIFF
--- a/Framework/src/ActivityHelpers.cxx
+++ b/Framework/src/ActivityHelpers.cxx
@@ -102,7 +102,9 @@ std::function<validity_time_t(void)> getCcdbSorTimeAccessor(uint64_t runNumber)
 
 std::function<validity_time_t(void)> getCcdbEorTimeAccessor(uint64_t runNumber)
 {
-  return [runNumber]() { return static_cast<validity_time_t>(ccdb::BasicCCDBManager::instance().getRunDuration(runNumber, false).second); };
+  return [runNumber]() {
+    return static_cast<validity_time_t>(ccdb::BasicCCDBManager::instance().getRunDuration(runNumber, false).second);
+  };
 }
 
 bool isLegacyValidity(ValidityInterval validity)

--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -22,6 +22,7 @@
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/RepoPathUtils.h"
+#include "QualityControl/ActivityHelpers.h"
 
 #include <string>
 #include <TGraphErrors.h>
@@ -124,9 +125,10 @@ void SliceTrendingTask::finalize(Trigger t, framework::ServiceRegistryRef)
 void SliceTrendingTask::trendValues(const Trigger& t,
                                     repository::DatabaseInterface& qcdb)
 {
-  mTime = t.timestamp / 1000; // ROOT expects seconds since epoch.
+  mTime = activity_helpers::isLegacyValidity(t.activity.mValidity)
+            ? t.timestamp / 1000
+            : t.activity.mValidity.getMax() / 1000; // ROOT expects seconds since epoch.
   mMetaData.runNumber = t.activity.mId;
-
   for (auto& dataSource : mConfig.dataSources) {
     mNumberPads[dataSource.name] = 0;
     mSources[dataSource.name]->clear();

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -21,6 +21,7 @@
 #include "QualityControl/Reductor.h"
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/RepoPathUtils.h"
+#include "QualityControl/ActivityHelpers.h"
 
 #include <TH1.h>
 #include <TH2F.h>
@@ -142,7 +143,9 @@ void TrendingTask::finalize(Trigger, framework::ServiceRegistryRef)
 
 void TrendingTask::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
-  mTime = t.timestamp / 1000; // ROOT expects seconds since epoch.
+  mTime = activity_helpers::isLegacyValidity(t.activity.mValidity)
+            ? t.timestamp / 1000
+            : t.activity.mValidity.getMax() / 1000; // ROOT expects seconds since epoch.
   mMetaData.runNumber = t.activity.mId;
 
   for (auto& dataSource : mConfig.dataSources) {

--- a/Modules/FIT/FDD/src/PostProcTask.cxx
+++ b/Modules/FIT/FDD/src/PostProcTask.cxx
@@ -83,7 +83,7 @@ void PostProcTask::configure(const boost::property_tree::ptree& config)
   node = config.get_child_optional(Form("%s.custom.timestampSourceLhcIf", configPath));
   if (node) {
     mTimestampSourceLhcIf = node.get_ptr()->get_child("").get_value<std::string>();
-    if (mTimestampSourceLhcIf == "last" || mTimestampSourceLhcIf == "trigger" || mTimestampSourceLhcIf == "metadata") {
+    if (mTimestampSourceLhcIf == "last" || mTimestampSourceLhcIf == "trigger" || mTimestampSourceLhcIf == "metadata" || mTimestampSourceLhcIf == "validUntil") {
       ILOG(Debug, Support) << "configure() : using timestampSourceLhcIf = \"" << mTimestampSourceLhcIf << "\"" << ENDM;
     } else {
       auto prev = mTimestampSourceLhcIf;
@@ -364,6 +364,8 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistryRef)
     ts = -1;
   } else if (mTimestampSourceLhcIf == "trigger") {
     ts = t.timestamp;
+  } else if (mTimestampSourceLhcIf == "validUntil") {
+    ts = t.activity.mValidity.getMax();
   } else if (mTimestampSourceLhcIf == "metadata") {
     for (auto metainfo : moBCvsTriggers->getMetadataMap()) {
       if (metainfo.first == "TFcreationTime")

--- a/Modules/FIT/FT0/src/PostProcTask.cxx
+++ b/Modules/FIT/FT0/src/PostProcTask.cxx
@@ -289,6 +289,8 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistryRef)
     ts = -1;
   } else if (mTimestampSourceLhcIf == "trigger") {
     ts = t.timestamp;
+  } else if (mTimestampSourceLhcIf == "validUntil") {
+    ts = t.activity.mValidity.getMax();
   } else if (mTimestampSourceLhcIf == "metadata") {
     for (auto metainfo : moBCvsTriggers->getMetadataMap()) {
       if (metainfo.first == "TFcreationTime")

--- a/Modules/FIT/FV0/src/PostProcTask.cxx
+++ b/Modules/FIT/FV0/src/PostProcTask.cxx
@@ -86,7 +86,7 @@ void PostProcTask::configure(const boost::property_tree::ptree& config)
   node = config.get_child_optional(Form("%s.custom.timestampSourceLhcIf", configPath));
   if (node) {
     mTimestampSourceLhcIf = node.get_ptr()->get_child("").get_value<std::string>();
-    if (mTimestampSourceLhcIf == "last" || mTimestampSourceLhcIf == "trigger" || mTimestampSourceLhcIf == "metadata") {
+    if (mTimestampSourceLhcIf == "last" || mTimestampSourceLhcIf == "trigger" || mTimestampSourceLhcIf == "metadata" || mTimestampSourceLhcIf == "validUntil") {
       ILOG(Debug, Support) << "configure() : using timestampSourceLhcIf = \"" << mTimestampSourceLhcIf << "\"" << ENDM;
     } else {
       auto prev = mTimestampSourceLhcIf;
@@ -428,6 +428,8 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistryRef)
     ts = -1;
   } else if (mTimestampSourceLhcIf == "trigger") {
     ts = t.timestamp;
+  } else if (mTimestampSourceLhcIf == "validUntil") {
+    ts = t.activity.mValidity.getMax();
   } else if (mTimestampSourceLhcIf == "metadata") {
     for (auto metainfo : moBCvsTriggers->getMetadataMap()) {
       if (metainfo.first == "TFcreationTime")

--- a/Modules/MUON/MCH/src/TrendingTracks.cxx
+++ b/Modules/MUON/MCH/src/TrendingTracks.cxx
@@ -25,6 +25,7 @@
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Reductor.h"
 #include "QualityControl/RootClassFactory.h"
+#include "QualityControl/ActivityHelpers.h"
 #include <boost/property_tree/ptree.hpp>
 #include <TH1.h>
 #include <TMath.h>
@@ -116,8 +117,9 @@ void TrendingTracks::finalize(Trigger t, framework::ServiceRegistryRef)
 
 void TrendingTracks::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
-  mTime = t.timestamp / 1000; // ROOT expects seconds since epoch
-  mMetaData.runNumber = t.activity.mId;
+  mTime = activity_helpers::isLegacyValidity(t.activity.mValidity)
+            ? t.timestamp / 1000
+            : t.activity.mValidity.getMax() / 1000; // ROOT expects seconds since epoch.  mMetaData.runNumber = t.activity.mId;
 
   std::shared_ptr<o2::quality_control::core::MonitorObject> moClusPerChamber = nullptr;
 

--- a/Modules/TOF/src/TrendingHits.cxx
+++ b/Modules/TOF/src/TrendingHits.cxx
@@ -23,6 +23,7 @@
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Reductor.h"
 #include "QualityControl/RootClassFactory.h"
+#include "QualityControl/ActivityHelpers.h"
 #include <boost/property_tree/ptree.hpp>
 #include <TH1.h>
 #include <TCanvas.h>
@@ -74,7 +75,9 @@ void TrendingHits::finalize(Trigger t, framework::ServiceRegistryRef)
 
 void TrendingHits::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
-  mTime = t.timestamp / 1000; // ROOT expects seconds since epoch
+  mTime = activity_helpers::isLegacyValidity(t.activity.mValidity)
+            ? t.timestamp / 1000
+            : t.activity.mValidity.getMax() / 1000; // ROOT expects seconds since epoch.
   mMetaData.runNumber = t.activity.mId;
 
   for (auto& dataSource : mConfig.dataSources) {

--- a/Modules/TOF/src/TrendingRate.cxx
+++ b/Modules/TOF/src/TrendingRate.cxx
@@ -25,6 +25,7 @@
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Reductor.h"
 #include "QualityControl/RootClassFactory.h"
+#include "QualityControl/ActivityHelpers.h"
 #include <boost/property_tree/ptree.hpp>
 #include <TH1.h>
 #include <TMath.h>
@@ -214,7 +215,9 @@ void TrendingRate::finalize(Trigger t, framework::ServiceRegistryRef)
 
 void TrendingRate::trendValues(const Trigger& t, repository::DatabaseInterface& qcdb)
 {
-  mTime = t.timestamp / 1000; // ROOT expects seconds since epoch
+  mTime = activity_helpers::isLegacyValidity(t.activity.mValidity)
+            ? t.timestamp / 1000
+            : t.activity.mValidity.getMax() / 1000; // ROOT expects seconds since epoch.
   mMetaData.runNumber = t.activity.mId;
 
   mActiveChannels = o2::tof::Geo::NCHANNELS;

--- a/Modules/TPC/src/TrendingTaskTPC.cxx
+++ b/Modules/TPC/src/TrendingTaskTPC.cxx
@@ -20,6 +20,7 @@
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/ActivityHelpers.h"
 #include "TPC/TrendingTaskTPC.h"
 #include "QualityControl/RepoPathUtils.h"
 
@@ -149,7 +150,9 @@ void TrendingTaskTPC::finalize(Trigger t, framework::ServiceRegistryRef)
 void TrendingTaskTPC::trendValues(const Trigger& t,
                                   repository::DatabaseInterface& qcdb)
 {
-  mTime = t.timestamp / 1000; // ROOT expects seconds since epoch.
+  mTime = activity_helpers::isLegacyValidity(t.activity.mValidity)
+            ? t.timestamp / 1000
+            : t.activity.mValidity.getMax() / 1000; // ROOT expects seconds since epoch.
   mMetaData.runNumber = t.activity.mId;
 
   for (auto& dataSource : mConfig.dataSources) {

--- a/Modules/TRD/src/TRDTrending.cxx
+++ b/Modules/TRD/src/TRDTrending.cxx
@@ -23,6 +23,7 @@
 #include "QualityControl/ObjectMetadataKeys.h"
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/RepoPathUtils.h"
+#include "QualityControl/ActivityHelpers.h"
 #include <TDatime.h>
 #include <TH1.h>
 #include <TCanvas.h>


### PR DESCRIPTION
If trended objects follow the new validity rules, they should use the end of validity as the timestamp of a data point, since the start will be usually the same (SOR). I did not touch tasks which use creation time or current timestamp instead, since these will not be affected by the change. FIT tasks have a way to select what kind of timestamps should be used, so I added a new option for "validUntil".