### PR TITLE
[QC-429] Assume nOrbitsPerTF = 32 until we retrieve it properly

### DIFF
--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -223,7 +223,7 @@ void TaskRunner::run(ProcessingContext& pCtx)
   auto [dataReady, timerReady] = validateInputs(pCtx.inputs());
 
   if (dataReady) {
-    mTimekeeper->updateByTimeFrameID(pCtx.services().get<TimingInfo>().tfCounter, pCtx.services().get<DataTakingContext>().nOrbitsPerTF);
+    mTimekeeper->updateByTimeFrameID(pCtx.services().get<TimingInfo>().tfCounter, 32);
     mTask->monitorData(pCtx);
     updateMonitoringStats(pCtx);
   }


### PR DESCRIPTION
The value from DataTakingContext is actually not set anywhere, so the default 128 was propagated, which is wrong at P2. I am putting this in place, since I might not be ready with a proper solution before my holidays. Removing this access will also let us remove the field from DataTakingContext, as agreed with David.