### PR TITLE
Generalise CompletionPolicy callback to allow for refactoring

### DIFF
--- a/Framework/src/AggregatorRunnerFactory.cxx
+++ b/Framework/src/AggregatorRunnerFactory.cxx
@@ -56,7 +56,7 @@ DataProcessorSpec AggregatorRunnerFactory::create(const core::CommonSpec& common
 // Specify a custom policy to trigger whenever something arrive regardless of the timeslice.
 void AggregatorRunnerFactory::customizeInfrastructure(std::vector<framework::CompletionPolicy>& policies)
 {
-  auto matcher = [label = AggregatorRunner::getLabel()](framework::DeviceSpec const& device) {
+  auto matcher = [label = AggregatorRunner::getLabel()](auto const& device) {
     return std::find(device.labels.begin(), device.labels.end(), label) != device.labels.end();
   };
   policies.emplace_back(CompletionPolicyHelpers::consumeWhenAny("aggregatorRunnerCompletionPolicy", matcher));

--- a/Framework/src/CheckRunnerFactory.cxx
+++ b/Framework/src/CheckRunnerFactory.cxx
@@ -67,7 +67,7 @@ DataProcessorSpec CheckRunnerFactory::createSinkDevice(const CheckRunnerConfig& 
 
 void CheckRunnerFactory::customizeInfrastructure(std::vector<framework::CompletionPolicy>& policies)
 {
-  auto matcher = [label = CheckRunner::getCheckRunnerLabel()](framework::DeviceSpec const& device) {
+  auto matcher = [label = CheckRunner::getCheckRunnerLabel()](auto const& device) {
     return std::find(device.labels.begin(), device.labels.end(), label) != device.labels.end();
   };
   policies.emplace_back(CompletionPolicyHelpers::consumeWhenAny("checkerCompletionPolicy", matcher));

--- a/Framework/src/RootFileSink.cxx
+++ b/Framework/src/RootFileSink.cxx
@@ -40,7 +40,7 @@ RootFileSink::RootFileSink(std::string filePath)
 
 void RootFileSink::customizeInfrastructure(std::vector<framework::CompletionPolicy>& policies)
 {
-  auto matcher = [label = RootFileSink::getLabel()](framework::DeviceSpec const& device) {
+  auto matcher = [label = RootFileSink::getLabel()](auto const& device) {
     return std::find(device.labels.begin(), device.labels.end(), label) != device.labels.end();
   };
 

--- a/Framework/src/TaskRunnerFactory.cxx
+++ b/Framework/src/TaskRunnerFactory.cxx
@@ -195,7 +195,7 @@ InputSpec TaskRunnerFactory::createTimerInputSpec(const CommonSpec& globalConfig
 
 void TaskRunnerFactory::customizeInfrastructure(std::vector<framework::CompletionPolicy>& policies)
 {
-  auto matcher = [label = TaskRunner::getTaskRunnerLabel()](framework::DeviceSpec const& device) {
+  auto matcher = [label = TaskRunner::getTaskRunnerLabel()](auto const& device) {
     return std::find(device.labels.begin(), device.labels.end(), label) != device.labels.end();
   };
   auto callback = TaskRunner::completionPolicyCallback;

--- a/Framework/test/testCheckWorkflow.cxx
+++ b/Framework/test/testCheckWorkflow.cxx
@@ -30,7 +30,7 @@ void customize(std::vector<CompletionPolicy>& policies)
   DataSampling::CustomizeInfrastructure(policies);
   quality_control::customizeInfrastructure(policies);
 
-  auto matcher = [](framework::DeviceSpec const& device) {
+  auto matcher = [](auto const& device) {
     return device.name.find(receiverName) != std::string::npos;
   };
 


### PR DESCRIPTION
Generalise CompletionPolicy callback to allow for refactoring

I will soon move to pass a DataProcessorSpec, rather than a DeviceSpec,
because the completion policy is a property of the former.

This will allow detecting consumeWhenAny policies early enough and
make dataprocessors associated to it be resilient to expendable devices
and Sporadic inputs.
