### PR TITLE
Fix assertion in reordering Aggregators

### DIFF
--- a/Framework/src/AggregatorRunner.cxx
+++ b/Framework/src/AggregatorRunner.cxx
@@ -404,7 +404,7 @@ void AggregatorRunner::reorderAggregators()
     ILOG(Error, Ops) << msg << ENDM;
     BOOST_THROW_EXCEPTION(FatalException() << errinfo_details(msg));
   }
-  assert(results.size() != mAggregators.size());
+  assert(results.size() == mAggregators.size());
   mAggregators = results;
 }
 


### PR DESCRIPTION
I think this went unnoticed, because assertions might be switched on only in debug builds