### PR TITLE
[QC-429] Propagate the validity through QC chain, but do not use it

### DIFF
--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -150,14 +150,14 @@ class CheckRunner : public framework::Task
    *
    * @param qualityObjects QOs to be stored in DB.
    */
-  void store(QualityObjectsType& qualityObjects);
+  void store(QualityObjectsType& qualityObjects, long validFrom);
 
   /**
    * \brief Store the MonitorObjects in the database.
    *
    * @param monitorObjects MOs to be stored in DB.
    */
-  void store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects);
+  void store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects, long validFrom);
 
   /**
    * \brief Send the QualityObjects on the DataProcessor output channel.

--- a/Framework/include/QualityControl/CheckRunner.h
+++ b/Framework/include/QualityControl/CheckRunner.h
@@ -150,14 +150,14 @@ class CheckRunner : public framework::Task
    *
    * @param qualityObjects QOs to be stored in DB.
    */
-  void store(QualityObjectsType& qualityObjects, long validFrom);
+  void store(QualityObjectsType& qualityObjects);
 
   /**
    * \brief Store the MonitorObjects in the database.
    *
    * @param monitorObjects MOs to be stored in DB.
    */
-  void store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects, long validFrom);
+  void store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects);
 
   /**
    * \brief Send the QualityObjects on the DataProcessor output channel.

--- a/Framework/src/AggregatorRunner.cxx
+++ b/Framework/src/AggregatorRunner.cxx
@@ -240,6 +240,10 @@ void AggregatorRunner::store(QualityObjectsType& qualityObjects)
     for (auto& qo : qualityObjects) {
       mDatabase->storeQO(qo);
     }
+    if (!qualityObjects.empty()) {
+      auto& qo = qualityObjects.at(0);
+      ILOG(Info, Devel) << "Validity of QO '" << qo->GetName() << "' is (" << qo->getValidity().getMin() << ", " << qo->getValidity().getMax() << ")" << ENDM;
+    }
   } catch (boost::exception& e) {
     ILOG(Info, Devel) << "Unable to " << diagnostic_information(e) << ENDM;
   }

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -239,12 +239,12 @@ void CcdbDatabase::storeMO(std::shared_ptr<const o2::quality_control::core::Moni
   auto from = static_cast<long>(validity.getMin());
   auto to = static_cast<long>(validity.getMax());
 
-  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
-    from = getCurrentTimestamp();
-  }
-  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
-    to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
-  }
+  //  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
+  from = getCurrentTimestamp();
+  //  }
+  //  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
+  to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
+                                               //  }
 
   if (from >= to) {
     ILOG(Error, Support) << "The start validity of '" << mo->GetName() << "' is not earlier than the end (" << from << ", " << to << "). The object will not be stored" << ENDM;
@@ -281,12 +281,12 @@ void CcdbDatabase::storeQO(std::shared_ptr<const o2::quality_control::core::Qual
   auto from = static_cast<long>(validity.getMin());
   auto to = static_cast<long>(validity.getMax());
 
-  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
-    from = getCurrentTimestamp();
-  }
-  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
-    to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
-  }
+  //  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
+  from = getCurrentTimestamp();
+  //  }
+  //  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
+  to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
+                                               //  }
   if (from >= to) {
     ILOG(Error, Support) << "The start validity of '" << qo->GetName() << "' is not earlier than the end (" << from << ", " << to << "). The object will not be stored" << ENDM;
     return;

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -239,12 +239,12 @@ void CcdbDatabase::storeMO(std::shared_ptr<const o2::quality_control::core::Moni
   auto from = static_cast<long>(validity.getMin());
   auto to = static_cast<long>(validity.getMax());
 
-  //  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
-  from = getCurrentTimestamp();
-  //  }
-  //  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
-  to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
-                                               //  }
+  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
+    from = getCurrentTimestamp();
+  }
+  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
+    to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
+  }
 
   if (from >= to) {
     ILOG(Error, Support) << "The start validity of '" << mo->GetName() << "' is not earlier than the end (" << from << ", " << to << "). The object will not be stored" << ENDM;
@@ -281,12 +281,13 @@ void CcdbDatabase::storeQO(std::shared_ptr<const o2::quality_control::core::Qual
   auto from = static_cast<long>(validity.getMin());
   auto to = static_cast<long>(validity.getMax());
 
-  //  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
-  from = getCurrentTimestamp();
-  //  }
-  //  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
-  to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
-                                               //  }
+  if (from == -1 || from == 0 || validity.getMin() == gInvalidValidityInterval.getMin() || validity.getMin() == gFullValidityInterval.getMin()) {
+    from = getCurrentTimestamp();
+  }
+  if (to == -1 || to == 0 || validity.getMax() == gInvalidValidityInterval.getMax() || validity.getMax() == gFullValidityInterval.getMax()) {
+    to = from + 1000l * 60 * 60 * 24 * 365 * 10; // ~10 years since the start of validity
+  }
+
   if (from >= to) {
     ILOG(Error, Support) << "The start validity of '" << qo->GetName() << "' is not earlier than the end (" << from << ", " << to << "). The object will not be stored" << ENDM;
     return;

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -240,14 +240,27 @@ void CheckRunner::init(framework::InitContext& iCtx)
   }
 }
 
+long getCurrentTimestamp()
+{
+  auto now = std::chrono::system_clock::now();
+  auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+  auto epoch = now_ms.time_since_epoch();
+  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
+  return value.count();
+}
+
 void CheckRunner::run(framework::ProcessingContext& ctx)
 {
   prepareCacheData(ctx.inputs());
 
   auto qualityObjects = check();
 
-  store(qualityObjects);
-  store(mMonitorObjectStoreVector);
+  // we want all objects that we are going to store to have the same validFrom values.
+  // ideally it should be SOR or the moving window start, but before GUI allows for this,
+  // we have to put the current timestamp.
+  auto now = getCurrentTimestamp();
+  store(qualityObjects, now);
+  store(mMonitorObjectStoreVector, now);
 
   send(qualityObjects, ctx.outputs());
 
@@ -360,12 +373,15 @@ QualityObjectsType CheckRunner::check()
   return allQOs;
 }
 
-void CheckRunner::store(QualityObjectsType& qualityObjects)
+void CheckRunner::store(QualityObjectsType& qualityObjects, long validFrom)
 {
   ILOG(Debug, Devel) << "Storing " << qualityObjects.size() << " QualityObjects" << ENDM;
   try {
     for (auto& qo : qualityObjects) {
+      auto tmpValidity = qo->getValidity();
+      qo->setValidity(ValidityInterval{ static_cast<unsigned long>(validFrom), validFrom + 10ull * 365 * 24 * 60 * 60 * 1000 });
       mDatabase->storeQO(qo);
+      qo->setValidity(tmpValidity);
       mTotalNumberQOStored++;
       mNumberQOStored++;
     }
@@ -379,12 +395,15 @@ void CheckRunner::store(QualityObjectsType& qualityObjects)
   }
 }
 
-void CheckRunner::store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects)
+void CheckRunner::store(std::vector<std::shared_ptr<MonitorObject>>& monitorObjects, long validFrom)
 {
   ILOG(Debug, Devel) << "Storing " << monitorObjects.size() << " MonitorObjects" << ENDM;
   try {
     for (auto& mo : monitorObjects) {
+      auto tmpValidity = mo->getValidity();
+      mo->setValidity(ValidityInterval{ static_cast<unsigned long>(validFrom), validFrom + 10ull * 365 * 24 * 60 * 60 * 1000 });
       mDatabase->storeMO(mo);
+      mo->setValidity(tmpValidity);
       mTotalNumberMOStored++;
       mNumberMOStored++;
     }

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -507,7 +507,7 @@ void TaskRunner::finishCycle(DataAllocator& outputs)
 
   // this stays until we move to using mTimekeeper.
   auto nowMs = getCurrentTimestamp();
-  mObjectsManager->setValidity(ValidityInterval{ nowMs, nowMs + 1000l * 60 * 60 * 24 * 365 * 10 });
+  mObjectsManager->setValidity(mTimekeeper->getValidity());
   mNumberObjectsPublishedInCycle += publish(outputs);
   mTotalNumberObjectsPublished += mNumberObjectsPublishedInCycle;
   saveToFile();


### PR DESCRIPTION
Another go at letting the validity propagate through the QC chain. During store, the old-style validity will be still used, but the new-style result will be reported.