### PR TITLE
[QC-1015] Do not trend slices if some objects are unavailable

### DIFF
--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -140,6 +140,9 @@ void SliceTrendingTask::trendValues(const Trigger& t,
       if (obj) {
         mReductors[dataSource.name]->update(obj, *mSources[dataSource.name],
                                             dataSource.axisDivision, mNumberPads[dataSource.name]);
+      } else {
+        ILOG(Error, Support) << "Some objects could not be retrieved, will skip this trending cycle" << ENDM;
+        return;
       }
 
     } else {


### PR DESCRIPTION
We saw several crashes at P2 when one of the requested objects was not available. In such case, `dataRetrieveVector->at(p)` calls would throw, since the vector was not filled all requested data points. I think the most sane thing to do in such case, is to avoid adding a new row in the TTree, otherwise we would have to fill it partially with 0, which might appear as very misleading in some of the produced plots.