### PR TITLE
Make sure printer task is considered resilient

### DIFF
--- a/Framework/src/runBasic.cxx
+++ b/Framework/src/runBasic.cxx
@@ -119,20 +119,21 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
   // Finally the printer
   if (hasChecks(qcConfigurationSource)) {
     DataProcessorSpec printer{
-      "printer",
-      Inputs{
+      .name = "printer",
+      .inputs = Inputs{
         { "checked-mo", "QC", Check::createCheckDataDescription(getFirstCheckName(qcConfigurationSource)), 0, Lifetime::Sporadic } },
-      Outputs{},
-      adaptFromTask<o2::quality_control::example::ExampleQualityPrinterSpec>()
+      .algorithm = adaptFromTask<o2::quality_control::example::ExampleQualityPrinterSpec>(),
+      .labels = { { "resilient" } }
     };
     specs.push_back(printer);
   } else {
     DataProcessorSpec printer{
-      "printer",
-      Inputs{
+      .name = "printer",
+      .inputs = Inputs{
         { "checked-mo", "QC", TaskRunner::createTaskDataDescription(getFirstTaskName(qcConfigurationSource)), 0, Lifetime::Sporadic } },
-      Outputs{},
-      adaptFromTask<o2::quality_control::example::ExamplePrinterSpec>()
+      .algorithm = adaptFromTask<o2::quality_control::example::ExamplePrinterSpec>(),
+      .labels = { { "resilient" } }
+
     };
     specs.push_back(printer);
   }


### PR DESCRIPTION
Make sure printer task is considered resilient

I.e. it can survive as dependency of expendable tasks, while not
being expendable itself.
