### PR TITLE
[QC-1012] Allow TrendingTaskITSFhr to trend slightly desynchronized objects

### DIFF
--- a/Framework/include/QualityControl/CcdbDatabase.h
+++ b/Framework/include/QualityControl/CcdbDatabase.h
@@ -112,6 +112,14 @@ class CcdbDatabase : public DatabaseInterface
   boost::property_tree::ptree getListingAsPtree(const std::string& path, const std::map<std::string, std::string>& metadata = {}, bool latestOnly = false);
 
   /**
+   * Return validity of the latest matching object
+   * @param path the folder we want to list the children of.
+   * @param metadata metadata to filter queried objects.
+   * @return validity of the latest matching object
+   */
+  core::ValidityInterval getLatestObjectValidity(const std::string& path, const std::map<std::string, std::string>& metadata) override;
+
+  /**
    * \brief Returns a vector of all 'valid from' timestamps for an object.
    * \path Path on an object.
    * \return A vector of all 'valid from' timestamps for an object in non-descending order.

--- a/Framework/include/QualityControl/DatabaseInterface.h
+++ b/Framework/include/QualityControl/DatabaseInterface.h
@@ -205,6 +205,14 @@ class DatabaseInterface
   virtual void truncate(std::string taskName, std::string objectName) = 0;
 
   virtual void setMaxObjectSize(size_t maxObjectSize) = 0;
+
+  /**
+   * Return validity of the latest matching object
+   * @param path the folder we want to list the children of.
+   * @param metadata metadata to filter queried objects.
+   * @return validity of the latest matching object
+   */
+  virtual core::ValidityInterval getLatestObjectValidity(const std::string& path, const std::map<std::string, std::string>& metadata = {}) = 0;
 };
 
 } // namespace o2::quality_control::repository

--- a/Framework/include/QualityControl/DummyDatabase.h
+++ b/Framework/include/QualityControl/DummyDatabase.h
@@ -58,6 +58,8 @@ class DummyDatabase : public DatabaseInterface
   void truncate(std::string taskName, std::string objectName) override;
   void setMaxObjectSize(size_t maxObjectSize) override;
 
+  core::ValidityInterval getLatestObjectValidity(const std::string& path, const std::map<std::string, std::string>& metadata = {}) override;
+
  private:
 };
 

--- a/Framework/src/DummyDatabase.cxx
+++ b/Framework/src/DummyDatabase.cxx
@@ -96,4 +96,9 @@ void DummyDatabase::setMaxObjectSize(size_t maxObjectSize)
 {
 }
 
+core::ValidityInterval DummyDatabase::getLatestObjectValidity(const std::string& path, const std::map<std::string, std::string>& metadata)
+{
+  return gInvalidValidityInterval;
+}
+
 } // namespace o2::quality_control::repository

--- a/Framework/test/testCcdbDatabase.cxx
+++ b/Framework/test/testCcdbDatabase.cxx
@@ -194,6 +194,10 @@ BOOST_AUTO_TEST_CASE(ccdb_retrieve_timestamps, *utf::depends_on("ccdb_store"))
   std::shared_ptr<QualityObject> qo = f.backend->retrieveQO(f.getQoPath("short", "", false), 15000);
   BOOST_REQUIRE_NE(qo, nullptr);
   BOOST_CHECK_EQUAL(qo->getName(), f.taskName + "/short");
+
+  auto qoValidity = f.backend->getLatestObjectValidity(f.getQoPath("short", "qc", true), {});
+  ValidityInterval expectedValidity{ 10000, 20000 };
+  BOOST_CHECK(qoValidity == expectedValidity);
 }
 
 BOOST_AUTO_TEST_CASE(ccdb_retrieve_inexisting_mo)

--- a/Modules/ITS/include/ITS/TrendingTaskConfigITS.h
+++ b/Modules/ITS/include/ITS/TrendingTaskConfigITS.h
@@ -50,6 +50,8 @@ struct TrendingTaskConfigITS : PostProcessingConfig {
 
   std::vector<Plot> plots;
   std::vector<DataSource> dataSources;
+
+  uint64_t maxObjectTimeShiftMs = 0;
 };
 
 } // namespace o2::quality_control::postprocessing

--- a/Modules/ITS/src/TrendingTaskConfigITS.cxx
+++ b/Modules/ITS/src/TrendingTaskConfigITS.cxx
@@ -86,6 +86,7 @@ TrendingTaskConfigITS::TrendingTaskConfigITS(
         id + ".dataSources'");
     }
   }
+  maxObjectTimeShiftMs = config.get<uint64_t>("qc.postprocessing." + id + ".maxObjectTimeShiftMs", 0);
 }
 
 } // namespace o2::quality_control::postprocessing


### PR DESCRIPTION
The FHR Task generates objects specific to particular detector layers. Since detector layers are assigned to different subsets of FLPs, the merged objects do not have exactly the same validity, as FLPs do not have QC cycles ideally in sync. Thus we have look for the objects a bit behind and forward from the trigger timestamp as well.

This introduces an configuration parameter `maxObjectTimeShiftMs` to allow for certain shift of QC objects coming from the trended task. Normally it should correspond to the cycle length of the latter.