### PR TITLE
When period is not provided, use the fallback value, not "unspecified"

### DIFF
--- a/Framework/include/QualityControl/runnerUtils.h
+++ b/Framework/include/QualityControl/runnerUtils.h
@@ -102,7 +102,7 @@ inline Activity computeActivity(framework::ServiceRegistryRef services, const Ac
   auto run_start_time_ms = computeActivityField<unsigned long>(services, "runStartTimeMs", fallbackActivity.mValidity.getMin());
   auto run_stop_time_ms = computeActivityField<unsigned long>(services, "runEndTimeMs", fallbackActivity.mValidity.getMax());
   auto partitionName = services.get<framework::RawDeviceService>().device()->fConfig->GetProperty<std::string>("environment_id", fallbackActivity.mPartitionName);
-  auto periodName = services.get<framework::RawDeviceService>().device()->fConfig->GetProperty<std::string>("lhcPeriod", "unspecified");
+  auto periodName = services.get<framework::RawDeviceService>().device()->fConfig->GetProperty<std::string>("lhcPeriod", fallbackActivity.mPeriodName);
   auto fillNumber = computeActivityField<int>(services, "fillInfoFillNumber", fallbackActivity.mFillNumber);
   auto beam_type = services.get<framework::RawDeviceService>().device()->fConfig->GetProperty<std::string>("fillInfoBeamType", fallbackActivity.mBeamType);
 


### PR DESCRIPTION
Otherwise, it breaks trending tasks, since they try to request objects with "unspecified" period even if they do not care about period.