### PR TITLE
Stop publishing all objects after PostProcessingInterface::finalize call 

### DIFF
--- a/Framework/include/QualityControl/ObjectsManager.h
+++ b/Framework/include/QualityControl/ObjectsManager.h
@@ -79,6 +79,9 @@ class ObjectsManager
    */
   void stopPublishing(const std::string& objectName);
 
+  /// \brief Stop publishing all registered objects
+  void stopPublishingAll();
+
   /**
    * Check whether an object is already being published
    * @param objectName

--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -113,6 +113,12 @@ void ObjectsManager::stopPublishing(const string& objectName)
   mMonitorObjects->Remove(mo);
 }
 
+void ObjectsManager::stopPublishingAll()
+{
+  removeAllFromServiceDiscovery();
+  mMonitorObjects->Clear();
+}
+
 bool ObjectsManager::isBeingPublished(const string& name)
 {
   return (mMonitorObjects->FindObject(name.c_str()) != nullptr);

--- a/Framework/src/PostProcessingRunner.cxx
+++ b/Framework/src/PostProcessingRunner.cxx
@@ -285,6 +285,7 @@ void PostProcessingRunner::doFinalize(const Trigger& trigger)
 
   mPublicationCallback(mObjectManager->getNonOwningArray());
   mTaskState = TaskState::Finished;
+  mObjectManager->stopPublishingAll();
 }
 
 const std::string& PostProcessingRunner::getID() const

--- a/Framework/test/testObjectsManager.cxx
+++ b/Framework/test/testObjectsManager.cxx
@@ -94,6 +94,12 @@ BOOST_AUTO_TEST_CASE(unpublish_test)
   BOOST_CHECK_EQUAL(objectsManager.getNumberPublishedObjects(), 0);
   BOOST_CHECK_THROW(objectsManager.stopPublishing("content"), ObjectNotFoundError);
   BOOST_CHECK_THROW(objectsManager.stopPublishing("asdf"), ObjectNotFoundError);
+
+  objectsManager.startPublishing(&s);
+  BOOST_CHECK_EQUAL(objectsManager.getNumberPublishedObjects(), 1);
+  objectsManager.stopPublishingAll();
+  BOOST_CHECK_EQUAL(objectsManager.getNumberPublishedObjects(), 0);
+  BOOST_CHECK_NO_THROW(objectsManager.stopPublishingAll());
 }
 
 BOOST_AUTO_TEST_CASE(getters_test)


### PR DESCRIPTION
In postprocessing the task flow is always initialize()->update()->finalize(), where update() is done any number of times, including 0. This allows us to safely stop publishing any objects after finalize() is called, because if the task will be reused in the next run, initialize() will be called first. Hopefully this will fix many crashes during START->STOP->START related to the fact, that we were trying to start publishing objects which are already registered, but also deleted.