### PR TITLE
[EMCAL-524, EMCAL-530] Adjustable multiplicity ranges

### DIFF
--- a/Modules/EMCAL/include/EMCAL/CellTask.h
+++ b/Modules/EMCAL/include/EMCAL/CellTask.h
@@ -65,11 +65,18 @@ class CellTask final : public TaskInterface
     bool mHasTimeVsCellID;
     bool mHasHistosCalib;
     bool mCalibrateEnergy;
+    bool mIsHighMultiplicity;
 
     double mAmpThresholdTimePhys = 0.15;
     double mAmpThresholdTimeCalib = 0.3;
     double mThresholdPHYS = 0.2;
     double mThresholdCAL = 0.5;
+
+    int mMultiplicityRange = 0;
+    int mMultiplicityRangeDetector = 0;
+    int mMultiplicityRangeThreshold = 0;
+    int mMultiplicityRangeSM = 0;
+    int mMultiplicityRangeSMThreshold = 0;
   };
   struct CellHistograms {
     o2::emcal::Geometry* mGeometry;
@@ -169,6 +176,9 @@ class CellTask final : public TaskInterface
       return mSubevents.size();
     };
   };
+  void parseMultiplicityRanges();
+  void initDefaultMultiplicityRanges();
+
   std::vector<CombinedEvent> buildCombinedEvents(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const o2::emcal::TriggerRecord>>& triggerrecords) const;
   TaskSettings mTaskSettings;                                ///< Settings of the task steered via task parameters
   Bool_t mIgnoreTriggerTypes = false;                        ///< Do not differenciate between trigger types, treat all triggers as phys. triggers

--- a/Modules/EMCAL/include/EMCAL/ClusterTask.h
+++ b/Modules/EMCAL/include/EMCAL/ClusterTask.h
@@ -113,6 +113,20 @@ class ClusterTask final : public TaskInterface
     void print(std::ostream& stream) const;
   };
 
+  /// \struct TaskParams
+  /// \brief Other task parameters
+  struct TaskParams {
+    bool mInternalClusterizer = false;   ///< Use run internal clusterizer, do not subscribe to external cluster collection
+    bool mCalibrate = false;             ///< Perform recalibration
+    bool mFillInvMassMeson = false;      ///< Fill invariant mass of meson candidates
+    bool mFillControlHistograms = false; ///< Fill control histograms at cell level
+    int mMultiplicityRange = 200;        ///< Range for multiplicity histograms
+
+    /// \brief Print task parameters to output stream
+    /// \param stream Stream used for printing
+    void print(std::ostream& stream) const;
+  };
+
   /// \brief Constructor
   ClusterTask() = default;
   /// \brief Destructor
@@ -201,6 +215,9 @@ class ClusterTask final : public TaskInterface
   /// \brief Configure meson selection (cluster and pair cuts) for meson candidate histograms
   void configureMesonSelection();
 
+  /// \brief Configure task parameters
+  void configureTaskParameters();
+
   /// \brief Check for config value in taskParameter list
   /// \param key Key to check
   /// \return true if the key is found in the taskParameters, false otherwise
@@ -238,6 +255,7 @@ class ClusterTask final : public TaskInterface
   std::unique_ptr<o2::emcal::EventHandler<o2::emcal::Cell>> mEventHandler;     ///< Event handler for event loop
   std::unique_ptr<o2::emcal::ClusterFactory<o2::emcal::Cell>> mClusterFactory; ///< Cluster factory for cluster kinematics
   std::unique_ptr<o2::emcal::Clusterizer<o2::emcal::Cell>> mClusterizer;       ///< Internal clusterizer
+  TaskParams mTaskParameters;                                                  ///< Task parameters (i.e. histogram ranges)
   ClusterizerParams mClusterizerSettings;                                      ///< Settings for internal clusterizer
   InputBindings mTaskInputBindings;                                            ///< Bindings for input containers
   MesonClusterSelection mMesonClusterCuts;                                     ///< Cuts used in the meson selection
@@ -249,11 +267,6 @@ class ClusterTask final : public TaskInterface
   o2::emcal::BadChannelMap* mBadChannelMap = nullptr;        ///< EMCAL channel map
   o2::emcal::TimeCalibrationParams* mTimeCalib = nullptr;    ///< EMCAL time calib
   o2::emcal::GainCalibrationFactors* mEnergyCalib = nullptr; ///< EMCAL energy calib factors
-
-  bool mInternalClusterizer = false;   ///< Use run internal clusterizer, do not subscribe to external cluster collection
-  bool mCalibrate = false;             ///< Perform recalibration
-  bool mFillInvMassMeson = false;      ///< Fill invariant mass of meson candidates
-  bool mFillControlHistograms = false; ///< Fill control histograms at cell level
 
   ///////////////////////////////////////////////////////////////////////////////
   /// Control histograms input cells                                          ///
@@ -330,6 +343,12 @@ std::ostream& operator<<(std::ostream& stream, const ClusterTask::MesonClusterSe
 /// \param cuts Meson candidate cuts to be printed
 /// \return Stream after printing the cuts
 std::ostream& operator<<(std::ostream& stream, const ClusterTask::MesonSelection& cuts);
+
+/// \brief Output stream operator for task parameters in the ClusterTask
+/// \param stream Stream used for printing the task parameter object
+/// \param cuts Task parameters to be printed
+/// \return Stream after printing the parameters
+std::ostream& operator<<(std::ostream& stream, const ClusterTask::TaskParams& params);
 
 } // namespace o2::quality_control_modules::emcal
 


### PR DESCRIPTION
Mutliplicity ranges can now be configured via the task
parameters for the cell task and the cluster task.
Needed in order to optimise histogram binning for pp
and PbPb runs which have very different ranges.