### PR TITLE
ITS FEE: added RDH plot cumulative since SOX

### DIFF
--- a/Modules/ITS/include/ITS/ITSFeeTask.h
+++ b/Modules/ITS/include/ITS/ITSFeeTask.h
@@ -131,7 +131,8 @@ class ITSFeeTask final : public TaskInterface
   TH2I* mIndexCheck; // should be zero
   TH2I* mIdCheck;    // should be 0x : e4
   TH2I* mRDHSummary;
-  TH2I* mLaneStatus[NFlags]; // 4 flags for each lane. 3/8/14 lane for each link. 3/2/2 link for each RU. TODO: remove the OK flag in these 4 flag plots, OK flag plot just used to debug.
+  TH2I* mRDHSummaryCumulative; // RDH plot which does NOT reset at every QC cycle
+  TH2I* mLaneStatus[NFlags];   // 4 flags for each lane. 3/8/14 lane for each link. 3/2/2 link for each RU. TODO: remove the OK flag in these 4 flag plots, OK flag plot just used to debug.
   TH2I* mLaneStatusCumulative[NFlags];
   TH2Poly* mLaneStatusOverview[NFlags] = { 0x0 };
   TH1I* mLaneStatusSummary[NLayer];


### PR DESCRIPTION
This is to have a copy of the already-existing RDH plot which DOES NOT reset at every cycle. This is useful to monitor the amount of trigger ramp bits after SOX. 