### PR TITLE
Increase the default post-processing period to 30s

### DIFF
--- a/Framework/include/QualityControl/CommonSpec.h
+++ b/Framework/include/QualityControl/CommonSpec.h
@@ -42,7 +42,7 @@ struct CommonSpec {
   std::string consulUrl;
   std::string conditionDBUrl = "http://ccdb-test.cern.ch:8080";
   DiscardFileParameters infologgerDiscardParameters;
-  double postprocessingPeriod = 10.0;
+  double postprocessingPeriod = 30.0;
   std::string bookkeepingUrl;
 };
 


### PR DESCRIPTION
I am fearing we are to heavy on the database with the recent growth of post-processing tasks