### PR TITLE
[QC-1036] Fix merging invalid validity

### DIFF
--- a/Framework/src/MonitorObjectCollection.cxx
+++ b/Framework/src/MonitorObjectCollection.cxx
@@ -57,8 +57,14 @@ void MonitorObjectCollection::merge(mergers::MergeInterface* const other)
       }
       // That might be another collection or a concrete object to be merged, we walk on the collection recursively.
       algorithm::merge(targetMO->getObject(), otherMO->getObject());
-      targetMO->updateValidity(otherMO->getValidity().getMin());
-      targetMO->updateValidity(otherMO->getValidity().getMax());
+      if (otherMO->getValidity().isValid()) {
+        if (targetMO->getValidity().isInvalid()) {
+          targetMO->setValidity(otherMO->getValidity());
+        } else {
+          targetMO->updateValidity(otherMO->getValidity().getMin());
+          targetMO->updateValidity(otherMO->getValidity().getMax());
+        }
+      }
     } else {
       // A corresponding object in the target collection could not be found.
       // We prefer to clone instead of passing the pointer in order to simplify deleting the `other`.


### PR DESCRIPTION
As discovered, when a plot is empty it correctly gets invalid validity range (uint_max, 0). However, when we merge it with a correct non-empty object, the invalid range becomes the inverted new range of the valid object (0, uint_max), which is wrong. This PR makes invalid validity intervals be ignored when merging objects.