### PR TITLE
ZDC: Fixed bug TDC and ADC Summary Mean Plot

### DIFF
--- a/Modules/ZDC/src/ZDCRecDataTask.cxx
+++ b/Modules/ZDC/src/ZDCRecDataTask.cxx
@@ -591,12 +591,12 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
   mEv.init(RecBC, Energy, TDCData, Info);
   while (mEv.next()) {
     // Histo 1D
+    mHisto1D.at(mIdhADC).histo->Reset();
+    mHisto1D.at(mIdhTDC).histo->Reset();
     for (int i = 0; i < (int)mHisto1D.size(); i++) {
       // Fill ADC 1D
       if (mHisto1D.at(i).typeh.compare("ADC1D") == 0 && mHisto1D.at(i).typech.compare("ADC") == 0) {
         mHisto1D.at(i).histo->Fill(getADCRecValue(mHisto1D.at(i).typech, mHisto1D.at(i).ch));
-        mHisto1D.at(mIdhADC).histo->SetBinContent(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMean());
-        mHisto1D.at(mIdhADC).histo->SetBinError(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMeanError());
       }
 
       // Fill TDC 1D
@@ -612,8 +612,6 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
               mHisto1D.at(i).histo->Fill(mEv.tdcA(tdcid, ihit));
             }
           }
-          mHisto1D.at(mIdhTDC).histo->SetBinContent(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMean());
-          mHisto1D.at(mIdhTDC).histo->SetBinError(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMeanError());
         }
       }
       // Fill CENTROID ZP
@@ -622,6 +620,15 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
       }
       if (mHisto1D.at(i).typeh.compare("CENTR_ZPC") == 0 && mHisto1D.at(i).typech.compare("ADC") == 0) {
         mHisto1D.at(i).histo->Fill(mEv.xZPC());
+      }
+      // Fill SUMMARY
+      if (mHisto1D.at(mIdhADC).typeh.compare("SUMMARY_ADC") == 0 && mHisto1D.at(i).typeh.compare("ADC1D") == 0 && mHisto1D.at(i).typech.compare("ADC") == 0 && i != mIdhADC) {
+        mHisto1D.at(mIdhADC).histo->SetBinContent(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMean());
+        mHisto1D.at(mIdhADC).histo->SetBinError(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMeanError());
+      }
+      if (mHisto1D.at(mIdhTDC).typeh.compare("SUMMARY_TDC") == 0 && mHisto1D.at(i).typeh.compare("TDC1D") == 0 && mHisto1D.at(i).typech.compare("TDCV") == 0 && i != mIdhTDC) {
+        mHisto1D.at(mIdhTDC).histo->SetBinContent(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMean());
+        mHisto1D.at(mIdhTDC).histo->SetBinError(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMeanError());
       }
     } // for histo 1D
 


### PR DESCRIPTION
This pull request should fix a problem in the previous version.
However, the problem has not been well understood, because in the test machine the two summary histograms: h_summary_TDC and h_summary_ADC are filled in correctly way, while at P2 we see strange results.

The h_summary_TDC histogram should show the mean values ​​of the following histograms: 
h_TDC_ZNA_TC_V, h_TDC_ZNA_SUM_V, h_TDC_ZNC_TC_V, h_TDC_ZNC_SUM_V, h_TDC_ZPA_TC_V, h_TDC_ZPA_SUM_V, h_TDC_ZPC_TC_V, h_TDC_ZPC_SUM _V. 
Locally this works. At P2 the values ​​continue to increase. Ratios between channels marked as TC and as SUM are maintained. You can see the bhrevior in the run 541694.
The same problem is present in the h_summary_ADC histogram for its channels.

The proposed solution was to reset the two histograms before each event and filling of the plots in a different way  adding controls.

For us these histograms will be very important in the lead lead because they will allow us to verify the quality of the data.

As said at the beginning, not being able to reproduce the problem, I'm not sure if it fixed the bug. If you think this solution doesn't work and you have other ideas, let me know.