### PR TITLE
Increase the chance of local and remote part communicate in multinode test

### DIFF
--- a/Framework/script/o2-qc-multinode-test.sh
+++ b/Framework/script/o2-qc-multinode-test.sh
@@ -80,9 +80,9 @@ else
 fi
 
 # store data
-o2-qc-run-producer --producers 2 --message-amount 15  --message-rate 1 -b | timeout -s INT 40s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --local --host localhost --run &
+timeout -s INT 40s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --remote --run &
+o2-qc-run-producer --producers 2 --message-amount 20  --message-rate 1 -b | timeout -s INT 35s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --local --host localhost --run &
 
-timeout -s INT 35s o2-qc --config json://${JSON_DIR}/multinode-test.json -b --remote --run
 
 # wait until the local QC quits before moving forward.
 wait


### PR DESCRIPTION
In one of the failing test executions I noticed sometimes the remote part starts a bit later, probably because the CI machine is overloaded or libraries take long time to load. In that specific case, there was only one message with MOs which could have been received, but it was sent together with EndOfStream. The remote part received this EndOfStream, but did not receive the message with MOs, maybe one got there faster than the other... While this is something which could be fixed at the level of passing data around, I do not assume this is reliable at this stage anyway.

Two mitigations are put in place:
- producer runs 5s longer (5 more messages), there is less chance that the only MonitorObjectCollection that proxy and Merger receive is sent during EOS
- the remote workflow part is started first, so it's less likely that a MonitorObjectCOllection is published before the proxy and Merger start.