### PR TITLE
Fix histogram ratio copy functions

### DIFF
--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -159,11 +159,13 @@ void TH1Ratio<T>::Copy(TObject& obj) const
     return;
   }
 
-  getNum()->Copy(*(dest->getNum()));
-  getDen()->Copy(*(dest->getDen()));
   T::Copy(obj);
 
-  dest->update();
+  if (mHistoNum && dest->getNum() && mHistoDen && dest->getDen()) {
+    mHistoNum->Copy(*(dest->getNum()));
+    mHistoDen->Copy(*(dest->getDen()));
+    dest->update();
+  }
 }
 
 template<class T>

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -160,11 +160,13 @@ void TH2Ratio<T>::Copy(TObject& obj) const
     return;
   }
 
-  getNum()->Copy(*(dest->getNum()));
-  getDen()->Copy(*(dest->getDen()));
   T::Copy(obj);
 
-  dest->update();
+  if (mHistoNum && dest->getNum() && mHistoDen && dest->getDen()) {
+    mHistoNum->Copy(*(dest->getNum()));
+    mHistoDen->Copy(*(dest->getDen()));
+    dest->update();
+  }
 }
 
 template<class T>


### PR DESCRIPTION
The update fixes a segfault in the `Copy()` functions whenever the numerator or denominator are not properly initialized.