### PR TITLE
ITS FHR: decoder parameter to ignore data during ROF ramp Up

### DIFF
--- a/Modules/ITS/include/ITS/ITSFhrTask.h
+++ b/Modules/ITS/include/ITS/ITSFhrTask.h
@@ -149,7 +149,7 @@ class ITSFhrTask final : public TaskInterface
   TH2D* mChipStaveOccupancy;
   TH2I* mChipStaveEventHitCheck;
   TH1D* mOccupancyPlot;
-
+  bool mIgnoreRampUpData = true;
   // Geometry decoder
   o2::its::GeometryTGeo* mGeom;
 };

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -52,7 +52,7 @@
                     "DoHitmapFilter": "1",
                     "PhysicalOccupancyIB": "1.7e-3",
                     "PhysicalOccupancyOB": "4.3e-5",
-                    "IgnoreRampUpData": "false"
+                    "IgnoreRampUpData": "true"
                 },
 	        "grpGeomRequest" : {
                     "geomRequest": "Aligned",

--- a/Modules/ITS/itsFhr.json
+++ b/Modules/ITS/itsFhr.json
@@ -51,7 +51,8 @@
 		    "CutSparseTF": "1",
                     "DoHitmapFilter": "1",
                     "PhysicalOccupancyIB": "1.7e-3",
-                    "PhysicalOccupancyOB": "4.3e-5"
+                    "PhysicalOccupancyOB": "4.3e-5",
+                    "IgnoreRampUpData": "false"
                 },
 	        "grpGeomRequest" : {
                     "geomRequest": "Aligned",

--- a/Modules/ITS/src/ITSFhrTask.cxx
+++ b/Modules/ITS/src/ITSFhrTask.cxx
@@ -109,6 +109,7 @@ void ITSFhrTask::initialize(o2::framework::InitContext& /*ctx*/)
   setPlotsFormat();
   mDecoder = new o2::itsmft::RawPixelDecoder<o2::itsmft::ChipMappingITS>();
   mDecoder->init();
+  mDecoder->setSkipRampUpData(mIgnoreRampUpData);
   mDecoder->setNThreads(mNThreads);
   mDecoder->setUserDataOrigin(header::DataOrigin("DS")); // set user data origin in dpl
   mDecoder->setUserDataDescription(header::DataDescription("RAWDATA0"));
@@ -722,6 +723,7 @@ void ITSFhrTask::monitorData(o2::framework::ProcessingContext& ctx)
 
 void ITSFhrTask::getParameters()
 {
+  mIgnoreRampUpData = o2::quality_control_modules::common::getFromConfig<bool>(mCustomParameters, "IgnoreRampUpData", mIgnoreRampUpData);
   mNThreads = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "decoderThreads", mNThreads);
   mLayer = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "Layer", mLayer);
   mHitCutForCheck = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "HitNumberCut", mHitCutForCheck);


### PR DESCRIPTION
Added decoder parameter to ignore data during ROF ramp Up