### PR TITLE
FV0: Fill BC vs FEE module plots correctly (bugfix)

### DIFF
--- a/Modules/FIT/FV0/etc/fv0-digits-qc.json
+++ b/Modules/FIT/FV0/etc/fv0-digits-qc.json
@@ -1,64 +1,117 @@
 {
-    "qc": {
-      "config": {
-        "database": {
-          "implementation": "CCDB",
-          "host": "http://localhost:8083",
-          "username": "not_applicable",
-          "password": "not_applicable",
-          "name": "not_applicable"
-        },
-        "Activity": {
-          "number": "42",
-          "type": "2"
-        },
-        "monitoring": {
-          "url": "infologger:///debug?METRIC"
-        },
-        "consul": {
-          "url": "http://localhost:8500"
-        },
-        "conditionDB": {
-          "url": "http://localhost:8083"
-        }
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "#host": "ccdb-test.cern.ch:8080",
+        "host": "http://localhost:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
       },
-      "tasks": {
-        "DigitQcTask": {
-          "active": "true",
-          "className": "o2::quality_control_modules::fv0::DigitQcTask",
-          "moduleName": "QcFV0",
-          "detectorName": "FV0",
-          "cycleDurationSeconds": "60",
-          "maxNumberCycles": "-1",
-          "dataSource": {
-              "type": "direct",
-              "query": "digits:FV0/DIGITSBC/0;channels:FV0/DIGITSCH/0"
-            },
-          "taskParameters": {
-            "ChannelIDs": "1,2,3,4,5,6,7,8,9,10"
-          },
-          "location": "local",
-          "localMachines": [
-            "localhost"
-          ],
-          "remoteMachine": "localhost",
-          "remotePort": "30132",
-          "mergingMode": "entire"
-        }
+      "monitoring": {
+        "url": "infologger:///debug?qc"
       },
-      "checks": {
-        "DummyAnalysisCheck": {
-          "active": "true",
-          "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
-          "moduleName": "QcSkeleton",
-          "policy": "OnAny",
-          "detectorName": "FV0",
-          "dataSource": [{
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "alice-ccdb.cern.ch"
+      },
+      "bookkeeping": {
+        "url": ""
+      }
+    },
+    "tasks": {
+      "DigitQcTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::DigitQcTask",
+        "moduleName": "QcFV0",
+        "detectorName": "FV0",
+        "cycleDurationSeconds": "300",
+        "maxNumberCycles": "-1",
+        "resetAfterCycles": "1",
+        "dataSource": {
+          "type": "direct",
+          "query": "digits:FV0/DIGITSBC/0;channels:FV0/DIGITSCH/0"
+        },
+        "taskParameters": {
+          "ChannelIDs": "0,1,2,3,4,5,6,7,8,9,10,11",
+          "ChannelIDsAmpVsTime": "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48",
+          "trgModeInnerOuterThresholdVar": "Ampl",
+          "trgThresholdNChannels": "2",
+          "trgThresholdCharge": "8",
+          "trgThresholdChargeInner": "4",
+          "trgThresholdChargeOuter": "4",
+          "trgChargeLevelLow": "10",
+          "trgChargeLevelHigh": "4095",
+          "minGateTimeForRatioHistogram": "-192",
+          "maxGateTimeForRatioHistogram": "192"
+        }
+      }
+    },
+    "checks": {
+      "CFDinTimeGateCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::GenericCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
             "type": "Task",
             "name": "DigitQcTask",
-            "MOs": ["example"]
-          }]
+            "MOs": [
+              "EventsInGateTime"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "thresholdWarningMinThresholdY": "0.8",
+          "thresholdErrorMinThresholdY": "0.6",
+          "ccdbUrl": "alice-ccdb.cern.ch"
+        }
+      },
+      "TrgValidationCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::TriggersSwVsTcmCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "DigitQcTask",
+            "MOs": [
+              "TriggersSoftwareVsTCM"
+            ]
+          }
+        ],
+        "checkParameters": {
+            "ccdbUrl": "alice-ccdb.cern.ch"
+        }
+      },
+      "CFDinADCgateCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::CFDEffCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "DigitQcTask",
+            "MOs": [
+              "CFD_efficiency"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "thresholdWarning": "0.8",
+          "thresholdError": "0.6",
+          "ccdbUrl": "alice-ccdb.cern.ch"
         }
       }
     }
+  }
 }

--- a/Modules/FIT/FV0/etc/fv0-qc-post-processing.json
+++ b/Modules/FIT/FV0/etc/fv0-qc-post-processing.json
@@ -1,0 +1,451 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "#host": "ccdb-test.cern.ch:8080",
+        "host": "http://localhost:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "alice-ccdb.cern.ch"
+      },
+      "bookkeeping": {
+        "url": ""
+      }
+    },
+    "checks": {
+      "OutOfBunchCollCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::OutOfBunchCollCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "PostProcessing",
+            "name": "PostProcTask",
+            "MOs": [
+              "OutOfBunchColl_BCvsTrg"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "thresholdWarning": "0.1",
+          "thresholdError": "0.15",
+          "binPos": "2"
+        }
+      },
+      "OutOfBunchCollCheckFee": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::OutOfBunchCollFeeModulesCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "PostProcessing",
+            "name": "PostProcTask",
+            "MOs": [
+              "OutOfBunchColl_BCvsFeeModules"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "TODO": "TODO"
+        }
+      },
+      "OutOfBunchCollCheckFeeCharge": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::OutOfBunchCollFeeModulesCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "PostProcessing",
+            "name": "PostProcTask",
+            "MOs": [
+              "OutOfBunchColl_BCvsFeeModulesForChargeTrg"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "TODO": "TODO"
+        }
+      },
+      "OutOfBunchCollCheckFeeNChannel": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::OutOfBunchCollFeeModulesCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "PostProcessing",
+            "name": "PostProcTask",
+            "MOs": [
+              "OutOfBunchColl_BCvsFeeModulesForNChanTrg"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "TODO": "TODO"
+        }
+      },
+      "OutOfBunchCollCheckFeeOrA": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::OutOfBunchCollFeeModulesCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "PostProcessing",
+            "name": "PostProcTask",
+            "MOs": [
+              "OutOfBunchColl_BCvsFeeModulesForOrATrg"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "TODO": "TODO"
+        }
+      },
+      "OutOfBunchCollCheckFeeOrAIn": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::OutOfBunchCollFeeModulesCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "PostProcessing",
+            "name": "PostProcTask",
+            "MOs": [
+              "OutOfBunchColl_BCvsFeeModulesForOrAInTrg"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "TODO": "TODO"
+        }
+      },
+      "OutOfBunchCollCheckFeeOrAOut": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::OutOfBunchCollFeeModulesCheck",
+        "moduleName": "QcFV0",
+        "policy": "OnAny",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "PostProcessing",
+            "name": "PostProcTask",
+            "MOs": [
+              "OutOfBunchColl_BCvsFeeModulesForOrAOutTrg"
+            ]
+          }
+        ],
+        "checkParameters": {
+          "TODO": "TODO"
+        }
+      }
+    },
+    "postprocessing": {
+      "PostProcTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::fv0::PostProcTask",
+        "moduleName": "QcFV0",
+        "detectorName": "FV0",
+        "custom": {
+          "numOrbitsInTF": "32",
+          "cycleDurationMoName": "CycleDurationNTF",
+          "timestampSourceLhcIf": "metadata"
+        },
+        "initTrigger": [
+          "newobject:qcdb:FV0/MO/DigitQcTask/TriggersCorrelation",
+          "newobject:qcdb:FV0/MO/DigitQcTask/BCvsFEEmodules"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:FV0/MO/DigitQcTask/TriggersCorrelation",
+          "newobject:qcdb:FV0/MO/DigitQcTask/BCvsFEEmodules"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "TrendingTask": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::TrendingTask",
+        "moduleName": "QcFV0",
+        "detectorName": "FV0",
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "FV0/MO/DigitQcTask",
+            "names": [
+              "CycleDuration",
+              "CycleDurationNTF",
+              "SumAmpA",
+              "Amp_channel0",
+              "Time_channel0",
+              "Amp_channel1",
+              "Time_channel1",
+              "Amp_channel2",
+              "Time_channel2",
+              "Amp_channel3",
+              "Time_channel3",
+              "Amp_channel4",
+              "Time_channel4",
+              "Amp_channel5",
+              "Time_channel5",
+              "Amp_channel6",
+              "Time_channel6",
+              "Amp_channel7",
+              "Time_channel7",
+              "Amp_channel8",
+              "Time_channel8",
+              "Amp_channel9",
+              "Time_channel9",
+              "Amp_channel10",
+              "Time_channel10",
+              "Amp_channel11",
+              "Time_channel11"
+            ],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcCommon"
+          }
+        ],
+        "plots": [
+          {
+            "name": "trend_cycle_duration",
+            "title": "cycle duration [ns]",
+            "varexp": "CycleDuration.entries:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_cycle_duration_ntf",
+            "title": "cycle duration [TimeFrames]",
+            "varexp": "CycleDurationNTF.entries:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "cycle_duration_corr",
+            "title": "cycle duration: ns/TF;time;cycle duration [ns/TimeFrames]",
+            "varexp": "CycleDuration.entries/CycleDurationNTF.entries:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "cycle_duration_ntf_corr",
+            "title": "TF duration [ns];#TF;TF duration [ns]",
+            "varexp": "CycleDuration.entries/CycleDurationNTF.entries:CycleDurationNTF.entries",
+            "selection": "",
+            "option": "colz"
+          },
+          {
+            "name": "trend_mean_sumAmpA",
+            "title": "Mean trend of the sum of amplitudes (TCM)",
+            "varexp": "SumAmpA.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_stddev_sumAmpA",
+            "title": "Stddev trend of the sum of amplitudes (TCM)",
+            "varexp": "SumAmpA.stddev:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp0",
+            "title": "Mean trend of the amplitude, channel0",
+            "varexp": "Amp_channel0.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp1",
+            "title": "Mean trend of the amplitude, channel1",
+            "varexp": "Amp_channel1.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp2",
+            "title": "Mean trend of the amplitude, channel2",
+            "varexp": "Amp_channel2.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp3",
+            "title": "Mean trend of the amplitude, channel3",
+            "varexp": "Amp_channel3.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp4",
+            "title": "Mean trend of the amplitude, channel4",
+            "varexp": "Amp_channel4.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp5",
+            "title": "Mean trend of the amplitude, channel5",
+            "varexp": "Amp_channel5.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp6",
+            "title": "Mean trend of the amplitude, channel6",
+            "varexp": "Amp_channel6.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp7",
+            "title": "Mean trend of the amplitude, channel7",
+            "varexp": "Amp_channel7.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp8",
+            "title": "Mean trend of the amplitude, channel8",
+            "varexp": "Amp_channel8.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp9",
+            "title": "Mean trend of the amplitude, channel9",
+            "varexp": "Amp_channel9.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp10",
+            "title": "Mean trend of the amplitude, channel10",
+            "varexp": "Amp_channel10.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_amp11",
+            "title": "Mean trend of the amplitude, channel11",
+            "varexp": "Amp_channel11.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time0",
+            "title": "Mean trend of the time, channel0",
+            "varexp": "Time_channel0.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time1",
+            "title": "Mean trend of the time, channel1",
+            "varexp": "Time_channel1.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time2",
+            "title": "Mean trend of the time, channel2",
+            "varexp": "Time_channel2.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time3",
+            "title": "Mean trend of the time, channel3",
+            "varexp": "Time_channel3.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time4",
+            "title": "Mean trend of the time, channel4",
+            "varexp": "Time_channel4.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time5",
+            "title": "Mean trend of the time, channel5",
+            "varexp": "Time_channel5.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time6",
+            "title": "Mean trend of the time, channel6",
+            "varexp": "Time_channel6.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time7",
+            "title": "Mean trend of the time, channel7",
+            "varexp": "Time_channel7.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time8",
+            "title": "Mean trend of the time, channel8",
+            "varexp": "Time_channel8.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time9",
+            "title": "Mean trend of the time, channel9",
+            "varexp": "Time_channel9.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time10",
+            "title": "Mean trend of the time, channel10",
+            "varexp": "Time_channel10.mean:time",
+            "selection": "",
+            "option": "*L"
+          },
+          {
+            "name": "trend_mean_time11",
+            "title": "Mean trend of the time, channel11",
+            "varexp": "Time_channel11.mean:time",
+            "selection": "",
+            "option": "*L"
+          }
+        ],
+        "initTrigger": [
+          "newobject:qcdb:FV0/MO/DigitQcTask/TriggersCorrelation"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:FV0/MO/DigitQcTask/TriggersCorrelation"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    }
+  }
+}

--- a/Modules/FIT/FV0/src/DigitQcTask.cxx
+++ b/Modules/FIT/FV0/src/DigitQcTask.cxx
@@ -584,11 +584,16 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     }
     for (const auto& feeHash : setFEEmodules) {
       mHistBCvsFEEmodules->Fill(static_cast<double>(digit.getIntRecord().bc), static_cast<double>(feeHash));
-      mHistBcVsFeeForOrATrg->Fill(static_cast<double>(digit.getIntRecord().bc), digit.mTriggers.getOrA());
-      mHistBcVsFeeForOrAOutTrg->Fill(static_cast<double>(digit.getIntRecord().bc), digit.mTriggers.getOrAOut());
-      mHistBcVsFeeForNChanTrg->Fill(static_cast<double>(digit.getIntRecord().bc), digit.mTriggers.getTrgNChan());
-      mHistBcVsFeeForChargeTrg->Fill(static_cast<double>(digit.getIntRecord().bc), digit.mTriggers.getTrgCharge());
-      mHistBcVsFeeForOrAInTrg->Fill(static_cast<double>(digit.getIntRecord().bc), digit.mTriggers.getOrAIn());
+      if (digit.mTriggers.getOrA())
+        mHistBcVsFeeForOrATrg->Fill(static_cast<double>(digit.getIntRecord().bc), static_cast<double>(feeHash));
+      if (digit.mTriggers.getOrAOut())
+        mHistBcVsFeeForOrAOutTrg->Fill(static_cast<double>(digit.getIntRecord().bc), static_cast<double>(feeHash));
+      if (digit.mTriggers.getTrgNChan())
+        mHistBcVsFeeForNChanTrg->Fill(static_cast<double>(digit.getIntRecord().bc), static_cast<double>(feeHash));
+      if (digit.mTriggers.getTrgCharge())
+        mHistBcVsFeeForChargeTrg->Fill(static_cast<double>(digit.getIntRecord().bc), static_cast<double>(feeHash));
+      if (digit.mTriggers.getOrAIn())
+        mHistBcVsFeeForOrAInTrg->Fill(static_cast<double>(digit.getIntRecord().bc), static_cast<double>(feeHash));
       mHistOrbitVsFEEmodules->Fill(static_cast<double>(digit.getIntRecord().orbit % sOrbitsPerTF), static_cast<double>(feeHash));
     }
 

--- a/Modules/FIT/FV0/src/PostProcTask.cxx
+++ b/Modules/FIT/FV0/src/PostProcTask.cxx
@@ -205,7 +205,7 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistryRef services)
     }
   }
 
-  mHistBcPatternFee = std::make_unique<TH2F>("bcPatternForFeeModules", "BC pattern", sBCperOrbit, 0, sBCperOrbit, 13, 0, 13);
+  mHistBcPatternFee = std::make_unique<TH2F>("bcPatternForFeeModules", "BC pattern", sBCperOrbit, 0, sBCperOrbit, mMapFEE2hash.size(), 0, mMapFEE2hash.size());
   mHistBcFeeOutOfBunchColl = std::make_unique<TH2F>("OutOfBunchColl_BCvsFeeModules", "BC vs FEE Modules for out-of-bunch collisions;BC;FEE Modules", sBCperOrbit, 0, sBCperOrbit, mMapFEE2hash.size(), 0, mMapFEE2hash.size());
   mHistBcFeeOutOfBunchCollForOrATrg = std::make_unique<TH2F>("OutOfBunchColl_BCvsFeeModulesForOrATrg", "BC vs FEE Modules for out-of-bunch collisions for OrA trg;BC;FEE Modules", sBCperOrbit, 0, sBCperOrbit, mMapFEE2hash.size(), 0, mMapFEE2hash.size());
   mHistBcFeeOutOfBunchCollForOrAOutTrg = std::make_unique<TH2F>("OutOfBunchColl_BCvsFeeModulesForOrAOutTrg", "BC vs FEE Modules for out-of-bunch collisions for OrAOut trg;BC;FEE Modules", sBCperOrbit, 0, sBCperOrbit, mMapFEE2hash.size(), 0, mMapFEE2hash.size());


### PR DESCRIPTION
- Fill BC vs FEE module plots correctly, these are used for the same plots for out-of-bunch collisions produced in post processing.
- Add example QC and post processing json files.