### PR TITLE
[EMCAL-524, EMCAL-530] Updates in cluster selection for pi0 candidates and cell selection for total energy

### DIFF
--- a/Modules/EMCAL/include/EMCAL/CellTask.h
+++ b/Modules/EMCAL/include/EMCAL/CellTask.h
@@ -19,6 +19,7 @@
 
 #include "QualityControl/TaskInterface.h"
 #include <array>
+#include <climits>
 #include <unordered_map>
 #include <string_view>
 #include <gsl/span>
@@ -81,6 +82,7 @@ class CellTask final : public TaskInterface
     double mTotalEnergyRange = 0.;
     double mTotalEnergyRangeDetector = 0.;
     double mTotalEnergyRangeSM = 0.;
+    double mMaxTimeTotalEnergy = DBL_MAX;
   };
   struct CellHistograms {
     o2::emcal::Geometry* mGeometry;

--- a/Modules/EMCAL/include/EMCAL/ClusterTask.h
+++ b/Modules/EMCAL/include/EMCAL/ClusterTask.h
@@ -87,6 +87,10 @@ class ClusterTask final : public TaskInterface
     double mMinE = 0.5;         ///< Min. Cluster E
     double mMaxTime = 25.;      ///< Max cluster time relative to 0
     int mMinNCell = 2;          ///< Min. Number of cells in cluster
+    double mMinM02 = -DBL_MAX;  ///< Min. M02 (shower shape)
+    double mMaxM02 = DBL_MAX;   ///< Max. M02 (shower shape)
+    double mMinM20 = -DBL_MAX;  ///< Min. M20 (shower shape)
+    double mMaxM20 = DBL_MAX;   ///< Max. M20 (shower shape)
     bool mRejectExotics = true; ///< Reject exotic clusters
 
     /// \brief Select cluster based on cluster cuts
@@ -124,6 +128,7 @@ class ClusterTask final : public TaskInterface
     int mMultiplicityRange = 200;               ///< Range for multiplicity histograms
     int mMesonMinClusterMultiplicity = 0;       ///< Min. cluster multiplicty meson selection
     int mMesonMaxClusterMultiplicity = INT_MAX; ///< Max. cluster multiplicity meson selection
+    double mMinELeadingMeson = 0;               ///< Min. energy leading leg meson candidates
 
     /// \brief Print task parameters to output stream
     /// \param stream Stream used for printing

--- a/Modules/EMCAL/src/CellTask.cxx
+++ b/Modules/EMCAL/src/CellTask.cxx
@@ -490,8 +490,11 @@ void CellTask::monitorData(o2::framework::ProcessingContext& ctx)
             if (goodcell) {
               numCellsGood[sm]++;
               auto cellenergy = cell.getAmplitude() * energycalib;
+              auto celltime = cell.getTimeStamp() - timeoffset;
               if (cellenergy > mTaskSettings.mThresholdTotalEnergy) {
-                totalEnergies[sm] += cellenergy;
+                if (std::abs(celltime) < mTaskSettings.mMaxTimeTotalEnergy) {
+                  totalEnergies[sm] += cellenergy;
+                }
               }
             } else {
               numCellsBad[sm]++;
@@ -694,6 +697,9 @@ void CellTask::parseMultiplicityRanges()
   }
   if (hasConfigValue("TotalEnergyRangeSM")) {
     mTaskSettings.mTotalEnergyRangeSM = std::stod(getConfigValue("TotalEnergyRangeSM"));
+  }
+  if (hasConfigValue("TotalEnergyMaxCellTime")) {
+    mTaskSettings.mMaxTimeTotalEnergy = std::stod(getConfigValue("TotalEnergyMaxCellTime"));
   }
 }
 

--- a/Modules/EMCAL/src/ClusterTask.cxx
+++ b/Modules/EMCAL/src/ClusterTask.cxx
@@ -556,6 +556,10 @@ void ClusterTask::buildAndAnalysePiOs(const gsl::span<const TLorentzVector> clus
   if (clustervectors.size() > 1) {
     for (int icl = 0; icl < clustervectors.size() - 1; icl++) {
       for (int jcl = icl + 1; jcl < clustervectors.size(); jcl++) {
+        auto emax = clustervectors[icl].E() > clustervectors[jcl].E() ? clustervectors[icl].E() : clustervectors[jcl].E();
+        if (emax < mTaskParameters.mMinELeadingMeson) {
+          continue;
+        }
         TLorentzVector pi0candidate = clustervectors[icl] + clustervectors[jcl];
         if (!mMesonCuts.isSelected(pi0candidate)) {
           continue;
@@ -839,6 +843,18 @@ void ClusterTask::configureMesonSelection()
   if (hasConfigValue("mesonClustersRejectExotics")) {
     mMesonClusterCuts.mRejectExotics = std::stoi(getConfigValue("mesonClustersRejectExotics"));
   }
+  if (hasConfigValue("mesonClusterMinM02")) {
+    mMesonClusterCuts.mMinM02 = std::stod(getConfigValueLower("mesonClusterMinM02"));
+  }
+  if (hasConfigValue("mesonClusterMaxM02")) {
+    mMesonClusterCuts.mMaxM02 = std::stod(getConfigValueLower("mesonClusterMaxM02"));
+  }
+  if (hasConfigValue("mesonClusterMinM20")) {
+    mMesonClusterCuts.mMinM20 = std::stod(getConfigValueLower("mesonClusterMinM20"));
+  }
+  if (hasConfigValue("mesonClusterMaxM20")) {
+    mMesonClusterCuts.mMaxM20 = std::stod(getConfigValueLower("mesonClusterMaxM20"));
+  }
   if (hasConfigValue("mesonMinPt")) {
     mMesonCuts.mMinPt = std::stod(getConfigValue("mesonMinPt"));
   }
@@ -876,6 +892,9 @@ void ClusterTask::configureTaskParameters()
   }
   if (hasConfigValue("mesonMaxClusterMultiplicity")) {
     mTaskParameters.mMesonMaxClusterMultiplicity = std::stoi(getConfigValueLower("mesonMaxClusterMultiplicity"));
+  }
+  if (hasConfigValue("mesonMinEClusterLeading")) {
+    mTaskParameters.mMinELeadingMeson = std::stod(getConfigValueLower("mesonMinEClusterLeading"));
   }
 
   ILOG(Info, Support) << mTaskParameters;
@@ -987,6 +1006,12 @@ bool ClusterTask::MesonClusterSelection::isSelected(const o2::emcal::AnalysisClu
   if (cluster.getNCells() < mMinNCell) {
     return false;
   }
+  if (cluster.getM02() < mMinM02 || cluster.getM02() > mMaxM02) {
+    return false;
+  }
+  if (cluster.getM20() < mMinM20 || cluster.getM20() > mMaxM20) {
+    return false;
+  }
   if (mRejectExotics && cluster.getIsExotic()) {
     return false;
   }
@@ -1000,6 +1025,10 @@ void ClusterTask::MesonClusterSelection::print(std::ostream& stream) const
          << "Min. energy:          " << mMinE << " GeV\n"
          << "Max. time:            " << mMaxTime << " ns\n"
          << "Min. number of cells: " << mMinNCell << "\n"
+         << "Min. M02:             " << mMinM02 << "\n"
+         << "Max. M02:             " << mMaxM02 << "\n"
+         << "Min. M20:             " << mMinM20 << "\n"
+         << "Max. M20:             " << mMaxM20 << "\n"
          << "Reject exotics:       " << (mRejectExotics ? "yes" : "no") << "\n";
 }
 
@@ -1028,7 +1057,8 @@ void ClusterTask::TaskParams::print(std::ostream& stream) const
          << "Invariant mass histograms for Meson candidates: " << (mFillInvMassMeson ? "enabled" : "disabled") << "\n"
          << "Max. range of multiplicity histograms:          " << mMultiplicityRange << "\n"
          << "Min. cluster multiplicity for Meson candidates: " << mMesonMinClusterMultiplicity << "\n"
-         << "Max. cluster mutliplicity for Meson candidates: " << mMesonMaxClusterMultiplicity << "\n";
+         << "Max. cluster mutliplicity for Meson candidates: " << mMesonMaxClusterMultiplicity << "\n"
+         << "Min. energy leading for Meson candidates:       " << mMinELeadingMeson << " GeV\n";
 }
 
 std::ostream& operator<<(std::ostream& stream, const ClusterTask::ClusterizerParams& params)


### PR DESCRIPTION
- [EMCAL-524] Cell time cut for total energy histogram (reject pileup for high-IR)
- [EMCAL-530] Shower shape cuts for cluster selection for pi0 candidates (background reduction in most central collisions)