### PR TITLE
[QC-429] Force 10y validity for the time being

### DIFF
--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -379,7 +379,7 @@ void CheckRunner::store(QualityObjectsType& qualityObjects, long validFrom)
   try {
     for (auto& qo : qualityObjects) {
       qo->setActivity(*mActivity);
-      qo->getActivity().mValidity.setMin(validFrom);
+      qo->getActivity().mValidity.set(validFrom, 0);
       mDatabase->storeQO(qo);
       mTotalNumberQOStored++;
       mNumberQOStored++;
@@ -395,7 +395,7 @@ void CheckRunner::store(std::vector<std::shared_ptr<MonitorObject>>& monitorObje
   try {
     for (auto& mo : monitorObjects) {
       mo->setActivity(*mActivity);
-      mo->getActivity().mValidity.setMin(validFrom);
+      mo->getActivity().mValidity.set(validFrom, 0);
       mDatabase->storeMO(mo);
       mTotalNumberMOStored++;
       mNumberMOStored++;


### PR DESCRIPTION
In this corner case, we were downloading SOR and EOR of an existing run (42) from BK, but overwriting SOR in CheckRunner to keep the old behaviour. However, we were not overwriting EOR, thus using the time from the past, making validity invalid. This forces CcdbDatabase to apply 10y validity until we move to the new rules.