### PR TITLE
Add missing Lifetime::Sporadic to QC inputs and outputs

### DIFF
--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -349,7 +349,7 @@ framework::WorkflowSpec InfrastructureGenerator::generateLocalBatchInfrastructur
       auto taskConfig = TaskRunnerFactory::extractConfig(infrastructureSpec.common, taskSpec, 0, 1);
       workflow.emplace_back(TaskRunnerFactory::create(taskConfig));
 
-      fileSinkInputs.emplace_back(taskSpec.taskName, TaskRunner::createTaskDataOrigin(taskSpec.detectorName), TaskRunner::createTaskDataDescription(taskSpec.taskName));
+      fileSinkInputs.emplace_back(taskSpec.taskName, TaskRunner::createTaskDataOrigin(taskSpec.detectorName), TaskRunner::createTaskDataDescription(taskSpec.taskName), Lifetime::Sporadic);
     }
   }
 

--- a/Framework/test/testCheckWorkflow.cxx
+++ b/Framework/test/testCheckWorkflow.cxx
@@ -110,7 +110,7 @@ class Receiver : public framework::Task
   {
     Inputs inputs;
     for (auto& checkName : mNames) {
-      inputs.push_back({ checkName, "QC", Check::createCheckDataDescription(checkName) });
+      inputs.push_back({ checkName, "QC", Check::createCheckDataDescription(checkName), Lifetime::Sporadic });
     }
     return inputs;
   }

--- a/Framework/test/testWorkflow.cxx
+++ b/Framework/test/testWorkflow.cxx
@@ -74,7 +74,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   DataProcessorSpec receiver{
     "receiver",
     Inputs{
-      { "checked-mo", "QC", Check::createCheckDataDescription(getFirstCheckName(qcConfigurationSource)), 0 } },
+      { "checked-mo", "QC", Check::createCheckDataDescription(getFirstCheckName(qcConfigurationSource)), 0, Lifetime::Sporadic } },
     Outputs{},
     AlgorithmSpec{
       [](ProcessingContext& pctx) {


### PR DESCRIPTION
...because DPL will require the Lifetime to match between inputs and outputs.