### PR TITLE
ZDC: add post-processing for ADC and TDC plots

### DIFF
--- a/Modules/ZDC/CMakeLists.txt
+++ b/Modules/ZDC/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(O2QcZDC)
 
-target_sources(O2QcZDC PRIVATE src/ZDCRecDataCheck.cxx  src/ZDCRecDataTask.cxx  src/ZDCRawDataCheck.cxx  src/ZDCRawDataTask.cxx )
+target_sources(O2QcZDC PRIVATE src/ZDCRecDataCheck.cxx  src/ZDCRecDataTask.cxx  src/ZDCRecDataPostProcessing.cxx src/PostProcessingConfigZDC.cxx  src/ZDCRawDataCheck.cxx  src/ZDCRawDataTask.cxx )
 
 target_include_directories(
   O2QcZDC
@@ -21,6 +21,7 @@ add_root_dictionary(O2QcZDC
                     HEADERS
   include/ZDC/ZDCRecDataCheck.h
   include/ZDC/ZDCRecDataTask.h
+  include/ZDC/ZDCRecDataPostProcessing.h
   include/ZDC/ZDCRawDataCheck.h
   include/ZDC/ZDCRawDataTask.h
                     LINKDEF include/ZDC/LinkDef.h)

--- a/Modules/ZDC/etc/zdcTaskRecData.json
+++ b/Modules/ZDC/etc/zdcTaskRecData.json
@@ -54,13 +54,138 @@
         "saveObjectsToFile": "QcZDCRecData.root",      "": "For debugging, path to the file where to save. If empty it won't save."
       }
     },
+    "postprocessing": {
+      "RecPP": {
+        "active": "true",
+        "className": "o2::quality_control_modules::zdc::ZDCRecDataPostProcessing",
+        "moduleName": "QcZDC",
+        "detectorName": "ZDC",
+        "customization": [
+        ],
+        "dataSourcesADC": [
+          {
+            "type": "repository",
+            "path": "ZDC/MO/QcZDCRecTask",
+            "names": [
+              "ZNAC:h_ADC_ZNA_TC",
+              "ZNA1:h_ADC_ZNA_T1",
+              "ZNA2:h_ADC_ZNA_T2",
+              "ZNA3:h_ADC_ZNA_T3",
+              "ZNA4:h_ADC_ZNA_T4",
+              "ZNAS:h_ADC_ZNA_SUM",
+              "ZPAC:h_ADC_ZPA_TC",
+              "ZPA1:h_ADC_ZPA_T1",
+              "ZPA2:h_ADC_ZPA_T2",
+              "ZPA3:h_ADC_ZPA_T3",
+              "ZPA4:h_ADC_ZPA_T4",
+              "ZPAS:h_ADC_ZPA_SUM",
+              "ZEM1:h_ADC_ZEM1",
+              "ZEM2:h_ADC_ZEM2",
+              "ZNCC:h_ADC_ZNC_TC",
+              "ZNC1:h_ADC_ZNC_T1",
+              "ZNC2:h_ADC_ZNC_T2",
+              "ZNC3:h_ADC_ZNC_T3",
+              "ZNC4:h_ADC_ZNC_T4",
+              "ZNCS:h_ADC_ZNC_SUM",
+              "ZPCC:h_ADC_ZPC_TC",
+              "ZPC1:h_ADC_ZPC_T1",
+              "ZPC2:h_ADC_ZPC_T2",
+              "ZPC3:h_ADC_ZPC_T3",
+              "ZPC4:h_ADC_ZPC_T4",
+              "ZPCS:h_ADC_ZPC_SUM"
+            ]
+          }
+        ],
+        "dataSourcesTDC": [
+          {
+            "type": "repository",
+            "path": "ZDC/MO/QcZDCRecTask",
+            "names": [
+              "ZNAC:h_TDC_ZNA_TC_V",
+              "ZNAS:h_TDC_ZNA_SUM_V",
+              "ZPAC:h_TDC_ZPA_TC_V",
+              "ZPAS:h_TDC_ZPA_SUM_V",
+              "ZEM1:h_TDC_ZEM1_V",
+              "ZEM2:h_TDC_ZEM2_V",
+              "ZNCC:h_TDC_ZNC_TC_V",
+              "ZNCS:h_TDC_ZNC_SUM_V",
+              "ZPCC:h_TDC_ZPC_TC_V",
+              "ZPCS:h_TDC_ZPC_SUM_V"
+            ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:ZDC/MO/QcZDCRecTask/h_ADC_ZNA_TC"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "ZDCQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QualityControl",
+        "detectorName": "ZDC",
+        "qualityGroups": [
+          {
+            "name": "global",
+            "title": "GLOBAL ZDC QUALITY",
+            "path": "ZDC/QO",
+            "ignoreQualitiesDetails": [
+              "Null",
+              "Good",
+              "Medium",
+              "Bad"
+            ],
+            "inputObjects": [
+              {
+                "name": "ZDCQuality/ZDCQuality",
+                "title": "ZDC Quality",
+                "messageBad": "Inform on-call immediately",
+                "messageMedium": "Add bookkeeping entry",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty!!!"
+              }
+            ]
+          },
+          {
+            "name": "details",
+            "title": "ZDC DETAILS",
+            "path": "ZDC/QO",
+            "ignoreQualitiesDetails": [],
+            "inputObjects": [
+              {
+                "name": "RecCheck/RecPP/h_summmary_ADC",
+                "title": "ADC summary"
+              },
+              {
+                "name": "RecCheck/RecPP/h_summmary_TDC",
+                "title": "TDC summary"
+              }
+            ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:ZDC/QO/ZDCQuality/ZDCQuality"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      }
+    },
     "checks": {
-          "QcZDCRecCheck": {
+          "RecCheck": {
             "active": "true",
             "className": "o2::quality_control_modules::zdc::ZDCRecDataCheck",
             "moduleName": "QcZDC",
             "detectorName" : "ZDC",
-            "policy": "OnAny",
+            "policy": "OnEachSeparately",
              "checkParameters" : {
               "ADC_ZNAC" : "461.2;10;20",
               "ADC_ZNA1" : "115.6;10;20",
@@ -104,12 +229,31 @@
               "TDC_POS_MSG_Y": "0.92"
             },
             "dataSource": [{
-              "type": "Task",
-              "name": "QcZDCRecTask",
+              "type": "PostProcessing",
+              "name": "RecPP",
               "MOs": ["h_summmary_ADC" , "h_summmary_TDC"]
             }]
           }
+    },
+    "aggregators": {
+      "ZDCQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QcCommon",
+        "policy": "OnAll",
+        "detectorName": "ZDC",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "RecCheck",
+            "QOs": [
+              "RecPP/h_Summary_ADC",
+              "RecPP/h_Summary_TDC"
+            ]
+          }
+        ]
       }
+    }
   },
   "dataSamplingPolicies": [
     {

--- a/Modules/ZDC/etc/zdcTaskRecData.json
+++ b/Modules/ZDC/etc/zdcTaskRecData.json
@@ -123,60 +123,6 @@
         "stopTrigger": [
           "userorcontrol"
         ]
-      },
-      "ZDCQuality": {
-        "active": "true",
-        "className": "o2::quality_control_modules::common::QualityTask",
-        "moduleName": "QualityControl",
-        "detectorName": "ZDC",
-        "qualityGroups": [
-          {
-            "name": "global",
-            "title": "GLOBAL ZDC QUALITY",
-            "path": "ZDC/QO",
-            "ignoreQualitiesDetails": [
-              "Null",
-              "Good",
-              "Medium",
-              "Bad"
-            ],
-            "inputObjects": [
-              {
-                "name": "ZDCQuality/ZDCQuality",
-                "title": "ZDC Quality",
-                "messageBad": "Inform on-call immediately",
-                "messageMedium": "Add bookkeeping entry",
-                "messageGood": "All checks are OK",
-                "messageNull": "Some histograms are empty!!!"
-              }
-            ]
-          },
-          {
-            "name": "details",
-            "title": "ZDC DETAILS",
-            "path": "ZDC/QO",
-            "ignoreQualitiesDetails": [],
-            "inputObjects": [
-              {
-                "name": "RecCheck/RecPP/h_summmary_ADC",
-                "title": "ADC summary"
-              },
-              {
-                "name": "RecCheck/RecPP/h_summmary_TDC",
-                "title": "TDC summary"
-              }
-            ]
-          }
-        ],
-        "initTrigger": [
-          "userorcontrol"
-        ],
-        "updateTrigger": [
-          "newobject:qcdb:ZDC/QO/ZDCQuality/ZDCQuality"
-        ],
-        "stopTrigger": [
-          "userorcontrol"
-        ]
       }
     },
     "checks": {
@@ -185,7 +131,7 @@
             "className": "o2::quality_control_modules::zdc::ZDCRecDataCheck",
             "moduleName": "QcZDC",
             "detectorName" : "ZDC",
-            "policy": "OnEachSeparately",
+            "policy": "OnAll",
              "checkParameters" : {
               "ADC_ZNAC" : "461.2;10;20",
               "ADC_ZNA1" : "115.6;10;20",
@@ -231,28 +177,9 @@
             "dataSource": [{
               "type": "PostProcessing",
               "name": "RecPP",
-              "MOs": ["h_summmary_ADC" , "h_summmary_TDC"]
+              "MOs": ["h_summary_ADC" , "h_summary_TDC"]
             }]
           }
-    },
-    "aggregators": {
-      "ZDCQuality": {
-        "active": "true",
-        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
-        "moduleName": "QcCommon",
-        "policy": "OnAll",
-        "detectorName": "ZDC",
-        "dataSource": [
-          {
-            "type": "Check",
-            "name": "RecCheck",
-            "QOs": [
-              "RecPP/h_Summary_ADC",
-              "RecPP/h_Summary_TDC"
-            ]
-          }
-        ]
-      }
     }
   },
   "dataSamplingPolicies": [

--- a/Modules/ZDC/include/ZDC/LinkDef.h
+++ b/Modules/ZDC/include/ZDC/LinkDef.h
@@ -7,4 +7,5 @@
 #pragma link C++ class o2::quality_control_modules::zdc::ZDCRawDataCheck+;
 #pragma link C++ class o2::quality_control_modules::zdc::ZDCRecDataTask+;
 #pragma link C++ class o2::quality_control_modules::zdc::ZDCRecDataCheck+;
+#pragma link C++ class o2::quality_control_modules::zdc::ZDCRecDataPostProcessing+;
 #endif

--- a/Modules/ZDC/include/ZDC/PostProcessingConfigZDC.h
+++ b/Modules/ZDC/include/ZDC/PostProcessingConfigZDC.h
@@ -1,0 +1,88 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    PostProcessingConfigZDC.h
+/// \author  Andrea Ferrero andrea.ferrero@cern.ch
+/// \brief   Header file for the configuration of MCH post-processing tasks
+/// \since   16/06/2022
+///
+
+#ifndef QC_MODULE_ZDC_PPCONFIG_H
+#define QC_MODULE_ZDC_PPCONFIG_H
+
+#include "QualityControl/PostProcessingConfig.h"
+#include <vector>
+#include <map>
+#include <string>
+#include <sstream>
+
+using namespace o2::quality_control::postprocessing;
+namespace o2::quality_control_modules::zdc
+{
+
+/// \brief  MCH trending configuration structure
+struct PostProcessingConfigZDC : PostProcessingConfig {
+  PostProcessingConfigZDC() = default;
+  PostProcessingConfigZDC(std::string name, const boost::property_tree::ptree& config);
+  ~PostProcessingConfigZDC() = default;
+
+  const bool hasParameter(std::string name) const
+  {
+    auto entry = parameters.find(name);
+    return (entry != parameters.end());
+  }
+
+  template <typename T>
+  const T getParameter(std::string name) const;
+
+  template <typename T>
+  const T getParameter(std::string name, T defaultValue) const;
+
+  struct DataSource {
+    std::string path;
+    std::string name;
+  };
+
+  std::map<std::string, std::string> parameters;
+  std::vector<DataSource> dataSourcesADC;
+  std::vector<DataSource> dataSourcesTDC;
+};
+
+template <typename T>
+const T PostProcessingConfigZDC::getParameter(std::string name) const
+{
+  T result{};
+  auto entry = parameters.find(name);
+  if (entry != parameters.end()) {
+    std::istringstream istr(entry->second);
+    istr >> result;
+  }
+
+  return result;
+}
+
+template <typename T>
+const T PostProcessingConfigZDC::getParameter(std::string name, T defaultValue) const
+{
+  T result = defaultValue;
+  auto entry = parameters.find(name);
+  if (entry != parameters.end()) {
+    std::istringstream istr(entry->second);
+    istr >> result;
+  }
+
+  return result;
+}
+
+} // namespace o2::quality_control_modules::zdc
+
+#endif // QC_MODULE_ZDC_PPCONFIG_H

--- a/Modules/ZDC/include/ZDC/PostProcessingConfigZDC.h
+++ b/Modules/ZDC/include/ZDC/PostProcessingConfigZDC.h
@@ -12,8 +12,8 @@
 ///
 /// \file    PostProcessingConfigZDC.h
 /// \author  Andrea Ferrero andrea.ferrero@cern.ch
-/// \brief   Header file for the configuration of MCH post-processing tasks
-/// \since   16/06/2022
+/// \brief   Header file for the configuration of ZDC post-processing tasks
+/// \since   30/08/2023
 ///
 
 #ifndef QC_MODULE_ZDC_PPCONFIG_H

--- a/Modules/ZDC/include/ZDC/ZDCRecDataPostProcessing.h
+++ b/Modules/ZDC/include/ZDC/ZDCRecDataPostProcessing.h
@@ -12,8 +12,8 @@
 ///
 /// \file    ZDCRecDataPostProcessing.h
 /// \author  Andrea Ferrero andrea.ferrero@cern.ch
-/// \brief   Post-processing of the MCH pre-clusters
-/// \since   21/06/2022
+/// \brief   Post-processing of the ZDC ADC and TDC plots
+/// \since   30/08/2023
 ///
 
 #ifndef QC_MODULE_ZDC_ZDCZDCRECDATAPP_H
@@ -22,6 +22,8 @@
 #include "QualityControl/PostProcessingInterface.h"
 
 #include <TH1F.h>
+#include <memory>
+#include <string>
 
 namespace o2::quality_control::repository
 {
@@ -65,7 +67,7 @@ struct MOHelper {
   uint64_t mTimeStamp{ 0 };
 };
 
-/// \brief  A post-processing task which processes the ADc and TDC plots from ZDC
+/// \brief  A post-processing task which processes the ADC and TDC plots from ZDC
 class ZDCRecDataPostProcessing : public PostProcessingInterface
 {
  public:

--- a/Modules/ZDC/include/ZDC/ZDCRecDataPostProcessing.h
+++ b/Modules/ZDC/include/ZDC/ZDCRecDataPostProcessing.h
@@ -1,0 +1,120 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    ZDCRecDataPostProcessing.h
+/// \author  Andrea Ferrero andrea.ferrero@cern.ch
+/// \brief   Post-processing of the MCH pre-clusters
+/// \since   21/06/2022
+///
+
+#ifndef QC_MODULE_ZDC_ZDCZDCRECDATAPP_H
+#define QC_MODULE_ZDC_ZDCZDCRECDATAPP_H
+
+#include "QualityControl/PostProcessingInterface.h"
+
+#include <TH1F.h>
+
+namespace o2::quality_control::repository
+{
+class DatabaseInterface;
+}
+
+using namespace o2::quality_control;
+using namespace o2::quality_control::postprocessing;
+
+namespace o2::quality_control_modules::zdc
+{
+
+struct MOHelper {
+  MOHelper();
+  MOHelper(std::string p, std::string n);
+
+  bool update(o2::quality_control::repository::DatabaseInterface* qcdb,
+              long timeStamp = -1,
+              const o2::quality_control::core::Activity& activity = {});
+  void setStartIme();
+  long getTimeStamp() { return mTimeStamp; }
+  template <typename T>
+  T* get()
+  {
+    if (!mObject) {
+      return nullptr;
+    }
+    if (!mObject->getObject()) {
+      return nullptr;
+    }
+
+    // Get histogram object
+    T* h = dynamic_cast<T*>(mObject->getObject());
+    return h;
+  }
+
+  std::shared_ptr<o2::quality_control::core::MonitorObject> mObject;
+  std::string mPath;
+  std::string mName;
+  uint64_t mTimeStart{ 0 };
+  uint64_t mTimeStamp{ 0 };
+};
+
+/// \brief  A post-processing task which processes the ADc and TDC plots from ZDC
+class ZDCRecDataPostProcessing : public PostProcessingInterface
+{
+ public:
+  ZDCRecDataPostProcessing() = default;
+  ~ZDCRecDataPostProcessing() override = default;
+
+  void configure(const boost::property_tree::ptree& config) override;
+  void initialize(Trigger, framework::ServiceRegistryRef) override;
+  void update(Trigger, framework::ServiceRegistryRef) override;
+  void finalize(Trigger, framework::ServiceRegistryRef) override;
+
+ private:
+  template <typename T>
+  void publishHisto(T* h, bool statBox = false,
+                    const char* drawOptions = "",
+                    const char* displayHints = "");
+  void createSummaryADCHistos(Trigger t, repository::DatabaseInterface* qcdb);
+  void createSummaryTDCHistos(Trigger t, repository::DatabaseInterface* qcdb);
+  void updateSummaryADCHistos(Trigger t, repository::DatabaseInterface* qcdb);
+  void updateSummaryTDCHistos(Trigger t, repository::DatabaseInterface* qcdb);
+
+  // CCDB object accessors
+  std::map<size_t, MOHelper> mMOsADC;
+  std::map<size_t, MOHelper> mMOsTDC;
+
+  // Hit rate histograms ===============================================
+  std::unique_ptr<TH1F> mSummaryADCHisto;
+  std::unique_ptr<TH1F> mSummaryTDCHisto;
+};
+
+template <typename T>
+void ZDCRecDataPostProcessing::publishHisto(T* h, bool statBox,
+                                            const char* drawOptions,
+                                            const char* displayHints)
+{
+  h->LabelsOption("v");
+  h->SetLineColor(kBlack);
+  if (!statBox) {
+    h->SetStats(0);
+  }
+  getObjectsManager()->startPublishing(h);
+  if (drawOptions) {
+    getObjectsManager()->setDefaultDrawOptions(h, drawOptions);
+  }
+  if (displayHints) {
+    getObjectsManager()->setDisplayHint(h, displayHints);
+  }
+}
+
+} // namespace o2::quality_control_modules::zdc
+
+#endif // QC_MODULE_ZDC_ZDCZDCRECDATAPP_H

--- a/Modules/ZDC/src/PostProcessingConfigZDC.cxx
+++ b/Modules/ZDC/src/PostProcessingConfigZDC.cxx
@@ -1,0 +1,93 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    PostProcessingConfigZDC.cxx
+/// \author  Andrea Ferrero andrea.ferrero@cern.ch
+/// \brief   File for the configuration of MCH post-processing tasks
+/// \since   05/10/2021
+///
+
+#include "ZDC/PostProcessingConfigZDC.h"
+#include <boost/property_tree/ptree.hpp>
+
+using namespace o2::quality_control::postprocessing;
+namespace o2::quality_control_modules::zdc
+{
+
+PostProcessingConfigZDC::PostProcessingConfigZDC(std::string name, const boost::property_tree::ptree& config)
+  : PostProcessingConfig(name, config)
+{
+  // parameters
+  if (const auto& customConfigs = config.get_child_optional("qc.postprocessing." + name + ".customization"); customConfigs.has_value()) {
+    for (const auto& customConfig : customConfigs.value()) {
+      if (const auto& customNames = customConfig.second.get_child_optional("name"); customNames.has_value()) {
+        parameters.insert(std::make_pair(customConfig.second.get<std::string>("name"), customConfig.second.get<std::string>("value")));
+      }
+    }
+  }
+
+  // Data source configuration
+  for (const auto& dataSourceConfig : config.get_child("qc.postprocessing." + name + ".dataSourcesADC")) {
+    if (const auto& sourceNames = dataSourceConfig.second.get_child_optional("names"); sourceNames.has_value()) {
+      for (const auto& sourceName : sourceNames.value()) {
+        dataSourcesADC.push_back({ dataSourceConfig.second.get<std::string>("path"),
+                                   sourceName.second.data() });
+      }
+    } else if (!dataSourceConfig.second.get<std::string>("name").empty()) {
+      // "name" : [ "something" ] would return an empty string here
+      dataSourcesADC.push_back({ dataSourceConfig.second.get<std::string>("path"),
+                                 dataSourceConfig.second.get<std::string>("name") });
+    } else {
+      throw std::runtime_error("No 'name' value or a 'names' vector in the path 'qc.postprocessing." + name + ".dataSourcesADC'");
+    }
+  }
+  for (const auto& dataSourceConfig : config.get_child("qc.postprocessing." + name + ".dataSourcesTDC")) {
+    if (const auto& sourceNames = dataSourceConfig.second.get_child_optional("names"); sourceNames.has_value()) {
+      for (const auto& sourceName : sourceNames.value()) {
+        dataSourcesTDC.push_back({ dataSourceConfig.second.get<std::string>("path"),
+                                   sourceName.second.data() });
+      }
+    } else if (!dataSourceConfig.second.get<std::string>("name").empty()) {
+      // "name" : [ "something" ] would return an empty string here
+      dataSourcesTDC.push_back({ dataSourceConfig.second.get<std::string>("path"),
+                                 dataSourceConfig.second.get<std::string>("name") });
+    } else {
+      throw std::runtime_error("No 'name' value or a 'names' vector in the path 'qc.postprocessing." + name + ".dataSourcesADC'");
+    }
+  }
+}
+
+template <>
+const std::string PostProcessingConfigZDC::getParameter(std::string name) const
+{
+  std::string result;
+  auto entry = parameters.find(name);
+  if (entry != parameters.end()) {
+    result = entry->second;
+  }
+
+  return result;
+}
+
+template <>
+const std::string PostProcessingConfigZDC::getParameter(std::string name, std::string defaultValue) const
+{
+  std::string result = defaultValue;
+  auto entry = parameters.find(name);
+  if (entry != parameters.end()) {
+    result = entry->second;
+  }
+
+  return result;
+}
+
+} // namespace o2::quality_control_modules::zdc

--- a/Modules/ZDC/src/PostProcessingConfigZDC.cxx
+++ b/Modules/ZDC/src/PostProcessingConfigZDC.cxx
@@ -12,8 +12,8 @@
 ///
 /// \file    PostProcessingConfigZDC.cxx
 /// \author  Andrea Ferrero andrea.ferrero@cern.ch
-/// \brief   File for the configuration of MCH post-processing tasks
-/// \since   05/10/2021
+/// \brief   File for the configuration of ZDC post-processing tasks
+/// \since   30/08/2023
 ///
 
 #include "ZDC/PostProcessingConfigZDC.h"

--- a/Modules/ZDC/src/ZDCRecDataCheck.cxx
+++ b/Modules/ZDC/src/ZDCRecDataCheck.cxx
@@ -14,9 +14,9 @@
 /// \author Carlo Puggioni
 ///
 /*
- * The task checks the two histograms: h_summmary_ADC and h_summmary_TDC .
- * - h_summmary_ADC: Each bin contains the average value of an ADC channel. Checking this histogram verifies that all ADC channels have a value within a threshold defined in the json file.
- * - h_summmary_TDC: Each bin contains the average value of an TDC channel. Checking this histogram verifies that all TDC channels have a value within a threshold defined in the json file.
+ * The task checks the two histograms: h_summary_ADC and h_summary_TDC .
+ * - h_summary_ADC: Each bin contains the average value of an ADC channel. Checking this histogram verifies that all ADC channels have a value within a threshold defined in the json file.
+ * - h_summary_TDC: Each bin contains the average value of an TDC channel. Checking this histogram verifies that all TDC channels have a value within a threshold defined in the json file.
  */
 
 #include "ZDC/ZDCRecDataCheck.h"
@@ -88,7 +88,7 @@ Quality ZDCRecDataCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
     mNumWTDC = 0;
     mStringWTDC = "";
     mStringETDC = "";
-    if (mo->getName() == "h_summmary_TDC") {
+    if (mo->getName() == "h_summary_TDC") {
       auto* h = dynamic_cast<TH1F*>(mo->getObject());
       // dumpVecParam((int)h->GetNbinsX(),(int)mVectParamTDC.size());
       if ((int)h->GetNbinsX() != (int)mVectParamTDC.size()) {
@@ -149,7 +149,7 @@ std::string ZDCRecDataCheck::getAcceptedType() { return "TH1"; }
 
 void ZDCRecDataCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  if (mo->getName() == "h_summmary_ADC") {
+  if (mo->getName() == "h_summary_ADC") {
     if (mQADC == 1) {
       setQualityInfo(mo, kGreen, getCurrentDataTime() + "ADC OK");
     } else if (mQADC == 3) {
@@ -160,7 +160,7 @@ void ZDCRecDataCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkR
       setQualityInfo(mo, kOrange, errorSt);
     }
   }
-  if (mo->getName() == "h_summmary_TDC") {
+  if (mo->getName() == "h_summary_TDC") {
     if (mQTDC == 1) {
       setQualityInfo(mo, kGreen, getCurrentDataTime() + "TDC OK");
     } else if (mQTDC == 3) {

--- a/Modules/ZDC/src/ZDCRecDataPostProcessing.cxx
+++ b/Modules/ZDC/src/ZDCRecDataPostProcessing.cxx
@@ -1,0 +1,241 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    ZDCRecDataPostProcessing.cxx
+/// \author  Andrea Ferrero andrea.ferrero@cern.ch
+/// \brief   Post-processing of the MCH pre-clusters
+/// \since   21/06/2022
+///
+
+#include "ZDC/ZDCRecDataPostProcessing.h"
+#include "ZDC/PostProcessingConfigZDC.h"
+#include "QualityControl/DatabaseInterface.h"
+#include "QualityControl/ObjectMetadataKeys.h"
+#include "QualityControl/QcInfoLogger.h"
+
+using namespace o2::quality_control_modules::zdc;
+
+//_________________________________________________________________________________________
+
+static void splitDataSourceName(std::string s, std::string& histName, std::string& moName)
+{
+  std::string delimiter = ":";
+  size_t pos = s.find(delimiter);
+  if (pos != std::string::npos) {
+    histName = s.substr(0, pos);
+    s.erase(0, pos + delimiter.length());
+  }
+
+  moName = s;
+}
+
+//_________________________________________________________________________________________
+
+static long getMoTimeStamp(std::shared_ptr<o2::quality_control::core::MonitorObject> mo)
+{
+  long timeStamp{ 0 };
+
+  auto iter = mo->getMetadataMap().find(repository::metadata_keys::created);
+  if (iter != mo->getMetadataMap().end()) {
+    timeStamp = std::stol(iter->second);
+  }
+
+  return timeStamp;
+}
+
+//_________________________________________________________________________________________
+
+static bool checkMoTimeStamp(std::shared_ptr<o2::quality_control::core::MonitorObject> mo, uint64_t& timeStampOld)
+{
+  auto timeStamp = getMoTimeStamp(mo);
+  bool result = (timeStamp != timeStampOld) ? true : false;
+  timeStampOld = timeStamp;
+  return result;
+}
+
+//_________________________________________________________________________________________
+
+template <typename T>
+T* getPlotFromMO(std::shared_ptr<o2::quality_control::core::MonitorObject> mo)
+{
+  // Get ROOT object
+  TObject* obj = mo ? mo->getObject() : nullptr;
+  if (!obj) {
+    return nullptr;
+  }
+
+  // Get histogram object
+  T* h = dynamic_cast<T*>(obj);
+  return h;
+}
+
+//_________________________________________________________________________________________
+
+MOHelper::MOHelper()
+{
+  setStartIme();
+}
+
+//_________________________________________________________________________________________
+
+MOHelper::MOHelper(std::string p, std::string n) : mPath(p), mName(n)
+{
+  setStartIme();
+}
+
+//_________________________________________________________________________________________
+
+void MOHelper::setStartIme()
+{
+  mTimeStart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+//_________________________________________________________________________________________
+
+bool MOHelper::update(repository::DatabaseInterface* qcdb, long timeStamp, const core::Activity& activity)
+{
+  mObject = qcdb->retrieveMO(mPath, mName, timeStamp, activity);
+  if (!mObject) {
+    return false;
+  }
+
+  if (timeStamp > mTimeStart) {
+    // we are requesting a new object, so check that the retrieved one
+    // was created after the start of the processing
+    if (getMoTimeStamp(mObject) < mTimeStart) {
+      return false;
+    }
+  }
+
+  if (!checkMoTimeStamp(mObject, mTimeStamp)) {
+    return false;
+  }
+
+  return true;
+}
+
+//_________________________________________________________________________________________
+
+void ZDCRecDataPostProcessing::configure(const boost::property_tree::ptree& config)
+{
+  PostProcessingConfigZDC zdcConfig(getID(), config);
+
+  // ADC summary plot
+  std::vector<std::string> binLabelsADC;
+  for (auto source : zdcConfig.dataSourcesADC) {
+    std::string histName, moName;
+    splitDataSourceName(source.name, histName, moName);
+    if (moName.empty()) {
+      continue;
+    }
+
+    binLabelsADC.emplace_back(histName);
+    mMOsADC.emplace(binLabelsADC.size(), MOHelper(source.path, moName));
+  }
+
+  mSummaryADCHisto = std::make_unique<TH1F>("h_summmary_ADC", "Summary ADC", binLabelsADC.size(), 0, binLabelsADC.size());
+  for (size_t bin = 0; bin < binLabelsADC.size(); bin++) {
+    mSummaryADCHisto->GetXaxis()->SetBinLabel(bin + 1, binLabelsADC[bin].c_str());
+  }
+  publishHisto(mSummaryADCHisto.get(), false, "E", "");
+
+  // TDC summary plot
+  std::vector<std::string> binLabelsTDC;
+  for (auto source : zdcConfig.dataSourcesTDC) {
+    std::string histName, moName;
+    splitDataSourceName(source.name, histName, moName);
+    if (moName.empty()) {
+      continue;
+    }
+
+    binLabelsTDC.emplace_back(histName);
+    mMOsTDC.emplace(binLabelsTDC.size(), MOHelper(source.path, moName));
+  }
+
+  mSummaryTDCHisto = std::make_unique<TH1F>("h_summmary_TDC", "Summary TDC", binLabelsTDC.size(), 0, binLabelsTDC.size());
+  for (size_t bin = 0; bin < binLabelsTDC.size(); bin++) {
+    mSummaryTDCHisto->GetXaxis()->SetBinLabel(bin + 1, binLabelsTDC[bin].c_str());
+  }
+  publishHisto(mSummaryTDCHisto.get(), false, "E", "");
+}
+
+//_________________________________________________________________________________________
+
+void ZDCRecDataPostProcessing::createSummaryADCHistos(Trigger t, repository::DatabaseInterface* qcdb)
+{
+}
+
+//_________________________________________________________________________________________
+
+void ZDCRecDataPostProcessing::createSummaryTDCHistos(Trigger t, repository::DatabaseInterface* qcdb)
+{
+}
+
+//_________________________________________________________________________________________
+
+void ZDCRecDataPostProcessing::initialize(Trigger t, framework::ServiceRegistryRef services)
+{
+  auto& qcdb = services.get<repository::DatabaseInterface>();
+
+  createSummaryADCHistos(t, &qcdb);
+  createSummaryADCHistos(t, &qcdb);
+}
+
+//_________________________________________________________________________________________
+
+void ZDCRecDataPostProcessing::updateSummaryADCHistos(Trigger t, repository::DatabaseInterface* qcdb)
+{
+  for (auto& [bin, mo] : mMOsADC) {
+    if (!mo.update(qcdb, t.timestamp, t.activity)) {
+      continue;
+    }
+    TH1F* h = mo.get<TH1F>();
+    if (!h) {
+      continue;
+    }
+    mSummaryADCHisto->SetBinContent(bin, h->GetMean());
+    mSummaryADCHisto->SetBinError(bin, h->GetMeanError());
+  }
+}
+
+//_________________________________________________________________________________________
+
+void ZDCRecDataPostProcessing::updateSummaryTDCHistos(Trigger t, repository::DatabaseInterface* qcdb)
+{
+  for (auto& [bin, mo] : mMOsTDC) {
+    if (!mo.update(qcdb, t.timestamp, t.activity)) {
+      continue;
+    }
+    TH1F* h = mo.get<TH1F>();
+    if (!h) {
+      continue;
+    }
+    mSummaryTDCHisto->SetBinContent(bin, h->GetMean());
+    mSummaryTDCHisto->SetBinError(bin, h->GetMeanError());
+  }
+}
+
+//_________________________________________________________________________________________
+
+void ZDCRecDataPostProcessing::update(Trigger t, framework::ServiceRegistryRef services)
+{
+  auto& qcdb = services.get<repository::DatabaseInterface>();
+
+  updateSummaryADCHistos(t, &qcdb);
+  updateSummaryTDCHistos(t, &qcdb);
+}
+
+//_________________________________________________________________________________________
+
+void ZDCRecDataPostProcessing::finalize(Trigger t, framework::ServiceRegistryRef)
+{
+}

--- a/Modules/ZDC/src/ZDCRecDataPostProcessing.cxx
+++ b/Modules/ZDC/src/ZDCRecDataPostProcessing.cxx
@@ -12,8 +12,8 @@
 ///
 /// \file    ZDCRecDataPostProcessing.cxx
 /// \author  Andrea Ferrero andrea.ferrero@cern.ch
-/// \brief   Post-processing of the MCH pre-clusters
-/// \since   21/06/2022
+/// \brief   Post-processing of the ZDC ADC and TDC plots
+/// \since   30/08/2023
 ///
 
 #include "ZDC/ZDCRecDataPostProcessing.h"
@@ -57,7 +57,7 @@ static long getMoTimeStamp(std::shared_ptr<o2::quality_control::core::MonitorObj
 static bool checkMoTimeStamp(std::shared_ptr<o2::quality_control::core::MonitorObject> mo, uint64_t& timeStampOld)
 {
   auto timeStamp = getMoTimeStamp(mo);
-  bool result = (timeStamp != timeStampOld) ? true : false;
+  bool result = timeStamp != timeStampOld;
   timeStampOld = timeStamp;
   return result;
 }

--- a/Modules/ZDC/src/ZDCRecDataPostProcessing.cxx
+++ b/Modules/ZDC/src/ZDCRecDataPostProcessing.cxx
@@ -142,7 +142,7 @@ void ZDCRecDataPostProcessing::configure(const boost::property_tree::ptree& conf
     mMOsADC.emplace(binLabelsADC.size(), MOHelper(source.path, moName));
   }
 
-  mSummaryADCHisto = std::make_unique<TH1F>("h_summmary_ADC", "Summary ADC", binLabelsADC.size(), 0, binLabelsADC.size());
+  mSummaryADCHisto = std::make_unique<TH1F>("h_summary_ADC", "Summary ADC", binLabelsADC.size(), 0, binLabelsADC.size());
   for (size_t bin = 0; bin < binLabelsADC.size(); bin++) {
     mSummaryADCHisto->GetXaxis()->SetBinLabel(bin + 1, binLabelsADC[bin].c_str());
   }
@@ -161,7 +161,7 @@ void ZDCRecDataPostProcessing::configure(const boost::property_tree::ptree& conf
     mMOsTDC.emplace(binLabelsTDC.size(), MOHelper(source.path, moName));
   }
 
-  mSummaryTDCHisto = std::make_unique<TH1F>("h_summmary_TDC", "Summary TDC", binLabelsTDC.size(), 0, binLabelsTDC.size());
+  mSummaryTDCHisto = std::make_unique<TH1F>("h_summary_TDC", "Summary TDC", binLabelsTDC.size(), 0, binLabelsTDC.size());
   for (size_t bin = 0; bin < binLabelsTDC.size(); bin++) {
     mSummaryTDCHisto->GetXaxis()->SetBinLabel(bin + 1, binLabelsTDC[bin].c_str());
   }

--- a/Modules/ZDC/src/ZDCRecDataTask.cxx
+++ b/Modules/ZDC/src/ZDCRecDataTask.cxx
@@ -447,10 +447,10 @@ void ZDCRecDataTask::initHisto()
   addNewHisto("MSG_REC", "h_msg", "Reconstruction messages", "INFO", "CH", "INFO", "MSG", 0);
   int idh_msg = (int)mHisto2D.size() - 1;
   setBinHisto1D(10, -0.5, 9.5);
-  addNewHisto("SUMMARY_TDC", "h_summmary_TDC", "Summary TDC", "TDCV", "", "", "", 0);
+  addNewHisto("SUMMARY_TDC", "h_summary_TDC", "Summary TDC", "TDCV", "", "", "", 0);
   mIdhTDC = (int)mHisto1D.size() - 1;
   setBinHisto1D(26, -0.5, 25.5);
-  addNewHisto("SUMMARY_ADC", "h_summmary_ADC", "Summary ADC", "ADC", "", "", "", 0);
+  addNewHisto("SUMMARY_ADC", "h_summary_ADC", "Summary ADC", "ADC", "", "", "", 0);
   mIdhADC = (int)mHisto1D.size() - 1;
   for (int ibx = 1; ibx <= o2::zdc::NChannels; ibx++) {
     mHisto2D.at(idh_msg).histo->GetXaxis()->SetBinLabel(ibx, o2::zdc::ChannelNames[ibx - 1].data());


### PR DESCRIPTION
The post-processing is needed in order to correctly plot the average values and errors from individual ADC and TDC plots.
The reference JSON configuration is also updated accordingly, with some improvements:
- added post-processing tasks
- updated checker to take post-processing output and use `OnEachSeparately` policy
- added quality aggregator and post-processing (summary)