### PR TITLE
Allow for TFID == 0 in async QC timekeeping for testing purposes

### DIFF
--- a/Framework/src/TimekeeperAsynchronous.cxx
+++ b/Framework/src/TimekeeperAsynchronous.cxx
@@ -45,10 +45,10 @@ void TimekeeperAsynchronous::updateByTimeFrameID(uint32_t tfid)
   }
   if (tfid == 0) {
     if (!mWarnedAboutTfIdZero) {
-      ILOG(Warning, Devel) << "Seen TFID equal to 0, which is not expected. Will not update TF-based validity, will not warn further." << ENDM;
+      ILOG(Warning, Support) << "Seen TFID equal to 0, which is not expected in production data. Will use 1 instead, will not warn further." << ENDM;
       mWarnedAboutTfIdZero = true;
+      tfid = 1;
     }
-    return;
   }
 
   auto tfValidity = computeTimestampFromTimeframeID(tfid);


### PR DESCRIPTION
As it has been demonstrated by a recent use case, some simulated data does not use correct TFID, having it as 0 instead. In such cases, we do not want to block the users from testing their sw, thus we allow for it and produce a warning. We overwrite TFID to 1, so it does not break the algorithm which computes the data timespan (production data starts with TFID == 1)