### PR TITLE
[QC-1049][QC-1050] Allow to republish an object

### DIFF
--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -62,8 +62,8 @@ ObjectsManager::~ObjectsManager()
 void ObjectsManager::startPublishing(TObject* object)
 {
   if (mMonitorObjects->FindObject(object->GetName()) != nullptr) {
-    ILOG(Warning, Support) << "Object is already being published (" << object->GetName() << ")" << ENDM;
-    BOOST_THROW_EXCEPTION(DuplicateObjectError() << errinfo_object_name(object->GetName()));
+    ILOG(Warning, Support) << "Object is already being published (" << object->GetName() << "), will remove it and add the new one" << ENDM;
+    stopPublishing(object->GetName());
   }
   auto* newObject = new MonitorObject(object, mTaskName, mTaskClass, mDetectorName);
   newObject->setIsOwner(false);

--- a/Framework/test/testObjectsManager.cxx
+++ b/Framework/test/testObjectsManager.cxx
@@ -54,7 +54,15 @@ BOOST_AUTO_TEST_CASE(duplicate_object_test)
   ObjectsManager objectsManager(config.taskName, config.taskClass, config.detectorName, config.consulUrl, 0, true);
   TObjString s("content");
   objectsManager.startPublishing(&s);
-  BOOST_CHECK_THROW(objectsManager.startPublishing(&s), o2::quality_control::core::DuplicateObjectError);
+  BOOST_CHECK_NO_THROW(objectsManager.startPublishing(&s));
+  BOOST_REQUIRE(objectsManager.getMonitorObject("content") != nullptr);
+
+  TObjString s2("content");
+  BOOST_CHECK_NO_THROW(objectsManager.startPublishing(&s2));
+  auto mo2 = objectsManager.getMonitorObject("content");
+  BOOST_REQUIRE(mo2 != nullptr);
+  BOOST_REQUIRE(mo2->getObject() != &s);
+  BOOST_REQUIRE(mo2->getObject() == &s2);
 }
 
 BOOST_AUTO_TEST_CASE(is_being_published_test)
@@ -66,7 +74,7 @@ BOOST_AUTO_TEST_CASE(is_being_published_test)
   TObjString s("content");
   BOOST_CHECK(!objectsManager.isBeingPublished("content"));
   objectsManager.startPublishing(&s);
-  BOOST_CHECK_THROW(objectsManager.startPublishing(&s), o2::quality_control::core::DuplicateObjectError);
+  BOOST_CHECK_NO_THROW(objectsManager.startPublishing(&s));
   BOOST_CHECK(objectsManager.isBeingPublished("content"));
 }
 


### PR DESCRIPTION
This allows to publish an object with the same name again, which now overwrites the previous one.

This is needed for START STOP START in postprocessing, where a task might want to replace an object with a new one. It also makes the framework survive if a task attempts to register  the same object again, because the registration happens at PostProcessingInterface::initialize(), which we want invoke at each START.