### PR TITLE
Do not specify Lifetime when creating the output

### DIFF
--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -420,7 +420,7 @@ void CheckRunner::send(QualityObjectsType& qualityObjects, framework::DataAlloca
     auto outputSpec = correspondingCheck.getOutputSpec();
     auto concreteOutput = framework::DataSpecUtils::asConcreteDataMatcher(outputSpec);
     allocator.snapshot(
-      framework::Output{ concreteOutput.origin, concreteOutput.description, concreteOutput.subSpec, outputSpec.lifetime }, *qo);
+      framework::Output{ concreteOutput.origin, concreteOutput.description, concreteOutput.subSpec}, *qo);
     mTotalQOSent++;
   }
 }

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -575,8 +575,7 @@ int TaskRunner::publish(DataAllocator& outputs)
   outputs.snapshot(
     Output{ concreteOutput.origin,
             concreteOutput.description,
-            concreteOutput.subSpec,
-            mTaskConfig.moSpec.lifetime },
+            concreteOutput.subSpec },
     *array);
 
   mLastPublicationDuration = publicationDurationTimer.getTime();

--- a/Modules/ITS/src/runITSClustersRootFileReader.cxx
+++ b/Modules/ITS/src/runITSClustersRootFileReader.cxx
@@ -99,9 +99,9 @@ class ITSClustersRootFileReader : public o2::framework::Task
     std::copy(patterns.begin(), patterns.end(), std::back_inserter(*clusPatternArr));
 
     // Output vectors
-    pc.outputs().snapshot(Output{ "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe }, *clusRofArr);
-    pc.outputs().snapshot(Output{ "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe }, *clusArr);
-    pc.outputs().snapshot(Output{ "ITS", "PATTERNS", 0, Lifetime::Timeframe }, *clusPatternArr);
+    pc.outputs().snapshot(Output{ "ITS", "CLUSTERSROF", 0}, *clusRofArr);
+    pc.outputs().snapshot(Output{ "ITS", "COMPCLUSTERS", 0}, *clusArr);
+    pc.outputs().snapshot(Output{ "ITS", "PATTERNS", 0}, *clusPatternArr);
 
     // move to a new entry in TTree
     ++mCurrentEntry;

--- a/Modules/ITS/src/runITSTracksRootFileReader.cxx
+++ b/Modules/ITS/src/runITSTracksRootFileReader.cxx
@@ -146,15 +146,15 @@ class ITSTracksRootFileReader : public o2::framework::Task
     std::copy(patterns.begin(), patterns.end(), std::back_inserter(*clusPatternArr));
 
     // Output vectors
-    pc.outputs().snapshot(Output{ "ITS", "ITSTrackROF", 0, Lifetime::Timeframe }, *trackRofArr);
-    pc.outputs().snapshot(Output{ "ITS", "TRACKS", 0, Lifetime::Timeframe }, *trackArr);
-    pc.outputs().snapshot(Output{ "ITS", "VERTICES", 0, Lifetime::Timeframe }, *vertexArr);
-    pc.outputs().snapshot(Output{ "ITS", "VERTICESROF", 0, Lifetime::Timeframe }, *vertexRofArr);
-    pc.outputs().snapshot(Output{ "ITS", "TRACKCLSID", 0, Lifetime::Timeframe }, *clusIdx);
+    pc.outputs().snapshot(Output{ "ITS", "ITSTrackROF", 0}, *trackRofArr);
+    pc.outputs().snapshot(Output{ "ITS", "TRACKS", 0}, *trackArr);
+    pc.outputs().snapshot(Output{ "ITS", "VERTICES", 0}, *vertexArr);
+    pc.outputs().snapshot(Output{ "ITS", "VERTICESROF", 0}, *vertexRofArr);
+    pc.outputs().snapshot(Output{ "ITS", "TRACKCLSID", 0}, *clusIdx);
 
-    pc.outputs().snapshot(Output{ "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe }, *clusRofArr);
-    pc.outputs().snapshot(Output{ "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe }, *clusArr);
-    pc.outputs().snapshot(Output{ "ITS", "PATTERNS", 0, Lifetime::Timeframe }, *clusPatternArr);
+    pc.outputs().snapshot(Output{ "ITS", "CLUSTERSROF", 0}, *clusRofArr);
+    pc.outputs().snapshot(Output{ "ITS", "COMPCLUSTERS", 0}, *clusArr);
+    pc.outputs().snapshot(Output{ "ITS", "PATTERNS", 0}, *clusPatternArr);
 
     // move to a new entry in TTree
     ++mCurrentEntry;

--- a/Modules/MFT/src/runMFTClustersRootFileReader.cxx
+++ b/Modules/MFT/src/runMFTClustersRootFileReader.cxx
@@ -115,9 +115,9 @@ class MFTClustersRootFileReader : public o2::framework::Task
     std::copy(patterns.begin(), patterns.end(), std::back_inserter(*clusPatternArr));
 
     // fill in the message
-    pc.outputs().snapshot(Output{ "MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe }, *clustersInROF);
-    pc.outputs().snapshot(Output{ "MFT", "CLUSTERSROF", 0, Lifetime::Timeframe }, *oneROFvec);
-    pc.outputs().snapshot(Output{ "MFT", "PATTERNS", 0, Lifetime::Timeframe }, *clusPatternArr);
+    pc.outputs().snapshot(Output{ "MFT", "COMPCLUSTERS", 0}, *clustersInROF);
+    pc.outputs().snapshot(Output{ "MFT", "CLUSTERSROF", 0}, *oneROFvec);
+    pc.outputs().snapshot(Output{ "MFT", "PATTERNS", 0}, *clusPatternArr);
 
     //  update the ROF counter
     mCurrentROF++;

--- a/Modules/MFT/src/runMFTDigitsHotPixelRootFileReader.cxx
+++ b/Modules/MFT/src/runMFTDigitsHotPixelRootFileReader.cxx
@@ -113,8 +113,8 @@ class MFTDigitsHotPixelRootFileReader : public o2::framework::Task
     AddHotPixel(digitsInROF, 35, 200, 200, 165);
 
     // fill in the message
-    pc.outputs().snapshot(Output{ "MFT", "DIGITS", 0, Lifetime::Timeframe }, *digitsInROF);
-    pc.outputs().snapshot(Output{ "MFT", "DIGITSROF", 0, Lifetime::Timeframe }, *oneROFvec);
+    pc.outputs().snapshot(Output{ "MFT", "DIGITS", 0}, *digitsInROF);
+    pc.outputs().snapshot(Output{ "MFT", "DIGITSROF", 0}, *oneROFvec);
 
     // update the ROF counter
     mCurrentROF++;

--- a/Modules/MFT/src/runMFTDigitsRootFileReader.cxx
+++ b/Modules/MFT/src/runMFTDigitsRootFileReader.cxx
@@ -109,8 +109,8 @@ class MFTDigitsRootFileReader : public o2::framework::Task
     std::copy(digits.begin() + index, digits.begin() + lastIndex, std::back_inserter(*digitsInROF));
 
     // fill in the message
-    pc.outputs().snapshot(Output{ "MFT", "DIGITS", 0, Lifetime::Timeframe }, *digitsInROF);
-    pc.outputs().snapshot(Output{ "MFT", "DIGITSROF", 0, Lifetime::Timeframe }, *oneROFvec);
+    pc.outputs().snapshot(Output{ "MFT", "DIGITS", 0}, *digitsInROF);
+    pc.outputs().snapshot(Output{ "MFT", "DIGITSROF", 0}, *oneROFvec);
 
     // update the ROF counter
     mCurrentROF++;

--- a/Modules/MFT/src/runMFTTracksRootFileReader.cxx
+++ b/Modules/MFT/src/runMFTTracksRootFileReader.cxx
@@ -111,8 +111,8 @@ class MFTTracksRootFileReader : public o2::framework::Task
     std::copy(tracks.begin() + index, tracks.begin() + lastIndex, std::back_inserter(*tracksInROF));
 
     // fill in the message
-    pc.outputs().snapshot(Output{ "MFT", "TRACKS", 0, Lifetime::Timeframe }, *tracksInROF);
-    pc.outputs().snapshot(Output{ "MFT", "MFTTrackROF", 0, Lifetime::Timeframe }, *oneROFvec);
+    pc.outputs().snapshot(Output{ "MFT", "TRACKS", 0}, *tracksInROF);
+    pc.outputs().snapshot(Output{ "MFT", "MFTTrackROF", 0}, *oneROFvec);
 
     //  update the ROF counter
     mCurrentROF++;

--- a/Modules/TPC/run/runTPCQCTrackReader.cxx
+++ b/Modules/TPC/run/runTPCQCTrackReader.cxx
@@ -83,24 +83,21 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
       (AlgorithmSpec::InitCallback)[inputFile, treeName, branchName](InitContext&){
 
         // root tree reader
-        //constexpr auto persistency = Lifetime::Transient;
-        constexpr auto persistency = Lifetime::Timeframe;
-
-  auto reader = std::make_shared<RootTreeReader>(treeName.data(),                      // tree name
-                                                 inputFile.data(),                     // input file name
-                                                 RootTreeReader::PublishingMode::Loop, // loop over
-                                                 Output{ "TPC", "TRACKS", 0, persistency },
-                                                 branchName.data() // name of the branch
-  );
+        auto reader = std::make_shared<RootTreeReader>(treeName.data(),                      // tree name
+                                                       inputFile.data(),                     // input file name
+                                                       RootTreeReader::PublishingMode::Loop, // loop over
+                                                       Output{ "TPC", "TRACKS", 0 },
+                                                       branchName.data() // name of the branch
+        );
 
   return (AlgorithmSpec::ProcessCallback)[reader](ProcessingContext & processingContext) mutable
   {
     //(++(*reader))(processingContext);
     if (reader->next()) {
       (*reader)(processingContext);
-      //LOG(info) << "Call producer AlgorithmSpec::ProcessCallback:  has data " << reader->getCount();
+      // LOG(info) << "Call producer AlgorithmSpec::ProcessCallback:  has data " << reader->getCount();
     } else {
-      //LOG(info) << "Call producer AlgorithmSpec::ProcessCallback:  no next data" << reader->getCount();
+      // LOG(info) << "Call producer AlgorithmSpec::ProcessCallback:  no next data" << reader->getCount();
     }
   };
 }


### PR DESCRIPTION
Do not specify Lifetime when creating the output

Lifetime cannot actually be changed on a per timeframe basis, it's a
property of the topology. Output will soon be refactored to remove it.
