### PR TITLE
TRD tracking task updated

### DIFF
--- a/Modules/TRD/CMakeLists.txt
+++ b/Modules/TRD/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcTRD PUBLIC O2QualityControl)
+target_link_libraries(O2QcTRD PUBLIC O2QualityControl O2QcCommon)
 
 install(TARGETS O2QcTRD
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/TRD/include/TRD/TrackingTask.h
+++ b/Modules/TRD/include/TRD/TrackingTask.h
@@ -24,7 +24,10 @@
 #include <TH1.h>
 // O2 includes
 #include "DataFormatsTRD/TrackTRD.h"
+#include "DataFormatsTRD/TrackTriggerRecord.h"
 #include "DataFormatsTRD/Constants.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
 #include <Framework/TimingInfo.h>
 // QC includes
 #include "QualityControl/TaskInterface.h"
@@ -57,12 +60,21 @@ class TrackingTask final : public TaskInterface
   void axisConfig(TH1* h, const char* xTitle, const char* yTitle, const char* zTitle, bool stat, float xOffset = 1., float yOffset = 1.);
   void publishObject(TObject* aObject, const char* drawOpt = "", const char* dispayOpt = "");
   void drawLayers(TH2* hist);
-  long int mTimestamp;
-
+  bool mDetailedTrackQC = false;                                 // flag whether or not to expect o2::trd::TrackQC input
+  std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; // specify which input to use
+  o2::globaltracking::RecoContainer mRecoCont;                   // helper to acess input from reconstruction
+  o2::dataformats::GlobalTrackID::mask_t mSrcSelected;           // the selected track sources from allowed ITS-TPC-TRD and TPC-TRD
+  // the input data spans
+  gsl::span<const o2::trd::TrackTRD> mITSTPCTRDTracks;
+  gsl::span<const o2::trd::TrackTriggerRecord> mTrigITSTPCTRD;
+  gsl::span<const o2::trd::TrackTRD> mTPCTRDTracks;
+  gsl::span<const o2::trd::TrackTriggerRecord> mTrigTPCTRD;
+  //
   float mPtMin = 0.0;                                                                 // minimum pT of tracks
   TString chrg[2] = { "Pos", "Neg" };                                                 // charge of tracks
   TH1D* mNtracks = nullptr;                                                           // number of ITS-TPC-TRD tracks per event
   TH1D* mNtracklets = nullptr;                                                        // number of TRD tracklets per track
+  TH2D* mTrackEtaPhi = nullptr;                                                       // eta-phi distribution of ITS-TPC-TRD tracks
   TH1D* mTrackEta = nullptr;                                                          // eta of ITS-TPC-TRD tracks
   TH1D* mTrackPhi = nullptr;                                                          // phi of ITS-TPC-TRD tracks
   TH1D* mTrackPt = nullptr;                                                           // pt of ITS-TPC-TRD tracks

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -1,3 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
 
 #include <TCanvas.h>
 #include <TH1.h>
@@ -7,16 +17,14 @@
 #include <TH2F.h>
 #include <TProfile.h>
 #include <TProfile2D.h>
-#include <TStopwatch.h>
-#include <THashList.h>
 
 #include "DataFormatsTRD/Constants.h"
 #include "DataFormatsTRD/Digit.h"
-#include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "QualityControl/ObjectsManager.h"
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "Common/Utils.h"
 #include "TRD/DigitsTask.h"
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
@@ -25,6 +33,9 @@
 #include <tuple>
 
 #include "CCDB/BasicCCDBManager.h"
+
+using namespace o2::quality_control_modules::common;
+
 namespace o2::quality_control_modules::trd
 {
 DigitsTask::~DigitsTask()
@@ -366,29 +377,15 @@ void DigitsTask::buildHistograms()
   }
 
   for (int iLayer = 0; iLayer < 6; ++iLayer) {
-    mLayers.push_back(new TH2F(Form("DigitsPerLayer/layer%i", iLayer), Form("Digit count per pad in layer %i;stack;sector", iLayer), 76, -0.5, 75.5, 2592, -0.5, 2591.5));
+    mLayers.push_back(new TH2F(Form("DigitsPerLayer/layer%i", iLayer), Form("Digit count per pad in layer %i;glb pad row;glb pad col", iLayer), 76, -0.5, 75.5, 2592, -0.5, 2591.5));
     auto xax = mLayers.back()->GetXaxis();
     auto yax = mLayers[iLayer]->GetYaxis();
     if (!mLayerLabelsIgnore) {
-      xax->SetNdivisions(5);
-      xax->SetBinLabel(8, "0");
-      xax->SetBinLabel(24, "1");
-      xax->SetBinLabel(38, "2");
-      xax->SetBinLabel(52, "3");
-      xax->SetBinLabel(68, "4");
-      xax->SetTicks("");
-      xax->SetTickSize(0.0);
       xax->SetLabelSize(0.045);
       xax->SetLabelOffset(0.005);
       xax->SetTitleOffset(0.95);
       xax->CenterTitle(true);
-      yax->SetNdivisions(18);
-      for (int iSec = 0; iSec < 18; ++iSec) {
-        auto lbl = std::to_string(iSec);
-        yax->SetBinLabel(iSec * 144 + 72, lbl.c_str());
-      }
-      yax->SetTicks("");
-      yax->SetTickSize(0.0);
+      yax->SetNdivisions(-18);
       yax->SetLabelSize(0.045);
       yax->SetLabelOffset(0.001);
       yax->SetTitleOffset(0.40);
@@ -409,52 +406,14 @@ void DigitsTask::initialize(o2::framework::InitContext& /*ctx*/)
   ILOG(Debug, Devel) << "initialize TRDDigitQcTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
 
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
-  if (auto param = mCustomParameters.find("driftRegionStart"); param != mCustomParameters.end()) {
-    mDriftRegion.first = stof(param->second);
-    ILOG(Debug, Support) << "configure() : using driftRegionStart = " << mDriftRegion.first << ENDM;
-  } else {
-    mDriftRegion.first = 7.0;
-    ILOG(Debug, Support) << "configure() : using default driftRegionStart = " << mDriftRegion.first << ENDM;
-  }
-  if (auto param = mCustomParameters.find("driftRegionEnd"); param != mCustomParameters.end()) {
-    mDriftRegion.second = stof(param->second);
-    ILOG(Debug, Support) << "configure() : using driftRegionEnd = " << mDriftRegion.second << ENDM;
-  } else {
-    mDriftRegion.second = 20.0;
-    ILOG(Debug, Support) << "configure() : using default driftRegionEnd = " << mDriftRegion.second << ENDM;
-  }
-  if (auto param = mCustomParameters.find("peakRegionStart"); param != mCustomParameters.end()) {
-    mPulseHeightPeakRegion.first = stof(param->second);
-    ILOG(Debug, Support) << "configure() : using peakRegionStart	= " << mPulseHeightPeakRegion.first << ENDM;
-  } else {
-    mPulseHeightPeakRegion.first = 0.0;
-    ILOG(Debug, Support) << "configure() : using default peakRegionStart = " << mPulseHeightPeakRegion.first << ENDM;
-  }
-  if (auto param = mCustomParameters.find("peakRegionEnd"); param != mCustomParameters.end()) {
-    mPulseHeightPeakRegion.second = stof(param->second);
-    ILOG(Debug, Support) << "configure() : using peakRegionEnd	= " << mPulseHeightPeakRegion.second << ENDM;
-  } else {
-    mPulseHeightPeakRegion.second = 5.0;
-    ILOG(Debug, Support) << "configure() : using default peakRegionEnd = " << mPulseHeightPeakRegion.second << ENDM;
-  }
-  if (auto param = mCustomParameters.find("phThreshold"); param != mCustomParameters.end()) {
-    mPulseHeightThreshold = stod(param->second);
-    ILOG(Debug, Support) << "configure() : using phThreshold 	= " << mPulseHeightThreshold << ENDM;
-  } else {
-    mPulseHeightThreshold = 400;
-    ILOG(Debug, Support) << "configure() : using phThreshold = " << mPulseHeightThreshold << ENDM;
-  }
-  if (auto param = mCustomParameters.find("ignoreChambers"); param != mCustomParameters.end()) {
-    mChambersToIgnore = param->second;
-    ILOG(Debug, Support) << "configure() : ignoreChambers = " << mChambersToIgnore << ENDM;
-  } else {
-    mChambersToIgnore = "16_3_0";
-    ILOG(Debug, Support) << "configure() : chambers to ignore for pulseheight calculations = " << mChambersToIgnore << ENDM;
-  }
-  if (auto param = mCustomParameters.find("ignoreLabels"); param != mCustomParameters.end()) {
-    mLayerLabelsIgnore = stoi(param->second);
-    ILOG(Debug, Support) << "configure() : ignoring labels on layer plots = " << mLayerLabelsIgnore << ENDM;
-  }
+  mDriftRegion.first = getFromConfig<float>(mCustomParameters, "driftRegionStart", 7.f);
+  mDriftRegion.second = getFromConfig<float>(mCustomParameters, "driftRegionEnd", 20.f);
+  mPulseHeightPeakRegion.first = getFromConfig<float>(mCustomParameters, "peakRegionStart", 0.f);
+  mPulseHeightPeakRegion.second = getFromConfig<float>(mCustomParameters, "peakRegionEnd", 5.f);
+  mPulseHeightThreshold = getFromConfig<unsigned int>(mCustomParameters, "phThreshold", 400u);
+  mChambersToIgnore = getFromConfig<string>(mCustomParameters, "ignoreChambers", "16_3_0");
+  mLayerLabelsIgnore = getFromConfig<bool>(mCustomParameters, "ignoreLabels", true);
+
   buildChamberIgnoreBP();
 
   retrieveCCDBSettings();
@@ -536,12 +495,6 @@ void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
         } else {
           mDigitsPerEvent->Fill(trigger.getNumberOfDigits());
         }
-        int trackletnumfix = trigger.getNumberOfTracklets();
-        int digitnumfix = trigger.getNumberOfDigits();
-        if (trigger.getNumberOfTracklets() > 2499)
-          trackletnumfix = 2499;
-        if (trigger.getNumberOfDigits() > 24999)
-          trackletnumfix = 24999;
         mDigitsSizevsTrackletSize->Fill(trigger.getNumberOfTracklets(), trigger.getNumberOfDigits());
         int tbmax = 0;
         int tbhi = 0;
@@ -553,15 +506,7 @@ void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
         int channel = 0;
 
         for (int currentdigit = trigger.getFirstDigit() + 1; currentdigit < trigger.getFirstDigit() + trigger.getNumberOfDigits() - 1; ++currentdigit) { // -1 and +1 as we are looking for consecutive digits pre and post the current one indexed.
-          if (digits[digitsIndex[currentdigit]].getChannel() > 21)
-            continue;
           int detector = digits[digitsIndex[currentdigit]].getDetector();
-          if (detector < 0 || detector >= 540) {
-            // for some reason online the sm value causes an error below and digittrask crashes.
-            // the only possibility is detector number is invalid
-            ILOG(Info, Support) << "Bad detector number from digit : " << detector << " for digit index of " << digitsIndex[currentdigit] << ENDM;
-            continue;
-          }
           int sm = detector / 30;
           int detLoc = detector % 30;
           int layer = detector % 6;

--- a/Modules/TRD/src/TrackingTask.cxx
+++ b/Modules/TRD/src/TrackingTask.cxx
@@ -20,32 +20,32 @@
 #include "TMath.h"
 // O2 includes
 #include "QualityControl/QcInfoLogger.h"
-#include "DataFormatsTRD/TrackTRD.h"
-#include "DataFormatsTRD/TrackTriggerRecord.h"
-#include "DataFormatsTRD/Tracklet64.h"
-#include "DataFormatsGlobalTracking/RecoContainer.h"
-#include "DataFormatsTRD/CalibratedTracklet.h"
 #include "TRDQC/Tracking.h"
 #include <Framework/InputRecord.h>
 #include "CCDB/BasicCCDBManager.h"
 // QC includes
 #include "TRD/TrackingTask.h"
+#include "Common/Utils.h"
 
 using namespace o2::trd;
 using namespace o2::trd::constants;
+using namespace o2::quality_control_modules::common;
 
 namespace o2::quality_control_modules::trd
 {
-using GTrackID = o2::dataformats::GlobalTrackID;
+using GID = o2::dataformats::GlobalTrackID;
 
 void TrackingTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Debug, Devel) << "initialize TRD TrackingTask" << ENDM;
 
-  // minimum pT of tracks is configurable from json
-  if (auto param = mCustomParameters.find("pTminvalue"); param != mCustomParameters.end()) {
-    mPtMin = std::stof(param->second);
-  }
+  mPtMin = getFromConfig<float>(mCustomParameters, "pTminvalue", 0.f);
+  mDetailedTrackQC = getFromConfig<bool>(mCustomParameters, "detailedQC");
+  std::string trackSources = getFromConfig<string>(mCustomParameters, "trackSources", "all");
+  GID::mask_t allowedSources = GID::getSourcesMask("TPC-TRD,ITS-TPC-TRD");
+  mSrcSelected = allowedSources & GID::getSourcesMask(trackSources);
+  mDataRequest = std::make_shared<o2::globaltracking::DataRequest>();
+  mDataRequest->requestTracks(mSrcSelected, false);
 
   buildHistograms();
 }
@@ -64,68 +64,92 @@ void TrackingTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
   ILOG(Debug, Devel) << "monitorData" << ENDM;
 
-  auto trackqcArr = ctx.inputs().get<gsl::span<o2::trd::TrackQC>>("tracksqc");
-  auto trackTRDArr = ctx.inputs().get<gsl::span<o2::trd::TrackTRD>>("tracksTRD");
-  auto tracktrigArr = ctx.inputs().get<gsl::span<o2::trd::TrackTriggerRecord>>("trigrectrk");
+  mRecoCont.collectData(ctx, *mDataRequest.get());
+  std::vector<uint8_t> sources;
+  if (mSrcSelected[GID::Source::ITSTPCTRD] == 1) {
+    mITSTPCTRDTracks = mRecoCont.getITSTPCTRDTracks<TrackTRD>();
+    mTrigITSTPCTRD = mRecoCont.getITSTPCTRDTriggers();
+    sources.push_back(GID::Source::ITSTPCTRD);
+  }
+  if (mSrcSelected[GID::Source::TPCTRD] == 1) {
+    mTPCTRDTracks = mRecoCont.getTPCTRDTracks<TrackTRD>();
+    mTrigTPCTRD = mRecoCont.getTPCTRDTriggers();
+    sources.push_back(GID::Source::TPCTRD);
+  }
 
-  for (const auto& tracktrig : tracktrigArr) {
-    int start = tracktrig.getFirstTrack();
-    int end = start + tracktrig.getNumberOfTracks();
-    mNtracks->Fill(tracktrig.getNumberOfTracks());
-    for (int itrack = start; itrack < end; ++itrack) {
-      const auto& trackTRD = trackTRDArr[itrack];
-      // remove tracks with pt below threshold
-      if (trackTRD.getPt() < mPtMin) {
-        continue;
-      }
-      // filling track information
-      mTrackPt->Fill(trackTRD.getPt());
-      mTrackPhi->Fill(trackTRD.getPhiPos());
-      mNtracklets->Fill(trackTRD.getNtracklets());
-      mTrackChi2->Fill(trackTRD.getReducedChi2());
-      mTrackEta->Fill(trackTRD.getEta());
-      // find charge bin of the track
-      int charge = trackTRD.getCharge() > 0 ? 0 : 1;
-      // eta-phi distribution of tracklets per layer
-      mTrackletsEtaPhi[charge]->Fill(trackTRD.getEta(), trackTRD.getPhiPos(), trackTRD.getNtracklets());
-      for (int iLayer = 0; iLayer < NLAYER; iLayer++) {
-        // skip layers with no tracklet
-        if (trackTRD.getTrackletIndex(iLayer) < 0) {
+  const gsl::span<const TrackQC>* trackQcPtr = nullptr;
+  using trkQcType = std::decay_t<decltype(ctx.inputs().get<gsl::span<o2::trd::TrackQC>>(""))>;
+  std::optional<trkQcType> trackQc;
+  if (mDetailedTrackQC) {
+    trackQc.emplace(ctx.inputs().get<gsl::span<o2::trd::TrackQC>>("tracksqc"));
+    trackQcPtr = &trackQc.value();
+  }
+
+  for (auto src : sources) {
+    const gsl::span<const TrackTriggerRecord>* trackTriggers = (src == GID::Source::ITSTPCTRD) ? &mTrigITSTPCTRD : &mTrigTPCTRD;
+    const gsl::span<const TrackTRD>* tracks = (src == GID::Source::ITSTPCTRD) ? &mITSTPCTRDTracks : &mTPCTRDTracks;
+    for (const auto& tracktrig : *trackTriggers) {
+      int start = tracktrig.getFirstTrack();
+      int end = start + tracktrig.getNumberOfTracks();
+      mNtracks->Fill(tracktrig.getNumberOfTracks());
+      for (int itrack = start; itrack < end; ++itrack) {
+        const auto& trackTRD = (*tracks)[itrack];
+        // remove tracks with pt below threshold
+        if (trackTRD.getPt() < mPtMin) {
           continue;
         }
-        // eta-phi distribution per layer
-        mTracksEtaPhiPerLayer[charge][iLayer]->Fill(trackTRD.getEta(), trackTRD.getPhiPos());
-      } // end of loop over layers
-    }   // end of loop over tracks
-  }     // end of loop over track trigger records
+        // filling track information
+        mTrackPt->Fill(trackTRD.getPt());
+        mTrackPhi->Fill(trackTRD.getOuterParam().getPhiPos());
+        mNtracklets->Fill(trackTRD.getNtracklets());
+        mTrackChi2->Fill(trackTRD.getReducedChi2());
+        mTrackEta->Fill(trackTRD.getOuterParam().getEta());
+        mTrackEtaPhi->Fill(trackTRD.getOuterParam().getEta(), trackTRD.getOuterParam().getPhiPos());
+        // find charge bin of the track
+        int charge = trackTRD.getCharge() > 0 ? 0 : 1;
+        // eta-phi distribution of tracklets per layer
+        mTrackletsEtaPhi[charge]->Fill(trackTRD.getOuterParam().getEta(), trackTRD.getOuterParam().getPhiPos(), trackTRD.getNtracklets());
+        for (int iLayer = 0; iLayer < NLAYER; iLayer++) {
+          // skip layers with no tracklet
+          if (trackTRD.getTrackletIndex(iLayer) < 0) {
+            continue;
+          }
+          // eta-phi distribution per layer
+          mTracksEtaPhiPerLayer[charge][iLayer]->Fill(trackTRD.getOuterParam().getEta(), trackTRD.getOuterParam().getPhiPos());
+        } // end of loop over layers
+      }   // end of loop over tracks
+    }     // end of loop over track trigger records
+  }
 
-  // Residuals in y and z using TRD/TRACKINGQC
-  for (const auto& trackqc : trackqcArr) {
-    // match only ITS-TPC tracks
-    auto trackType = trackqc.refGlobalTrackId.getSource();
-    if (!(trackType == GTrackID::Source::ITSTPC)) {
-      continue;
-    }
-    // remove tracks with pt below threshold
-    if (trackqc.trackTRD.getPt() < mPtMin) {
-      continue;
-    }
-    for (int iLayer = 0; iLayer < NLAYER; iLayer++) {
-      // skip layers with no tracklet
-      if (trackqc.trackTRD.getTrackletIndex(iLayer) < 0) {
+  if (mDetailedTrackQC && trackQcPtr) {
+    // Residuals in y and z using TRD/TRACKINGQC
+    for (const auto& trackqc : *trackQcPtr) {
+      // match only ITS-TPC tracks
+      auto trackType = trackqc.refGlobalTrackId.getSource();
+      if (!(trackType == GID::Source::ITSTPC)) {
         continue;
       }
-      // residuals information
-      mDeltaY->Fill(trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
-      mDeltaZ->Fill(trackqc.trackProp[iLayer].getZ() - trackqc.trackletZ[iLayer]);
-      mDeltaYDet->Fill(trackqc.trklt64[iLayer].getDetector(), trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
-      mDeltaZDet->Fill(trackqc.trklt64[iLayer].getDetector(), trackqc.trackProp[iLayer].getZ() - trackqc.trackletZ[iLayer]);
-      mDeltaYvsSphi->Fill(trackqc.trackProp[iLayer].getSnp(), trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
-      mDeltaYinEtaPerLayer[iLayer]->Fill(trackqc.trackProp[iLayer].getEta(), trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
-      mDeltaYinPhiPerLayer[iLayer]->Fill(trackqc.trackProp[iLayer].getPhiPos(), trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
-      mTrackletDef->Fill(trackqc.trackProp[iLayer].getSnp(), trackqc.trkltCalib[iLayer].getDy());
-    } // end of loop over layers
-  }   // end of loop over tracks
+      // remove tracks with pt below threshold
+      if (trackqc.trackTRD.getPt() < mPtMin) {
+        continue;
+      }
+      for (int iLayer = 0; iLayer < NLAYER; iLayer++) {
+        // skip layers with no tracklet
+        if (trackqc.trackTRD.getTrackletIndex(iLayer) < 0) {
+          continue;
+        }
+        // residuals information
+        mDeltaY->Fill(trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
+        mDeltaZ->Fill(trackqc.trackProp[iLayer].getZ() - trackqc.trackletZ[iLayer]);
+        mDeltaYDet->Fill(trackqc.trklt64[iLayer].getDetector(), trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
+        mDeltaZDet->Fill(trackqc.trklt64[iLayer].getDetector(), trackqc.trackProp[iLayer].getZ() - trackqc.trackletZ[iLayer]);
+        mDeltaYvsSphi->Fill(trackqc.trackProp[iLayer].getSnp(), trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
+        mDeltaYinEtaPerLayer[iLayer]->Fill(trackqc.trackProp[iLayer].getEta(), trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
+        mDeltaYinPhiPerLayer[iLayer]->Fill(trackqc.trackProp[iLayer].getPhiPos(), trackqc.trackProp[iLayer].getY() - trackqc.trackletY[iLayer]);
+        mTrackletDef->Fill(trackqc.trackProp[iLayer].getSnp(), trackqc.trkltCalib[iLayer].getDy());
+      } // end of loop over layers
+    }   // end of loop over tracks
+  }
 }
 
 void TrackingTask::endOfCycle()
@@ -145,14 +169,23 @@ void TrackingTask::reset()
   mNtracklets->Reset();
   mTrackEta->Reset();
   mTrackPhi->Reset();
+  mTrackEtaPhi->Reset();
   mTrackPt->Reset();
   mTrackChi2->Reset();
-  mDeltaY->Reset();
-  mDeltaZ->Reset();
-  mDeltaYDet->Reset();
-  mDeltaZDet->Reset();
-  mDeltaYvsSphi->Reset();
-  mTrackletDef->Reset();
+  if (mDetailedTrackQC) {
+    mDeltaY->Reset();
+    mDeltaZ->Reset();
+    mDeltaYDet->Reset();
+    mDeltaZDet->Reset();
+    mDeltaYvsSphi->Reset();
+    mTrackletDef->Reset();
+    for (auto h : mDeltaYinEtaPerLayer) {
+      h->Reset();
+    }
+    for (auto h : mDeltaYinPhiPerLayer) {
+      h->Reset();
+    }
+  }
   for (auto h : mTrackletsEtaPhi) {
     h->Reset();
   }
@@ -160,12 +193,6 @@ void TrackingTask::reset()
     for (auto hh : h) {
       hh->Reset();
     }
-  }
-  for (auto h : mDeltaYinEtaPerLayer) {
-    h->Reset();
-  }
-  for (auto h : mDeltaYinPhiPerLayer) {
-    h->Reset();
   }
 }
 
@@ -187,37 +214,42 @@ void TrackingTask::buildHistograms()
   axisConfig(mTrackPhi, "#phi", "Counts", "", 1, 1.0, 1.1);
   publishObject(mTrackPhi);
 
+  mTrackEtaPhi = new TH2D("TrackEtaPhi", ";#eta;#phi;counts", 100, -1., 1., 180, 0, TMath::TwoPi());
+  publishObject(mTrackEtaPhi, "colz");
+
   mTrackPt = new TH1D("TrackPt", "p_{T} Distribution", 100, 0.0, 10.0);
-  axisConfig(mTrackPt, "p_{T}", "Counts", "", 1, 1.0, 1.1);
+  axisConfig(mTrackPt, "p_{T} (GeV)", "Counts", "", 1, 1.0, 1.1);
   publishObject(mTrackPt, "", "logx");
 
   mTrackChi2 = new TH1D("TrackChi2", "Reduced Chi2Distribution", 100, 0.0, 10.0);
   axisConfig(mTrackChi2, "reduced #chi^{2}", "Counts", "", 1, 1.0, 1.1);
   publishObject(mTrackChi2);
 
-  mDeltaY = new TH1D("DeltaY", "Residuals in Y", 100, -10.0, 10.0);
-  axisConfig(mDeltaY, "track Y - tracklet Y (cm)", "Counts", "", 1, 1.0, 1.1);
-  publishObject(mDeltaY);
+  if (mDetailedTrackQC) {
+    mDeltaY = new TH1D("DeltaY", "Residuals in Y", 100, -10.0, 10.0);
+    axisConfig(mDeltaY, "track Y - tracklet Y (cm)", "Counts", "", 1, 1.0, 1.1);
+    publishObject(mDeltaY);
 
-  mDeltaZ = new TH1D("DeltaZ", "Residuals in Z", 100, -25.0, 25.0);
-  axisConfig(mDeltaZ, "track Z - tracklet Z (cm)", "Counts", "", 1, 1.0, 1.1);
-  publishObject(mDeltaZ);
+    mDeltaZ = new TH1D("DeltaZ", "Residuals in Z", 100, -25.0, 25.0);
+    axisConfig(mDeltaZ, "track Z - tracklet Z (cm)", "Counts", "", 1, 1.0, 1.1);
+    publishObject(mDeltaZ);
 
-  mDeltaYDet = new TH2D("DeltaYvsDet", "YResiduals per chamber", 540, -0.5, 539.5, 50, -10, 10);
-  axisConfig(mDeltaYDet, "chamber number", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);
-  publishObject(mDeltaYDet, "colz", "logz");
+    mDeltaYDet = new TH2D("DeltaYvsDet", "YResiduals per chamber", 540, -0.5, 539.5, 50, -10, 10);
+    axisConfig(mDeltaYDet, "chamber number", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);
+    publishObject(mDeltaYDet, "colz", "logz");
 
-  mDeltaZDet = new TH2D("DeltaZvsDet", "ZResiduals per chamber", 540, -0.5, 539.5, 50, -25, 25);
-  axisConfig(mDeltaZDet, "chamber number", "track Z - tracklet Z (cm)", "Counts", 0, 1.0, 1.1);
-  publishObject(mDeltaZDet, "colz", "logz");
+    mDeltaZDet = new TH2D("DeltaZvsDet", "ZResiduals per chamber", 540, -0.5, 539.5, 50, -25, 25);
+    axisConfig(mDeltaZDet, "chamber number", "track Z - tracklet Z (cm)", "Counts", 0, 1.0, 1.1);
+    publishObject(mDeltaZDet, "colz", "logz");
 
-  mDeltaYvsSphi = new TH2D("DeltaYsnphi", "YResiduals vs Track sin(#phi)", 50, -0.4, 0.4, 50, -10, 10);
-  axisConfig(mDeltaYvsSphi, "track #it{sin(#phi)}", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);
-  publishObject(mDeltaYvsSphi, "colz", "logz");
+    mDeltaYvsSphi = new TH2D("DeltaYsnphi", "YResiduals vs Track sin(#phi)", 50, -0.4, 0.4, 50, -10, 10);
+    axisConfig(mDeltaYvsSphi, "track #it{sin(#phi)}", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);
+    publishObject(mDeltaYvsSphi, "colz", "logz");
 
-  mTrackletDef = new TH2D("TrackletDeflection", "Tracklet slope vs Track sin(#phi)", 100, -0.5, 0.5, 100, -1.5, 1.5);
-  axisConfig(mTrackletDef, "track #it{sin(#phi)}", "tracklet D_{y}", "Counts", 0, 1.0, 1.1);
-  publishObject(mTrackletDef, "colz", "logz");
+    mTrackletDef = new TH2D("TrackletDeflection", "Tracklet slope vs Track sin(#phi)", 100, -0.5, 0.5, 100, -1.5, 1.5);
+    axisConfig(mTrackletDef, "track #it{sin(#phi)}", "tracklet D_{y}", "Counts", 0, 1.0, 1.1);
+    publishObject(mTrackletDef, "colz", "logz");
+  }
 
   for (int i = 0; i < NLAYER; ++i) {
     for (int j = 0; j < 2; ++j) {
@@ -226,13 +258,15 @@ void TrackingTask::buildHistograms()
       drawLayers(mTracksEtaPhiPerLayer[i][j]);
       publishObject(mTracksEtaPhiPerLayer[i][j], "colz", "");
     }
-    mDeltaYinEtaPerLayer[i] = new TH2D(Form("YResinEtaPerLayer/layer%i", i), Form("YResiduals in eta for layer %i", i), 100, -0.856, 0.856, 100, -10, 10);
-    axisConfig(mDeltaYinEtaPerLayer[i], "#eta", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);
-    publishObject(mDeltaYinEtaPerLayer[i], "colz", "logz");
+    if (mDetailedTrackQC) {
+      mDeltaYinEtaPerLayer[i] = new TH2D(Form("YResinEtaPerLayer/layer%i", i), Form("YResiduals in eta for layer %i", i), 100, -0.856, 0.856, 100, -10, 10);
+      axisConfig(mDeltaYinEtaPerLayer[i], "#eta", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);
+      publishObject(mDeltaYinEtaPerLayer[i], "colz", "logz");
 
-    mDeltaYinPhiPerLayer[i] = new TH2D(Form("YResinPhiPerLayer/layer%i", i), Form("YResiduals in phi for layer %i", i), 180, 0, TMath::TwoPi(), 100, -10, 10);
-    axisConfig(mDeltaYinPhiPerLayer[i], "#phi", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);
-    publishObject(mDeltaYinPhiPerLayer[i], "colz", "logz");
+      mDeltaYinPhiPerLayer[i] = new TH2D(Form("YResinPhiPerLayer/layer%i", i), Form("YResiduals in phi for layer %i", i), 180, 0, TMath::TwoPi(), 100, -10, 10);
+      axisConfig(mDeltaYinPhiPerLayer[i], "#phi", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);
+      publishObject(mDeltaYinPhiPerLayer[i], "colz", "logz");
+    }
   }
   for (int i = 0; i < 2; ++i) {
     mTrackletsEtaPhi[i] = new TProfile2D(Form("EtaPhiTracklets/%sTracks", chrg[i].Data()), Form("EtaPhi for %s tracks (tracklets)", chrg[i].Data()), 100, -0.856, 0.856, 180, 0, TMath::TwoPi(), 0, 6);

--- a/Modules/TRD/src/TrackingTask.cxx
+++ b/Modules/TRD/src/TrackingTask.cxx
@@ -221,10 +221,10 @@ void TrackingTask::buildHistograms()
 
   for (int i = 0; i < NLAYER; ++i) {
     for (int j = 0; j < 2; ++j) {
-      mTracksEtaPhiPerLayer[j][i] = new TH2D(Form("EtaPhi%sTrackPerLayer/layer%i", chrg[j].Data(), i), Form("EtaPhi for %s tracks in layer %i", chrg[j].Data(), i), 100, -0.856, 0.856, 180, 0, TMath::TwoPi());
-      axisConfig(mTracksEtaPhiPerLayer[j][i], "#eta", "#phi", "Counts", 0, 1.0, 1.1);
-      drawLayers(mTracksEtaPhiPerLayer[j][i]);
-      publishObject(mTracksEtaPhiPerLayer[j][i], "colz", "");
+      mTracksEtaPhiPerLayer[i][j] = new TH2D(Form("EtaPhi%sTrackPerLayer/layer%i", chrg[j].Data(), i), Form("EtaPhi for %s tracks in layer %i", chrg[j].Data(), i), 100, -0.856, 0.856, 180, 0, TMath::TwoPi());
+      axisConfig(mTracksEtaPhiPerLayer[i][j], "#eta", "#phi", "Counts", 0, 1.0, 1.1);
+      drawLayers(mTracksEtaPhiPerLayer[i][j]);
+      publishObject(mTracksEtaPhiPerLayer[i][j], "colz", "");
     }
     mDeltaYinEtaPerLayer[i] = new TH2D(Form("YResinEtaPerLayer/layer%i", i), Form("YResiduals in eta for layer %i", i), 100, -0.856, 0.856, 100, -10, 10);
     axisConfig(mDeltaYinEtaPerLayer[i], "#eta", "track Y - tracklet Y (cm)", "Counts", 0, 1.0, 1.1);

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "QualityControl/QcInfoLogger.h"
+#include "Common/Utils.h"
 #include "TRD/TrackletsTask.h"
 #include "TRDQC/StatusHelper.h"
 #include <Framework/InputRecord.h>
@@ -35,6 +36,8 @@
 #include "DataFormatsTRD/NoiseCalibration.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "CCDB/BasicCCDBManager.h"
+
+using namespace o2::quality_control_modules::common;
 
 namespace o2::quality_control_modules::trd
 {
@@ -295,29 +298,16 @@ void TrackletsTask::drawHashOnLayers(int layer, int hcid, int rowstart, int rowe
 void TrackletsTask::buildTrackletLayers()
 {
   for (int iLayer = 0; iLayer < 6; ++iLayer) {
-    mLayers[iLayer] = new TH2F(Form("TrackletsPerLayer/layer%i", iLayer), Form("Tracklet count per mcm in layer %i;Stack;Sector", iLayer), 76, -0.5, 75.5, 144, -0.5, 143.5);
+    mLayers[iLayer] = new TH2F(Form("TrackletsPerLayer/layer%i", iLayer), Form("Tracklet count per mcm in layer %i;glb pad row;glb MCM col", iLayer), 76, -0.5, 75.5, 144, -0.5, 143.5);
     auto xax = mLayers[iLayer]->GetXaxis();
     auto yax = mLayers[iLayer]->GetYaxis();
     if (!mLayerLabelsIgnore) {
-      xax->SetNdivisions(5);
-      xax->SetBinLabel(8, "0");
-      xax->SetBinLabel(24, "1");
-      xax->SetBinLabel(38, "2");
-      xax->SetBinLabel(52, "3");
-      xax->SetBinLabel(68, "4");
-      xax->SetTicks("");
       xax->SetTickSize(0.0);
       xax->SetLabelSize(0.045);
       xax->SetLabelOffset(0.005);
       xax->SetTitleOffset(0.95);
       xax->CenterTitle(true);
-      yax->SetNdivisions(18);
-      for (int iSec = 0; iSec < 18; ++iSec) {
-        auto lbl = std::to_string(iSec);
-        yax->SetBinLabel(iSec * 8 + 4, lbl.c_str());
-      }
-      yax->SetTicks("");
-      yax->SetTickSize(0.0);
+      yax->SetNdivisions(-18);
       yax->SetLabelSize(0.045);
       yax->SetLabelOffset(0.001);
       yax->SetTitleOffset(0.40);
@@ -381,11 +371,7 @@ void TrackletsTask::drawHashedOnHistsPerLayer(int iLayer)
 void TrackletsTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Debug, Devel) << "initialize TrackletsTask" << ENDM;
-
-  if (auto param = mCustomParameters.find("ignoreLabels"); param != mCustomParameters.end()) {
-    mLayerLabelsIgnore = stoi(param->second);
-    ILOG(Debug, Support) << "configure() : ignoring labels on layer plots = " << mLayerLabelsIgnore << ENDM;
-  }
+  mLayerLabelsIgnore = getFromConfig<bool>(mCustomParameters, "ignoreLabels", true);
   retrieveCCDBSettings();
   buildHistograms();
 }


### PR DESCRIPTION
Hi @maroozm with this change the `TrackQC` input becomes optional (we will most likely not have it during synch. reco) and one can configure to use either ITS-TPC-TRD tracks, TPC-TRD tracks or both as input. At the moment all goes to the same histograms. For some it will be interesting to have it separately, but this can also come later. During synch. reco we will only see ITS-TPC-TRD tracks.