### PR TITLE
ITS: Bug fix on fine granularity plots + style simplification

### DIFF
--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -299,13 +299,13 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
 
         for (int ix = 1; ix <= hAverageClusterSizeSummaryZPhi[iLayer]->GetNbinsX(); ix++)
           for (int iy = 1; iy <= hAverageClusterSizeSummaryZPhi[iLayer]->GetNbinsY(); iy++) {
-            hAverageClusterSizeSummaryZPhi[iLayer]->getDen()->SetBinContent(ix, iy, hAverageClusterOccupancySummaryZPhi[iLayer]->GetBinContent(ix, iy));
+            hAverageClusterSizeSummaryZPhi[iLayer]->getDen()->SetBinContent(ix, iy, hAverageClusterOccupancySummaryZPhi[iLayer]->getNum()->GetBinContent(ix, iy));
           }
         hAverageClusterOccupancySummaryZPhi[iLayer]->getDen()->SetBinContent(1, 1, mNRofs);
 
         for (int ix = 1; ix <= hAverageClusterSizeSummaryFine[iLayer]->GetNbinsX(); ix++)
           for (int iy = 1; iy <= hAverageClusterSizeSummaryFine[iLayer]->GetNbinsY(); iy++) {
-            hAverageClusterSizeSummaryFine[iLayer]->getDen()->SetBinContent(ix, iy, hAverageClusterOccupancySummaryFine[iLayer]->GetBinContent(ix, iy));
+            hAverageClusterSizeSummaryFine[iLayer]->getDen()->SetBinContent(ix, iy, hAverageClusterOccupancySummaryFine[iLayer]->getNum()->GetBinContent(ix, iy));
           }
         hAverageClusterOccupancySummaryFine[iLayer]->getDen()->SetBinContent(1, 1, mNRofs);
 
@@ -384,13 +384,13 @@ void ITSClusterTask::reset()
       hAverageClusterSizeSummaryZPhi[iLayer]->Reset();
       hAverageClusterOccupancySummaryFine[iLayer]->Reset();
       hAverageClusterSizeSummaryFine[iLayer]->Reset();
-      addLines();
     }
   }
   std::fill(&mClusterSize[0][0][0], &mClusterSize[0][0][0] + 7 * 48 * 28, 0);
   std::fill(&nClusters[0][0][0], &nClusters[0][0][0] + 7 * 48 * 28, 0);
   std::fill(&mClusterOccupancyIB[0][0][0], &mClusterOccupancyIB[0][0][0] + 7 * 48 * 9, 0);
   std::fill(&mClusterOccupancyOB[0][0][0], &mClusterOccupancyOB[0][0][0] + 7 * 48 * 28, 0);
+  mNRofs = 0;
 }
 
 void ITSClusterTask::createAllHistos()
@@ -473,22 +473,14 @@ void ITSClusterTask::createAllHistos()
       hAverageClusterSizeSummaryIB[iLayer]->GetXaxis()->SetLabelSize(0.02);
       // Fine check
       if (mDoPublishDetailedSummary == 1) {
-        hAverageClusterOccupancySummaryFine[iLayer] = std::make_shared<TH2FRatio>(Form("Layer%d/ClusterOccupancyFine", iLayer), Form("Cluster occupancy on Layer %d", iLayer), mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB, -0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB) - 0.5, mNStaves[iLayer] * nRphiBinsIB, -0.5, mNStaves[iLayer] * nRphiBinsIB - 0.5, true);
+        hAverageClusterOccupancySummaryFine[iLayer] = std::make_shared<TH2FRatio>(Form("Layer%d/ClusterOccupancyFine", iLayer), Form("Cluster occupancy on Layer %d; Pixel group (column direction); Pixel group (row direction)", iLayer), mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB, -0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB) - 0.5, mNStaves[iLayer] * nRphiBinsIB, -0.5, mNStaves[iLayer] * nRphiBinsIB - 0.5, true);
         hAverageClusterOccupancySummaryFine[iLayer]->SetStats(0);
         hAverageClusterOccupancySummaryFine[iLayer]->SetBit(TH1::kIsAverage);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetYaxis()->SetLabelSize(0);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetXaxis()->SetLabelSize(0);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetYaxis()->SetTickSize(0);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetXaxis()->SetTickSize(0);
         addObject(hAverageClusterOccupancySummaryFine[iLayer].get());
 
-        hAverageClusterSizeSummaryFine[iLayer] = std::make_shared<TH2FRatio>(Form("Layer%d/ClusterSizeFine", iLayer), Form("Cluster size on Layer %d", iLayer), mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB, -0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB) - 0.5, mNStaves[iLayer] * nRphiBinsIB, -0.5, mNStaves[iLayer] * nRphiBinsIB - 0.5, false);
+        hAverageClusterSizeSummaryFine[iLayer] = std::make_shared<TH2FRatio>(Form("Layer%d/ClusterSizeFine", iLayer), Form("Cluster size on Layer %d; Pixel group (column direction); Pixel group (row direction)", iLayer), mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB, -0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB) - 0.5, mNStaves[iLayer] * nRphiBinsIB, -0.5, mNStaves[iLayer] * nRphiBinsIB - 0.5, false);
         hAverageClusterSizeSummaryFine[iLayer]->SetStats(0);
         hAverageClusterSizeSummaryFine[iLayer]->SetBit(TH1::kIsAverage);
-        hAverageClusterSizeSummaryFine[iLayer]->GetYaxis()->SetLabelSize(0);
-        hAverageClusterSizeSummaryFine[iLayer]->GetXaxis()->SetLabelSize(0);
-        hAverageClusterSizeSummaryFine[iLayer]->GetYaxis()->SetTickSize(0);
-        hAverageClusterSizeSummaryFine[iLayer]->GetXaxis()->SetTickSize(0);
         addObject(hAverageClusterSizeSummaryFine[iLayer].get());
       }
 
@@ -541,22 +533,14 @@ void ITSClusterTask::createAllHistos()
 
       // Fine check
       if (mDoPublishDetailedSummary == 1) {
-        hAverageClusterOccupancySummaryFine[iLayer] = std::make_shared<TH2FRatio>(Form("Layer%d/ClusterOccupancyFine", iLayer), Form("Cluster occupancy on Layer %d", iLayer), mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB, -0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB) - 0.5, mNStaves[iLayer] * nRphiBinsOB, -0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5, true);
+        hAverageClusterOccupancySummaryFine[iLayer] = std::make_shared<TH2FRatio>(Form("Layer%d/ClusterOccupancyFine", iLayer), Form("Cluster occupancy on Layer %d; Pixel group (column direction); Pixel group (row direction)", iLayer), mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB, -0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB) - 0.5, mNStaves[iLayer] * nRphiBinsOB, -0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5, true);
         hAverageClusterOccupancySummaryFine[iLayer]->SetStats(0);
         hAverageClusterOccupancySummaryFine[iLayer]->SetBit(TH1::kIsAverage);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetYaxis()->SetLabelSize(0);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetXaxis()->SetLabelSize(0);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetYaxis()->SetTickSize(0);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetXaxis()->SetTickSize(0);
         addObject(hAverageClusterOccupancySummaryFine[iLayer].get());
 
-        hAverageClusterSizeSummaryFine[iLayer] = std::make_shared<TH2FRatio>(Form("Layer%d/ClusterSizeFine", iLayer), Form("Cluster size on Layer %d", iLayer), mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB, -0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB) - 0.5, mNStaves[iLayer] * nRphiBinsOB, -0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5, false);
+        hAverageClusterSizeSummaryFine[iLayer] = std::make_shared<TH2FRatio>(Form("Layer%d/ClusterSizeFine", iLayer), Form("Cluster size on Layer %d; Pixel group (column direction); Pixel group (row direction)", iLayer), mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB, -0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB) - 0.5, mNStaves[iLayer] * nRphiBinsOB, -0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5, false);
         hAverageClusterSizeSummaryFine[iLayer]->SetStats(0);
         hAverageClusterSizeSummaryFine[iLayer]->SetBit(TH1::kIsAverage);
-        hAverageClusterSizeSummaryFine[iLayer]->GetYaxis()->SetLabelSize(0);
-        hAverageClusterSizeSummaryFine[iLayer]->GetXaxis()->SetLabelSize(0);
-        hAverageClusterSizeSummaryFine[iLayer]->GetYaxis()->SetTickSize(0);
-        hAverageClusterSizeSummaryFine[iLayer]->GetXaxis()->SetTickSize(0);
         addObject(hAverageClusterSizeSummaryFine[iLayer].get());
       }
 
@@ -700,92 +684,6 @@ float ITSClusterTask::getVerticalBin(float rphi, int stave, int layer)
     return_index = (float)(stave * nRphiBinsOB + index_rphi);
   }
   return return_index;
-}
-
-void ITSClusterTask::addLines()
-{
-  for (int iLayer = 0; iLayer < NLayer; iLayer++) {
-    for (int i = 1; i <= (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer]); i++) // vertical
-    {
-      if (iLayer < NLayerIB) {
-        if (i != (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer])) { // black lines
-          TLine* l_v1 = new TLine(i * nZBinsIB - 0.5, -0.5, i * nZBinsIB - 0.5, mNStaves[iLayer] * nRphiBinsIB - 0.5);
-          l_v1->SetLineWidth(2);
-          hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(l_v1);
-          TLine* l_v2 = new TLine(i * nZBinsIB - 0.5, -0.5, i * nZBinsIB - 0.5, mNStaves[iLayer] * nRphiBinsIB - 0.5);
-          l_v2->SetLineWidth(2);
-          hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(l_v2);
-        }
-        TLatex* latex_v1 = new TLatex(nZBinsIB / 4 + (i - 1) * nZBinsIB, -1 * nRphiBinsIB, Form("#bf{Chip %d}", i - 1));
-        hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(latex_v1);
-        TLatex* latex_v2 = new TLatex(nZBinsIB / 4 + (i - 1) * nZBinsIB, -1 * nRphiBinsIB, Form("#bf{Chip %d}", i - 1));
-        hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(latex_v2);
-      } else {
-        if (i != (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer])) { // black lines
-          TLine* l_v1 = new TLine(i * nZBinsOB - 0.5, -0.5, i * nZBinsOB - 0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5);
-          l_v1->SetLineWidth(2);
-          hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(l_v1);
-          TLine* l_v2 = new TLine(i * nZBinsOB - 0.5, -0.5, i * nZBinsOB - 0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5);
-          l_v2->SetLineWidth(2);
-          hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(l_v2);
-        }
-      }
-    }
-    if (iLayer >= NLayerIB) {
-      for (int i = 1; i <= (mNLanePerHic[iLayer] * mNHicPerStave[iLayer]); i++) // vertical
-      {
-        if (i != mNLanePerHic[iLayer] * mNHicPerStave[iLayer]) { // red lines
-          TLine* l_red1 = new TLine(i * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] - 0.5, -0.5, i * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] - 0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5);
-          l_red1->SetLineColor(kRed);
-          l_red1->SetLineWidth(2);
-          hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(l_red1);
-          TLine* l_red2 = new TLine(i * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] - 0.5, -0.5, i * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] - 0.5, mNStaves[iLayer] * nRphiBinsOB - 0.5);
-          l_red2->SetLineColor(kRed);
-          l_red2->SetLineWidth(2);
-          hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(l_red2);
-        }
-        std::string xLabel = (iLayer < 5) ? Form("#bf{%s}", OBLabel34[i - 1]) : Form("#bf{%s}", OBLabel56[i - 1]);
-        TLatex* latex_v1 = new TLatex(nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] / 2 + (i - 1) * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], -1 * nRphiBinsOB, xLabel.c_str());
-        latex_v1->SetTextAngle(-20);
-        latex_v1->SetTextSize(0.03);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(latex_v1);
-        TLatex* latex_v2 = new TLatex(nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer] / 2 + (i - 1) * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], -1 * nRphiBinsOB, xLabel.c_str());
-        latex_v2->SetTextAngle(-20);
-        latex_v2->SetTextSize(0.03);
-        hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(latex_v2);
-      }
-    }
-    for (int j = 1; j <= mNStaves[iLayer]; j++) // horizontal
-    {
-      if (iLayer < NLayerIB) {
-        TLine* l_h1 = new TLine(-0.5, j * nRphiBinsIB - 0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB) - 0.5, j * nRphiBinsIB - 0.5);
-        l_h1->SetLineWidth(2);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(l_h1);
-        TLine* l_h2 = new TLine(-0.5, j * nRphiBinsIB - 0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsIB) - 0.5, j * nRphiBinsIB - 0.5);
-        l_h2->SetLineWidth(2);
-        hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(l_h2);
-
-        TLatex* latex_h1 = new TLatex(-1 * nZBinsIB, nRphiBinsIB / 4 + (j - 1) * nRphiBinsIB, Form("#bf{Stave %d}", j - 1));
-        hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(latex_h1);
-        TLatex* latex_h2 = new TLatex(-1 * nZBinsIB, nRphiBinsIB / 4 + (j - 1) * nRphiBinsIB, Form("#bf{Stave %d}", j - 1));
-        hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(latex_h2);
-      } else {
-        TLine* l_h1 = new TLine(-0.5, j * nRphiBinsOB - 0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB) - 0.5, j * nRphiBinsOB - 0.5);
-        l_h1->SetLineWidth(2);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(l_h1);
-        TLine* l_h2 = new TLine(-0.5, j * nRphiBinsOB - 0.5, (mNChipsPerHic[iLayer] * mNHicPerStave[iLayer] * nZBinsOB) - 0.5, j * nRphiBinsOB - 0.5);
-        l_h2->SetLineWidth(2);
-        hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(l_h2);
-
-        TLatex* latex_h1 = new TLatex(-1.5 * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], nRphiBinsOB / 8 + (j - 1) * nRphiBinsOB, Form("#bf{Stave %d}", j - 1));
-        latex_h1->SetTextSize(0.03);
-        hAverageClusterOccupancySummaryFine[iLayer]->GetListOfFunctions()->Add(latex_h1);
-        TLatex* latex_h2 = new TLatex(-1.5 * nZBinsOB * mNChipsPerHic[iLayer] / mNLanePerHic[iLayer], nRphiBinsOB / 8 + (j - 1) * nRphiBinsOB, Form("#bf{Stave %d}", j - 1));
-        latex_h2->SetTextSize(0.03);
-        hAverageClusterSizeSummaryFine[iLayer]->GetListOfFunctions()->Add(latex_h2);
-      }
-    }
-  }
 }
 
 } // namespace o2::quality_control_modules::its


### PR DESCRIPTION
**NOT NEEDED IN ONLINE QC AT P2**

Fine-granularity plots affected by a bug in the average cluster size plots (wrong denominator). Since they are TH2Ratio, it seems that it's not possible to add TLines and TLatex to their list of functions: hence I removed the function addLines() and simply placed some meaningful titles to X and Y axis. 
