### PR TITLE
TPC Aggregator & Update of QualityObserver

### DIFF
--- a/Modules/TPC/CMakeLists.txt
+++ b/Modules/TPC/CMakeLists.txt
@@ -31,7 +31,8 @@ target_sources(O2QcTPC PRIVATE src/PID.cxx
                              src/CheckOfPads.cxx
                              src/CalPadClusterReductor.cxx
                              src/IDCScaleReductor.cxx
-                             src/SACs.cxx)
+                             src/SACs.cxx
+                             src/TPCAggregator.cxx)
 
 target_include_directories(
   O2QcTPC
@@ -83,6 +84,7 @@ add_root_dictionary(O2QcTPC
                             include/TPC/CalPadClusterReductor.h
                             include/TPC/IDCScaleReductor.h
                             include/TPC/SACs.h
+                            include/TPC/TPCAggregator.h
                     LINKDEF include/TPC/LinkDef.h)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/TPC

--- a/Modules/TPC/include/TPC/LinkDef.h
+++ b/Modules/TPC/include/TPC/LinkDef.h
@@ -36,6 +36,7 @@
 #pragma link C++ class o2::quality_control_modules::tpc::CalPadClusterReductor + ;
 #pragma link C++ class o2::quality_control_modules::tpc::IDCScaleReductor + ;
 #pragma link C++ class o2::quality_control_modules::tpc::SACs + ;
+#pragma link C++ class o2::quality_control_modules::tpc::TPCAggregator + ;
 
 #pragma link C++ function o2::quality_control_modules::tpc::addAndPublish + ;
 #pragma link C++ function o2::quality_control_modules::tpc::toVector + ;

--- a/Modules/TPC/include/TPC/QualityObserver.h
+++ b/Modules/TPC/include/TPC/QualityObserver.h
@@ -75,6 +75,7 @@ class QualityObserver : public PostProcessingInterface
   std::unordered_map<std::string, std::vector<std::string>> mQualities;
   std::unordered_map<std::string, int> mColors;
   TCanvas* mCanvas = nullptr;
+  size_t mLineLength = 70;
 
   bool mViewDetails;
   std::unordered_map<std::string, std::vector<std::string>> mReasons;

--- a/Modules/TPC/include/TPC/QualityObserver.h
+++ b/Modules/TPC/include/TPC/QualityObserver.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
+#include <TPaveText.h>
 class TCanvas;
 
 namespace o2::quality_control::repository
@@ -64,6 +65,10 @@ class QualityObserver : public PostProcessingInterface
   void getQualities(const Trigger& t, o2::quality_control::repository::DatabaseInterface&);
   /// \brief Method to create and publish the overview panel
   void generatePanel();
+  /// \brief Method to add text to the TPaveText
+  void generateText(TPaveText* pt, bool isReason, std::string QOMetaText);
+  /// \brief Method to break Text into smaller pieces
+  void breakText(TPaveText* pt, std::string infoType, std::string textUnbroken);
 
   std::vector<Config> mConfig;
   std::string mObserverName;

--- a/Modules/TPC/include/TPC/TPCAggregator.h
+++ b/Modules/TPC/include/TPC/TPCAggregator.h
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TPCAggregator.h
+/// \author Marcel Lesch
+///
+
+#ifndef QUALITYCONTROL_TPCAGGREGATOR_H
+#define QUALITYCONTROL_TPCAGGREGATOR_H
+
+// ROOT
+#include <Rtypes.h>
+// QC
+#include "QualityControl/AggregatorInterface.h"
+
+namespace o2::quality_control_modules::tpc
+{
+
+/// \brief  Aggregator which selects the worst Quality and aggregates MetaData of TPC QOs
+/// \author Marcel Lesch
+class TPCAggregator : public o2::quality_control::checker::AggregatorInterface
+{
+ public:
+  // Override interface
+  void configure() override;
+  std::map<std::string, o2::quality_control::core::Quality>
+    aggregate(o2::quality_control::core::QualityObjectsMapType& qoMap) override;
+
+  ClassDefOverride(TPCAggregator, 1);
+};
+
+} // namespace o2::quality_control_modules::tpc
+
+#endif // QUALITYCONTROL_TPCAGGREGATOR_H

--- a/Modules/TPC/include/TPC/TPCAggregator.h
+++ b/Modules/TPC/include/TPC/TPCAggregator.h
@@ -36,6 +36,9 @@ class TPCAggregator : public o2::quality_control::checker::AggregatorInterface
     aggregate(o2::quality_control::core::QualityObjectsMapType& qoMap) override;
 
   ClassDefOverride(TPCAggregator, 1);
+
+ private:
+  void insertQOName(std::string& MetaData, std::string& insertTitle);
 };
 
 } // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/run/tpcQCCheckTrending.json
+++ b/Modules/TPC/run/tpcQCCheckTrending.json
@@ -19,6 +19,20 @@
       "conditionDB": {
         "url": "ccdb-test.cern.ch:8080"
       }
+    },    
+    "aggregators": {
+      "TPCTestAggregator1": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::TPCAggregator",
+        "moduleName": "QcTPC",
+        "policy": "OnAll",
+        "detectorName": "TPC",
+        "dataSource": [{
+          "type": "Check",
+          "name": "CheckOfTrack_Trending",
+            "QOs" : ["Tracks_Trending/hEta_StatMean_Trend", "Tracks_Trending/hNClustersAfterCuts_StatMean_Trend" ]
+        }]
+      }
     },
     "checks" : {
       "CheckOfPID_Trending" : {
@@ -60,12 +74,12 @@
         "dataSource" : [ {
           "type" : "PostProcessing",
           "name" : "Tracks_Trending",
-          "MOs" : [ "hEta_StatMean_Trend" ]
+          "MOs" : [ "hEta_StatMean_Trend", "hNClustersAfterCuts_StatMean_Trend" ]
         } ],
 
         "stopTrigger_comment": [ "Parameters are needed to choose if check should be performed only as last point comparison to average or average comparison to expected value." ],
         "checkParameters": {
-          "CheckChoice" : "Zero, Mean",
+          "CheckChoice" : "Range",
           "SliceTrending" : "false",
           "expectedPhysicsValue" : "0.1",
           "EPV_comment" : "This value is used for the Expected Physics Value and the Range Check",
@@ -124,13 +138,39 @@
         "detectorName": "TPC",
         "qualityObserverName": "TestQualityCheckerTrending",
         "observeDetails": "true", 
-        "qualityDetailChoice": "Null, Good, Medium, Bad",
+        "qualityDetailChoice": "Null, Good, Medium, Bad, Comment",
         "qualityObserverConfig": [
           {
             "groupTitle": "Tracks Trending",
             "path": "TPC/QO/",
             "inputObjects": [ "CheckOfTrack_Trending/Tracks_Trending/hEta_StatMean_Trend", "CheckOfTrack_Trending_Slice/Tracks_Trending_Slice/hEta_StatMean_Trend" ],
             "inputObjectTitles": [ "Eta, Mean Trend, Framework Trend",  "Eta, Mean Trend, Slice Trend" ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "10 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "TestTPCAggregatorObserver": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::QualityObserver",
+        "moduleName": "QcTPC",
+        "detectorName": "TPC",
+        "qualityObserverName": "TestQualityCheckerTrending",
+        "observeDetails": "true", 
+        "qualityDetailChoice": "Null, Good, Medium, Bad, Comment",
+        "qualityObserverConfig": [
+          {
+            "groupTitle": "Tracks Trending",
+            "path": "TPC/QO/",
+            "inputObjects": [ "CheckOfTrack_Trending/Tracks_Trending/hEta_StatMean_Trend", "CheckOfTrack_Trending/Tracks_Trending/hNClustersAfterCuts_StatMean_Trend", "TPCTestAggregator1/TPCTestAggregator1" ],
+            "inputObjectTitles": [ "Eta",  "NClusters", "Aggregated" ]
           }
         ],
         "initTrigger": [

--- a/Modules/TPC/run/tpcQCCheckTrending.json
+++ b/Modules/TPC/run/tpcQCCheckTrending.json
@@ -23,9 +23,9 @@
     "aggregators": {
       "TPCTestAggregator1": {
         "active": "true",
-        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "className": "o2::quality_control_modules::tpc::TPCAggregator",
         "moduleName": "QcTPC",
-        "policy": "OnAll",
+        "policy": "OnAny",
         "detectorName": "TPC",
         "dataSource": [{
           "type": "Check",

--- a/Modules/TPC/run/tpcQCCheckTrending.json
+++ b/Modules/TPC/run/tpcQCCheckTrending.json
@@ -32,6 +32,23 @@
           "name": "CheckOfTrack_Trending",
             "QOs" : ["Tracks_Trending/hEta_StatMean_Trend", "Tracks_Trending/hNClustersAfterCuts_StatMean_Trend" ]
         }]
+      }, 
+      "TPCTestAggregator2": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tpc::TPCAggregator",
+        "moduleName": "QcTPC",
+        "policy": "OnAny",
+        "detectorName": "TPC",
+        "dataSource": [{
+          "type": "Aggregator",
+          "name": "TPCTestAggregator1",
+            "QOs" : ["TPCTestAggregator1" ]
+        },
+        {
+          "type": "Check",
+          "name": "CheckOfTrack_Trending",
+            "QOs" : ["Tracks_Trending/hNClustersBeforeCuts_StatMean_Trend" ]
+        }]
       }
     },
     "checks" : {
@@ -74,7 +91,7 @@
         "dataSource" : [ {
           "type" : "PostProcessing",
           "name" : "Tracks_Trending",
-          "MOs" : [ "hEta_StatMean_Trend", "hNClustersAfterCuts_StatMean_Trend" ]
+          "MOs" : [ "hEta_StatMean_Trend", "hNClustersAfterCuts_StatMean_Trend", "hNClustersBeforeCuts_StatMean_Trend" ]
         } ],
 
         "stopTrigger_comment": [ "Parameters are needed to choose if check should be performed only as last point comparison to average or average comparison to expected value." ],
@@ -164,13 +181,14 @@
         "detectorName": "TPC",
         "qualityObserverName": "TestQualityCheckerTrending",
         "observeDetails": "true", 
-        "qualityDetailChoice": "Null, Good, Medium, Bad, Comment",
+        "qualityDetailChoice": "Null, Good, Medium, Bad",
+        "lineLength": "70",
         "qualityObserverConfig": [
           {
             "groupTitle": "Tracks Trending",
             "path": "TPC/QO/",
-            "inputObjects": [ "CheckOfTrack_Trending/Tracks_Trending/hEta_StatMean_Trend", "CheckOfTrack_Trending/Tracks_Trending/hNClustersAfterCuts_StatMean_Trend", "TPCTestAggregator1/TPCTestAggregator1" ],
-            "inputObjectTitles": [ "Eta",  "NClusters", "Aggregated" ]
+            "inputObjects": [ "CheckOfTrack_Trending/Tracks_Trending/hEta_StatMean_Trend", "CheckOfTrack_Trending/Tracks_Trending/hNClustersAfterCuts_StatMean_Trend", "CheckOfTrack_Trending/Tracks_Trending/hNClustersBeforeCuts_StatMean_Trend", "TPCTestAggregator1/TPCTestAggregator1", "TPCTestAggregator2/TPCTestAggregator2" ],
+            "inputObjectTitles": [ "Eta",  "NClusters after", "NClusters before", "Aggregated 1", "Aggregated 2" ]
           }
         ],
         "initTrigger": [

--- a/Modules/TPC/run/tpcQCCheckTrending.json
+++ b/Modules/TPC/run/tpcQCCheckTrending.json
@@ -23,7 +23,7 @@
     "aggregators": {
       "TPCTestAggregator1": {
         "active": "true",
-        "className": "o2::quality_control_modules::tpc::TPCAggregator",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
         "moduleName": "QcTPC",
         "policy": "OnAll",
         "detectorName": "TPC",

--- a/Modules/TPC/src/QualityObserver.cxx
+++ b/Modules/TPC/src/QualityObserver.cxx
@@ -171,36 +171,10 @@ void QualityObserver::generatePanel()
       ((TText*)pt->GetListOfLines()->Last())->SetTextAlign(12);
 
       if (mViewDetails && mQualityDetails[mQualities[config.groupTitle].at(i).data()]) {
-
-        generateText(pt, true, mReasons[config.groupTitle].at(i));   // print reasons
-        generateText(pt, false, mComments[config.groupTitle].at(i)); // print comments
-        std::cout << "5" << std::endl;
-        std::cout << "6" << std::endl;
-
-        /* if (mReasons[config.groupTitle].at(i) != "") {
-          std::string delimiter = "\n";
-
-          if (mReasons[config.groupTitle].at(i).find(delimiter) != std::string::npos) {
-            size_t pos = 0;
-            std::string subText;
-            while ((pos = mReasons[config.groupTitle].at(i).find(delimiter)) != std::string::npos) {
-              subText = mReasons[config.groupTitle].at(i).substr(0, pos);
-              pt->AddText(Form("#color[%d]{#rightarrow Reason: %s}", kGray + 2, subText.data()));
-              ((TText*)pt->GetListOfLines()->Last())->SetTextAlign(12);
-              mReasons[config.groupTitle].at(i).erase(0, pos + delimiter.length());
-            }
-          } else {
-            pt->AddText(Form("#color[%d]{#rightarrow Reason: %s}", kGray + 2, mReasons[config.groupTitle].at(i).data()));
-            ((TText*)pt->GetListOfLines()->Last())->SetTextAlign(12);
-          }
-        }
-        if (mComments[config.groupTitle].at(i) != "") {
-          pt->AddText(Form("#color[%d]{#rightarrow Comment: %s}", kGray + 2, mComments[config.groupTitle].at(i).data()));
-          ((TText*)pt->GetListOfLines()->Last())->SetTextAlign(12);
-        }*/
+        generateText(pt, true, mReasons[config.groupTitle].at(i)); // print reasons
       }
       if (mViewDetails && mQualityDetails["Comment"]) {
-        // generateText(pt, false, mComments[config.groupTitle].at(i)); //print comments
+        generateText(pt, false, mComments[config.groupTitle].at(i)); // print comments //GANESHA ask berkin if this if should be there
       }
     }
 
@@ -218,9 +192,6 @@ void QualityObserver::generatePanel()
 
 void QualityObserver::generateText(TPaveText* pt, bool isReason, std::string qoMetaText)
 {
-
-  ILOG(Warning, Support) << "Entering generateText" << ENDM;
-
   std::string infoType = "Reason";
   if (!isReason) {
     infoType = "Comment";
@@ -236,34 +207,26 @@ void QualityObserver::generateText(TPaveText* pt, bool isReason, std::string qoM
         qoMetaText.erase(0, pos + delimiter.length());
 
         breakText(pt, infoType, subText); // break up reason/comment for better visualisation on qcg
-        // pt->AddText(Form("#color[%d]{#rightarrow %s: %s}", kGray + 2, infoType.data(), subText.data()));
-        //((TText*)pt->GetListOfLines()->Last())->SetTextAlign(12);
       }
     } else {
       breakText(pt, infoType, qoMetaText);
-      // pt->AddText(Form("#color[%d]{#rightarrow %s: %s}", kGray + 2, infoType.data(), qoMetaText.data()));
-      //((TText*)pt->GetListOfLines()->Last())->SetTextAlign(12);
     }
   } // if (qoMetaText != "")
-  ILOG(Warning, Support) << "Exiting generateText" << ENDM;
 }
 
 void QualityObserver::breakText(TPaveText* pt, std::string infoType, std::string textUnbroken)
 {
-  ILOG(Warning, Support) << "   Entering breakText" << ENDM;
   const size_t maxStringLength = 40; // GANESHA this has to be configurable
   std::string subLine = "";
   std::string subLineDelimiter = " ";
   size_t subpos = 0;
 
   if (textUnbroken.length() < maxStringLength) {
-    ILOG(Warning, Support) << "   Here 0" << ENDM;
     pt->AddText(Form("#color[%d]{#rightarrow %s: %s}", kGray + 2, infoType.data(), textUnbroken.data()));
     ((TText*)pt->GetListOfLines()->Last())->SetTextAlign(12);
-    ILOG(Warning, Support) << "   Leaving breakText" << ENDM;
     return;
   }
-  ILOG(Warning, Support) << "   Here 1" << ENDM;
+
   if (textUnbroken.find(subLineDelimiter) != std::string::npos) {
     bool firstOccurance = true;
     int colorInfoType = kGray + 2;
@@ -315,11 +278,8 @@ void QualityObserver::breakText(TPaveText* pt, std::string infoType, std::string
     }
 
   } else { // string longer than maxStringLength but does not contain subLineDelimiter
-    ILOG(Warning, Support) << "   Here 4" << ENDM;
     pt->AddText(Form("#color[%d]{#rightarrow %s: %s}", kGray + 2, infoType.data(), textUnbroken.data()));
     ((TText*)pt->GetListOfLines()->Last())->SetTextAlign(12);
-    ILOG(Warning, Support) << "   Leaving breakText" << ENDM;
     return;
   }
-  ILOG(Warning, Support) << "   Leaving breakText" << ENDM;
 }

--- a/Modules/TPC/src/QualityObserver.cxx
+++ b/Modules/TPC/src/QualityObserver.cxx
@@ -34,7 +34,7 @@ void QualityObserver::configure(const boost::property_tree::ptree& config)
   auto& id = getID();
   mObserverName = config.get<std::string>("qc.postprocessing." + id + ".qualityObserverName");
   mViewDetails = config.get<bool>("qc.postprocessing." + id + ".observeDetails", true);
-  mQualityDetailChoice = config.get<std::string>("qc.postprocessing." + id + ".qualityDetailChoice", "Null, Good, Medium, Bad, Comment");
+  mQualityDetailChoice = config.get<std::string>("qc.postprocessing." + id + ".qualityDetailChoice", "Null, Good, Medium, Bad");
   mLineLength = config.get<size_t>("qc.postprocessing." + id + ".lineLength", 70);
 
   for (const auto& dataSourceConfig : config.get_child("qc.postprocessing." + id + ".qualityObserverConfig")) {

--- a/Modules/TPC/src/TPCAggregator.cxx
+++ b/Modules/TPC/src/TPCAggregator.cxx
@@ -52,13 +52,16 @@ std::map<std::string, Quality> TPCAggregator::aggregate(QualityObjectsMapType& q
       current.addReason(reason.first, reason.second);
     }
 
-    // AggregatorMetaData[qo->getQuality().getName()] += fmt::format("{}\n", qo->getName());
     std::string qoTitle = qo->getName();
     std::string qoMetaData = qo->getQuality().getMetadata(qo->getQuality().getName(), "");
     std::string qoMetaDataComment = qo->getQuality().getMetadata("Comment", "");
     std::string insertTitle = "(" + qoTitle + ") \n";
 
-    /*if(qoMetaData != ""){
+   ILOG(Error, Support) << qoTitle << ENDM;
+   ILOG(Error, Support) << qoMetaData << ENDM;
+   ILOG(Error, Support) << qoMetaDataComment << ENDM;
+
+    /* if(qoMetaData != ""){
       std::string delimiter = "\n";
       size_t pos = 0;
       while ((pos = qoMetaData.find("\n", pos)) != std::string::npos) {
@@ -74,7 +77,7 @@ std::map<std::string, Quality> TPCAggregator::aggregate(QualityObjectsMapType& q
         qoMetaDataComment.replace(pos,delimiter.size(),insertTitle);
         pos += insertTitle.size();
       }
-    }*/
+    }*/ 
 
     AggregatorMetaData[qo->getQuality().getName()] += qoMetaData;
     AggregatorMetaData["Comment"] += qoMetaDataComment;
@@ -85,11 +88,17 @@ std::map<std::string, Quality> TPCAggregator::aggregate(QualityObjectsMapType& q
   }
   ILOG(Info, Devel) << "Aggregated Quality: " << current << ENDM;
 
-  current.addMetadata(Quality::Bad.getName(), AggregatorMetaData[Quality::Bad.getName()]);
-  current.addMetadata(Quality::Medium.getName(), AggregatorMetaData[Quality::Medium.getName()]);
-  current.addMetadata(Quality::Good.getName(), AggregatorMetaData[Quality::Good.getName()]);
-  current.addMetadata(Quality::Null.getName(), AggregatorMetaData[Quality::Null.getName()]);
-  current.addMetadata("Comment", AggregatorMetaData["Comment"]);
+  //current.addMetadata(Quality::Bad.getName(), AggregatorMetaData[Quality::Bad.getName()]);
+  //current.addMetadata(Quality::Medium.getName(), AggregatorMetaData[Quality::Medium.getName()]);
+  //current.addMetadata(Quality::Good.getName(), AggregatorMetaData[Quality::Good.getName()]);
+  //current.addMetadata(Quality::Null.getName(), AggregatorMetaData[Quality::Null.getName()]);
+  //current.addMetadata("Comment", AggregatorMetaData["Comment"]);
+
+  current.addMetadata(Quality::Bad.getName(), "TestBAD");
+  current.addMetadata(Quality::Medium.getName(), "TestMEDIUM");
+  current.addMetadata(Quality::Good.getName(), "TestGOOD");
+  current.addMetadata(Quality::Null.getName(), "TestNULL");
+  current.addMetadata("Comment","TestCOMMENT");
 
   return { { mName, current } };
 }

--- a/Modules/TPC/src/TPCAggregator.cxx
+++ b/Modules/TPC/src/TPCAggregator.cxx
@@ -57,27 +57,8 @@ std::map<std::string, Quality> TPCAggregator::aggregate(QualityObjectsMapType& q
     std::string qoMetaDataComment = qo->getQuality().getMetadata("Comment", "");
     std::string insertTitle = "(" + qoTitle + ") \n";
 
-   ILOG(Error, Support) << qoTitle << ENDM;
-   ILOG(Error, Support) << qoMetaData << ENDM;
-   ILOG(Error, Support) << qoMetaDataComment << ENDM;
-
-    /* if(qoMetaData != ""){
-      std::string delimiter = "\n";
-      size_t pos = 0;
-      while ((pos = qoMetaData.find("\n", pos)) != std::string::npos) {
-        qoMetaData.replace(pos,delimiter.size(),insertTitle);
-        pos += insertTitle.size();
-      }
-    }
-
-    if(qoMetaDataComment != ""){
-      std::string delimiter = "\n";
-      size_t pos = 0;
-      while ((pos = qoMetaDataComment.find("\n", pos)) != std::string::npos) {
-        qoMetaDataComment.replace(pos,delimiter.size(),insertTitle);
-        pos += insertTitle.size();
-      }
-    }*/ 
+    insertQOName(qoMetaData, insertTitle);
+    insertQOName(qoMetaDataComment, insertTitle);
 
     AggregatorMetaData[qo->getQuality().getName()] += qoMetaData;
     AggregatorMetaData["Comment"] += qoMetaDataComment;
@@ -88,19 +69,33 @@ std::map<std::string, Quality> TPCAggregator::aggregate(QualityObjectsMapType& q
   }
   ILOG(Info, Devel) << "Aggregated Quality: " << current << ENDM;
 
-  //current.addMetadata(Quality::Bad.getName(), AggregatorMetaData[Quality::Bad.getName()]);
-  //current.addMetadata(Quality::Medium.getName(), AggregatorMetaData[Quality::Medium.getName()]);
-  //current.addMetadata(Quality::Good.getName(), AggregatorMetaData[Quality::Good.getName()]);
-  //current.addMetadata(Quality::Null.getName(), AggregatorMetaData[Quality::Null.getName()]);
-  //current.addMetadata("Comment", AggregatorMetaData["Comment"]);
-
-  current.addMetadata(Quality::Bad.getName(), "TestBAD");
-  current.addMetadata(Quality::Medium.getName(), "TestMEDIUM");
-  current.addMetadata(Quality::Good.getName(), "TestGOOD");
-  current.addMetadata(Quality::Null.getName(), "TestNULL");
-  current.addMetadata("Comment","TestCOMMENT");
+  current.addMetadata(Quality::Bad.getName(), AggregatorMetaData[Quality::Bad.getName()]);
+  current.addMetadata(Quality::Medium.getName(), AggregatorMetaData[Quality::Medium.getName()]);
+  current.addMetadata(Quality::Good.getName(), AggregatorMetaData[Quality::Good.getName()]);
+  current.addMetadata(Quality::Null.getName(), AggregatorMetaData[Quality::Null.getName()]);
+  current.addMetadata("Comment", AggregatorMetaData["Comment"]);
 
   return { { mName, current } };
+}
+
+void TPCAggregator::insertQOName(std::string& metaData, std::string& insertTitle)
+{
+
+  std::string delimiter = "\n";
+  size_t pos = 0;
+
+  if (metaData != "") {
+    if (metaData.find(delimiter) != std::string::npos) {
+      while ((pos = metaData.find("\n", pos)) != std::string::npos) {
+        metaData.replace(pos, delimiter.size(), insertTitle);
+        pos += insertTitle.size();
+      }
+    } else {
+      metaData += " " + insertTitle;
+    }
+  }
+
+  return;
 }
 
 } // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/src/TPCAggregator.cxx
+++ b/Modules/TPC/src/TPCAggregator.cxx
@@ -1,0 +1,97 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TPCAggregator.cxx
+/// \author Marcel Lesch
+///
+
+#include "TPC/TPCAggregator.h"
+#include "QualityControl/QcInfoLogger.h"
+
+using namespace o2::quality_control::core;
+using namespace o2::quality_control;
+
+namespace o2::quality_control_modules::tpc
+{
+
+void TPCAggregator::configure()
+{
+}
+
+std::map<std::string, Quality> TPCAggregator::aggregate(QualityObjectsMapType& qoMap)
+{
+  if (qoMap.empty()) {
+    Quality null = Quality::Null;
+    std::string NullReason = "QO map given to the aggregator '" + mName + "' is empty.";
+    null.addReason(FlagReasonFactory::UnknownQuality(), NullReason);
+    null.addMetadata(Quality::Null.getName(), NullReason);
+    return { { mName, null } };
+  }
+
+  std::unordered_map<std::string, std::string> AggregatorMetaData;
+  AggregatorMetaData[Quality::Null.getName()] = "";
+  AggregatorMetaData[Quality::Bad.getName()] = "";
+  AggregatorMetaData[Quality::Medium.getName()] = "";
+  AggregatorMetaData[Quality::Good.getName()] = "";
+  AggregatorMetaData["Comment"] = "";
+
+  // we return the worse quality of all the objects we receive, but we preserve all FlagReasons
+  Quality current = Quality::Good;
+  for (const auto& [qoName, qo] : qoMap) {
+    (void)qoName;
+    for (const auto& reason : qo->getReasons()) {
+      current.addReason(reason.first, reason.second);
+    }
+
+    // AggregatorMetaData[qo->getQuality().getName()] += fmt::format("{}\n", qo->getName());
+    std::string qoTitle = qo->getName();
+    std::string qoMetaData = qo->getQuality().getMetadata(qo->getQuality().getName(), "");
+    std::string qoMetaDataComment = qo->getQuality().getMetadata("Comment", "");
+    std::string insertTitle = "(" + qoTitle + ") \n";
+
+    /*if(qoMetaData != ""){
+      std::string delimiter = "\n";
+      size_t pos = 0;
+      while ((pos = qoMetaData.find("\n", pos)) != std::string::npos) {
+        qoMetaData.replace(pos,delimiter.size(),insertTitle);
+        pos += insertTitle.size();
+      }
+    }
+
+    if(qoMetaDataComment != ""){
+      std::string delimiter = "\n";
+      size_t pos = 0;
+      while ((pos = qoMetaDataComment.find("\n", pos)) != std::string::npos) {
+        qoMetaDataComment.replace(pos,delimiter.size(),insertTitle);
+        pos += insertTitle.size();
+      }
+    }*/
+
+    AggregatorMetaData[qo->getQuality().getName()] += qoMetaData;
+    AggregatorMetaData["Comment"] += qoMetaDataComment;
+
+    if (qo->getQuality().isWorseThan(current)) {
+      current.set(qo->getQuality());
+    }
+  }
+  ILOG(Info, Devel) << "Aggregated Quality: " << current << ENDM;
+
+  current.addMetadata(Quality::Bad.getName(), AggregatorMetaData[Quality::Bad.getName()]);
+  current.addMetadata(Quality::Medium.getName(), AggregatorMetaData[Quality::Medium.getName()]);
+  current.addMetadata(Quality::Good.getName(), AggregatorMetaData[Quality::Good.getName()]);
+  current.addMetadata(Quality::Null.getName(), AggregatorMetaData[Quality::Null.getName()]);
+  current.addMetadata("Comment", AggregatorMetaData["Comment"]);
+
+  return { { mName, current } };
+}
+
+} // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/src/TPCAggregator.cxx
+++ b/Modules/TPC/src/TPCAggregator.cxx
@@ -55,7 +55,7 @@ std::map<std::string, Quality> TPCAggregator::aggregate(QualityObjectsMapType& q
     std::string qoTitle = qo->getName();
     std::string qoMetaData = qo->getQuality().getMetadata(qo->getQuality().getName(), "");
     std::string qoMetaDataComment = qo->getQuality().getMetadata("Comment", "");
-    std::string insertTitle = "(" + qoTitle + ") \n";
+    std::string insertTitle = qoTitle + ": ";
 
     insertQOName(qoMetaData, insertTitle);
     insertQOName(qoMetaDataComment, insertTitle);
@@ -87,11 +87,19 @@ void TPCAggregator::insertQOName(std::string& metaData, std::string& insertTitle
   if (metaData != "") {
     if (metaData.find(delimiter) != std::string::npos) {
       while ((pos = metaData.find("\n", pos)) != std::string::npos) {
-        metaData.replace(pos, delimiter.size(), insertTitle);
-        pos += insertTitle.size();
+        // metaData.replace(pos, delimiter.size(), insertTitle);
+        metaData.insert(pos + delimiter.size(), insertTitle);
+        pos += insertTitle.size() + delimiter.size();
       }
-    } else {
-      metaData += " " + insertTitle;
+
+      metaData.erase(metaData.length() - insertTitle.size());
+    } // else {
+    // metaData = " " + insertTitle;
+    metaData = insertTitle + metaData;
+    // }
+
+    if (metaData.substr(metaData.length() - delimiter.size(), delimiter.size()) != "\n") {
+      metaData += " \n";
     }
   }
 


### PR DESCRIPTION
PR includes
- New `TPCAggregator`: Similar to `common::WorstOfAllAggregator` but it also aggregates the metadata & comments of the QOs and tags them with the name of the respective tasks
- Update of `QualityObserver`: if metadata or comments are too long, the line is now broken after a maximum of 70 (default) characters. Text is only broken after words, not in between. The maximum of characters per line can be configured in the json via `lineLength`