### PR TITLE
[QC-992] Optimize port selection procedure in Service Discovery

### DIFF
--- a/Framework/include/QualityControl/ServiceDiscovery.h
+++ b/Framework/include/QualityControl/ServiceDiscovery.h
@@ -37,9 +37,8 @@ class ServiceDiscovery
   /// \param url 		Consul URL
   /// \param name		Service name
   /// \param id 		Unique instance ID
-  /// \param healthEndpoint	Local endpoint that is then used for health checks
-  ///				(default value it set to  <hostname>:7777)
-  ServiceDiscovery(const std::string& url, const std::string& name, const std::string& id, const std::string& healthEndUrl = GetDefaultUrl());
+  /// \param healthEndUrl	Local endpoint that is then used for health checks
+  ServiceDiscovery(const std::string& url, const std::string& name, const std::string& id, const std::string& healthEndUrl = "");
 
   /// Stops the health thread and deregisteres from Consul health checks
   ~ServiceDiscovery();
@@ -50,17 +49,6 @@ class ServiceDiscovery
 
   /// Deregisters service
   void deregister();
-
-  static bool PortInUse(unsigned short port);
-
-  static inline std::string GetDefaultUrl() ///< Provides default health check URL
-  {
-    return GetDefaultUrl(GetHealthPort());
-  }
-
-  /// Find a free port in the range [HealthPortRangeEnd;HealthPortRangeStart] if any available.
-  static size_t GetHealthPort();
-  static std::string GetDefaultUrl(size_t port); ///< Provides default health check URL
 
   static constexpr size_t HealthPortRangeStart = 47800; ///< Health check port range start
   static constexpr size_t HealthPortRangeEnd = 47899;   ///< Health check port range end
@@ -75,7 +63,8 @@ class ServiceDiscovery
   const std::string mConsulUrl;     ///< Consul URL
   const std::string mName;          ///< Instance (service) Name
   const std::string mId;            ///< Instance (service) ID
-  std::string mHealthUrl;           ///< hostname and port of health check endpoint
+  std::string mHealthUrl;           ///< hostname of health check endpoint
+  size_t mHealthPort;               ///< Port of the health check endpoint
   std::thread mHealthThread;        ///< Health check thread
   std::atomic<bool> mThreadRunning; ///< Health check thread running flag
 
@@ -85,8 +74,8 @@ class ServiceDiscovery
   /// Sends PUT request
   bool send(const std::string& path, std::string&& request);
 
-  /// Health check thread loop
-  void runHealthServer(unsigned int port);
+  /// Health check thread loop + port computation
+  void runHealthServer();
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -25,27 +25,29 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/io_service.hpp>
+#include <iostream>
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
 
 using boost::asio::ip::tcp;
-
+using namespace boost::system;
 namespace o2::quality_control::core
 {
 
 ServiceDiscovery::ServiceDiscovery(const std::string& url, const std::string& name, const std::string& id, const std::string& healthEndUrl)
   : curlHandle(initCurl(), &ServiceDiscovery::deleteCurl), mConsulUrl(url), mName(name), mId(id), mHealthUrl(healthEndUrl)
 {
-  // parameter check
-  if (mHealthUrl.find(':') == std::string::npos) {
-    mHealthUrl = GetDefaultUrl();
-  }
-  if (_register("")) {
-    mHealthThread = std::thread([=] {
+  mHealthUrl = mHealthUrl.empty() ? boost::asio::ip::host_name() : mHealthUrl;
+
+  mHealthThread = std::thread([=] {
 #ifdef __linux__
-      std::string threadName = "QC/SrvcDiscov";
-      pthread_setname_np(pthread_self(), threadName.c_str());
+    std::string threadName = "QC/SrvcDiscov";
+    pthread_setname_np(pthread_self(), threadName.c_str());
 #endif
-      runHealthServer(std::stoi(mHealthUrl.substr(mHealthUrl.find(":") + 1)));
-    });
+    runHealthServer();
+  });
+  if(!_register("")) {
+    ILOG(Error, Support) << "Could not register to ServiceDiscovery." << ENDM;
   }
 }
 
@@ -94,7 +96,7 @@ bool ServiceDiscovery::_register(const std::string& objects)
   check.put("Name", "Health check " + mId);
   check.put("Interval", "5s");
   check.put("DeregisterCriticalServiceAfter", "1m");
-  check.put("TCP", mHealthUrl);
+  check.put("TCP", mHealthUrl+":"+std::to_string(mHealthPort));
   checks.push_back(std::make_pair("", check));
 
   pt.put("Name", mName);
@@ -114,7 +116,7 @@ void ServiceDiscovery::deregister()
   ILOG(Debug, Devel) << "Deregistration from ServiceDiscovery" << ENDM;
 }
 
-void ServiceDiscovery::runHealthServer(unsigned int port)
+void ServiceDiscovery::runHealthServer()
 {
   using boost::asio::ip::tcp;
   mThreadRunning = true;
@@ -126,14 +128,48 @@ void ServiceDiscovery::runHealthServer(unsigned int port)
   context.setField(infoContext::FieldName::System, "QC");
   threadInfoLogger.setContext(context);
 
-  try {
-    boost::asio::io_service io_service;
-    tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), port));
+  // Find a free port and create the endpoint and the acceptor
+  boost::asio::io_service io_service;
+  tcp::acceptor* acceptor = nullptr;
+  size_t port = 0;
+  std::random_device rd;  // obtain a random number from hardware
+  std::mt19937 gen(rd()); // seed the generator
+  size_t rangeLength = HealthPortRangeEnd - HealthPortRangeStart + 1;
+  std::uniform_int_distribution<> distr(0, rangeLength - 1); // define the inclusive range
+  size_t index = distr(gen); // get a random index in the range
+  size_t cycle = 0;                                // count how many ports we tried
+  while(cycle < rangeLength) { // until we exhaust the range or we find a free port
+    try {
+      index = (index + 1) % rangeLength;             // pick the next index
+      port = HealthPortRangeStart + index;
+      ILOG(Debug, Trace) << "ServiceDiscovery test port: " << port << ENDM;
+      cycle++;
+
+      tcp::endpoint endpoint(tcp::v4(), port);
+      acceptor = new tcp::acceptor(io_service, endpoint);
+    }
+    catch (boost::system::system_error& e) {
+      ILOG(Debug, Trace) << "ServiceDiscovery::runHealthServer - cound not bind to " << port << ENDM;
+      continue; // try the next one
+    }
+    // if we reach this point it means that we could bind
+    mHealthPort = port;
+    ILOG(Debug, Devel) << "ServiceDiscovery selected port: " << mHealthPort << ENDM;
+    break;
+  }
+
+  if (cycle == rangeLength) {
+    ILOG(Error, Support) << "Could not find a free port for the ServiceDiscovery, aborting the ServiceDiscovery health check" << ENDM;
+    return;
+  }
+
+  // run the thread
+  try{
     boost::asio::deadline_timer timer(io_service);
     while (mThreadRunning) {
       io_service.reset();
       timer.expires_from_now(boost::posix_time::seconds(1));
-      acceptor.async_accept([this](boost::system::error_code ec, tcp::socket socket) {
+      acceptor->async_accept([this](boost::system::error_code ec, tcp::socket socket) {
       });
       timer.async_wait([&](boost::system::error_code ec) {
         io_service.stop();
@@ -174,49 +210,6 @@ bool ServiceDiscovery::send(const std::string& path, std::string&& post)
     return false;
   }
   return true;
-}
-
-// https://stackoverflow.com/questions/33358321/using-c-and-boost-or-not-to-check-if-a-specific-port-is-being-used
-bool ServiceDiscovery::PortInUse(unsigned short port)
-{
-  boost::asio::io_service svc;
-  tcp::acceptor a(svc);
-
-  boost::system::error_code ec;
-  a.open(tcp::v4(), ec) || a.bind({ tcp::v4(), port }, ec);
-
-  return ec == boost::asio::error::address_in_use;
-}
-
-size_t ServiceDiscovery::GetHealthPort()
-{
-  // inspired by https://stackoverflow.com/questions/7560114/random-number-c-in-some-range/7560151
-  size_t port;
-  std::random_device rd;  // obtain a random number from hardware
-  std::mt19937 gen(rd()); // seed the generator
-  size_t rangeLength = HealthPortRangeEnd - HealthPortRangeStart + 1;
-  std::uniform_int_distribution<> distr(0, rangeLength - 1); // define the inclusive range
-
-  size_t index = distr(gen); // get a random index in the range
-  port = HealthPortRangeStart + index;
-  size_t cycle = 1;                                // count how many ports we tried
-  while (cycle < rangeLength && PortInUse(port)) { // if the port is in use and we did not go through the whole range
-    index = (index + 1) % rangeLength;             // pick the next index
-    port = HealthPortRangeStart + index;
-    cycle++;
-  }
-  if (cycle == rangeLength) {
-    ILOG(Error, Support) << "Could not find a free port for the ServiceDiscovery" << ENDM;
-    // we keep the last port but all calls will fail.
-  } else {
-    ILOG(Debug, Devel) << "ServiceDiscovery selected port: " << port << ENDM;
-  }
-  return port;
-}
-
-std::string ServiceDiscovery::GetDefaultUrl(size_t port) ///< Provides default health check URL
-{
-  return boost::asio::ip::host_name() + ":" + std::to_string(port);
 }
 
 } // namespace o2::quality_control::core

--- a/Framework/src/ServiceDiscovery.cxx
+++ b/Framework/src/ServiceDiscovery.cxx
@@ -46,7 +46,7 @@ ServiceDiscovery::ServiceDiscovery(const std::string& url, const std::string& na
 #endif
     runHealthServer();
   });
-  if(!_register("")) {
+  if (!_register("")) {
     ILOG(Error, Support) << "Could not register to ServiceDiscovery." << ENDM;
   }
 }
@@ -96,7 +96,7 @@ bool ServiceDiscovery::_register(const std::string& objects)
   check.put("Name", "Health check " + mId);
   check.put("Interval", "5s");
   check.put("DeregisterCriticalServiceAfter", "1m");
-  check.put("TCP", mHealthUrl+":"+std::to_string(mHealthPort));
+  check.put("TCP", mHealthUrl + ":" + std::to_string(mHealthPort));
   checks.push_back(std::make_pair("", check));
 
   pt.put("Name", mName);
@@ -136,19 +136,18 @@ void ServiceDiscovery::runHealthServer()
   std::mt19937 gen(rd()); // seed the generator
   size_t rangeLength = HealthPortRangeEnd - HealthPortRangeStart + 1;
   std::uniform_int_distribution<> distr(0, rangeLength - 1); // define the inclusive range
-  size_t index = distr(gen); // get a random index in the range
-  size_t cycle = 0;                                // count how many ports we tried
-  while(cycle < rangeLength) { // until we exhaust the range or we find a free port
+  size_t index = distr(gen);                                 // get a random index in the range
+  size_t cycle = 0;                                          // count how many ports we tried
+  while (cycle < rangeLength) {                              // until we exhaust the range or we find a free port
     try {
-      index = (index + 1) % rangeLength;             // pick the next index
+      index = (index + 1) % rangeLength; // pick the next index
       port = HealthPortRangeStart + index;
       ILOG(Debug, Trace) << "ServiceDiscovery test port: " << port << ENDM;
       cycle++;
 
       tcp::endpoint endpoint(tcp::v4(), port);
       acceptor = new tcp::acceptor(io_service, endpoint);
-    }
-    catch (boost::system::system_error& e) {
+    } catch (boost::system::system_error& e) {
       ILOG(Debug, Trace) << "ServiceDiscovery::runHealthServer - cound not bind to " << port << ENDM;
       continue; // try the next one
     }
@@ -164,7 +163,7 @@ void ServiceDiscovery::runHealthServer()
   }
 
   // run the thread
-  try{
+  try {
     boost::asio::deadline_timer timer(io_service);
     while (mThreadRunning) {
       io_service.reset();


### PR DESCRIPTION
 Try to start a server immediately on a selected port and retry a different one in case of failure.