### PR TITLE
ITS FEETask payload parsing optimization

### DIFF
--- a/Modules/ITS/include/ITS/ITSFeeTask.h
+++ b/Modules/ITS/include/ITS/ITSFeeTask.h
@@ -166,7 +166,9 @@ class ITSFeeTask final : public TaskInterface
   int mNPayloadSizeBins = 4096;
   bool mResetLaneStatus = false;
   bool mResetPayload = false;
-  bool mEnablePayloadParse = true;
+  int mPayloadParseEvery_n_HBF_per_TF = 32; // -1 to disable, 1 to process all the HBFs
+  int mPayloadParseEvery_n_TF = 1;          // Use >= 1 values
+  bool mEnableIHWReading = 0;
 
   TH1I* mTFInfo; // count vs TF ID
   TH2I* mTriggerVsFeeId;

--- a/Modules/ITS/itsFee.json
+++ b/Modules/ITS/itsFee.json
@@ -36,10 +36,12 @@
                 },
                 "location": "local",
                 "taskParameters": {
-		    "EnablePayloadParsing": "1",
                     "NPayloadSizeBins": "4096",
                     "ResetLaneStatus": "1",
-                    "ResetPayload": "0"
+                    "ResetPayload": "0",
+		    "EnableIHWReading": "1",
+		    "PayloadParsingEvery_n_HBFperTF": "0",
+		    "PayloadParsingEvery_n_TF": "1"
                 }
             }
         },


### PR DESCRIPTION
Now the parsing of payload to count the GBT word identifiers can be triggered with a custom Orbit and TF periodicity. 
In addition, the ITS Header Word decoding can be disabled.
@IsakovAD @iravasen 