### PR TITLE
Move CompletionPolicy to new API

### DIFF
--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -25,6 +25,7 @@
 #include <Framework/CompletionPolicy.h>
 #include <Framework/DataTakingContext.h>
 #include <Headers/DataHeader.h>
+#include <Framework/ServiceRegistryRef.h>
 // QC
 #include "QualityControl/TaskRunnerConfig.h"
 
@@ -93,7 +94,7 @@ class TaskRunner : public framework::Task
   void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) override;
 
   /// \brief TaskRunner's completion policy callback
-  static framework::CompletionPolicy::CompletionOp completionPolicyCallback(o2::framework::InputSpan const& inputs);
+  static framework::CompletionPolicy::CompletionOp completionPolicyCallback(o2::framework::InputSpan const& inputs, std::vector<framework::InputSpec> const&, framework::ServiceRegistryRef&);
 
   std::string getDeviceName() const { return mTaskConfig.deviceName; };
   const framework::Inputs& getInputsSpecs() const { return mTaskConfig.inputSpecs; };

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -222,7 +222,7 @@ void TaskRunner::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   mTask->finaliseCCDB(matcher, obj);
 }
 
-CompletionPolicy::CompletionOp TaskRunner::completionPolicyCallback(o2::framework::InputSpan const& inputs)
+CompletionPolicy::CompletionOp TaskRunner::completionPolicyCallback(o2::framework::InputSpan const& inputs, std::vector<framework::InputSpec> const&, ServiceRegistryRef&)
 {
   // fixme: we assume that there is one timer input and the rest are data inputs. If some other implicit inputs are
   //  added, this will break.


### PR DESCRIPTION
Move CompletionPolicy to new API

The new API was introduced years ago. Time to let the old one go.
