### PR TITLE
Take any latest trend when resuming. 

### DIFF
--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -52,7 +52,7 @@ void SliceTrendingTask::initialize(Trigger, framework::ServiceRegistryRef servic
     ILOG(Info, Support) << "Trying to retrieve an existing TTree for this task to continue the trend." << ENDM;
     auto& qcdb = services.get<repository::DatabaseInterface>();
     auto path = RepoPathUtils::getMoPath(mConfig.detectorName, PostProcessingInterface::getName(), "", "", false);
-    auto mo = qcdb.retrieveMO(path, PostProcessingInterface::getName(), -1, mConfig.activity);
+    auto mo = qcdb.retrieveMO(path, PostProcessingInterface::getName(), repository::DatabaseInterface::Timestamp::Latest);
     if (mo && mo->getObject()) {
       auto tree = dynamic_cast<TTree*>(mo->getObject());
       if (tree) {

--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -60,7 +60,7 @@ void SliceTrendingTask::initialize(Trigger, framework::ServiceRegistryRef servic
         mo->setIsOwner(false);
       }
     } else {
-      ILOG(Warning, Support) << "Could not retrieve an existing TTree for this task, maybe there is none which match these Activity settings" << ENDM;
+      ILOG(Warning, Support) << "Could not retrieve an existing TTree for this task." << ENDM;
     }
   }
   if (mTrend == nullptr) {

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -84,7 +84,7 @@ void TrendingTask::initialize(Trigger, framework::ServiceRegistryRef services)
     ILOG(Info, Support) << "Trying to retrieve an existing TTree for this task to continue the trend." << ENDM;
     auto& qcdb = services.get<repository::DatabaseInterface>();
     auto path = RepoPathUtils::getMoPath(mConfig.detectorName, PostProcessingInterface::getName(), "", "", false);
-    auto mo = qcdb.retrieveMO(path, PostProcessingInterface::getName(), -1, mConfig.activity);
+    auto mo = qcdb.retrieveMO(path, PostProcessingInterface::getName(), repository::DatabaseInterface::Timestamp::Latest);
     if (mo && mo->getObject()) {
       auto tree = dynamic_cast<TTree*>(mo->getObject());
       if (tree) {

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -93,8 +93,7 @@ void TrendingTask::initialize(Trigger, framework::ServiceRegistryRef services)
       }
     } else {
       ILOG(Warning, Support)
-        << "Could not retrieve an existing TTree for this task, maybe there is none which match these Activity settings"
-        << ENDM;
+        << "Could not retrieve an existing TTree for this task" << ENDM;
     }
   }
   for (const auto& source : mConfig.dataSources) {


### PR DESCRIPTION
It does not really make sense to restrict resuming the trend to the existing run only, since in case of failure, we are not able to recover a task anyway in the same run. The main use-case was always to perform a trend across many runs or even periods, thus we cannot restrict the retrieval to the current activity.

Also, this commit fixes the retrieval by taking the latest object, not the one matching the current timestamp, which would not work with the new validity rules since a few months.