### PR TITLE
Qc grid branch 4

### DIFF
--- a/Modules/TRD/CMakeLists.txt
+++ b/Modules/TRD/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(O2QcTRD)
 
-target_sources(O2QcTRD PRIVATE src/TRDReductor.cxx src/PulsePositionCheck.cxx  src/TrackingTask.cxx  src/PulseHeightTrackMatch.cxx  src/TrackletsCheck.cxx  src/TrackletsTask.cxx  src/PulseHeightCheck.cxx  src/PulseHeight.cxx  src/RawData.cxx  src/DigitsTask.cxx
+target_sources(O2QcTRD PRIVATE src/TrackletPerTriggerCheck.cxx  src/TRDReductor.cxx src/PulsePositionCheck.cxx  src/TrackingTask.cxx  src/PulseHeightTrackMatch.cxx  src/TrackletsCheck.cxx  src/TrackletsTask.cxx  src/PulseHeightCheck.cxx  src/PulseHeight.cxx  src/RawData.cxx  src/DigitsTask.cxx
                              src/DigitsCheck.cxx src/TRDTrending.cxx src/TrendingTaskConfigTRD.cxx src/PulseHeightPostProcessing.cxx)
 
 target_include_directories(
@@ -20,6 +20,7 @@ install(TARGETS O2QcTRD
 
 add_root_dictionary(O2QcTRD
                     HEADERS
+  include/TRD/TrackletPerTriggerCheck.h
   include/TRD/TRDReductor.h
   include/TRD/PulsePositionCheck.h
   include/TRD/TrackingTask.h

--- a/Modules/TRD/TRDQC.json
+++ b/Modules/TRD/TRDQC.json
@@ -154,6 +154,131 @@
         "saveObjectsToFile": "trackingqcobject.root"
       }
     },
+    "checks": {
+      "TrackletPerTriggerCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::trd::TrackletPerTriggerCheck",
+        "moduleName": "QcTRD",
+        "policy": "OnAny",
+        "detectorName": "TRD",
+        "dataSource": [{
+          "type": "Task",
+          "name": "TrackletsTask",
+          "MOs": [ "trackletsperevent" ]
+        }],
+        "checkParameters":{
+          "Lowerthreshold":"500.0",
+          "Upperthreshold":"520.0",
+          "StatThreshold": "1"
+        }
+      }
+    },
+    "aggregators": {
+      "TRDQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QualityControl",
+        "policy": "OnAll",
+        "detectorName": "TRD",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "TrackletPerTriggerCheck"
+          }
+        ]
+      }
+    },
+    "postprocessing": {
+      "TRDTrending": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::TRDTrending",
+        "moduleName": "QualityControl",
+        "detectorName": "TRD",
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "TRD/MO/TrackletsTask/",		       
+            "names": [ "trackletspertimeframe","trackletsperevent" ],
+            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+            "moduleName": "QcTRD"
+          }
+        ],
+        "plots": [
+          {
+            "names": ["mean_distribution_trackletpertimeframe","mean_distribution_trackletperevent"],
+            "title": ["mean distribution of tracklet per timeframe","mean distribution of tracklet per event"],
+            "varexp": ["trackletspertimeframe.mean","trackletsperevent.mean"],
+            "selection": "",
+            "option": ""
+          },
+          {
+            "names": ["mean_trend_trackletspertimeframe", "mean_trend_trackletperevent"],
+            "title": ["Mean trend of the Tracklet per time frame","Mean trend of tracklet per event"],
+            "varexp": ["trackletspertimeframe.mean:time","trackletsperevent.mean:time"],
+            "selection": "",
+            "option": "PL"
+          }
+        ],
+        "initTrigger": [
+          "usercontrol"
+        ],
+        "updateTrigger": [
+            "10 seconds"
+        ],
+        "stopTrigger": [
+          "usercontrol"
+        ]
+      },
+      "Quality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QualityControl",
+        "detectorName": "TRD",
+        "qualityGroups": [
+          {
+            "name" : "global",
+            "title" : "GLOBAL TRD QUALITY",
+            "path": "TRD/QO",
+            "ignoreQualitiesDetails" : ["Null", "Good", "Medium", "Bad"],
+            "inputObjects": [
+              {
+                "name" : "TRDQuality/TRDQuality",
+                "title" : "TRD Quality",
+                "messageBad" : "Inform TRD on-call immediately",
+                "messageMedium": "Add bookkeeping entry",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty!!!"
+              }
+            ]
+          },
+          {
+            "name" : "TrackletQuality",
+            "title" : "TRD Tracklet Quality",
+            "path": "TRD/QO",
+            "ignoreQualitiesDetails" : [],
+            "inputObjects": [
+              {
+                "name" : "TrackletPerTriggerCheck",
+                "title" : "Check on Mean of Tracklet per Event",
+                "messageBad" : "Inform TRD on-call immediately",
+                "messageMedium": "Add bookkeeping entry",
+                "messageGood": "TrackletPerTriggerCheck check is OK",
+                "messageNull": "Some histograms are empty!!!"
+              }
+            ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol","60sec","SOR"
+        ],
+        "updateTrigger": [
+          "60 seconds"
+        ],
+        "stopTrigger": [
+          "userorcontrol","EOR"
+        ]
+      }
+    },
     "dataSamplingPolicies": []
   }
 }

--- a/Modules/TRD/TrackletPerTriggerCheck.json
+++ b/Modules/TRD/TrackletPerTriggerCheck.json
@@ -164,7 +164,7 @@
                   "title" : "Check on Mean of Tracklet per Event",
                   "messageBad" : "Inform TRD on-call immediately",
                   "messageMedium": "Add bookkeeping entry",
-                  "messageGood": "PulsePosition check is OK",
+                  "messageGood": "TrackletPerTriggerCheck check is OK",
                   "messageNull": "Some histograms are empty!!!"
                 }
               ]

--- a/Modules/TRD/TrackletPerTriggerCheck.json
+++ b/Modules/TRD/TrackletPerTriggerCheck.json
@@ -1,0 +1,187 @@
+{
+    "qc": {
+      "config": {
+        "database": {
+          "implementation": "CCDB",
+          "host": "ccdb-test.cern.ch:8080",
+          "username": "not_applicable",
+          "password": "not_applicable",
+          "name": "not_applicable",
+          "maxObjectSize": "2097152",       "": "[Bytes, default=2MB] Maximum size allowed, larger objects are rejected."
+        },
+        "Activity": {
+          "number": "42",
+          "type": "2",
+          "periodName": "",           "": "Period name - e.g. LHC22c, LHC22c1b_test",
+          "passName": "",             "": "Pass type - e.g. spass, cpass1",
+          "provenance": "qc",         "": "Provenance - qc or qc_mc depending whether it is normal data or monte carlo data"
+        },
+        "monitoring": {
+          "url": "infologger:///debug?qc"
+        },
+        "consul": {
+          "url": ""
+        },
+        "conditionDB": {
+          "url": "ccdb-test.cern.ch:8080"
+        },
+        "infologger": {                     "": "Configuration of the Infologger (optional).",
+          "filterDiscardDebug": "false",    "": "Set to true to discard debug and trace messages (default: false)",
+          "filterDiscardLevel": "11",       "": "Message at this level or above are discarded (default: 21 - Trace)",
+          "filterDiscardFile": "/tmp/_ID_.txt", "": ["If set, the messages discarded because of filterDiscardLevel",
+            "will go to this file (default: <none>); The keyword _ID_ is replaced by the device id. Discarded Debug ",
+            "messages won't go there."]
+        },
+        "bookkeeping": {
+          "url": ""
+        },
+        "postprocessing": {
+          "periodSeconds": "60"
+        }
+      },
+      "tasks": {
+        "DTrackletsTask": {
+          "active": "true",
+          "className": "o2::quality_control_modules::trd::TrackletsTask",
+          "moduleName": "QcTRD",
+          "detectorName": "TRD",
+          "cycleDurationSeconds": "60",
+          "maxNumberCycles": "-1", "..........try this value..............":"-1",
+          "dataSource": {
+            "type": "direct",
+            "query": "tracklets:TRD/TRACKLETS;digits:TRD/DIGITS;triggers:TRD/TRKTRGRD" ,"":"digits:TRD/DIGITS;tracklets:TRD/TRACKLETS;triggers:TRD/TRKTRGRD;rawstats:TRD/RAWSTATS"
+          },
+          "taskParameters": {},
+          "location": "remote",
+          "saveObjectsToFile": "TrackletPerTriggerCheck.root"
+        }
+      },
+      "checks": {
+        "DTrackletPerTriggerCheck": {
+          "active": "true",
+          "className": "o2::quality_control_modules::trd::TrackletPerTriggerCheck",
+          "moduleName": "QcTRD",
+          "policy": "OnAny",
+          "detectorName": "TRD",
+          "dataSource": [{
+            "type": "Task",
+            "name": "DTrackletsTask",
+            "MOs": [ "trackletsperevent" ]
+          }],
+          "checkParameters":{
+            "Lowerthreshold":"500.0",
+            "Upperthreshold":"520.0",
+            "StatThreshold": "1"
+          }
+        }
+      },
+      "aggregators": {
+        "TRDQuality": {
+          "active": "true",
+          "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+          "moduleName": "QualityControl",
+          "policy": "OnAll",
+          "detectorName": "TRD",
+          "dataSource": [
+            {
+              "type": "Check",
+              "name": "DTrackletPerTriggerCheck"
+            }
+          ]
+        }
+      },
+      "postprocessing": {
+        "TRDTrending": {
+          "active": "true",
+          "className": "o2::quality_control::postprocessing::TRDTrending",
+          "moduleName": "QualityControl",
+          "detectorName": "TRD",
+          "dataSources": [
+            {
+              "type": "repository",
+              "path": "TRD/MO/DTrackletsTask/",		       
+              "names": [ "trackletspertimeframe","trackletsperevent" ],
+              "reductorName": "o2::quality_control_modules::common::TH1Reductor",
+              "moduleName": "QcTRD"
+            }
+          ],
+          "plots": [
+            {
+              "names": ["mean_distribution_trackletpertimeframe","mean_distribution_trackletperevent"],
+              "title": ["mean distribution of tracklet per timeframe","mean distribution of tracklet per event"],
+              "varexp": ["trackletspertimeframe.mean","trackletsperevent.mean"],
+              "selection": "",
+              "option": ""
+            },
+            {
+              "names": ["mean_trend_trackletspertimeframe", "mean_trend_trackletperevent"],
+              "title": ["Mean trend of the Tracklet per time frame","Mean trend of tracklet per event"],
+              "varexp": ["trackletspertimeframe.mean:time","trackletsperevent.mean:time"],
+              "selection": "",
+              "option": "PL"
+            }
+          ],
+          "initTrigger": [
+            "usercontrol"
+          ],
+          "updateTrigger": [
+              "10 seconds"
+          ],
+          "stopTrigger": [
+            "usercontrol"
+          ]
+	      },
+        "Quality": {
+          "active": "true",
+          "className": "o2::quality_control_modules::common::QualityTask",
+          "moduleName": "QualityControl",
+          "detectorName": "TRD",
+          "qualityGroups": [
+            {
+              "name" : "global",
+              "title" : "GLOBAL TRD QUALITY",
+              "path": "TRD/QO",
+              "ignoreQualitiesDetails" : ["Null", "Good", "Medium", "Bad"],
+              "inputObjects": [
+                {
+                  "name" : "TRDQuality/TRDQuality",
+                  "title" : "TRD Quality",
+                  "messageBad" : "Inform TRD on-call immediately",
+                  "messageMedium": "Add bookkeeping entry",
+                  "messageGood": "All checks are OK",
+                  "messageNull": "Some histograms are empty!!!"
+                }
+              ]
+            },
+            {
+              "name" : "TrackletQuality",
+              "title" : "TRD Tracklet Quality",
+              "path": "TRD/QO",
+              "ignoreQualitiesDetails" : [],
+              "inputObjects": [
+                {
+                  "name" : "DTrackletPerTriggerCheck",
+                  "title" : "Check on Mean of Tracklet per Event",
+                  "messageBad" : "Inform TRD on-call immediately",
+                  "messageMedium": "Add bookkeeping entry",
+                  "messageGood": "PulsePosition check is OK",
+                  "messageNull": "Some histograms are empty!!!"
+                }
+              ]
+            }
+          ],
+          "initTrigger": [
+            "userorcontrol","60sec","SOR"
+          ],
+          "updateTrigger": [
+            "60 seconds"
+          ],
+          "stopTrigger": [
+            "userorcontrol","EOR"
+          ]
+        }
+      }
+    }
+  }
+  
+  

--- a/Modules/TRD/include/TRD/LinkDef.h
+++ b/Modules/TRD/include/TRD/LinkDef.h
@@ -17,5 +17,5 @@
 #pragma link C++ class o2::quality_control_modules::trd::TrackingTask + ;
 #pragma link C++ class o2::quality_control_modules::trd::PulsePositionCheck + ;
 #pragma link C++ class o2::quality_control_modules::trd::TRDReductor + ;
-#pragma link C++ class o2::quality_control_modules::trd::TrackletPerTriggerCheck+;
+#pragma link C++ class o2::quality_control_modules::trd::TrackletPerTriggerCheck + ;
 #endif

--- a/Modules/TRD/include/TRD/LinkDef.h
+++ b/Modules/TRD/include/TRD/LinkDef.h
@@ -17,4 +17,5 @@
 #pragma link C++ class o2::quality_control_modules::trd::TrackingTask + ;
 #pragma link C++ class o2::quality_control_modules::trd::PulsePositionCheck + ;
 #pragma link C++ class o2::quality_control_modules::trd::TRDReductor + ;
+#pragma link C++ class o2::quality_control_modules::trd::TrackletPerTriggerCheck+;
 #endif

--- a/Modules/TRD/include/TRD/TrackletPerTriggerCheck.h
+++ b/Modules/TRD/include/TRD/TrackletPerTriggerCheck.h
@@ -11,7 +11,7 @@
 
 ///
 /// \file   TrackletPerTriggerCheck.h
-/// \author My Name
+/// \author Deependra Sharma
 ///
 
 #ifndef QC_MODULE_TRD_TRDTRACKLETPERTRIGGERCHECK_H
@@ -38,7 +38,8 @@ class TrackletPerTriggerCheck : public o2::quality_control::checker::CheckInterf
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;
   long int mTimeStamp;
-  std::pair<float,float> DesiredMeanRegion;
+  std::pair<float, float> DesiredMeanRegion;
+  long int StatThreshold;
 
   ClassDefOverride(TrackletPerTriggerCheck, 2);
 };

--- a/Modules/TRD/include/TRD/TrackletPerTriggerCheck.h
+++ b/Modules/TRD/include/TRD/TrackletPerTriggerCheck.h
@@ -1,0 +1,48 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TrackletPerTriggerCheck.h
+/// \author My Name
+///
+
+#ifndef QC_MODULE_TRD_TRDTRACKLETPERTRIGGERCHECK_H
+#define QC_MODULE_TRD_TRDTRACKLETPERTRIGGERCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+
+namespace o2::quality_control_modules::trd
+{
+
+/// \brief  QC Check on TrackletPerTriggerCheck
+/// \author Deependra Sharma
+class TrackletPerTriggerCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  TrackletPerTriggerCheck() = default;
+  /// Destructor
+  ~TrackletPerTriggerCheck() override = default;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+  long int mTimeStamp;
+  std::pair<float,float> DesiredMeanRegion;
+
+  ClassDefOverride(TrackletPerTriggerCheck, 2);
+};
+
+} // namespace o2::quality_control_modules::trd
+
+#endif // QC_MODULE_TRD_TRDTRACKLETPERTRIGGERCHECK_H

--- a/Modules/TRD/src/TRDReductor.cxx
+++ b/Modules/TRD/src/TRDReductor.cxx
@@ -11,6 +11,7 @@
 
 ///
 /// \file   TRDReductor.cxx
+/// \author Deependra Sharma
 ///
 
 #include <TH1.h>

--- a/Modules/TRD/src/TrackletPerTriggerCheck.cxx
+++ b/Modules/TRD/src/TrackletPerTriggerCheck.cxx
@@ -1,0 +1,123 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TrackletPerTriggerCheck.cxx
+/// \author Deependra Sharma
+///
+
+#include "TRD/TrackletPerTriggerCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
+// ROOT
+#include <TH1.h>
+#include "TPaveText.h"
+
+#include <DataFormatsQualityControl/FlagReasons.h>
+#include "CCDB/BasicCCDBManager.h"
+
+using namespace std;
+using namespace o2::quality_control;
+
+namespace o2::quality_control_modules::trd
+{
+
+void TrackletPerTriggerCheck::configure() {
+  if (auto param = mCustomParameters.find("ccdbtimestamp"); param != mCustomParameters.end()) {
+    mTimeStamp = std::stol(mCustomParameters["ccdbtimestamp"]);
+    ILOG(Debug, Support) << "configure() : using ccdbtimestamp = " << mTimeStamp << ENDM;
+  } else {
+    mTimeStamp = o2::ccdb::getCurrentTimestamp();
+    ILOG(Debug, Support) << "configure() : using default timestam of now = " << mTimeStamp << ENDM;
+  }
+  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+  mgr.setTimestamp(mTimeStamp);
+
+  ILOG(Debug, Devel) << "initialize TrackletPertriggerCheck" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
+
+  if(auto param = mCustomParameters.find("Lowerthreshold"); param != mCustomParameters.end()){
+    DesiredMeanRegion.first =stof(param->second);
+    ILOG(Debug,Support)<<"configure() : using json Lowerthreshold"<<DesiredMeanRegion.first<<ENDM;
+  }else{
+    DesiredMeanRegion.first=500.0;
+    ILOG(Debug,Support)<<"configure() : using default Lowerthreshold"<<DesiredMeanRegion.first<<ENDM;
+  }
+
+  if(auto param = mCustomParameters.find("Upperthreshold"); param != mCustomParameters.end()){
+    DesiredMeanRegion.second = stof(param->second);
+    ILOG(Debug,Support)<<"configure() : using json Upperthreshold"<<DesiredMeanRegion.second<<ENDM;
+  }else{
+    DesiredMeanRegion.second = 520.0;
+    ILOG(Debug,Support)<<"configure() : using default Upperthreshold"<<DesiredMeanRegion.second<<ENDM;
+  }
+
+}
+
+Quality TrackletPerTriggerCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Null;
+
+  // you can get details about the activity via the object mActivity:
+  ILOG(Debug, Devel) << "Run " << getActivity()->mId << ", type: " << getActivity()->mType << ", beam: " << getActivity()->mBeamType << ENDM;
+  // and you can get your custom parameters:
+  ILOG(Debug, Devel) << "custom param physics.pp.myOwnKey1 : " << mCustomParameters.atOrDefaultValue("myOwnKey1", "physics", "pp", "default_value") << ENDM;
+
+  for (auto& [moName, mo] : *moMap) {
+
+    (void)moName;
+    if (mo->getName() == "trackletsperevent") {
+      auto* h = dynamic_cast<TH1F*>(mo->getObject());
+
+      TPaveText* msg1 = new TPaveText(0.1,0.8,0.2,0.9,"NDC"); // check option "br","NDC"
+      h->GetListOfFunctions()->Add(msg1);
+      int Entries = h->GetEntries();
+      if(Entries>0){
+        msg1->AddText("hist can't be ignored");
+      }
+
+
+      float MeanTracletPertrigger=h->GetMean();
+      if(MeanTracletPertrigger>520.0 && MeanTracletPertrigger<500.0){
+        result = Quality::Good;
+      }else{
+        result = Quality::Bad;
+        result.addReason(FlagReasonFactory::Unknown(),"MeanTracletPertrigger is not in bound region");
+      }
+
+      result.addMetadata("mykey", "myvalue");
+    }
+  }
+  return result;
+}
+
+std::string TrackletPerTriggerCheck::getAcceptedType() { return "TH1"; }
+
+void TrackletPerTriggerCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (mo->getName() == "trackletsperevent") {
+    auto* h = dynamic_cast<TH1F*>(mo->getObject());
+    
+
+    if (checkResult == Quality::Good) {
+      h->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      ILOG(Debug, Devel) << "Quality::Bad, setting to red" << ENDM;
+      h->SetFillColor(kRed);
+    } else if (checkResult == Quality::Medium) {
+      ILOG(Debug, Devel) << "Quality::medium, setting to orange" << ENDM;
+      h->SetFillColor(kOrange);
+    }
+    h->SetLineColor(kBlack);
+  }
+}
+
+} // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/src/TrackletPerTriggerCheck.cxx
+++ b/Modules/TRD/src/TrackletPerTriggerCheck.cxx
@@ -67,7 +67,7 @@ void TrackletPerTriggerCheck::configure()
     StatThreshold = stod(param->second);
     ILOG(Debug, Support) << "configure() : using json StatThreshold" << StatThreshold << ENDM;
   } else {
-    StatThreshold = 0;
+    StatThreshold = 1000;
     ILOG(Debug, Support) << "configure() : using default StatThreshold" << StatThreshold << ENDM;
   }
 }
@@ -98,7 +98,7 @@ Quality TrackletPerTriggerCheck::check(std::map<std::string, std::shared_ptr<Mon
       } else if (Entries > 0) {
         msg1->AddText(TString::Format("Hist Can be ignored. Stat is low. Entries: %d < Threshold: %d", Entries, StatThreshold));
         // msg1->SetTextColor(kYellow);
-      } else if (Entries = 0) {
+      } else if (Entries == 0) {
         msg1->AddText(TString::Format("Hist is empty. Entries: %d < Threshold: %d", Entries, StatThreshold));
         msg1->SetTextColor(kRed);
       }


### PR DESCRIPTION
1. Check on position of mean of "trackletperevent" hist generated by "TrackletTask". Then it tag good or bad depending on if mean is (or not) found in desired region
provided by user with config file. SetFillColor red/green/yellow depending on qulity of check.

2. Write text over hist if statistics is (or not) enough wrt reference given with config file. One know if hist is (or not) to be ignored based on stat.

3. TrackletPerTriggerCheck.json: (a) Does not only give input to above Check class but also plot trending plot of mean distribution of tracklet per event and time frame.
				 (b) Plot Global TRD Quality, Plot Quality of TrackletperTriggerCheck and do beautification.