### PR TITLE
TOF: adding pads in the HitMap

### DIFF
--- a/Modules/TOF/include/TOF/CheckHitMap.h
+++ b/Modules/TOF/include/TOF/CheckHitMap.h
@@ -52,16 +52,13 @@ class CheckHitMap : public o2::quality_control::checker::CheckInterface
   MessagePad mPhosModuleMessage{ "PHOS", 13.f, 38.f, 16.f, 53.f }; // Values corresponding to the PHOS hole
   /// Name of the accepted MO
   static constexpr char mAcceptedName[] = "HitMap";
-  /// Flag to enable or disable the check with respect to the reference map
-  bool mEnableReferenceHitMap = true;
-  /// Name of the Path to get on CCDB for the ref. map
-  std::string mRefMapCcdbPath = "/TOF/Calib/FEELIGHT";
-  /// Timestamp to get on CCDB for the ref. map
-  int mRefMapTimestamp = -1;
-  int mNWithHits = 0;                 /// Number of half strips with hits
-  int mNEnabled = 0;                  /// Number of enabled half strips
-  int mTrheshold = 317;               /// Threshold of agreement between read and enabled half strips
-  bool mEnablePadPerMismatch = false; /// Flag to enable showing where the mismatch happens in the plot with TPads
+  bool mEnableReferenceHitMap = true;                  /// Flag to enable or disable the check with respect to the reference map
+  bool mEnablePadPerMismatch = false;                  /// Flag to enable showing where the mismatch happens in the plot with TPads
+  std::string mRefMapCcdbPath = "/TOF/Calib/FEELIGHT"; /// Name of the Path to get on CCDB for the ref. map
+  int mRefMapTimestamp = -1;                           /// Timestamp to get on CCDB for the ref. map
+  int mNWithHits = 0;                                  /// Number of half strips with hits
+  int mNEnabled = 0;                                   /// Number of enabled half strips
+  int mTrheshold = 317;                                /// Threshold of agreement between read and enabled half strips
 
   ClassDefOverride(CheckHitMap, 2);
 };

--- a/Modules/TOF/include/TOF/CheckHitMap.h
+++ b/Modules/TOF/include/TOF/CheckHitMap.h
@@ -58,9 +58,9 @@ class CheckHitMap : public o2::quality_control::checker::CheckInterface
   std::string mRefMapCcdbPath = "/TOF/Calib/FEELIGHT";
   /// Timestamp to get on CCDB for the ref. map
   int mRefMapTimestamp = -1;
-  int mNWithHits = 0;                /// Number of half strips with hits
-  int mNEnabled = 0;                 /// Number of enabled half strips
-  int mTrheshold = 317;              /// Threshold of agreement between read and enabled half strips
+  int mNWithHits = 0;                 /// Number of half strips with hits
+  int mNEnabled = 0;                  /// Number of enabled half strips
+  int mTrheshold = 317;               /// Threshold of agreement between read and enabled half strips
   bool mEnablePadPerMismatch = false; /// Flag to enable showing where the mismatch happens in the plot with TPads
 
   ClassDefOverride(CheckHitMap, 2);

--- a/Modules/TOF/include/TOF/CheckHitMap.h
+++ b/Modules/TOF/include/TOF/CheckHitMap.h
@@ -43,6 +43,8 @@ class CheckHitMap : public o2::quality_control::checker::CheckInterface
   /// Reference hit map taken from the CCDB and translated into QC binning
   std::shared_ptr<TH2F> mHistoRefHitMap = nullptr;    /// TOF reference hit map
   std::shared_ptr<TH2F> mHistoBinaryHitMap = nullptr; /// TOF binary (yes or no) hit map
+  std::vector<std::pair<int, int>> mHitMoreThanRef;
+  std::vector<std::pair<int, int>> mRefMoreThanHit;
 
   /// Messages to print on the output PAD
   MessagePad mShifterMessages;
@@ -51,14 +53,15 @@ class CheckHitMap : public o2::quality_control::checker::CheckInterface
   /// Name of the accepted MO
   static constexpr char mAcceptedName[] = "HitMap";
   /// Flag to enable or disable the check with respect to the reference map
-  bool mEnableReferenceHitMap = false;
+  bool mEnableReferenceHitMap = true;
   /// Name of the Path to get on CCDB for the ref. map
   std::string mRefMapCcdbPath = "/TOF/Calib/FEELIGHT";
   /// Timestamp to get on CCDB for the ref. map
   int mRefMapTimestamp = -1;
-  int mNWithHits = 0; /// Number of half strips with hits
-  int mNEnabled = 0;  /// Number of enabled half strips
-  int mTrheshold = 0; /// Threshold of agreement between read and enabled half strips
+  int mNWithHits = 0;                /// Number of half strips with hits
+  int mNEnabled = 0;                 /// Number of enabled half strips
+  int mTrheshold = 317;              /// Threshold of agreement between read and enabled half strips
+  bool mEnablePadPerMismatch = false; /// Flag to enable showing where the mismatch happens in the plot with TPads
 
   ClassDefOverride(CheckHitMap, 2);
 };

--- a/Modules/TOF/src/CheckHitMap.cxx
+++ b/Modules/TOF/src/CheckHitMap.cxx
@@ -33,7 +33,8 @@ namespace o2::quality_control_modules::tof
 {
 
 void CheckHitMap::configure()
-{ utils::parseBooleanParameter(mCustomParameters, "EnableReferenceHitMap", mEnableReferenceHitMap);
+{
+  utils::parseBooleanParameter(mCustomParameters, "EnableReferenceHitMap", mEnableReferenceHitMap);
   utils::parseStrParameter(mCustomParameters, "RefMapCcdbPath", mRefMapCcdbPath);
   utils::parseIntParameter(mCustomParameters, "RefMapTimestamp", mRefMapTimestamp);
   utils::parseBooleanParameter(mCustomParameters, "EnablePadPerMismatch", mEnablePadPerMismatch);
@@ -115,7 +116,7 @@ Quality CheckHitMap::check(std::map<std::string, std::shared_ptr<MonitorObject>>
       result = Quality::Good;
       const auto mNMishmatching = mHitMoreThanRef.size() + mRefMoreThanHit.size();
       if (mNMishmatching > mTrheshold) {
-          result = Quality::Bad;
+        result = Quality::Bad;
         if (mNWithHits > mNEnabled) {
           mShifterMessages.AddMessage(Form("Hits %i > enabled %i (Thr. %i), %zu Mismatch", mNWithHits, mNEnabled, mTrheshold, mNMishmatching));
         } else {
@@ -156,7 +157,7 @@ void CheckHitMap::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
     }
     msgPhos->SetFillStyle(3004);
     msgPhos->AddText("PHOS");
-    if (mEnablePadPerMismatch) { // Adding pads to highlight mismatches
+    if (mEnablePadPerMismatch) {             // Adding pads to highlight mismatches
       for (const auto p : mHitMoreThanRef) { // Pads for when hits are more than the reference map
         float xl = h->GetXaxis()->GetBinLowEdge(p.first);
         float xu = h->GetXaxis()->GetBinUpEdge(p.first);

--- a/Modules/TOF/src/CheckHitMap.cxx
+++ b/Modules/TOF/src/CheckHitMap.cxx
@@ -157,7 +157,7 @@ void CheckHitMap::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
 
         TPaveText* pad = new TPaveText(xl, yl, xu, yu);
 
-        pad->SetName(Form("hits more than ref_%i_%i", p.first));
+        pad->SetName(Form("hits_more_than_ref_%i_%i", p.first, p.second));
         h->GetListOfFunctions()->Add(pad);
         pad->SetBorderSize(1);
         pad->SetFillColor(kBlack);
@@ -175,7 +175,7 @@ void CheckHitMap::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
 
         TPaveText* pad = new TPaveText(xl, yl, xu, yu);
 
-        pad->SetName(Form("hits more than ref_%i_%i", p.first));
+        pad->SetName(Form("ref_more_than_hits_%i_%i", p.first, p.second));
         h->GetListOfFunctions()->Add(pad);
         pad->SetBorderSize(1);
         pad->SetFillColor(kRed);

--- a/Modules/TOF/src/CheckHitMap.cxx
+++ b/Modules/TOF/src/CheckHitMap.cxx
@@ -123,15 +123,6 @@ Quality CheckHitMap::check(std::map<std::string, std::shared_ptr<MonitorObject>>
           mShifterMessages.AddMessage(Form("Hits %i < enabled %i (Thr. %i), %zu Mismatch", mNWithHits, mNEnabled, mTrheshold, mNMishmatching));
         }
       }
-
-      /*result = Quality::Good;
-      if ((mNWithHits - mNEnabled) > mTrheshold) {
-        mShifterMessages.AddMessage(Form("Hits %i > enabled %i (Thr. %i)", mNWithHits, mNEnabled, mTrheshold));
-        result = Quality::Bad;
-      } else if ((mNWithHits - mNEnabled) < mTrheshold) {
-        mShifterMessages.AddMessage(Form("Hits %i < enabled %i (Thr. %i)", mNWithHits, mNEnabled, mTrheshold));
-        result = Quality::Bad;
-      }*/
       return result;
     }
   }


### PR DESCRIPTION
New pads are added in the Hit map in order to localize the mismatching between the Hit and the Reference map. The pads can be turned on or off in the configuration.
the condition in the checker  is also changed and the number of mismatching is now used to determine the quality of the checker.