### PR TITLE
Temporarily raise validity logging level for Grid

### DIFF
--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -23,6 +23,7 @@
 #include <Framework/Task.h>
 #include <Framework/DataProcessorSpec.h>
 #include <Framework/CompletionPolicy.h>
+#include <Framework/DataTakingContext.h>
 #include <Headers/DataHeader.h>
 // QC
 #include "QualityControl/TaskRunnerConfig.h"
@@ -146,6 +147,7 @@ class TaskRunner : public framework::Task
   bool mCycleOn = false;
   bool mNoMoreCycles = false;
   int mCycleNumber = 0;
+  framework::DeploymentMode mDeploymentMode = framework::DeploymentMode::Local;
 
   // stats
   int mNumberMessagesReceivedInCycle = 0;


### PR DESCRIPTION
On grid we display only Info/Ops logs. This raises the validity log level on grid, so I can verify that it will work as expected there.