### PR TITLE
[QC-1049] Clear QualityTask members before initializing

### DIFF
--- a/Modules/Common/include/Common/QualityTask.h
+++ b/Modules/Common/include/Common/QualityTask.h
@@ -96,8 +96,6 @@ class QualityTask : public quality_control::postprocessing::PostProcessingInterf
   std::unordered_map<std::string, int> mColors;
   /// \brief numerical IDs associated to each quality state (Good/Medium/Bad/Null)
   std::unordered_map<std::string, int> mQualityIDs;
-  /// \brief messages associated to each quality state (Good/Medium/Bad/Null)
-  std::unordered_map<std::string, std::string> mCheckerMessages;
   /// \brief Quality Objects histograms
   std::unordered_map<std::string, std::unique_ptr<TH1F>> mHistograms;
   /// \brief Quality Objects trends

--- a/Modules/Common/src/QualityTask.cxx
+++ b/Modules/Common/src/QualityTask.cxx
@@ -149,6 +149,13 @@ static void setQualityLabels(TH1F* h)
 
 void QualityTask::initialize(quality_control::postprocessing::Trigger t, framework::ServiceRegistryRef services)
 {
+  mLatestTimestamps.clear();
+  mColors.clear();
+  mQualityIDs.clear();
+  mHistograms.clear();
+  mTrends.clear();
+  mQualityCanvas.reset();
+
   mColors[Quality::Null.getName()] = kViolet - 6;
   mColors[Quality::Bad.getName()] = kRed;
   mColors[Quality::Medium.getName()] = kOrange - 3;


### PR DESCRIPTION
In case of the Start->Stop->Start, the later emplace calls in the initialize method were not effective, since values already existed for given keys.
Thus, old histograms and trends were used instead.