### PR TITLE
FIT: some preparations for migration FLP->EPN

### DIFF
--- a/Modules/FIT/Common/CMakeLists.txt
+++ b/Modules/FIT/Common/CMakeLists.txt
@@ -5,12 +5,15 @@ set(MODULE_NAME "O2QcFITCommon")
 set(SRCS
   src/HelperFIT.cxx
   src/HelperHist.cxx
+  src/HelperLUT.cxx
   src/DigitSync.cxx
 )
 
 set(HEADERS
+  include/FITCommon/HelperCommon.h
   include/FITCommon/HelperFIT.h
   include/FITCommon/HelperHist.h
+  include/FITCommon/HelperLUT.h
   include/FITCommon/DigitSync.h
 )
 
@@ -24,7 +27,15 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_link_libraries(${MODULE_NAME} PUBLIC O2QualityControl ROOT::Core ROOT::Hist O2::CommonDataFormat O2::DataFormatsFIT O2QcCommon)
+target_link_libraries(${MODULE_NAME} PUBLIC O2QualityControl
+                                            ROOT::Core
+                                            ROOT::Hist
+                                            O2::CommonDataFormat
+                                            O2::DataFormatsFIT
+                                            O2QcCommon
+                                            O2::DataFormatsFDD
+                                            O2::DataFormatsFT0
+                                            O2::DataFormatsFV0)
 
 set(CMAKE_REQUIRED_INCLUDES ${O2_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
 

--- a/Modules/FIT/Common/include/FITCommon/HelperCommon.h
+++ b/Modules/FIT/Common/include/FITCommon/HelperCommon.h
@@ -1,0 +1,115 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   HelperHist.h
+/// \author Artur Furs afurs@cern.ch
+/// \brief Histogram helper
+
+#ifndef QC_MODULE_FIT_HELPERCOMMON_H
+#define QC_MODULE_FIT_HELPERCOMMON_H
+
+#include <map>
+#include <vector>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <memory>
+#include <type_traits>
+#include <regex>
+
+#include <boost/property_tree/ptree.hpp>
+
+#include "QualityControl/QcInfoLogger.h"
+namespace o2::quality_control_modules::fit
+{
+
+namespace helper
+{
+
+template <typename ValueType>
+inline ValueType getConfigFromPropertyTree(const boost::property_tree::ptree& config, const char* fieldName, ValueType value = {})
+{
+  const auto& node = config.get_child_optional(fieldName);
+  if (node) {
+    value = node.get_ptr()->get_child("").get_value<ValueType>();
+    ILOG(Debug, Support) << fieldName << ": " << value << "\"" << ENDM;
+  } else {
+    ILOG(Debug, Support) << "Default " << fieldName << ": " << value << ENDM;
+  }
+  return value;
+}
+
+template <typename Param_t,
+          typename = typename std::enable_if<std::is_floating_point<Param_t>::value ||
+                                             std::is_same<std::string, Param_t>::value || (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>
+inline auto parseParameters(const std::string& param, const std::string& del)
+{
+  std::regex reg(del);
+  std::sregex_token_iterator first{ param.begin(), param.end(), reg, -1 }, last;
+  std::vector<Param_t> vecResult;
+  for (auto it = first; it != last; it++) {
+    if constexpr (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value) {
+      vecResult.push_back(std::stoi(*it));
+    } else if constexpr (std::is_floating_point<Param_t>::value) {
+      vecResult.push_back(std::stod(*it));
+    } else if constexpr (std::is_same<std::string, Param_t>::value) {
+      vecResult.push_back(*it);
+    }
+  }
+  return vecResult;
+}
+
+// first entry - start BC, second - number of BCs in row
+template <typename BitSetBC>
+inline std::vector<std::pair<int, int>> getMapBCtrains(const BitSetBC& bitsetBC)
+{
+  std::vector<std::pair<int, int>> vecTrains{};
+  int nBCs{ 0 };
+  int firstBC{ -1 };
+  for (int iBC = 0; iBC < bitsetBC.size(); iBC++) {
+    if (bitsetBC.test(iBC)) {
+      // BC in train
+      nBCs++;
+      if (firstBC == -1) {
+        // first BC in train
+        firstBC = iBC;
+      }
+    } else if (nBCs > 0) {
+      // Next after end of train BC
+      vecTrains.push_back({ firstBC, nBCs });
+      firstBC = -1;
+      nBCs = 0;
+    }
+  }
+  if (nBCs > 0) { // last iteration
+    vecTrains.push_back({ firstBC, nBCs });
+  }
+  return vecTrains;
+}
+
+std::map<unsigned int, std::string> multiplyMaps(const std::vector<std::tuple<std::string, std::map<unsigned int, std::string>, std::string>>& vecPreffixMapSuffix, bool useMapSizeAsMultFactor = true);
+
+template <typename R, typename... Args, std::size_t... IArgs>
+auto funcWithArgsAsTupleBase(std::function<R(Args...)> func, const std::tuple<Args...>& tupleArgs, std::index_sequence<IArgs...>)
+{
+  return func(std::get<IArgs>(tupleArgs)...);
+}
+
+template <typename R, typename... Args>
+auto funcWithArgsAsTuple(std::function<R(Args...)> func, const std::tuple<Args...>& tupleArgs)
+{
+  return funcWithArgsAsTupleBase(func, tupleArgs, std::make_index_sequence<sizeof...(Args)>{});
+}
+
+} // namespace helper
+} // namespace o2::quality_control_modules::fit
+#endif

--- a/Modules/FIT/Common/include/FITCommon/HelperFIT.h
+++ b/Modules/FIT/Common/include/FITCommon/HelperFIT.h
@@ -18,14 +18,22 @@
 #define QC_MODULE_FIT_FITHELPER_H
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <unordered_map>
 #include <functional>
 #include <array>
 #include <vector>
-#include <DataFormatsFIT/Triggers.h>
+#include <bitset>
 
+#include "TH1D.h"
+#include "TH2F.h"
+
+#include <DataFormatsFIT/Triggers.h>
+#include "CommonDataFormat/BunchFilling.h"
+
+#include <FITCommon/HelperHist.h>
 namespace o2::quality_control_modules::fit
 {
 
@@ -212,6 +220,74 @@ class TrgValidation
      } }
   };
   std::function<void(DataTCM_t&)> mFunctorTrgCalc;
+};
+
+struct RatioProcessor2D {
+  RatioProcessor2D() = default;
+  ~RatioProcessor2D() = default;
+  using SchemaBC_t = o2::BunchFilling::Pattern;
+  using TF_t = long long;
+  std::set<int> mBinsCollBC{};
+  std::set<int> mBinsCollFirstBCinTrain{};
+  std::set<int> mBinsNonCollBC{};
+  std::map<int, int> mBinsBCtrains{};
+
+  SchemaBC_t mSchemaBC{};
+  TF_t mNTFs; // processed number of TFs
+  //
+  double mLengthTF{}; //
+  void init()
+  {
+    for (const auto& initType : mSetInitTypes) {
+      (mMapInitFns.find(initType)->second)();
+    }
+  }
+  bool addFnType(const std::string& fnType)
+  {
+    if (mMapInitFnNames.find(fnType) == mMapInitFnNames.end()) {
+      return false;
+    }
+    mSetInitTypes.insert(mMapInitFnNames.find(fnType)->second);
+  }
+  std::set<std::string> mSetInitTypes{}; // set of projection functors which will participate in calculations
+  const std::map<std::string, std::function<TH1D*(const TH2F*, std::pair<double, double>, int)>> mMapRatios = {
+    { "out_of_coll", [this](const TH2F* histSrc, std::pair<double, double> rangeProj, int axis) {
+       return helper::makePartialProj(histSrc, "out_of_coll", "out_of_coll", mBinsNonCollBC, rangeProj, axis);
+     } },
+    { "in_coll", [this](const TH2F* histSrc, std::pair<double, double> rangeProj, int axis) {
+       return helper::makePartialProj(histSrc, "in_coll", "in_coll", mBinsCollBC, rangeProj, axis);
+     } },
+
+    { "in_coll_norm_train", [this](const TH2F* histSrc, std::pair<double, double> rangeProj, int axis) {
+       return helper::makePartialProj(histSrc, "in_coll", "in_coll", mBinsCollBC, rangeProj, axis);
+     } },
+    { "proj", [this](const TH2F* histSrc, std::pair<double, double> rangeProj, int axis) {
+       return helper::makeProj(histSrc, "proj", "proj", rangeProj, axis);
+     } }
+  };
+  const std::map<std::string, std::string> mMapInitFnNames = {
+    { "out_of_coll", "bc_schema" },
+    { "in_coll", "bc_schema" },
+    { "in_coll_norm_train", "bc_schema" },
+    { "proj", "none" }
+  };
+  std::map<std::string, std::function<void(void)>> mMapInitFns = {
+    { "bc_schema", [this]() {
+       for (int iBC = 0; iBC < mSchemaBC.size(); iBC) {
+         if (mSchemaBC.test(iBC)) {
+           mBinsCollBC.insert(iBC + 1);
+         } else {
+           mBinsNonCollBC.insert(iBC + 1);
+         }
+       }
+       const auto& mapBCtrains = helper::getMapBCtrains(mSchemaBC);
+       for (const auto& entry : mapBCtrains) {
+         mBinsBCtrains.insert({ entry.first + 1, entry.second });
+         mBinsCollFirstBCinTrain.insert(entry.first + 1);
+       }
+     } },
+    { "none", [this]() {} }
+  };
 };
 
 } // namespace o2::quality_control_modules::fit

--- a/Modules/FIT/Common/include/FITCommon/HelperLUT.h
+++ b/Modules/FIT/Common/include/FITCommon/HelperLUT.h
@@ -1,0 +1,60 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   HelperHist.h
+/// \author Artur Furs afurs@cern.ch
+/// \brief Temporary helper class for LookupTable of FIT detectors, shoud be moved into O2
+#ifndef QC_MODULE_FIT_HELPERLUT_H
+#define QC_MODULE_FIT_HELPERLUT_H
+
+#include <map>
+#include <string>
+
+#include "Headers/DataHeader.h"
+
+namespace o2::quality_control_modules::fit
+{
+namespace helperLUT
+{
+//(epID,linkID)->moduleName mapping
+using FEEID_t = std::pair<int, int>;
+using Fee2ModuleName_t = std::map<FEEID_t, std::string>;
+template <typename EPID_t, typename LinkID_t>
+inline FEEID_t getFEEID(EPID_t&& epID, LinkID_t&& linkID)
+{
+  return FEEID_t{ static_cast<typename FEEID_t::first_type>(std::forward<EPID_t>(epID)), static_cast<typename FEEID_t::second_type>(std::forward<LinkID_t>(linkID)) };
+}
+
+template <typename LUT>
+inline Fee2ModuleName_t getMapFEE2ModuleName(const LUT& lut)
+{
+  Fee2ModuleName_t mapFEE2ModuleName{};
+  const auto& vecFEE = lut.getVecMetadataFEE();
+  for (const auto& entryFEE : vecFEE) {
+    const auto& entryCRU = entryFEE.mEntryCRU;
+    mapFEE2ModuleName.insert({ getFEEID(entryCRU.mEndPointID, entryCRU.mLinkID), entryFEE.mModuleName });
+  }
+  return mapFEE2ModuleName;
+}
+
+template <typename LUT>
+inline void obtainAllParamsLUT(const LUT& lut, Fee2ModuleName_t& mapFEE2ModuleName)
+{
+  // Put here all LUT params you would like to have
+  mapFEE2ModuleName = getMapFEE2ModuleName(lut);
+}
+
+void obtainFromLUT(const o2::header::DataOrigin& det, Fee2ModuleName_t& mapFEE2ModuleName, long timestamp = -1);
+} // namespace helperLUT
+
+} // namespace o2::quality_control_modules::fit
+#endif

--- a/Modules/FIT/Common/src/HelperCommon.cxx
+++ b/Modules/FIT/Common/src/HelperCommon.cxx
@@ -1,0 +1,67 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   HelperHist.cxx
+/// \author Artur Furs afurs@cern.ch
+
+#include "FITCommon/HelperHist.h"
+
+namespace o2::quality_control_modules::fit
+{
+namespace helper
+{
+
+std::map<unsigned int, std::string> multiplyMaps(const std::vector<std::tuple<std::string, std::map<unsigned int, std::string>, std::string>>& vecPreffixMapSuffix, bool useMapSizeAsMultFactor = true)
+{
+
+  auto multiplyPairMaps = [](bool useMapSizeAsMultFactor, const std::tuple<std::string, std::map<unsigned int, std::string>, std::string>& firstPreffixMapSuffix,
+                             const std::tuple<std::string, std::map<unsigned int, std::string>, std::string>& secondPreffixMapSuffix = {}) -> std::map<unsigned int, std::string> {
+    std::map<unsigned int, std::string> mapResult{};
+    const auto& firstPreffix = std::get<0>(firstPreffixMapSuffix);
+    const auto& firstSuffix = std::get<2>(firstPreffixMapSuffix);
+    const auto& firstMap = std::get<1>(firstPreffixMapSuffix);
+
+    const auto& secondPreffix = std::get<0>(secondPreffixMapSuffix);
+    const auto& secondSuffix = std::get<2>(secondPreffixMapSuffix);
+    const auto& secondMap = std::get<1>(secondPreffixMapSuffix);
+
+    const unsigned int lastPosSecondMap = secondMap.size() > 0 ? (--secondMap.end())->first : 0;
+    const unsigned int multFactor = (useMapSizeAsMultFactor && secondMap.size() > 0) ? secondMap.size() : lastPosSecondMap + 1;
+
+    for (const auto& entryFirst : firstMap) {
+      const std::string newEntrySecond_preffix = firstPreffix + entryFirst.second + firstSuffix;
+      const unsigned int startIndex = entryFirst.first * multFactor;
+      for (const auto& entrySecond : secondMap) {
+        const std::string newEntrySecond = newEntrySecond_preffix + secondPreffix + entrySecond.second + secondSuffix;
+        const unsigned int newEntryFirst = startIndex + entrySecond.first;
+        mapResult.insert({ newEntryFirst, newEntrySecond });
+      }
+      if (secondMap.size() == 0) {
+        // Only add preffix and suffix
+        mapResult.insert({ startIndex, newEntrySecond_preffix });
+      }
+    }
+    return mapResult;
+  };
+  std::map<unsigned int, std::string> mapResult{};
+  if (vecPreffixMapSuffix.size() > 0) {
+    mapResult = multiplyPairMaps(useMapSizeAsMultFactor, vecPreffixMapSuffix[0]);
+    for (int iEntry = 1; iEntry < vecPreffixMapSuffix.size(); iEntry++) {
+      const std::string s1{ "" }, s2{ "" };
+      mapResult = multiplyPairMaps(useMapSizeAsMultFactor, std::tie(s1, mapResult, s2), vecPreffixMapSuffix[iEntry]);
+    }
+  }
+  return mapResult;
+}
+
+} // namespace helper
+} // namespace o2::quality_control_modules::fit

--- a/Modules/FIT/Common/src/HelperLUT.cxx
+++ b/Modules/FIT/Common/src/HelperLUT.cxx
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   HelperHist.cxx
+/// \author Artur Furs afurs@cern.ch
+
+#include "FITCommon/HelperLUT.h"
+
+#include "DataFormatsFIT/LookUpTable.h"
+#include "DataFormatsFDD/LookUpTable.h"
+#include "DataFormatsFT0/LookUpTable.h"
+#include "DataFormatsFV0/LookUpTable.h"
+namespace o2::quality_control_modules::fit
+{
+namespace helperLUT
+{
+void obtainFromLUT(const o2::header::DataOrigin& det, Fee2ModuleName_t& mapFEE2ModuleName, long timestamp)
+{
+  if (det == o2::header::gDataOriginFDD) {
+    obtainAllParamsLUT(o2::fdd::SingleLUT::Instance(nullptr, timestamp), mapFEE2ModuleName);
+  } else if (det == o2::header::gDataOriginFT0) {
+    obtainAllParamsLUT(o2::ft0::SingleLUT::Instance(nullptr, timestamp), mapFEE2ModuleName);
+  } else if (det == o2::header::gDataOriginFV0) {
+    obtainAllParamsLUT(o2::fv0::SingleLUT::Instance(nullptr, timestamp), mapFEE2ModuleName);
+  }
+}
+} // namespace helperLUT
+
+} // namespace o2::quality_control_modules::fit

--- a/Modules/FIT/FDD/CMakeLists.txt
+++ b/Modules/FIT/FDD/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcFDD PUBLIC O2QualityControl O2QcCommon)
+target_link_libraries(O2QcFDD PUBLIC O2QualityControl O2QcCommon O2QcFITCommon)
 
 install(TARGETS O2QcFDD
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/FIT/FDD/include/FDD/PostProcTask.h
+++ b/Modules/FIT/FDD/include/FDD/PostProcTask.h
@@ -64,7 +64,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
 
   std::map<o2::fdd::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
   std::map<int, std::string> mMapDigitTrgNames;
-
+  std::map<unsigned int, std::string> mMapBasicTrgBits;
   o2::quality_control::repository::DatabaseInterface* mDatabase = nullptr;
   o2::ccdb::CcdbApi mCcdbApi;
 
@@ -76,9 +76,10 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   std::unique_ptr<TH2F> mHistChDataNegBits;
   std::unique_ptr<TH1F> mHistTriggers;
 
-  std::unique_ptr<TH1F> mHistTimeUpperFraction;
-  std::unique_ptr<TH1F> mHistTimeLowerFraction;
   std::unique_ptr<TH1F> mHistTimeInWindow;
+  std::unique_ptr<TH1F> mHistCFDEff;
+  std::unique_ptr<TH1F> mHistTrgValidation;
+  std::unique_ptr<TH1F> mHistAmpSaturation;
 
   std::unique_ptr<TCanvas> mRatesCanv;
   TProfile* mAmpl = nullptr;
@@ -90,6 +91,11 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   std::unique_ptr<TH2F> mHistBcTrgOutOfBunchColl;
 
   std::map<unsigned int, TH1D*> mMapTrgHistBC;
+
+  int mLowTimeThreshold{ -192 };
+  int mUpTimeThreshold{ 192 };
+  double mLowAmpSat;
+  double mUpAmpSat;
 };
 
 } // namespace o2::quality_control_modules::fdd

--- a/Modules/FIT/FIT/CMakeLists.txt
+++ b/Modules/FIT/FIT/CMakeLists.txt
@@ -3,6 +3,8 @@ set(MODULE_NAME "O2QcFIT")
 
 add_library(${MODULE_NAME})
 
+target_sources(${MODULE_NAME} PRIVATE src/LevelCheck.cxx)
+target_sources(${MODULE_NAME} PRIVATE src/RawDataMetricTask.cxx)
 target_sources(${MODULE_NAME} PRIVATE src/RecoFITQcTask.cxx)
 
 target_include_directories(
@@ -25,7 +27,9 @@ install(TARGETS ${MODULE_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_root_dictionary(${MODULE_NAME}
-  HEADERS include/FIT/RecoFITQcTask.h
+  HEADERS include/FIT/LevelCheck.h
+          include/FIT/RawDataMetricTask.h
+          include/FIT/RecoFITQcTask.h
   LINKDEF include/FIT/LinkDef.h)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/FIT

--- a/Modules/FIT/FIT/include/FIT/LevelCheck.h
+++ b/Modules/FIT/FIT/include/FIT/LevelCheck.h
@@ -1,0 +1,60 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   RatioCheck.h
+/// \author Artur Furs afurs@cern.ch
+///
+
+#ifndef QC_MODULE_FIT_LEVELCHECK_H
+#define QC_MODULE_FIT_LEVELCHECK_H
+
+#include <regex>
+#include <numeric>
+#include <set>
+
+#include "QualityControl/CheckInterface.h"
+
+namespace o2::quality_control_modules::fit
+{
+
+class LevelCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  LevelCheck() = default;
+  ~LevelCheck() override = default;
+
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+ private:
+  void updateBinsToIgnoreWithDCM();
+
+  std::string mBinsToIgnoreAsStr{ "" };
+  std::string mPathDeadChannelMap{ "" };
+  std::string mUrlCCDB{ "" };
+  std::string mNameObjectToCheck{ "" };
+  std::set<int> mBinsToIgnore{};
+  bool mIsInvertedThrsh; // check if values should be upper
+  std::string mSignCheck{ "" };
+  float mThreshWarning;
+  float mThreshError;
+  int mNumWarnings;
+  int mNumErrors;
+  std::vector<double> mVecLabelPos{ 0.15, 0.2, 0.85, 0.45 };
+  ClassDefOverride(LevelCheck, 1);
+};
+
+} // namespace o2::quality_control_modules::fit
+
+#endif // QC_MODULE_FIT_LEVELCHECK_H

--- a/Modules/FIT/FIT/include/FIT/LinkDef.h
+++ b/Modules/FIT/FIT/include/FIT/LinkDef.h
@@ -3,6 +3,8 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::quality_control_modules::fit::LevelCheck + ;
+#pragma link C++ class o2::quality_control_modules::fit::RawDataMetricTask + ;
 #pragma link C++ class o2::quality_control_modules::fit::RecoFITQcTask + ;
 
 #endif

--- a/Modules/FIT/FIT/include/FIT/RawDataMetricTask.h
+++ b/Modules/FIT/FIT/include/FIT/RawDataMetricTask.h
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   RawDataMetricTask.h
+/// \author Artur Furs afurs@cern.ch
+/// QC task for RawDataMetric QC proccessing at FIT detectors
+
+#ifndef QC_MODULE_FIT_RAWDATAMETRICTASK_H
+#define QC_MODULE_FIT_RAWDATAMETRICTASK_H
+
+#include <memory>
+#include <set>
+
+#include <FITCommon/HelperLUT.h>
+
+#include "Headers/DataHeader.h"
+#include "QualityControl/TaskInterface.h"
+#include <TH1.h>
+#include <TH2.h>
+using namespace o2::quality_control::core;
+
+namespace o2::quality_control_modules::fit
+{
+
+class RawDataMetricTask final : public TaskInterface
+{
+ public:
+  /// \brief Constructor
+  RawDataMetricTask() = default;
+  /// Destructor
+  ~RawDataMetricTask() override;
+  // Definition of the methods for the template method pattern
+  void initialize(o2::framework::InitContext& ctx) override;
+  void startOfActivity(const Activity& activity) override;
+  void startOfCycle() override;
+  void monitorData(o2::framework::ProcessingContext& ctx) override;
+  void endOfCycle() override;
+  void endOfActivity(const Activity& activity) override;
+  void reset() override;
+
+ private:
+  // Objects which will be published
+  std::string mDetName{ "" };  // detector name
+  unsigned int mBinPosUnknown; // position for uknown FEE;
+  std::unique_ptr<TH2F> mHistRawDataMetrics;
+  std::map<helperLUT::FEEID_t, unsigned int> mMapFEE2binPos{};     //(epID,linkID)->bin position, alphabet sorted by module name
+  static const std::set<o2::header::DataOrigin> sSetOfAllowedDets; // set of allowed detectors: FDD, FT, FV0
+};
+
+} // namespace o2::quality_control_modules::fit
+
+#endif // QC_MODULE_FIT_RAWDATAMETRICTASK_H

--- a/Modules/FIT/FIT/src/LevelCheck.cxx
+++ b/Modules/FIT/FIT/src/LevelCheck.cxx
@@ -1,0 +1,185 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   LevelCheck.cxx
+/// \author Artur Furs afurs@cern.ch
+///
+
+#include <FIT/LevelCheck.h>
+#include <FITCommon/HelperCommon.h>
+#include "DataFormatsFIT/DeadChannelMap.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
+// ROOT
+#include <TH1.h>
+#include <TPaveText.h>
+#include <TLine.h>
+#include <TList.h>
+
+#include <DataFormatsQualityControl/FlagReasons.h>
+#include "Common/Utils.h"
+using namespace std;
+using namespace o2::quality_control;
+
+namespace o2::quality_control_modules::fit
+{
+
+void LevelCheck::updateBinsToIgnoreWithDCM()
+{
+  if (mPathDeadChannelMap.size() > 0) {
+    const auto deadChannelMap = retrieveConditionAny<o2::fit::DeadChannelMap>(mPathDeadChannelMap);
+    for (unsigned chID = 0; chID < deadChannelMap->map.size(); chID++) {
+      if (!deadChannelMap->isChannelAlive(chID)) {
+        mBinsToIgnore.insert(chID);
+      }
+    }
+  }
+}
+
+void LevelCheck::configure()
+{
+  mThreshWarning = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "thresholdWarning", 0.9);
+  mThreshError = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "thresholdError", 0.8);
+  mNameObjectToCheck = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "nameObjectToCheck", "CFD_efficiency");
+
+  mIsInvertedThrsh = o2::quality_control_modules::common::getFromConfig<bool>(mCustomParameters, "isInversedThresholds", false);
+  mSignCheck = mIsInvertedThrsh ? std::string{ ">" } : std::string{ "<" };
+
+  mPathDeadChannelMap = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "pathDeadChannelMap", "");
+  mUrlCCDB = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "ccdbUrl", "o2-ccdb.internal");
+  setCcdbUrl(mUrlCCDB);
+
+  const std::string labelPos = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "labelPos", "0.15, 0.2, 0.85, 0.45");
+  mVecLabelPos = helper::parseParameters<double>(labelPos, ",");
+  if (mVecLabelPos.size() != 4) {
+    ILOG(Error, Devel) << "Incorrect label coordinates! Setting default." << ENDM;
+    mVecLabelPos = { 0.15, 0.2, 0.85, 0.45 };
+  }
+
+  const std::string binsToIgnore = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "binsToIgnore", "");
+  // Getting bins to ignore directly from config,
+  // they will be combined with automatic bin selection
+  if (binsToIgnore.size() > 0) {
+    const auto vecParams = helper::parseParameters<int>(binsToIgnore, ",");
+    for (const auto& chId : vecParams) {
+      mBinsToIgnore.insert(chId);
+    }
+  }
+  // Automatic selection of bins to ignore
+  // Dead channel map
+  updateBinsToIgnoreWithDCM();
+  // Prepare list of bins to ignore as str
+  for (const auto& bin : mBinsToIgnore) {
+    mBinsToIgnoreAsStr += (mBinsToIgnoreAsStr.empty() ? "" : ",") + std::to_string(bin);
+  }
+  if (mBinsToIgnore.size() == 0) {
+    mBinsToIgnoreAsStr = "EMPTY";
+  }
+}
+
+Quality LevelCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Null;
+
+  for (const auto& entry : *moMap) {
+    const auto& mo = entry.second;
+    if (mo->getName() == mNameObjectToCheck) {
+      auto* h = dynamic_cast<TH1*>(mo->getObject());
+      if (h == nullptr) {
+        ILOG(Warning, Devel) << "Could not cast " << mo->getName() << " to TH1* => Quality::Bad" << ENDM;
+        result = Quality::Bad;
+        continue;
+      }
+
+      result = Quality::Good;
+      mNumErrors = 0;
+      mNumWarnings = 0;
+      for (int bin = 0; bin < h->GetNbinsX(); bin++) {
+        if (mBinsToIgnore.find(bin) != mBinsToIgnore.end()) {
+          continue;
+        }
+        const auto val = h->GetBinContent(bin + 1);
+        const bool isError = (val < mThreshError && !mIsInvertedThrsh) || (val > mThreshError && mIsInvertedThrsh);
+        const bool isWarning = (val < mThreshWarning && !mIsInvertedThrsh) || (val > mThreshWarning && mIsInvertedThrsh);
+        if (isError) {
+          if (result.isBetterThan(Quality::Bad)) {
+            result.set(Quality::Bad);
+          }
+          mNumErrors++;
+          const std::string message = "Ratio " + mSignCheck + "\"Error\" threshold in element " + std::to_string(bin);
+          result.addReason(FlagReasonFactory::Unknown(), message);
+          continue;
+        } else if (isWarning) {
+          if (result.isBetterThan(Quality::Medium))
+            result.set(Quality::Medium);
+          mNumWarnings++;
+          const std::string message = "Ratio " + mSignCheck + "\"Warning\" threshold in element " + std::to_string(bin);
+          result.addReason(FlagReasonFactory::Unknown(), message);
+        }
+      }
+    }
+  }
+  result.addMetadata("nErrors", std::to_string(mNumErrors));
+  result.addMetadata("nWarnings", std::to_string(mNumWarnings));
+  return result;
+}
+
+std::string LevelCheck::getAcceptedType() { return "TH1"; }
+
+void LevelCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (mo->getName() == mNameObjectToCheck) {
+    auto* h = dynamic_cast<TH1F*>(mo->getObject());
+
+    TPaveText* msg = new TPaveText(mVecLabelPos[0], mVecLabelPos[1], mVecLabelPos[2], mVecLabelPos[3], "NDC");
+    h->GetListOfFunctions()->Add(msg);
+    msg->SetName(Form("%s_msg", mo->GetName()));
+    msg->Clear();
+    if (mBinsToIgnoreAsStr != "EMPTY") {
+      msg->AddText(("Ignore elements: " + mBinsToIgnoreAsStr).c_str());
+    }
+    msg->AddText(Form("N elements with warning (%s %.3f) = %d", mSignCheck.c_str(), mThreshWarning, mNumWarnings));
+    msg->AddText(Form("N elements with error   (%s %.3f) = %d", mSignCheck.c_str(), mThreshError, mNumErrors));
+    if (checkResult == Quality::Good) {
+      msg->AddText(">> Quality::Good <<");
+      msg->SetFillColor(kGreen);
+    } else if (checkResult == Quality::Bad) {
+      auto reasons = checkResult.getReasons();
+      msg->SetFillColor(kRed);
+      msg->AddText(">> Quality::Bad <<");
+    } else if (checkResult == Quality::Medium) {
+      auto reasons = checkResult.getReasons();
+      msg->SetFillColor(kOrange);
+      msg->AddText(">> Quality::Medium <<");
+    } else if (checkResult == Quality::Null) {
+      msg->AddText(">> Quality::Null <<");
+      msg->SetFillColor(kGray);
+    }
+    // add threshold lines
+    Double_t xMin = h->GetXaxis()->GetXmin();
+    Double_t xMax = h->GetXaxis()->GetXmax();
+    auto* lineError = new TLine(xMin, mThreshError, xMax, mThreshError);
+    auto* lineWarning = new TLine(xMin, mThreshWarning, xMax, mThreshWarning);
+    lineError->SetLineWidth(3);
+    lineWarning->SetLineWidth(3);
+    lineError->SetLineStyle(kDashed);
+    lineWarning->SetLineStyle(kDashed);
+    lineError->SetLineColor(kRed);
+    lineWarning->SetLineColor(kOrange);
+    h->GetListOfFunctions()->Add(lineError);
+    h->GetListOfFunctions()->Add(lineWarning);
+    h->SetStats(0);
+  }
+}
+
+} // namespace o2::quality_control_modules::fit

--- a/Modules/FIT/FIT/src/RawDataMetricTask.cxx
+++ b/Modules/FIT/FIT/src/RawDataMetricTask.cxx
@@ -1,0 +1,134 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   RawDataMetricTask.cxx
+/// \author Artur Furs afurs@cern.ch
+/// \brief Task for checking FIT RawDataMetric
+
+#include <vector>
+#include <string>
+
+#include "QualityControl/QcInfoLogger.h"
+#include "Common/Utils.h"
+#include <FITCommon/HelperHist.h>
+#include <DataFormatsFIT/RawDataMetric.h>
+
+#include <FIT/RawDataMetricTask.h>
+
+#include <Framework/InputRecord.h>
+#include "QualityControl/QcInfoLogger.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputRecord.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/DataSpecUtils.h"
+
+namespace o2::quality_control_modules::fit
+{
+const std::set<o2::header::DataOrigin> RawDataMetricTask::sSetOfAllowedDets = { o2::header::gDataOriginFDD, o2::header::gDataOriginFT0, o2::header::gDataOriginFV0 };
+RawDataMetricTask::~RawDataMetricTask()
+{
+}
+
+void RawDataMetricTask::initialize(o2::framework::InitContext& ctx)
+{
+  // Obtaining data origin, i.e. detector ID
+  const auto& inputRouts = ctx.services().get<const o2::framework::DeviceSpec>().inputs;
+  std::set<header::DataOrigin> setOfOrigins{}; // should be only one
+  header::DataOrigin det;
+  for (const auto& route : inputRouts) {
+    for (const auto& allowedDet : sSetOfAllowedDets) {
+      if (o2::framework::DataSpecUtils::partialMatch(route.matcher, allowedDet)) {
+        setOfOrigins.insert(allowedDet);
+      }
+    }
+  }
+
+  if (setOfOrigins.size() == 1) {
+    det = *setOfOrigins.begin();
+    mDetName = std::string{ det.str };
+  } else {
+    ILOG(Error, Devel) << "Cannot recognize detector!" << ENDM;
+
+    return;
+    // assertion
+  }
+  {
+    const auto useModuleNamesForBins = o2::quality_control_modules::common::getFromConfig<bool>(mCustomParameters, "useModuleNamesForBins", false);
+    std::map<unsigned int, std::string> mapBinPos2FeeLabel{};
+    helperLUT::Fee2ModuleName_t mapFEE2ModuleName{};
+    helperLUT::obtainFromLUT(det, mapFEE2ModuleName);
+    mMapFEE2binPos.clear();
+    unsigned int binPos = 0;
+    for (const auto& entry : mapFEE2ModuleName) {
+      const auto& entryFEE = entry.first; // (epID,linkID)
+      const auto& epID = entryFEE.first;
+      const auto& linkID = entryFEE.second;
+      const auto& moduleName = entry.second;
+      std::string binLabel = useModuleNamesForBins ? moduleName : Form("%i/%i", epID, linkID);
+      mapBinPos2FeeLabel.insert({ binPos, binLabel });
+      mMapFEE2binPos.insert({ entryFEE, binPos });
+      binPos++;
+    }
+    mBinPosUnknown = mMapFEE2binPos.size();
+    mapBinPos2FeeLabel.insert({ mBinPosUnknown, "Unknown" });
+    const std::string titleAxisX = useModuleNamesForBins ? "FEE module" : "EPID/LinkID";
+    mHistRawDataMetrics = helper::registerHist<TH2F>(getObjectsManager(), "COLZ", "RawDataMetric", Form("%s raw data metric statistics;%s;Raw data metric bits", mDetName.c_str(), titleAxisX.c_str()), mapBinPos2FeeLabel, o2::fit::RawDataMetric::sMapBitsToNames);
+  }
+  //
+}
+
+void RawDataMetricTask::startOfActivity(const Activity& activity)
+{
+  mHistRawDataMetrics->Reset();
+}
+
+void RawDataMetricTask::startOfCycle()
+{
+}
+
+void RawDataMetricTask::monitorData(o2::framework::ProcessingContext& ctx)
+{
+  const auto& vecRawDataMetric = ctx.inputs().get<gsl::span<o2::fit::RawDataMetric>>("rawDataMetric");
+  for (const auto& rawDataMetric : vecRawDataMetric) {
+    const auto& itBinPos = mMapFEE2binPos.find(helperLUT::getFEEID(rawDataMetric.mEPID, rawDataMetric.mLinkID));
+    if (itBinPos != mMapFEE2binPos.end()) { // registered FEE
+      const auto& binPos = itBinPos->second;
+      for (int iPosY = 0; iPosY < rawDataMetric.mBitStats.size(); iPosY++) {
+        mHistRawDataMetrics->Fill(binPos, iPosY, rawDataMetric.mBitStats[iPosY]);
+      }
+    } else { // non-registered FEE => unknown, info will be in IL
+      for (int iPosY = 0; iPosY < rawDataMetric.mBitStats.size(); iPosY++) {
+        mHistRawDataMetrics->Fill(mBinPosUnknown, iPosY, rawDataMetric.mBitStats[iPosY]);
+      }
+    }
+  }
+}
+
+void RawDataMetricTask::endOfCycle()
+{
+  ILOG(Debug, Devel) << "endOfCycle" << ENDM;
+  // one has to set num. of entries manually because
+  // default TH1Reductor gets only mean,stddev and entries (no integral)
+}
+
+void RawDataMetricTask::endOfActivity(const Activity& /*activity*/)
+{
+  ILOG(Debug, Devel) << "endOfActivity" << ENDM;
+}
+
+void RawDataMetricTask::reset()
+{
+  // clean all the monitor objects here
+  mHistRawDataMetrics->Reset();
+}
+
+} // namespace o2::quality_control_modules::fit

--- a/Modules/FIT/FT0/include/FT0/DigitQcTask.h
+++ b/Modules/FIT/FT0/include/FT0/DigitQcTask.h
@@ -82,26 +82,6 @@ class DigitQcTask final : public TaskInterface
 
   long mTFcreationTime = 0;
 
-  template <typename Param_t,
-            typename = typename std::enable_if<std::is_floating_point<Param_t>::value ||
-                                               std::is_same<std::string, Param_t>::value || (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value)>::type>
-  auto parseParameters(const std::string& param, const std::string& del)
-  {
-    std::regex reg(del);
-    std::sregex_token_iterator first{ param.begin(), param.end(), reg, -1 }, last;
-    std::vector<Param_t> vecResult;
-    for (auto it = first; it != last; it++) {
-      if constexpr (std::is_integral<Param_t>::value && !std::is_same<bool, Param_t>::value) {
-        vecResult.push_back(std::stoi(*it));
-      } else if constexpr (std::is_floating_point<Param_t>::value) {
-        vecResult.push_back(std::stod(*it));
-      } else if constexpr (std::is_same<std::string, Param_t>::value) {
-        vecResult.push_back(*it);
-      }
-    }
-    return vecResult;
-  }
-
   void rebinFromConfig();
   unsigned int getModeParameter(std::string, unsigned int, std::map<unsigned int, std::string>);
   int getNumericalParameter(std::string, int);

--- a/Modules/FIT/FT0/include/FT0/PostProcTask.h
+++ b/Modules/FIT/FT0/include/FT0/PostProcTask.h
@@ -51,6 +51,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistryRef) override;
 
   constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
+  constexpr static std::size_t sNCHANNELS_PM = o2::ft0::Constants::sNCHANNELS_PM;
 
  private:
   std::string mPathGrpLhcIf;
@@ -76,6 +77,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   std::unique_ptr<TH1F> mHistTriggers;
 
   std::unique_ptr<TH1F> mHistTimeInWindow;
+  std::unique_ptr<TH1F> mHistCFDEff;
 
   std::unique_ptr<TH1F> mHistChannelID_outOfBC;
   std::unique_ptr<TH1F> mHistTrgValidation;

--- a/Modules/FIT/FT0/src/DigitQcTask.cxx
+++ b/Modules/FIT/FT0/src/DigitQcTask.cxx
@@ -26,6 +26,7 @@
 #include "Common/Utils.h"
 
 #include "FITCommon/HelperHist.h"
+#include "FITCommon/HelperCommon.h"
 #include "FITCommon/HelperFIT.h"
 
 namespace o2::quality_control_modules::ft0
@@ -289,7 +290,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   if (auto param = mCustomParameters.find("ChannelIDs"); param != mCustomParameters.end()) {
     const auto chIDs = param->second;
     const std::string del = ",";
-    vecChannelIDs = parseParameters<unsigned int>(chIDs, del);
+    vecChannelIDs = helper::parseParameters<unsigned int>(chIDs, del);
   }
   for (const auto& entry : vecChannelIDs) {
     mSetAllowedChIDs.insert(entry);
@@ -298,7 +299,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   if (auto param = mCustomParameters.find("ChannelIDsAmpVsTime"); param != mCustomParameters.end()) {
     const auto chIDs = param->second;
     const std::string del = ",";
-    vecChannelIDsAmpVsTime = parseParameters<unsigned int>(chIDs, del);
+    vecChannelIDsAmpVsTime = helper::parseParameters<unsigned int>(chIDs, del);
   }
   for (const auto& entry : vecChannelIDsAmpVsTime) {
     mSetAllowedChIDsAmpVsTime.insert(entry);

--- a/Modules/FIT/FV0/CMakeLists.txt
+++ b/Modules/FIT/FV0/CMakeLists.txt
@@ -22,7 +22,8 @@ target_link_libraries(O2QcFV0 PUBLIC O2QualityControl
                                      O2::DataFormatsFV0
                                      O2::FV0Base
                                      O2::DataFormatsParameters
-                                     O2QcCommon)
+                                     O2QcCommon
+                                     O2QcFITCommon)
 
 install(TARGETS O2QcFV0
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/FIT/FV0/include/FV0/PostProcTask.h
+++ b/Modules/FIT/FV0/include/FV0/PostProcTask.h
@@ -53,7 +53,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistryRef) override;
 
   constexpr static std::size_t sBCperOrbit = o2::constants::lhc::LHCMaxBunches;
-  constexpr static std::size_t sNCHANNELS_FV0_PLUSREF = o2::fv0::Constants::nFv0ChannelsPlusRef;
+  constexpr static std::size_t sNCHANNELS_PM = o2::fv0::Constants::nFv0ChannelsPlusRef;
 
  private:
   std::string mPathGrpLhcIf;
@@ -66,6 +66,7 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
 
   std::map<o2::fv0::ChannelData::EEventDataBit, std::string> mMapChTrgNames;
   std::map<int, std::string> mMapDigitTrgNames;
+  std::map<unsigned int, std::string> mMapBasicTrgBits;
 
   o2::quality_control::repository::DatabaseInterface* mDatabase = nullptr;
   o2::ccdb::CcdbApi mCcdbApi;
@@ -78,9 +79,9 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   std::unique_ptr<TH2F> mHistChDataNegBits;
   std::unique_ptr<TH1F> mHistTriggers;
 
-  std::unique_ptr<TH1F> mHistTimeUpperFraction;
-  std::unique_ptr<TH1F> mHistTimeLowerFraction;
   std::unique_ptr<TH1F> mHistTimeInWindow;
+  std::unique_ptr<TH1F> mHistCFDEff;
+  std::unique_ptr<TH1F> mHistTrgValidation;
 
   std::unique_ptr<TCanvas> mRatesCanv;
   TProfile* mAmpl = nullptr;
@@ -99,10 +100,13 @@ class PostProcTask final : public quality_control::postprocessing::PostProcessin
   std::unique_ptr<TH2F> mHistBcFeeOutOfBunchCollForOrAInTrg;
 
   uint8_t mTCMhash;
-  std::array<uint8_t, sNCHANNELS_FV0_PLUSREF> mChID2PMhash; // map chID->hashed PM value
+  std::array<uint8_t, sNCHANNELS_PM> mChID2PMhash; // map chID->hashed PM value
   std::map<uint8_t, bool> mMapPMhash2isInner;
   std::map<unsigned int, TH1D*> mMapTrgHistBC;
   std::map<std::string, uint8_t> mMapFEE2hash;
+
+  int mLowTimeThreshold{ -192 };
+  int mUpTimeThreshold{ 192 };
 };
 
 } // namespace o2::quality_control_modules::fv0

--- a/Modules/FIT/FV0/src/PostProcTask.cxx
+++ b/Modules/FIT/FV0/src/PostProcTask.cxx
@@ -374,32 +374,6 @@ void PostProcTask::update(Trigger t, framework::ServiceRegistryRef)
     */
   }
 
-  /*
-    auto mo3 = mDatabase->retrieveMO(mPathDigitQcTask, "AmpPerChannel", t.timestamp, t.activity);
-    auto hAmpPerChannel = mo3 ? dynamic_cast<TH2F*>(mo3->getObject()) : nullptr;
-    if (!hAmpPerChannel) {
-      ILOG(Error) << "MO \"AmpPerChannel\" NOT retrieved!!!"
-                  << ENDM;
-    }
-    auto mo4 = mDatabase->retrieveMO(mPathDigitQcTask, "TimePerChannel", t.timestamp, t.activity);
-    auto hTimePerChannel = mo4 ? dynamic_cast<TH2F*>(mo4->getObject()) : nullptr;
-    if (!hTimePerChannel) {
-      ILOG(Error) << "MO \"TimePerChannel\" NOT retrieved!!!"
-                  << ENDM;
-    } else {
-      auto projLower = hTimePerChannel->ProjectionX("projLower", 0, hTimePerChannel->GetYaxis()->FindBin(-190.));
-      auto projUpper = hTimePerChannel->ProjectionX("projUpper", hTimePerChannel->GetYaxis()->FindBin(190.), -1);
-      auto projInWindow = hTimePerChannel->ProjectionX("projInWindow", hTimePerChannel->GetYaxis()->FindBin(-190.), hTimePerChannel->GetYaxis()->FindBin(190.));
-      auto projFull = hTimePerChannel->ProjectionX("projFull");
-      mHistTimeUpperFraction->Divide(projUpper, projFull);
-      mHistTimeLowerFraction->Divide(projLower, projFull);
-      mHistTimeInWindow->Divide(projInWindow, projFull);
-      delete projLower;
-      delete projUpper;
-      delete projInWindow;
-      delete projFull;
-    }
-  */
   auto mo3 = mDatabase->retrieveMO(mPathDigitQcTask, "AmpPerChannel", t.timestamp, t.activity);
   auto hAmpPerChannel = mo3 ? dynamic_cast<TH2F*>(mo3->getObject()) : nullptr;
   if (!hAmpPerChannel) {


### PR DESCRIPTION
**FLP->EPN migration:**
1. FT0: `CFD_efficiency` is cloned from `DigitQcTask` into `PostProc`
2. FDD: `TrgValidation`, `TimeInWindowFraction`, `CFD_efficiency` are cloned from FT0 into `FDD::PostProc`. `AmpSaturation` taken from `FDD::DigitQcTask`
3. FV0: `TrgValidation`, `TimeInWindowFraction`, `CFD_efficiency` are cloned from FT0 into `FV0::PostProc`.

**New FIT tasks:**
1. `RawDataMetricTask` - since decoder is produce special metrics, now it is possible to visualize them in QC
2. `LevelCheck` - level check tasks. Checks if level of given bins in TH1 is below or upper than threshold. Contains option for `DeadChannelMap`. Common for all FIT detectors.

**Some utilities:**
Helper headers are divided into corresponding sections: Common, Hists, FIT, LUT(LookUpTable). Some of them is not use in given QC version. Preparation for next refactoring.
