### PR TITLE
Improvements to the THRatio initialization and interface

### DIFF
--- a/Modules/Common/include/Common/TH1Ratio.h
+++ b/Modules/Common/include/Common/TH1Ratio.h
@@ -20,6 +20,7 @@
 #include "Mergers/MergeInterface.h"
 #include <TH1F.h>
 #include <TH1D.h>
+#include <TDirectory.h>
 
 namespace o2::quality_control_modules::common
 {
@@ -28,7 +29,7 @@ template <class T>
 class TH1Ratio : public T, public o2::mergers::MergeInterface
 {
  public:
-  TH1Ratio() = default;
+  TH1Ratio();
   TH1Ratio(TH1Ratio const& copymerge);
   TH1Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, bool uniformScaling = false);
   TH1Ratio(const char* name, const char* title, bool uniformScaling = false);
@@ -49,6 +50,11 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
     return mHistoDen;
   }
 
+  void setHasUniformScaling(bool flag)
+  {
+    mUniformScaling = flag;
+  }
+
   bool hasUniformScaling() const
   {
     return mUniformScaling;
@@ -58,6 +64,8 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
 
   // functions inherited from TH1x
   void Reset(Option_t* option = "") override;
+  void SetName(const char* name) override;
+  void SetTitle(const char* title) override;
   void Copy(TObject& obj) const override;
   Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1, Double_t c2 = 1) override;
   Bool_t Add(const TH1* h1, Double_t c1 = 1) override;

--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -25,6 +25,8 @@ TH1Ratio<T>::TH1Ratio()
     o2::mergers::MergeInterface(),
     mUniformScaling(true)
 {
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
   {
     TDirectory::TContext ctx(nullptr);
     mHistoNum = new T("num", "num", 10, 0, 10);
@@ -41,14 +43,15 @@ TH1Ratio<T>::TH1Ratio(TH1Ratio const& copymerge)
     mUniformScaling(copymerge.hasUniformScaling())
 {
   // do not add cloned histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
   {
-    TString name_num = T::GetName() + TString("_num");
-    TString name_den = T::GetName() + TString("_den");
-    TString title_num = T::GetTitle() + TString(" num");
-    TString title_den = T::GetTitle() + TString(" den");
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
     TDirectory::TContext ctx(nullptr);
-    mHistoNum = new T(name_num, title_num, 10, 0, 10);
-    mHistoDen = new T(name_den, title_den, 1, -1, 1);
+    mHistoNum = new T(nameNum, titleNum, 10, 0, 10);
+    mHistoDen = new T(nameDen, titleDen, 1, -1, 1);
   }
   copymerge.Copy(*this);
 
@@ -61,18 +64,19 @@ TH1Ratio<T>::TH1Ratio(const char* name, const char* title, int nbinsx, double xm
     o2::mergers::MergeInterface(),
     mUniformScaling(uniformScaling)
 {
-  // do not add cloned histograms to gDirectory
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
   {
-    TString name_num = T::GetName() + TString("_num");
-    TString name_den = T::GetName() + TString("_den");
-    TString title_num = T::GetTitle() + TString(" num");
-    TString title_den = T::GetTitle() + TString(" den");
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
     TDirectory::TContext ctx(nullptr);
-    mHistoNum = new T(name_num, title_num, nbinsx, xmin, xmax);
+    mHistoNum = new T(nameNum, titleNum, nbinsx, xmin, xmax);
     if (mUniformScaling) {
-      mHistoDen = new T(name_den, title_den, 1, -1, 1);
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1);
     } else {
-      mHistoDen = new T(name_den, title_den, nbinsx, xmin, xmax);
+      mHistoDen = new T(nameDen, titleDen, nbinsx, xmin, xmax);
     }
   }
 
@@ -85,18 +89,19 @@ TH1Ratio<T>::TH1Ratio(const char* name, const char* title, bool uniformScaling)
     o2::mergers::MergeInterface(),
     mUniformScaling(uniformScaling)
 {
-  // do not add cloned histograms to gDirectory
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
   {
-    TString name_num = T::GetName() + TString("_num");
-    TString name_den = T::GetName() + TString("_den");
-    TString title_num = T::GetTitle() + TString(" num");
-    TString title_den = T::GetTitle() + TString(" den");
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
     TDirectory::TContext ctx(nullptr);
-    mHistoNum = new T(name_num, title_num, 10, 0, 10);
+    mHistoNum = new T(nameNum, titleNum, 10, 0, 10);
     if (mUniformScaling) {
-      mHistoDen = new T(name_den, title_den, 1, -1, 1);
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1);
     } else {
-      mHistoDen = new T(name_den, title_den, 10, 0, 10);
+      mHistoDen = new T(nameDen, titleDen, 10, 0, 10);
     }
   }
 
@@ -183,10 +188,10 @@ void TH1Ratio<T>::SetName(const char* name)
   T::SetName(name);
 
   //setting the names (appending the correct ending)
-  TString name_num = name + TString("_num");
-  TString name_den = name + TString("_den");
-  mHistoNum->SetName(name_num);
-  mHistoDen->SetName(name_den);
+  TString nameNum = name + TString("_num");
+  TString nameDen = name + TString("_den");
+  mHistoNum->SetName(nameNum);
+  mHistoDen->SetName(nameDen);
 }
 
 template<class T>
@@ -195,10 +200,10 @@ void TH1Ratio<T>::SetTitle(const char* title)
   T::SetTitle(title);
 
   //setting the titles (appending the correct ending)
-  TString title_num = title + TString("_num");
-  TString title_den = title + TString("_den");
-  mHistoNum->SetTitle(title_num);
-  mHistoDen->SetTitle(title_den);
+  TString titleNum = title + TString("_num");
+  TString titleDen = title + TString("_den");
+  mHistoNum->SetTitle(titleNum);
+  mHistoDen->SetTitle(titleDen);
 }
 
 template<class T>

--- a/Modules/Common/include/Common/TH2Ratio.h
+++ b/Modules/Common/include/Common/TH2Ratio.h
@@ -20,6 +20,7 @@
 #include "Mergers/MergeInterface.h"
 #include <TH2F.h>
 #include <TH2D.h>
+#include <TDirectory.h>
 
 namespace o2::quality_control_modules::common
 {
@@ -28,7 +29,7 @@ template <class T>
 class TH2Ratio : public T, public o2::mergers::MergeInterface
 {
  public:
-  TH2Ratio() = default;
+  TH2Ratio();
   TH2Ratio(TH2Ratio const& copymerge);
   TH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, bool uniformScaling = false);
   TH2Ratio(const char* name, const char* title, bool uniformScaling = false);
@@ -49,6 +50,11 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
     return mHistoDen;
   }
 
+  void setHasUniformScaling(bool flag)
+  {
+    mUniformScaling = flag;
+  }
+
   bool hasUniformScaling() const
   {
     return mUniformScaling;
@@ -58,6 +64,8 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
 
   // functions inherited from TH2x
   void Reset(Option_t* option = "") override;
+  void SetName(const char* name) override;
+  void SetTitle(const char* title) override;
   void Copy(TObject& obj) const override;
   Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1, Double_t c2 = 1) override;
   Bool_t Add(const TH1* h1, Double_t c1 = 1) override;

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -25,6 +25,8 @@ TH2Ratio<T>::TH2Ratio()
     o2::mergers::MergeInterface(),
     mUniformScaling(true)
 {
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
   {
     TDirectory::TContext ctx(nullptr);
     mHistoNum = new T("num", "num", 10, 0, 10, 10, 0, 10);
@@ -41,14 +43,15 @@ TH2Ratio<T>::TH2Ratio(TH2Ratio const& copymerge)
     mUniformScaling(copymerge.hasUniformScaling())
 {
   // do not add cloned histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
   {
-    TString name_num = T::GetName() + TString("_num");
-    TString name_den = T::GetName() + TString("_den");
-    TString title_num = T::GetTitle() + TString(" num");
-    TString title_den = T::GetTitle() + TString(" den");
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
     TDirectory::TContext ctx(nullptr);
-    mHistoNum = new T(name_num, title_num, 10, 0, 10, 10, 0, 10);
-    mHistoDen = new T(name_den, title_den, 1, -1, 1, 1, -1, 1);
+    mHistoNum = new T(nameNum, titleNum, 10, 0, 10, 10, 0, 10);
+    mHistoDen = new T(nameDen, titleDen, 1, -1, 1, 1, -1, 1);
   }
   copymerge.Copy(*this);
 
@@ -61,18 +64,19 @@ TH2Ratio<T>::TH2Ratio(const char* name, const char* title, int nbinsx, double xm
     o2::mergers::MergeInterface(),
     mUniformScaling(uniformScaling)
 {
-  // do not add cloned histograms to gDirectory
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
   {
-    TString name_num = T::GetName() + TString("_num");
-    TString name_den = T::GetName() + TString("_den");
-    TString title_num = T::GetTitle() + TString(" num");
-    TString title_den = T::GetTitle() + TString(" den");
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
     TDirectory::TContext ctx(nullptr);
-    mHistoNum = new T(name_num, title_num, nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+    mHistoNum = new T(nameNum, titleNum, nbinsx, xmin, xmax, nbinsy, ymin, ymax);
     if (mUniformScaling) {
-      mHistoDen = new T(name_den, title_den, 1, -1, 1, 1, -1, 1);
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1, 1, -1, 1);
     } else {
-      mHistoDen = new T(name_den, title_den, nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+      mHistoDen = new T(nameDen, titleDen, nbinsx, xmin, xmax, nbinsy, ymin, ymax);
     }
   }
 
@@ -85,18 +89,19 @@ TH2Ratio<T>::TH2Ratio(const char* name, const char* title, bool uniformScaling)
     o2::mergers::MergeInterface(),
     mUniformScaling(uniformScaling)
 {
-  // do not add cloned histograms to gDirectory
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
   {
-    TString name_num = T::GetName() + TString("_num");
-    TString name_den = T::GetName() + TString("_den");
-    TString title_num = T::GetTitle() + TString(" num");
-    TString title_den = T::GetTitle() + TString(" den");
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
     TDirectory::TContext ctx(nullptr);
-    mHistoNum = new T(name_num, title_num, 10, 0, 10, 10, 0, 10);
+    mHistoNum = new T(nameNum, titleNum, 10, 0, 10, 10, 0, 10);
     if (mUniformScaling) {
-      mHistoDen = new T(name_den, title_den, 1, -1, 1, 1, -1, 1);
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1, 1, -1, 1);
     } else {
-      mHistoDen = new T(name_den, title_den, 10, 0, 10, 10, 0, 10);
+      mHistoDen = new T(nameDen, titleDen, 10, 0, 10, 10, 0, 10);
     }
   }
 
@@ -184,10 +189,10 @@ void TH2Ratio<T>::SetName(const char* name)
   T::SetName(name);
 
   //setting the names (appending the correct ending)
-  TString name_num = name + TString("_num");
-  TString name_den = name + TString("_den");
-  mHistoNum->SetName(name_num);
-  mHistoDen->SetName(name_den);
+  TString nameNum = name + TString("_num");
+  TString nameDen = name + TString("_den");
+  mHistoNum->SetName(nameNum);
+  mHistoDen->SetName(nameDen);
 }
 
 template<class T>
@@ -196,10 +201,10 @@ void TH2Ratio<T>::SetTitle(const char* title)
   T::SetTitle(title);
 
   //setting the titles (appending the correct ending)
-  TString title_num = title + TString("_num");
-  TString title_den = title + TString("_den");
-  mHistoNum->SetTitle(title_num);
-  mHistoDen->SetTitle(title_den);
+  TString titleNum = title + TString("_num");
+  TString titleDen = title + TString("_den");
+  mHistoNum->SetTitle(titleNum);
+  mHistoDen->SetTitle(titleDen);
 }
 
 template<class T>

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -20,18 +20,37 @@ namespace o2::quality_control_modules::common
 {
 
 template<class T>
+TH2Ratio<T>::TH2Ratio()
+  : T(),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(true)
+{
+  {
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T("num", "num", 10, 0, 10, 10, 0, 10);
+    mHistoDen = new T("den", "den", 1, -1, 1, 1, -1, 1);
+  }
+
+  init();
+}
+
+template<class T>
 TH2Ratio<T>::TH2Ratio(TH2Ratio const& copymerge)
-  : T(copymerge.GetName(), copymerge.GetTitle(),
-         copymerge.getNum()->GetXaxis()->GetNbins(), copymerge.getNum()->GetXaxis()->GetXmin(), copymerge.getNum()->GetXaxis()->GetXmax(),
-         copymerge.getNum()->GetYaxis()->GetNbins(), copymerge.getNum()->GetYaxis()->GetXmin(), copymerge.getNum()->GetYaxis()->GetXmax()),
+  : T(),
     o2::mergers::MergeInterface(),
     mUniformScaling(copymerge.hasUniformScaling())
 {
-  Bool_t bStatus = TH1::AddDirectoryStatus();
-  TH1::AddDirectory(kFALSE);
-  mHistoNum = (T*)copymerge.getNum()->Clone();
-  mHistoDen = (T*)copymerge.getDen()->Clone();
-  TH1::AddDirectory(bStatus);
+  // do not add cloned histograms to gDirectory
+  {
+    TString name_num = T::GetName() + TString("_num");
+    TString name_den = T::GetName() + TString("_den");
+    TString title_num = T::GetTitle() + TString(" num");
+    TString title_den = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(name_num, title_num, 10, 0, 10, 10, 0, 10);
+    mHistoDen = new T(name_den, title_den, 1, -1, 1, 1, -1, 1);
+  }
+  copymerge.Copy(*this);
 
   init();
 }
@@ -42,15 +61,20 @@ TH2Ratio<T>::TH2Ratio(const char* name, const char* title, int nbinsx, double xm
     o2::mergers::MergeInterface(),
     mUniformScaling(uniformScaling)
 {
-  Bool_t bStatus = TH1::AddDirectoryStatus();
-  TH1::AddDirectory(kFALSE);
-  mHistoNum = new T("num", "num", nbinsx, xmin, xmax, nbinsy, ymin, ymax);
-  if (mUniformScaling) {
-    mHistoDen = new T("den", "den", 1, -1, 1, 1, -1, 1);
-  } else {
-    mHistoDen = new T("den", "den", nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+  // do not add cloned histograms to gDirectory
+  {
+    TString name_num = T::GetName() + TString("_num");
+    TString name_den = T::GetName() + TString("_den");
+    TString title_num = T::GetTitle() + TString(" num");
+    TString title_den = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(name_num, title_num, nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+    if (mUniformScaling) {
+      mHistoDen = new T(name_den, title_den, 1, -1, 1, 1, -1, 1);
+    } else {
+      mHistoDen = new T(name_den, title_den, nbinsx, xmin, xmax, nbinsy, ymin, ymax);
+    }
   }
-  TH1::AddDirectory(bStatus);
 
   init();
 }
@@ -61,15 +85,20 @@ TH2Ratio<T>::TH2Ratio(const char* name, const char* title, bool uniformScaling)
     o2::mergers::MergeInterface(),
     mUniformScaling(uniformScaling)
 {
-  Bool_t bStatus = TH1::AddDirectoryStatus();
-  TH1::AddDirectory(kFALSE);
-  mHistoNum = new T("num", "num", 10, 0, 10, 10, 0, 10);
-  if (mUniformScaling) {
-    mHistoDen = new T("den", "den", 1, -1, 1, 1, -1, 1);
-  } else {
-    mHistoDen = new T("den", "den", 10, 0, 10, 10, 0, 10);
+  // do not add cloned histograms to gDirectory
+  {
+    TString name_num = T::GetName() + TString("_num");
+    TString name_den = T::GetName() + TString("_den");
+    TString title_num = T::GetTitle() + TString(" num");
+    TString title_den = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(name_num, title_num, 10, 0, 10, 10, 0, 10);
+    if (mUniformScaling) {
+      mHistoDen = new T(name_den, title_den, 1, -1, 1, 1, -1, 1);
+    } else {
+      mHistoDen = new T(name_den, title_den, 10, 0, 10, 10, 0, 10);
+    }
   }
-  TH1::AddDirectory(bStatus);
 
   init();
 }
@@ -95,8 +124,6 @@ void TH2Ratio<T>::init()
   mHistoNum->Sumw2();
   mHistoDen->Sumw2();
   T::Sumw2();
-
-  update();
 }
 
 template<class T>
@@ -122,7 +149,6 @@ void TH2Ratio<T>::update()
   const char* title = this->GetTitle();
 
   T::Reset();
-  T::SetNameTitle(name, title);
   T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
   T::GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXmin(), mHistoNum->GetYaxis()->GetXmax());
   T::SetBinsLength();
@@ -153,12 +179,38 @@ void TH2Ratio<T>::Reset(Option_t* option)
 }
 
 template<class T>
+void TH2Ratio<T>::SetName(const char* name)
+{
+  T::SetName(name);
+
+  //setting the names (appending the correct ending)
+  TString name_num = name + TString("_num");
+  TString name_den = name + TString("_den");
+  mHistoNum->SetName(name_num);
+  mHistoDen->SetName(name_den);
+}
+
+template<class T>
+void TH2Ratio<T>::SetTitle(const char* title)
+{
+  T::SetTitle(title);
+
+  //setting the titles (appending the correct ending)
+  TString title_num = title + TString("_num");
+  TString title_den = title + TString("_den");
+  mHistoNum->SetTitle(title_num);
+  mHistoDen->SetTitle(title_den);
+}
+
+template<class T>
 void TH2Ratio<T>::Copy(TObject& obj) const
 {
   auto dest = dynamic_cast<TH2Ratio*>(&obj);
   if (!dest) {
     return;
   }
+
+  dest->setHasUniformScaling(hasUniformScaling());
 
   T::Copy(obj);
 

--- a/Modules/Common/test/testCommonHistRatios.cxx
+++ b/Modules/Common/test/testCommonHistRatios.cxx
@@ -82,6 +82,78 @@ BOOST_AUTO_TEST_CASE(test_TH1FRatio)
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_TH1FRatioCopy)
+{
+  auto histo1 = std::make_unique<TH1FRatio>("test1", "test1", 10, 0, 10.0, true);
+  auto histo2 = std::make_unique<TH1FRatio>("test2", "test2", 100, 0, 10.0, false);
+  auto histo3 = std::make_unique<TH1FRatio>("test3", "test3");
+
+  for (int bin = 1; bin <= 10; bin++) {
+    histo1->getNum()->SetBinContent(bin, bin * 4);
+  }
+
+  histo1->getDen()->SetBinContent(1, 2);
+
+  histo1->update();
+
+  histo1->Copy(*(histo2.get()));
+  histo1->Copy(*(histo3.get()));
+
+  BOOST_REQUIRE_EQUAL(histo2->hasUniformScaling(), true);
+  BOOST_REQUIRE_EQUAL(histo3->hasUniformScaling(), true);
+
+  BOOST_REQUIRE_EQUAL(histo2->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo3->GetXaxis()->GetNbins(), 10);
+
+  BOOST_REQUIRE_EQUAL(histo2->getNum()->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo3->getNum()->GetXaxis()->GetNbins(), 10);
+
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetXaxis()->GetNbins(), 1);
+  BOOST_REQUIRE_EQUAL(histo3->getDen()->GetXaxis()->GetNbins(), 1);
+
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetBinContent(1), 2);
+  BOOST_REQUIRE_EQUAL(histo3->getDen()->GetBinContent(1), 2);
+
+  for (int bin = 1; bin <= 10; bin++) {
+    float value_num = bin * 4.0;
+    BOOST_REQUIRE_EQUAL(histo2->getNum()->GetBinContent(bin), value_num);
+    BOOST_REQUIRE_EQUAL(histo3->getNum()->GetBinContent(bin), value_num);
+    float value = bin * 2.0;
+    BOOST_REQUIRE_EQUAL(histo2->GetBinContent(bin), value);
+    BOOST_REQUIRE_EQUAL(histo3->GetBinContent(bin), value);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_TH1FRatioClone)
+{
+  auto histo1 = std::make_unique<TH1FRatio>("test1", "test1", 10, 0, 10.0, true);
+
+  for (int bin = 1; bin <= 10; bin++) {
+    histo1->getNum()->SetBinContent(bin, bin * 4);
+  }
+
+  histo1->getDen()->SetBinContent(1, 2);
+
+  histo1->update();
+
+  TH1FRatio* histo2 = (TH1FRatio*)histo1->Clone("test1_clone");
+
+  BOOST_REQUIRE_EQUAL(histo2->GetName(), "test1_clone");
+  BOOST_REQUIRE_EQUAL(histo2->hasUniformScaling(), true);
+  BOOST_REQUIRE_EQUAL(histo2->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo2->getNum()->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetXaxis()->GetNbins(), 1);
+
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetBinContent(1), 2);
+
+  for (int bin = 1; bin <= 10; bin++) {
+    float value_num = bin * 4.0;
+    BOOST_REQUIRE_EQUAL(histo2->getNum()->GetBinContent(bin), value_num);
+    float value = bin * 2.0;
+    BOOST_REQUIRE_EQUAL(histo2->GetBinContent(bin), value);
+  }
+}
+
 BOOST_AUTO_TEST_CASE(test_TH2FRatioUniform)
 {
   auto histo1 = std::make_unique<TH2FRatio>("test1", "test1", 10, 0, 10.0, 10, 0, 10.0, true);
@@ -138,6 +210,98 @@ BOOST_AUTO_TEST_CASE(test_TH2FRatio)
     for (int xbin = 1; xbin <= 10; xbin++) {
       float value = 9.0 * xbin * ybin / 7.0;
       BOOST_REQUIRE_EQUAL(histoMerged->GetBinContent(xbin, ybin), value);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_TH2FRatioCopy)
+{
+  auto histo1 = std::make_unique<TH2FRatio>("test1", "test1", 10, 0, 10.0, 10, 0, 10.0, true);
+  auto histo2 = std::make_unique<TH2FRatio>("test2", "test2", 100, 0, 10.0, 100, 0, 10.0, false);
+  auto histo3 = std::make_unique<TH2FRatio>("test3", "test3");
+
+  for (int ybin = 1; ybin <= 10; ybin++) {
+    for (int xbin = 1; xbin <= 10; xbin++) {
+      histo1->getNum()->SetBinContent(xbin, ybin, xbin * ybin * 4);
+    }
+  }
+
+  histo1->getDen()->SetBinContent(1, 1, 2);
+
+  histo1->update();
+
+  histo1->Copy(*(histo2.get()));
+  histo1->Copy(*(histo3.get()));
+
+  BOOST_REQUIRE_EQUAL(histo2->hasUniformScaling(), true);
+  BOOST_REQUIRE_EQUAL(histo3->hasUniformScaling(), true);
+
+  BOOST_REQUIRE_EQUAL(histo2->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo3->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo2->GetYaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo3->GetYaxis()->GetNbins(), 10);
+
+  BOOST_REQUIRE_EQUAL(histo2->getNum()->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo3->getNum()->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo2->getNum()->GetYaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo3->getNum()->GetYaxis()->GetNbins(), 10);
+
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetXaxis()->GetNbins(), 1);
+  BOOST_REQUIRE_EQUAL(histo3->getDen()->GetXaxis()->GetNbins(), 1);
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetYaxis()->GetNbins(), 1);
+  BOOST_REQUIRE_EQUAL(histo3->getDen()->GetYaxis()->GetNbins(), 1);
+
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetBinContent(1, 1), 2);
+  BOOST_REQUIRE_EQUAL(histo3->getDen()->GetBinContent(1, 1), 2);
+
+  for (int ybin = 1; ybin <= 10; ybin++) {
+    for (int xbin = 1; xbin <= 10; xbin++) {
+      float value_num = xbin * ybin * 4;
+      BOOST_REQUIRE_EQUAL(histo2->getNum()->GetBinContent(xbin, ybin), value_num);
+      BOOST_REQUIRE_EQUAL(histo3->getNum()->GetBinContent(xbin, ybin), value_num);
+      float value = xbin * ybin * 2;
+      BOOST_REQUIRE_EQUAL(histo2->GetBinContent(xbin, ybin), value);
+      BOOST_REQUIRE_EQUAL(histo3->GetBinContent(xbin, ybin), value);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_TH2FRatioClone)
+{
+  auto histo1 = std::make_unique<TH2FRatio>("test1", "test1", 10, 0, 10.0, 10, 0, 10.0, true);
+
+  for (int ybin = 1; ybin <= 10; ybin++) {
+    for (int xbin = 1; xbin <= 10; xbin++) {
+      histo1->getNum()->SetBinContent(xbin, ybin, xbin * ybin * 4);
+    }
+  }
+
+  histo1->getDen()->SetBinContent(1, 1, 2);
+
+  histo1->update();
+
+  TH2FRatio* histo2 = (TH2FRatio*)histo1->Clone("test1_clone");
+
+  BOOST_REQUIRE_EQUAL(histo2->GetName(), "test1_clone");
+  BOOST_REQUIRE_EQUAL(histo2->hasUniformScaling(), true);
+
+  BOOST_REQUIRE_EQUAL(histo2->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo2->GetYaxis()->GetNbins(), 10);
+
+  BOOST_REQUIRE_EQUAL(histo2->getNum()->GetXaxis()->GetNbins(), 10);
+  BOOST_REQUIRE_EQUAL(histo2->getNum()->GetYaxis()->GetNbins(), 10);
+
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetXaxis()->GetNbins(), 1);
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetYaxis()->GetNbins(), 1);
+
+  BOOST_REQUIRE_EQUAL(histo2->getDen()->GetBinContent(1, 1), 2);
+
+  for (int ybin = 1; ybin <= 10; ybin++) {
+    for (int xbin = 1; xbin <= 10; xbin++) {
+      float value_num = xbin * ybin * 4;
+      BOOST_REQUIRE_EQUAL(histo2->getNum()->GetBinContent(xbin, ybin), value_num);
+      float value = xbin * ybin * 2;
+      BOOST_REQUIRE_EQUAL(histo2->GetBinContent(xbin, ybin), value);
     }
   }
 }


### PR DESCRIPTION
Various improvements to the THRatio copying and cloning functions:
- numerator and denominator plots are initialized with dummy parameters in the default constructor, instead of assigning `nullptr` to the corresponding pointers
- added override functions to update the histo name and title, and propagate the changes to the internal numerator and denominator
- Copy() function also updates the `mUniformScaling` parameter of the destination object
- added unit tests for Copy() and Clone() functions