### PR TITLE
ITS - Fixes and improvement on FEE Task checker

### DIFF
--- a/Modules/ITS/include/ITS/ITSFeeCheck.h
+++ b/Modules/ITS/include/ITS/ITSFeeCheck.h
@@ -90,6 +90,7 @@ class ITSFeeCheck : public o2::quality_control::checker::CheckInterface
 
   std::string skipbinstrg = "";
   std::string skipfeeids = "";
+  int maxtfdifference = -1;
   int minPayloadSize = 1400;
   int maxbadchipsIB = 2;
   int maxbadlanesML = 4;

--- a/Modules/ITS/itsFee.json
+++ b/Modules/ITS/itsFee.json
@@ -55,9 +55,11 @@
                 "checkParameters": {
                   "skipbinstrg": "",
                   "skipfeeids": "",
-                  "maxbadchipsIB": "2",
+                  "maxTFdifferenceAllowed": "1000000000",
+		  "maxbadchipsIB": "2",
                   "maxbadlanesML": "4",
                   "maxbadlanesOL": "7",
+		  "minPayloadSize": "1400",
                   "maxfractionbadlanes": "0.1",
 		  "expectedROFperOrbit": "18",
                   "plotWithTextMessage": "",

--- a/Modules/ITS/src/ITSFeeCheck.cxx
+++ b/Modules/ITS/src/ITSFeeCheck.cxx
@@ -175,14 +175,14 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
           }
           // checking trigger flags supposed to have exactly one entry
           else if (TrgExactlyOne.Contains(trgname)) {
-            if (h->GetBinContent(ifee, itrg + 1) != 1) {
+            if (bincontent != 1) {
               badTrigger = true;
               break;
             }
           }
           // checking trigger flags supposed to have no entries
           else {
-            if (h->GetBinContent(ifee, itrg + 1) > 0) {
+            if (bincontent > 0) {
               badTrigger = true;
               break;
             }


### PR DESCRIPTION
@iravasen @IsakovAD , this is on the checks for the TriggerVsFeeID plot

- Fix: Before the checker took into account only the number of FEEs excluded from the checks, not their IDs
- Feature: New check allowing to spot if a FEEId stays behind with the number of shipped TFs (e.g. module going off along the run)