### PR TITLE
[QC-1014] Avoid extending validity to numeric limit based on triggers

### DIFF
--- a/Framework/include/QualityControl/ActivityHelpers.h
+++ b/Framework/include/QualityControl/ActivityHelpers.h
@@ -94,6 +94,8 @@ std::function<validity_time_t(void)> getCcdbEorTimeAccessor(uint64_t runNumber);
 /// \brief checks if the provided validity uses old rules, where start is creation time, end is 10 years in the future.
 bool isLegacyValidity(ValidityInterval);
 
+bool onNumericLimit(validity_time_t timestamp);
+
 namespace implementation
 {
 template <typename Iter, typename Accessor>

--- a/Framework/include/QualityControl/PostProcessingRunner.h
+++ b/Framework/include/QualityControl/PostProcessingRunner.h
@@ -93,6 +93,7 @@ class PostProcessingRunner
   static PostProcessingRunnerConfig extractConfig(const core::CommonSpec& commonSpec, const PostProcessingTaskSpec& ppTaskSpec);
 
  private:
+  void updateValidity(const Trigger& trigger);
   void doInitialize(const Trigger& trigger);
   void doUpdate(const Trigger& trigger);
   void doFinalize(const Trigger& trigger);

--- a/Framework/src/ActivityHelpers.cxx
+++ b/Framework/src/ActivityHelpers.cxx
@@ -112,4 +112,9 @@ bool isLegacyValidity(ValidityInterval validity)
   return validity.isValid() && validity.delta() > 9ull * 365 * 24 * 60 * 60 * 1000ull;
 }
 
+bool onNumericLimit(validity_time_t value)
+{
+  return value == std::numeric_limits<validity_time_t>::min() || value == std::numeric_limits<validity_time_t>::max();
+}
+
 } // namespace o2::quality_control::core::activity_helpers


### PR DESCRIPTION
This tackles situations where a trigger may return an activity with validity with one of the boundaries being correct, but another one being on numeric limit.