### PR TITLE
MFT: displaying dead chips in digit maps

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTDigitCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitCheck.h
@@ -45,6 +45,27 @@ class QcMFTDigitCheck : public o2::quality_control::checker::CheckInterface
   int mZoneThresholdMedium;
   int mZoneThresholdBad;
 
+  // masked chips part
+  bool mFirstCall;
+  std::vector<int> mMaskedChips;
+  std::vector<string> mChipMapName;
+
+  void readMaskedChips();
+  void createMaskedChipsNames();
+
+  // to form the name of the masked chips histograms
+  int mHalf[936] = { 0 };
+  int mDisk[936] = { 0 };
+  int mFace[936] = { 0 };
+  int mZone[936] = { 0 };
+  int mSensor[936] = { 0 };
+  int mTransID[936] = { 0 };
+  int mLayer[936] = { 0 };
+  int mLadder[936] = { 0 };
+  float mX[936] = { 0 };
+  float mY[936] = { 0 };
+  void getChipMapData();
+
   ClassDefOverride(QcMFTDigitCheck, 2);
 };
 

--- a/Modules/MFT/include/MFT/QcMFTDigitTask.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitTask.h
@@ -96,7 +96,6 @@ class QcMFTDigitTask final : public TaskInterface
   std::unique_ptr<TH2F> mDigitDoubleColumnSensorIndices = nullptr;
 
   std::unique_ptr<TH1F> mDigitsROFSize = nullptr;
-  std::unique_ptr<TH1F> mNOfDigitsTime = nullptr;
   std::unique_ptr<TH1F> mDigitsBC = nullptr;
 
   std::vector<std::unique_ptr<TH2F>> mDigitChipOccupancyMap;

--- a/Modules/MFT/mft-digits.json
+++ b/Modules/MFT/mft-digits.json
@@ -60,7 +60,27 @@
         "dataSource" : [ {
           "type" : "Task",
           "name" : "Digits",
-            "MOs"  : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
+            "MOs"  : ["ChipOccupancyMaps/Half_0/Disk_0/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_0/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_1/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_1/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_2/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_2/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_3/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_3/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_4/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_0/Disk_4/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_0/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_0/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_1/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_1/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_2/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_2/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_3/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_3/Face_0/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_4/Face_1/mDigitChipOccupancyMap",
+            "ChipOccupancyMaps/Half_1/Disk_4/Face_0/mDigitChipOccupancyMap",
+            "mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
         } ]
       }
     }

--- a/Modules/MFT/src/QcMFTDigitCheck.cxx
+++ b/Modules/MFT/src/QcMFTDigitCheck.cxx
@@ -16,6 +16,8 @@
 /// \author Katarina Krizkova Gajdosova
 /// \author Diana Maria Krupova
 
+// C++
+#include <string>
 // Fair
 #include <fairlogger/Logger.h>
 // ROOT
@@ -24,11 +26,17 @@
 #include <TLatex.h>
 #include <TList.h>
 #include <TPaveText.h>
+// O2
+#include <DataFormatsITSMFT/NoiseMap.h>
+#include "CCDB/CcdbApi.h"
+#include <ITSMFTReconstruction/ChipMappingMFT.h>
+
 // Quality Control
 #include "MFT/QcMFTDigitCheck.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "MFT/QcMFTUtilTables.h"
 
 using namespace std;
 
@@ -37,7 +45,6 @@ namespace o2::quality_control_modules::mft
 
 void QcMFTDigitCheck::configure()
 {
-
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
   if (auto param = mCustomParameters.find("ZoneThresholdMedium"); param != mCustomParameters.end()) {
     ILOG(Info, Support) << "Custom parameter - ZoneThresholdMedium: " << param->second << ENDM;
@@ -47,6 +54,9 @@ void QcMFTDigitCheck::configure()
     ILOG(Info, Support) << "Custom parameter - ZoneThresholdBad: " << param->second << ENDM;
     mZoneThresholdBad = stoi(param->second);
   }
+
+  // no call to beautifier yet
+  mFirstCall = true;
 }
 
 Quality QcMFTDigitCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
@@ -105,8 +115,73 @@ Quality QcMFTDigitCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
 
 std::string QcMFTDigitCheck::getAcceptedType() { return "TH1"; }
 
+void QcMFTDigitCheck::readMaskedChips()
+{
+  o2::ccdb::CcdbApi api;
+  api.init("alice-ccdb.cern.ch");
+  long timestamp = -1;
+  map<string, string> headers;
+  map<std::string, std::string> filter;
+  auto calib = api.retrieveFromTFileAny<o2::itsmft::NoiseMap>("MFT/Calib/DeadMap/", filter, timestamp, &headers);
+  for (int i = 0; i < calib->size(); i++) {
+    if (calib->isFullChipMasked(i)) {
+      mMaskedChips.push_back(i);
+    }
+  }
+}
+
+void QcMFTDigitCheck::getChipMapData()
+{
+  const o2::itsmft::ChipMappingMFT mapMFT;
+  auto chipMapData = mapMFT.getChipMappingData();
+  QcMFTUtilTables MFTTable;
+
+  for (int i = 0; i < 936; i++) {
+    mHalf[i] = chipMapData[i].half;
+    mDisk[i] = chipMapData[i].disk;
+    mLayer[i] = chipMapData[i].layer;
+    mFace[i] = mLayer[i] % 2;
+    mZone[i] = chipMapData[i].zone;
+    mSensor[i] = chipMapData[i].localChipSWID;
+    mTransID[i] = chipMapData[i].cable;
+    mLadder[i] = MFTTable.mLadder[i];
+    mX[i] = MFTTable.mX[i];
+    mY[i] = MFTTable.mY[i];
+  }
+}
+
+void QcMFTDigitCheck::createMaskedChipsNames()
+{
+  for (int i = 0; i < mMaskedChips.size(); i++) {
+    mChipMapName.push_back(Form("ChipOccupancyMaps/Half_%d/Disk_%d/Face_%d/mDigitChipOccupancyMap",
+                                mHalf[mMaskedChips[i]], mDisk[mMaskedChips[i]], mFace[mMaskedChips[i]]));
+  }
+}
+
 void QcMFTDigitCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
+  // set up masking of dead chips once
+  if (mFirstCall) {
+    mFirstCall = false;
+    readMaskedChips();
+    getChipMapData();
+    createMaskedChipsNames();
+  }
+  // print skull in maps to display dead chips
+  int nMaskedChips = mMaskedChips.size();
+  for (int i = 0; i < nMaskedChips; i++) {
+    if (mo->getName().find(mChipMapName[i]) != std::string::npos) {
+      auto* hMap = dynamic_cast<TH2F*>(mo->getObject());
+      int binCx = hMap->GetXaxis()->FindBin(mX[mMaskedChips[i]]);
+      int binCy = hMap->GetYaxis()->FindBin(mY[mMaskedChips[i]]);
+      // the -0.5 is a shift to centre better the skulls
+      TLatex* tl = new TLatex(hMap->GetXaxis()->GetBinCenter(binCx) - 0.5, hMap->GetYaxis()->GetBinCenter(binCy), "N");
+      tl->SetTextFont(142);
+      tl->SetTextSize(0.08);
+      hMap->GetListOfFunctions()->Add(tl);
+      tl->Draw();
+    }
+  }
 
   if (mo->getName().find("mDigitOccupancySummary") != std::string::npos) {
     auto* hOccupancySummary = dynamic_cast<TH2F*>(mo->getObject());

--- a/Modules/MFT/src/QcMFTDigitTask.cxx
+++ b/Modules/MFT/src/QcMFTDigitTask.cxx
@@ -158,10 +158,6 @@ void QcMFTDigitTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mDigitsROFSize.get());
   getObjectsManager()->setDisplayHint(mDigitsROFSize.get(), "logx logy");
 
-  mNOfDigitsTime = std::make_unique<TH1F>("mNOfDigitsTime", "Number of Digits per time bin; time (s); # entries", NofTimeBins, 0, maxDuration);
-  mNOfDigitsTime->SetMinimum(0.1);
-  getObjectsManager()->startPublishing(mNOfDigitsTime.get());
-
   mDigitsBC = std::make_unique<TH1F>("mDigitsBC", "Digits per BC; BCid; # entries", o2::constants::lhc::LHCMaxBunches, 0, o2::constants::lhc::LHCMaxBunches);
   mDigitsBC->SetMinimum(0.1);
   getObjectsManager()->startPublishing(mDigitsBC.get());
@@ -264,7 +260,6 @@ void QcMFTDigitTask::monitorData(o2::framework::ProcessingContext& ctx)
   for (const auto& rof : rofs) {
     mDigitsROFSize->Fill(rof.getNEntries());
     float seconds = orbitToSeconds(rof.getBCData().orbit, mRefOrbit) + rof.getBCData().bc * o2::constants::lhc::LHCBunchSpacingNS * 1e-9;
-    mNOfDigitsTime->Fill(seconds, rof.getNEntries());
     mDigitsBC->Fill(rof.getBCData().bc, rof.getNEntries());
   }
 
@@ -324,7 +319,6 @@ void QcMFTDigitTask::reset()
     mDigitChipStdDev->Reset();
   mDigitOccupancySummary->Reset();
   mDigitsROFSize->Reset();
-  mNOfDigitsTime->Reset();
   mDigitsBC->Reset();
 
   // maps


### PR DESCRIPTION
- displaying of excluded (dead or masked) chips in the digit chip maps using the beautifier
- removal of redundant mNOfDigitsTime histogram that was causing messages in FLP infologgers (`Object mNOfDigitsTime bigger than maximum allowed size` and `Object mNOfDigitsTime will not be uploaded`)