### PR TITLE
[EMCAL-524] Optional energy recalibration on-the-fly

### DIFF
--- a/Modules/EMCAL/include/EMCAL/CellTask.h
+++ b/Modules/EMCAL/include/EMCAL/CellTask.h
@@ -41,6 +41,7 @@ namespace emcal
 class Geometry;
 class BadChannelMap;
 class TimeCalibrationParams;
+class GainCalibrationFactors;
 class Cell;
 } // namespace emcal
 
@@ -63,6 +64,7 @@ class CellTask final : public TaskInterface
     bool mHasAmpVsCellID;
     bool mHasTimeVsCellID;
     bool mHasHistosCalib;
+    bool mCalibrateEnergy;
 
     double mAmpThresholdTimePhys = 0.15;
     double mAmpThresholdTimeCalib = 0.3;
@@ -96,6 +98,8 @@ class CellTask final : public TaskInterface
     TH2* mCellOccupancyGood = nullptr;                  ///< Cell occupancy EMCAL and DCAL good cells
     TH2* mCellOccupancyBad = nullptr;                   ///< Cell occupancy EMCAL and DCAL bad cells
     TH2* mIntegratedOccupancy = nullptr;                ///< Cell integrated occupancy
+    TH2* mAverageCellEnergy = nullptr;                  ///< Average cell energy
+    TH2* mAverageCellTime = nullptr;                    ///< Average cell time
     TH1* mCellAmplitude_tot = nullptr;                  ///< Cell amplitude in EMCAL,DCAL
     TH1* mCellAmplitudeEMCAL = nullptr;                 ///< Cell amplitude in EMCAL
     TH1* mCellAmplitudeDCAL = nullptr;                  ///< Cell amplitude in DCAL
@@ -118,7 +122,7 @@ class CellTask final : public TaskInterface
     void reset();
     void clean();
 
-    void fillHistograms(const o2::emcal::Cell& cell, bool isGood, double timeoffset, int bcphase);
+    void fillHistograms(const o2::emcal::Cell& cell, bool isGood, double timeoffset, double energycalib, int bcphase);
     void countEvent();
   };
 
@@ -172,6 +176,7 @@ class CellTask final : public TaskInterface
   o2::emcal::Geometry* mGeometry = nullptr;                  ///< EMCAL geometry
   o2::emcal::BadChannelMap* mBadChannelMap = nullptr;        ///< EMCAL channel map
   o2::emcal::TimeCalibrationParams* mTimeCalib = nullptr;    ///< EMCAL time calib
+  o2::emcal::GainCalibrationFactors* mEnergyCalib = nullptr; ///< EMCAL energy calibration
   int mTimeFramesPerCycles = 0;                              ///< TF per cycles
 
   TH1* mEvCounterTF = nullptr;      ///< Number of Events per timeframe


### PR DESCRIPTION
- Add option to recalibrate cell energy on-the-fly
  (synchronous QC only)
- Add histograms for average cell energy (sensitive
  to gain calibration) and average cell time (sensitive
  to time calibration)