### PR TITLE
[EMCAL-526] Protection against unexpected tower ID

### DIFF
--- a/Modules/EMCAL/src/RawTask.cxx
+++ b/Modules/EMCAL/src/RawTask.cxx
@@ -601,16 +601,23 @@ void RawTask::monitorData(o2::framework::ProcessingContext& ctx)
           if (chType == CHTYP::LEDMON || chType == CHTYP::TRU)
             continue;
 
-          auto [row, col] = mGeometry->ShiftOnlineToOfflineCellIndexes(supermoduleID, rowOnline, colOnline);
-          // tower absolute ID
-          auto cellID = mGeometry->GetAbsCellIdFromCellIndexes(supermoduleID, row, col);
-          ;
-          if (cellID > 17664) {
+          int globRow(-1), globCol(-1);
+          try {
+            auto [row, col] = mGeometry->ShiftOnlineToOfflineCellIndexes(supermoduleID, rowOnline, colOnline);
+            // tower absolute ID
+            auto cellID = mGeometry->GetAbsCellIdFromCellIndexes(supermoduleID, row, col);
+            if (cellID > 17664) {
+              mErrorTypeAltro->Fill(feeID, 9);
+              continue;
+            }
+            // position in the EMCAL
+            auto [globRowTmp, globColTmp] = mGeometry->GlobalRowColFromIndex(cellID);
+            globRow = globRowTmp;
+            globCol = globColTmp;
+          } catch (o2::emcal::InvalidCellIDException& e) {
             mErrorTypeAltro->Fill(feeID, 9);
             continue;
           }
-          // position in the EMCAL
-          auto [globRow, globCol] = mGeometry->GlobalRowColFromIndex(cellID);
 
           fecIndex = chan.getFECIndex();
           branchIndex = chan.getBranchIndex();


### PR DESCRIPTION
Unexpected tower IDs might be a result of a data
corruption, must be caught and discarded.