### PR TITLE
Include what you use: ptree.h

### DIFF
--- a/Modules/EMCAL/src/CalibMonitoringTask.cxx
+++ b/Modules/EMCAL/src/CalibMonitoringTask.cxx
@@ -29,6 +29,7 @@
 #include "TPaveText.h"
 #include "TH1D.h"
 #include "TH2D.h"
+#include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
 using namespace o2::quality_control::core;

--- a/Modules/GLO/src/MeanVertexPostProcessing.cxx
+++ b/Modules/GLO/src/MeanVertexPostProcessing.cxx
@@ -21,6 +21,7 @@
 #include "QualityControl/QcInfoLogger.h"
 
 #include <TMath.h>
+#include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
 

--- a/Modules/TOF/src/PostProcessHitMap.cxx
+++ b/Modules/TOF/src/PostProcessHitMap.cxx
@@ -30,6 +30,7 @@
 #include <TH2F.h>
 #include <TCanvas.h>
 #include <TPaveText.h>
+#include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
 

--- a/Modules/TPC/src/CalDetPublisher.cxx
+++ b/Modules/TPC/src/CalDetPublisher.cxx
@@ -29,6 +29,7 @@
 #include "TPaveText.h"
 
 #include <fmt/format.h>
+#include <boost/property_tree/ptree.hpp>
 #include <algorithm>
 
 using namespace o2::quality_control::postprocessing;

--- a/Modules/TPC/src/ClusterVisualizer.cxx
+++ b/Modules/TPC/src/ClusterVisualizer.cxx
@@ -30,6 +30,7 @@
 #include "TPaveText.h"
 
 #include <fmt/format.h>
+#include <boost/property_tree/ptree.hpp>
 #include <algorithm>
 
 using namespace o2::quality_control::postprocessing;

--- a/Modules/TPC/src/DCSPTemperature.cxx
+++ b/Modules/TPC/src/DCSPTemperature.cxx
@@ -28,6 +28,7 @@
 #include "TStyle.h"
 
 #include <fmt/format.h>
+#include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
 

--- a/Modules/TPC/src/IDCs.cxx
+++ b/Modules/TPC/src/IDCs.cxx
@@ -30,6 +30,7 @@
 
 #include <fmt/format.h>
 #include <boost/optional/optional.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
 using namespace o2::tpc;

--- a/Modules/TPC/src/IDCsVsSACs.cxx
+++ b/Modules/TPC/src/IDCsVsSACs.cxx
@@ -28,6 +28,7 @@
 #include "TCanvas.h"
 
 #include <fmt/format.h>
+#include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
 using namespace o2::tpc;

--- a/Modules/TPC/src/LaserTracks.cxx
+++ b/Modules/TPC/src/LaserTracks.cxx
@@ -25,6 +25,7 @@
 
 // root includes
 #include "TCanvas.h"
+#include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
 

--- a/Modules/TPC/src/SACs.cxx
+++ b/Modules/TPC/src/SACs.cxx
@@ -27,6 +27,7 @@
 
 #include <fmt/format.h>
 #include <boost/optional/optional.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
 using namespace o2::tpc;

--- a/Modules/TRD/src/PulseHeightPostProcessing.cxx
+++ b/Modules/TRD/src/PulseHeightPostProcessing.cxx
@@ -36,6 +36,8 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
+
 using namespace o2::quality_control;
 using namespace o2::quality_control::core;
 using namespace o2::quality_control::repository;


### PR DESCRIPTION
Framework will soon reduce exposing ptree.h to the bare minimum, due to interference with ROOT.