### PR TITLE
[QC-429] Get nOrbitsPerTF from CCDB in async QC

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -91,7 +91,8 @@ add_library(O2QualityControl
   src/runnerUtils.cxx
   src/Timekeeper.cxx
   src/TimekeeperSynchronous.cxx
-  src/TimekeeperAsynchronous.cxx)
+  src/TimekeeperAsynchronous.cxx
+  src/TimekeeperFactory.cxx)
 
 
 target_include_directories(

--- a/Framework/include/QualityControl/Timekeeper.h
+++ b/Framework/include/QualityControl/Timekeeper.h
@@ -50,10 +50,13 @@ class Timekeeper
   void setEndOfActivity(validity_time_t ecsTimestamp = 0, validity_time_t configTimestamp = 0, validity_time_t currentTimestamp = 0,
                         std::function<validity_time_t(void)> ccdbTimestampAccessor = nullptr);
 
+  /// \brief asdf
+  void setCCDBOrbitsPerTFAccessor(std::function<int(void)>);
+
   /// \brief updates the validity based on the provided timestamp (ms since epoch)
   virtual void updateByCurrentTimestamp(validity_time_t timestampMs) = 0;
   /// \brief updates the validity based on the provided TF ID
-  virtual void updateByTimeFrameID(uint32_t tfID, uint64_t nOrbitsPerTF) = 0;
+  virtual void updateByTimeFrameID(uint32_t tfID) = 0;
 
   /// \brief resets the state of the mCurrent* counters
   virtual void reset() = 0;
@@ -64,6 +67,7 @@ class Timekeeper
   ValidityInterval getActivityDuration() const;
 
  protected:
+  std::function<int(void)> getCCDBOrbitsPerTFAccessor(void);
   /// \brief defines how a class implementation chooses the activity (run) boundaries
   // by using an accessor to ccdb, we do not call if we are not interested
   virtual validity_time_t
@@ -73,10 +77,14 @@ class Timekeeper
                                       std::function<validity_time_t(void)> ccdbTimestampAccessor) = 0;
 
  protected:
+  // children should set these members according to the updates they receive
   ValidityInterval mActivityDuration = gInvalidValidityInterval;        // from O2StartTime to O2EndTime or current timestamp
   ValidityInterval mCurrentValidityTimespan = gInvalidValidityInterval; // since the last reset time until `update()` call
   ValidityInterval mCurrentSampleTimespan = gInvalidValidityInterval;   // since the last reset
   TimeframeIdRange mCurrentTimeframeIdRange = gInvalidTimeframeIdRange; // since the last reset
+
+ private:
+  std::function<uint64_t()> mCCDBOrbitsPerTFAccessor = nullptr;
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/TimekeeperAsynchronous.h
+++ b/Framework/include/QualityControl/TimekeeperAsynchronous.h
@@ -29,7 +29,7 @@ class TimekeeperAsynchronous : public Timekeeper
   ~TimekeeperAsynchronous() = default;
 
   void updateByCurrentTimestamp(validity_time_t timestampMs) override;
-  void updateByTimeFrameID(uint32_t tfID, uint64_t nOrbitsPerTF) override;
+  void updateByTimeFrameID(uint32_t tfID) override;
   void reset() override;
 
  protected:
@@ -39,6 +39,7 @@ class TimekeeperAsynchronous : public Timekeeper
 
  private:
   validity_time_t mWindowLengthMs = 0;
+  uint64_t mOrbitsPerTF = 0;
   bool mWarnedAboutTfIdZero = false;
 };
 

--- a/Framework/include/QualityControl/TimekeeperFactory.h
+++ b/Framework/include/QualityControl/TimekeeperFactory.h
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TimekeeperFactory.h
+/// \author Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_TIMEKEEPERFACTORY_H
+#define QUALITYCONTROL_TIMEKEEPERFACTORY_H
+
+#include "QualityControl/Timekeeper.h"
+#include <Framework/DataTakingContext.h>
+#include <memory>
+
+namespace o2::quality_control::core
+{
+
+class TimekeeperFactory
+{
+ public:
+  static std::unique_ptr<Timekeeper> create(framework::DeploymentMode);
+  static bool needsGRPECS(framework::DeploymentMode);
+};
+
+} // namespace o2::quality_control::core
+
+#endif // QUALITYCONTROL_TIMEKEEPERFACTORY_H

--- a/Framework/include/QualityControl/TimekeeperSynchronous.h
+++ b/Framework/include/QualityControl/TimekeeperSynchronous.h
@@ -29,7 +29,7 @@ class TimekeeperSynchronous : public Timekeeper
   ~TimekeeperSynchronous() = default;
 
   void updateByCurrentTimestamp(validity_time_t timestampMs) override;
-  void updateByTimeFrameID(uint32_t tfID, uint64_t nOrbitsPerTF) override;
+  void updateByTimeFrameID(uint32_t tfID) override;
 
   void reset() override;
 

--- a/Framework/script/o2-qc-batch-test.sh
+++ b/Framework/script/o2-qc-batch-test.sh
@@ -54,7 +54,6 @@ fi
 
 delete_data
 
-export O2_DPL_DEPLOYMENT_MODE=Grid
 # Run the Tasks 3 times, including twice with the same file.
 o2-qc-run-producer --message-amount 100 --message-rate 100 | o2-qc --config json:/${JSON_DIR}/batch-test.json --local-batch /tmp/batch_test_mergedA${UNIQUE_ID}.root --run
 o2-qc-run-producer --message-amount 100 --message-rate 100 | o2-qc --config json:/${JSON_DIR}/batch-test.json --local-batch /tmp/batch_test_mergedA${UNIQUE_ID}.root --run

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -44,8 +44,7 @@
 #include "QualityControl/ConfigParamGlo.h"
 #include "QualityControl/ObjectsManager.h"
 #include "QualityControl/Bookkeeping.h"
-#include "QualityControl/TimekeeperSynchronous.h"
-#include "QualityControl/TimekeeperAsynchronous.h"
+#include "QualityControl/TimekeeperFactory.h"
 #include "QualityControl/ActivityHelpers.h"
 
 #include <string>
@@ -166,22 +165,8 @@ void TaskRunner::init(InitContext& iCtx)
 
   // setup timekeeping
   mDeploymentMode = DefaultsHelpers::deploymentMode();
-  switch (mDeploymentMode) {
-    case DeploymentMode::Grid: {
-      ILOG(Info, Devel) << "Detected async deployment, object validity will be based on incoming data and available SOR/EOR times" << ENDM;
-      mTimekeeper = std::make_shared<TimekeeperAsynchronous>();
-      break;
-    }
-    case DeploymentMode::Local:
-    case DeploymentMode::OnlineECS:
-    case DeploymentMode::OnlineDDS:
-    case DeploymentMode::OnlineAUX:
-    case DeploymentMode::FST:
-    default: {
-      ILOG(Info, Devel) << "Detected sync deployment, object validity will be based primarily on current time" << ENDM;
-      mTimekeeper = std::make_shared<TimekeeperSynchronous>();
-    }
-  }
+  mTimekeeper = TimekeeperFactory::create(mDeploymentMode);
+  mTimekeeper->setCCDBOrbitsPerTFAccessor([]() { return o2::base::GRPGeomHelper::getNHBFPerTF(); });
 
   // setup user's task
   mTask.reset(TaskFactory::create(mTaskConfig, mObjectsManager));
@@ -223,7 +208,7 @@ void TaskRunner::run(ProcessingContext& pCtx)
   auto [dataReady, timerReady] = validateInputs(pCtx.inputs());
 
   if (dataReady) {
-    mTimekeeper->updateByTimeFrameID(pCtx.services().get<TimingInfo>().tfCounter, 32);
+    mTimekeeper->updateByTimeFrameID(pCtx.services().get<TimingInfo>().tfCounter);
     mTask->monitorData(pCtx);
     updateMonitoringStats(pCtx);
   }

--- a/Framework/src/TaskRunnerFactory.cxx
+++ b/Framework/src/TaskRunnerFactory.cxx
@@ -20,6 +20,7 @@
 #include "QualityControl/TaskRunnerConfig.h"
 #include "QualityControl/TaskSpec.h"
 #include "QualityControl/InfrastructureSpecReader.h"
+#include "QualityControl/TimekeeperFactory.h"
 #include "QualityControl/QcInfoLogger.h"
 
 #include <Framework/DeviceSpec.h>
@@ -27,6 +28,7 @@
 #include <Headers/DataHeader.h>
 #include <Framework/O2ControlLabels.h>
 #include <Framework/DataProcessorLabel.h>
+#include <Framework/DefaultsHelpers.h>
 #include <DetectorsBase/GRPGeomHelper.h>
 #include <DataFormatsGlobalTracking/RecoContainer.h>
 #include <ReconstructionDataFormats/GlobalTrackID.h>
@@ -85,7 +87,8 @@ TaskRunnerConfig TaskRunnerFactory::extractConfig(const CommonSpec& globalConfig
     { "Ideal", o2::base::GRPGeomRequest::GeomRequest::Ideal },
     { "Alignments", o2::base::GRPGeomRequest::GeomRequest::Alignments }
   };
-  const auto& grp = taskSpec.grpGeomRequestSpec;
+  auto grp = taskSpec.grpGeomRequestSpec;
+  grp.askGRPECS |= TimekeeperFactory::needsGRPECS(DefaultsHelpers::deploymentMode());
   auto grpGeomRequest = grp.anyRequestEnabled()                                                               //
                           ? std::make_shared<o2::base::GRPGeomRequest>(                                       //
                               grp.askTime, grp.askGRPECS, grp.askGRPLHCIF, grp.askGRPMagField, grp.askMatLUT, //

--- a/Framework/src/Timekeeper.cxx
+++ b/Framework/src/Timekeeper.cxx
@@ -62,4 +62,14 @@ ValidityInterval Timekeeper::getActivityDuration() const
   return mActivityDuration;
 }
 
+void Timekeeper::setCCDBOrbitsPerTFAccessor(std::function<int(void)> accessor)
+{
+  mCCDBOrbitsPerTFAccessor = std::move(accessor);
+}
+
+std::function<int(void)> Timekeeper::getCCDBOrbitsPerTFAccessor(void)
+{
+  return mCCDBOrbitsPerTFAccessor;
+}
+
 } // namespace o2::quality_control::core

--- a/Framework/src/TimekeeperFactory.cxx
+++ b/Framework/src/TimekeeperFactory.cxx
@@ -1,0 +1,52 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TimekeeperFactory.cxx
+/// \author Piotr Konopka
+///
+
+#include "QualityControl/TimekeeperFactory.h"
+#include "QualityControl/TimekeeperSynchronous.h"
+#include "QualityControl/TimekeeperAsynchronous.h"
+#include "QualityControl/QcInfoLogger.h"
+
+using namespace o2::framework;
+
+namespace o2::quality_control::core
+{
+
+std::unique_ptr<Timekeeper> TimekeeperFactory::create(framework::DeploymentMode deploymentMode)
+{
+  switch (deploymentMode) {
+    case DeploymentMode::Grid: {
+      ILOG(Info, Devel) << "Detected async deployment, object validity will be based on incoming data and available SOR/EOR times" << ENDM;
+      return std::make_unique<TimekeeperAsynchronous>();
+      break;
+    }
+    case DeploymentMode::Local:
+    case DeploymentMode::OnlineECS:
+    case DeploymentMode::OnlineDDS:
+    case DeploymentMode::OnlineAUX:
+    case DeploymentMode::FST:
+    default: {
+      ILOG(Info, Devel) << "Detected sync deployment, object validity will be based primarily on current time" << ENDM;
+      return std::make_unique<TimekeeperSynchronous>();
+    }
+  }
+}
+
+bool TimekeeperFactory::needsGRPECS(framework::DeploymentMode deploymentMode)
+{
+  return deploymentMode == DeploymentMode::Grid;
+}
+
+} // namespace o2::quality_control::core

--- a/Framework/src/TimekeeperSynchronous.cxx
+++ b/Framework/src/TimekeeperSynchronous.cxx
@@ -32,7 +32,7 @@ void TimekeeperSynchronous::updateByCurrentTimestamp(validity_time_t timestampMs
   mActivityDuration.update(timestampMs);
 }
 
-void TimekeeperSynchronous::updateByTimeFrameID(uint32_t tfid, uint64_t nOrbitsPerTF)
+void TimekeeperSynchronous::updateByTimeFrameID(uint32_t tfid)
 {
   if (tfid == 0) {
     if (!mWarnedAboutTfIdZero) {
@@ -56,6 +56,7 @@ void TimekeeperSynchronous::updateByTimeFrameID(uint32_t tfid, uint64_t nOrbitsP
   // fixme: We might want to use this once we know how to get orbitResetTime:
   //  std::ceil((timingInfo.firstTForbit * o2::constants::lhc::LHCOrbitNS / 1000 + orbitResetTime) / 1000);
   //  Until then, we use a less precise method:
+  constexpr uint64_t nOrbitsPerTF = 32; // naively assuming it's 32 for any new data. anyway, it is not crucial for sync QC
   auto tfDuration = constants::lhc::LHCOrbitNS / 1000000 * nOrbitsPerTF;
   auto tfStart = mActivityDuration.getMin() + tfDuration * (tfid - 1);
   auto tfEnd = tfStart + tfDuration - 1;


### PR DESCRIPTION
nOrbitsPerTF is equal to nHBFperTF by definition.

I hesitated to access it also in sync QC, because the access mechanism is not well testable and fails in ways I do not understand (complaints about token missing when I do have a token). Fortunately, in sync QC this number is not crucial and so far it is going to be used only for reporting some statistics, thus I feel moderately comfortable with assuming it is 32.