### PR TITLE
MCH: updates for async QC

### DIFF
--- a/Modules/MUON/MCH/include/MCH/DigitsTask.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsTask.h
@@ -93,6 +93,7 @@ class DigitsTask /*final*/ : public TaskInterface // todo add back the "final" w
 
   uint32_t mNOrbits[FecId::sFeeNum][FecId::sLinkNum];
   uint32_t mLastOrbitSeen[FecId::sFeeNum][FecId::sLinkNum];
+  int mNOrbitsPerTF{ -1 };
 
   // 2D Histograms, using Elec view (where x and y uniquely identify each pad based on its Elec info (fee, link, de)
   std::unique_ptr<MergeableTH2Ratio> mHistogramOccupancyElec;       // Occupancy histogram (Elec view)

--- a/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
@@ -47,8 +47,10 @@ void DigitsPostProcessing::configure(const boost::property_tree::ptree& config)
   mCcdbObjects.emplace(orbitsSourceName(), CcdbObjectHelper());
   mCcdbObjects.emplace(orbitsSignalSourceName(), CcdbObjectHelper());
 
-  mCcdbObjectsRef.emplace(rateSourceName(), CcdbObjectHelper());
-  mCcdbObjectsRef.emplace(rateSignalSourceName(), CcdbObjectHelper());
+  if (mRefTimeStamp > 0) {
+    mCcdbObjectsRef.emplace(rateSourceName(), CcdbObjectHelper());
+    mCcdbObjectsRef.emplace(rateSignalSourceName(), CcdbObjectHelper());
+  }
 
   for (auto source : mchConfig.dataSources) {
     std::string sourceType, sourceName;

--- a/Modules/MUON/MCH/src/DigitsTask.cxx
+++ b/Modules/MUON/MCH/src/DigitsTask.cxx
@@ -28,6 +28,7 @@
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHRawDecoder/DataDecoder.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 #include <Framework/InputRecord.h>
 #include <CommonConstants/LHCConstants.h>
 #include <DetectorsRaw/HBFUtils.h>
@@ -127,6 +128,8 @@ void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
   bool hasOrbits = checkInput(ctx, "orbits");
 
+  mNOrbitsPerTF = o2::base::GRPGeomHelper::instance().getNHBFPerTF();
+
   if (hasOrbits) {
     // if (ctx.inputs().isValid("orbits")) {
     auto orbits = ctx.inputs().get<gsl::span<uint64_t>>("orbits");
@@ -174,7 +177,7 @@ void DigitsTask::addDefaultOrbitsInTF()
 {
   for (int fee = 0; fee < FecId::sFeeNum; fee++) {
     for (int li = 0; li < FecId::sLinkNum; li++) {
-      mNOrbits[fee][li] += o2::raw::HBFUtils::Instance().getNOrbitsPerTF();
+      mNOrbits[fee][li] += mNOrbitsPerTF;
     }
   }
 }

--- a/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
@@ -38,13 +38,14 @@ void PreclustersPostProcessing::configure(const boost::property_tree::ptree& con
   mFullHistos = mchConfig.getParameter<bool>("FullHistos", false);
 
   mCcdbObjects.emplace(effSourceName(), CcdbObjectHelper());
-  mCcdbObjectsRef.emplace(effSourceName(), CcdbObjectHelper());
-
   mCcdbObjects.emplace(clusterChargeSourceName(), CcdbObjectHelper());
-  mCcdbObjectsRef.emplace(clusterChargeSourceName(), CcdbObjectHelper());
-
   mCcdbObjects.emplace(clusterSizeSourceName(), CcdbObjectHelper());
-  mCcdbObjectsRef.emplace(clusterSizeSourceName(), CcdbObjectHelper());
+
+  if (mRefTimeStamp > 0) {
+    mCcdbObjectsRef.emplace(effSourceName(), CcdbObjectHelper());
+    mCcdbObjectsRef.emplace(clusterChargeSourceName(), CcdbObjectHelper());
+    mCcdbObjectsRef.emplace(clusterSizeSourceName(), CcdbObjectHelper());
+  }
 
   for (auto source : mchConfig.dataSources) {
     std::string sourceType, sourceName;


### PR DESCRIPTION
A couple of fixes for the async processing:
- do not try to load reference plots if time stamp is not provided
- read TF length from gRPC in digits task