### PR TITLE
[O2-2818] Disable FairMQ's autoBind in the proxies

### DIFF
--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -374,7 +374,7 @@ void InfrastructureGenerator::generateDataSamplingPolicyLocalProxyBind(framework
   std::string proxyName = policyName + "-proxy";
   std::string channelName = policyName + "-" + localMachine;
   std::string channelConfig = "name=" + channelName + ",type=pub,method=bind,address=tcp://*:" + localPort +
-                              ",rateLogging=60,transport=zeromq,sndBufSize=4";
+                              ",rateLogging=60,transport=zeromq,sndBufSize=4,autoBind=false";
   auto channelSelector = [channelName](InputSpec const&, const std::unordered_map<std::string, std::vector<fair::mq::Channel>>&) {
     return channelName;
   };
@@ -445,7 +445,7 @@ void InfrastructureGenerator::generateDataSamplingPolicyRemoteProxyBind(framewor
   const std::string& channelName = policyName;
   const std::string& proxyName = channelName; // channel name has to match proxy name
 
-  std::string channelConfig = "name=" + channelName + ",type=sub,method=bind,address=tcp://*:" + remotePort + ",rateLogging=60,transport=zeromq,rcvBufSize=1";
+  std::string channelConfig = "name=" + channelName + ",type=sub,method=bind,address=tcp://*:" + remotePort + ",rateLogging=60,transport=zeromq,rcvBufSize=1,autoBind=false";
 
   auto proxy = specifyExternalFairMQDeviceProxy(
     proxyName.c_str(),
@@ -491,7 +491,7 @@ void InfrastructureGenerator::generateLocalTaskRemoteProxy(framework::WorkflowSp
   }
 
   std::string channelConfig = "name=" + channelName + ",type=sub,method=bind,address=tcp://*:" + remotePort +
-                              ",rateLogging=60,transport=zeromq,rcvBufSize=1";
+                              ",rateLogging=60,transport=zeromq,rcvBufSize=1,autoBind=false";
 
   auto proxy = specifyExternalFairMQDeviceProxy(
     proxyName.c_str(),


### PR DESCRIPTION
This prevents FairMQ from binding another port if it fails to bind the specified one.