### PR TITLE
[QC-429] Old validity in aggregators until we move everything

### DIFF
--- a/Framework/src/AggregatorRunner.cxx
+++ b/Framework/src/AggregatorRunner.cxx
@@ -236,9 +236,13 @@ QualityObjectsType AggregatorRunner::aggregate()
 void AggregatorRunner::store(QualityObjectsType& qualityObjects)
 {
   ILOG(Info, Devel) << "Storing " << qualityObjects.size() << " QualityObjects" << ENDM;
+  auto validFrom = getCurrentTimestamp();
   try {
     for (auto& qo : qualityObjects) {
+      auto tmpValidity = qo->getValidity();
+      qo->setValidity(ValidityInterval{ static_cast<unsigned long>(validFrom), validFrom + 10ull * 365 * 24 * 60 * 60 * 1000 });
       mDatabase->storeQO(qo);
+      qo->setValidity(tmpValidity);
     }
     if (!qualityObjects.empty()) {
       auto& qo = qualityObjects.at(0);


### PR DESCRIPTION
Contrary to my assumptions, we cannot use the new validity rules just in aggregators without applying them to check outputs, because they are used at the same time in some postprocessing tasks.