### PR TITLE
MFT: dead chips displayed in cluster maps

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTClusterCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterCheck.h
@@ -46,6 +46,27 @@ class QcMFTClusterCheck : public o2::quality_control::checker::CheckInterface
   int mZoneThresholdMedium;
   int mZoneThresholdBad;
 
+  // masked chips part
+  bool mFirstCall;
+  std::vector<int> mMaskedChips;
+  std::vector<string> mChipMapName;
+
+  void readMaskedChips(std::shared_ptr<MonitorObject> mo);
+  void createMaskedChipsNames();
+
+  // to form the name of the masked chips histograms
+  int mHalf[936] = { 0 };
+  int mDisk[936] = { 0 };
+  int mFace[936] = { 0 };
+  int mZone[936] = { 0 };
+  int mSensor[936] = { 0 };
+  int mTransID[936] = { 0 };
+  int mLayer[936] = { 0 };
+  int mLadder[936] = { 0 };
+  float mX[936] = { 0 };
+  float mY[936] = { 0 };
+  void getChipMapData();
+
   ClassDefOverride(QcMFTClusterCheck, 2);
 };
 

--- a/Modules/MFT/mft-clusters.json
+++ b/Modules/MFT/mft-clusters.json
@@ -61,7 +61,28 @@
         "dataSource" : [ {
           "type" : "Task",
           "name" : "Clusters",
-          "MOs" : ["mClusterOccupancy","mClusterPatternIndex","mClusterSizeSummary", "mGroupedClusterSizeSummary", "mClusterOccupancySummary"]
+          "MOs" : ["mClusterOccupancy","mClusterPatternIndex","mClusterSizeSummary", "mGroupedClusterSizeSummary", "mClusterOccupancySummary",
+              "ChipOccupancyMaps/Half_0/Disk_0/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_0/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_1/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_1/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_2/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_2/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_3/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_3/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_4/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_0/Disk_4/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_0/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_0/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_1/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_1/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_2/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_2/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_3/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_3/Face_0/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_4/Face_1/mClusterChipOccupancyMap",
+              "ChipOccupancyMaps/Half_1/Disk_4/Face_0/mClusterChipOccupancyMap"
+          ]
         } ],
         "checkParameters" : {
           "ZoneThresholdMedium" : "2",

--- a/Modules/MFT/src/QcMFTClusterCheck.cxx
+++ b/Modules/MFT/src/QcMFTClusterCheck.cxx
@@ -16,6 +16,8 @@
 /// \author Katarina Krizkova Gajdosova
 /// \author Diana Maria Krupova
 
+// C++
+#include <string>
 // Fair
 #include <fairlogger/Logger.h>
 // ROOT
@@ -24,11 +26,17 @@
 #include <TLatex.h>
 #include <TList.h>
 #include <TPaveText.h>
+// O2
+#include <DataFormatsITSMFT/NoiseMap.h>
+#include <ITSMFTReconstruction/ChipMappingMFT.h>
+
 // Quality Control
 #include "MFT/QcMFTClusterCheck.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "MFT/QcMFTUtilTables.h"
+#include "QualityControl/UserCodeInterface.h"
 
 using namespace std;
 
@@ -47,6 +55,9 @@ void QcMFTClusterCheck::configure()
     ILOG(Info, Support) << "Custom parameter - ZoneThresholdBad: " << param->second << ENDM;
     mZoneThresholdBad = stoi(param->second);
   }
+
+  // no call to beautifier yet
+  mFirstCall = true;
 }
 
 Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
@@ -141,8 +152,71 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
 
 std::string QcMFTClusterCheck::getAcceptedType() { return "TH1"; }
 
+void QcMFTClusterCheck::readMaskedChips(std::shared_ptr<MonitorObject> mo)
+{
+  long timestamp = mo->getValidity().getMin();
+  map<string, string> headers;
+  map<std::string, std::string> filter;
+  auto calib = UserCodeInterface::retrieveConditionAny<o2::itsmft::NoiseMap>("MFT/Calib/DeadMap/", filter, timestamp);
+  for (int i = 0; i < calib->size(); i++) {
+    if (calib->isFullChipMasked(i)) {
+      mMaskedChips.push_back(i);
+    }
+  }
+}
+
+void QcMFTClusterCheck::getChipMapData()
+{
+  const o2::itsmft::ChipMappingMFT mapMFT;
+  auto chipMapData = mapMFT.getChipMappingData();
+  QcMFTUtilTables MFTTable;
+
+  for (int i = 0; i < 936; i++) {
+    mHalf[i] = chipMapData[i].half;
+    mDisk[i] = chipMapData[i].disk;
+    mLayer[i] = chipMapData[i].layer;
+    mFace[i] = mLayer[i] % 2;
+    mZone[i] = chipMapData[i].zone;
+    mSensor[i] = chipMapData[i].localChipSWID;
+    mTransID[i] = chipMapData[i].cable;
+    mLadder[i] = MFTTable.mLadder[i];
+    mX[i] = MFTTable.mX[i];
+    mY[i] = MFTTable.mY[i];
+  }
+}
+
+void QcMFTClusterCheck::createMaskedChipsNames()
+{
+  for (int i = 0; i < mMaskedChips.size(); i++) {
+    mChipMapName.push_back(Form("ChipOccupancyMaps/Half_%d/Disk_%d/Face_%d/mClusterChipOccupancyMap",
+                                mHalf[mMaskedChips[i]], mDisk[mMaskedChips[i]], mFace[mMaskedChips[i]]));
+  }
+}
+
 void QcMFTClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
+  // set up masking of dead chips once
+  if (mFirstCall) {
+    mFirstCall = false;
+    readMaskedChips(mo);
+    getChipMapData();
+    createMaskedChipsNames();
+  }
+  // print skull in maps to display dead chips
+  int nMaskedChips = mMaskedChips.size();
+  for (int i = 0; i < nMaskedChips; i++) {
+    if (mo->getName().find(mChipMapName[i]) != std::string::npos) {
+      auto* hMap = dynamic_cast<TH2F*>(mo->getObject());
+      int binCx = hMap->GetXaxis()->FindBin(mX[mMaskedChips[i]]);
+      int binCy = hMap->GetYaxis()->FindBin(mY[mMaskedChips[i]]);
+      // the -0.5 is a shift to centre better the skulls
+      TLatex* tl = new TLatex(hMap->GetXaxis()->GetBinCenter(binCx) - 0.5, hMap->GetYaxis()->GetBinCenter(binCy), "N");
+      tl->SetTextFont(142);
+      tl->SetTextSize(0.08);
+      hMap->GetListOfFunctions()->Add(tl);
+      tl->Draw();
+    }
+  }
   if (mo->getName().find("mClusterOccupancySummary") != std::string::npos) {
     auto* hOccupancySummary = dynamic_cast<TH2F*>(mo->getObject());
     TPaveText* msg1 = new TPaveText(0.05, 0.9, 0.35, 1.0, "NDC NB");


### PR DESCRIPTION
- display excluded (dead and masked) chips in MFT cluster maps (as was done for [digit maps](https://github.com/AliceO2Group/QualityControl/commit/c9a007dc72c583423b21ebbda887a00dd3364f61) previously), using the dead map from CCBD