### PR TITLE
THRatio: fix division of histograms with different bin labels

### DIFF
--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -150,9 +150,6 @@ void TH1Ratio<T>::update()
     return;
   }
 
-  const char* name = this->GetName();
-  const char* title = this->GetTitle();
-
   T::Reset();
   T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
   T::SetBinsLength();
@@ -164,6 +161,12 @@ void TH1Ratio<T>::update()
     double norm = (entries > 0) ? 1.0 / entries : 0;
     T::Scale(norm);
   } else {
+    if (T::GetXaxis()->GetLabels())  {
+      // copy bin labels to denominator before dividing, otherwise we get a warning
+      for (int bin = 1; bin <= T::GetXaxis()->GetNbins(); bin++) {
+        mHistoDen->GetXaxis()->SetBinLabel(bin, T::GetXaxis()->GetBinLabel(bin));
+      }
+    }
     T::Divide(mHistoDen);
   }
 }

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -150,9 +150,6 @@ void TH2Ratio<T>::update()
     return;
   }
 
-  const char* name = this->GetName();
-  const char* title = this->GetTitle();
-
   T::Reset();
   T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
   T::GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXmin(), mHistoNum->GetYaxis()->GetXmax());
@@ -165,6 +162,17 @@ void TH2Ratio<T>::update()
     double norm = (entries > 0) ? 1.0 / entries : 0;
     T::Scale(norm);
   } else {
+    // copy bin labels to denominator before dividing, otherwise we get a warning
+    if (T::GetXaxis()->GetLabels())  {
+      for (int bin = 1; bin <= T::GetXaxis()->GetNbins(); bin++) {
+        mHistoDen->GetXaxis()->SetBinLabel(bin, T::GetXaxis()->GetBinLabel(bin));
+      }
+    }
+    if (T::GetYaxis()->GetLabels())  {
+      for (int bin = 1; bin <= T::GetYaxis()->GetNbins(); bin++) {
+        mHistoDen->GetYaxis()->SetBinLabel(bin, T::GetYaxis()->GetBinLabel(bin));
+      }
+    }
     T::Divide(mHistoDen);
   }
 }


### PR DESCRIPTION
If the histogram has bin labels, the labels need to be set identically in the denominator.
This fixes the InfoLogger warning messages of this kind:
```
Warning in <o2::quality_control_modules::common::TH1Ratio<TH1F>::Divide>: Dividing histograms with different labels task="alio2-cr1-hv-gw01.cern.ch:/opt/git/ControlWorkflows/tasks/jit-7abe323a47097871d9b0ae2a90447dd0c4b2dd8a-ITS-MERGER-ITSDECODING1l-0@93087985f19b7f8c370f2b878b236f82d240f965#2kFrfucUyac"
```