### PR TITLE
QC-1100 Allow to stop publishing an object without accessing GetName

### DIFF
--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -104,7 +104,19 @@ void ObjectsManager::removeAllFromServiceDiscovery()
 
 void ObjectsManager::stopPublishing(TObject* object)
 {
-  stopPublishing(object->GetName());
+  // We look for the MonitorObject which observes the provided object by comparing its address
+  // This way, we avoid invoking any methods of the provided object, thus we can stop publishing it even after it is deleted
+  TObject* objectToRemove = nullptr;
+  for (auto moAsTObject : *mMonitorObjects) {
+    auto mo = dynamic_cast<MonitorObject*>(moAsTObject);
+    if (mo && mo->getObject() == object) {
+      objectToRemove = moAsTObject;
+      continue;
+    }
+  }
+  if (objectToRemove) {
+    mMonitorObjects->Remove(objectToRemove);
+  }
 }
 
 void ObjectsManager::stopPublishing(const string& objectName)

--- a/Framework/test/testObjectsManager.cxx
+++ b/Framework/test/testObjectsManager.cxx
@@ -95,11 +95,20 @@ BOOST_AUTO_TEST_CASE(unpublish_test)
   BOOST_CHECK_THROW(objectsManager.stopPublishing("content"), ObjectNotFoundError);
   BOOST_CHECK_THROW(objectsManager.stopPublishing("asdf"), ObjectNotFoundError);
 
+  // unpublish all
   objectsManager.startPublishing(&s);
   BOOST_CHECK_EQUAL(objectsManager.getNumberPublishedObjects(), 1);
   objectsManager.stopPublishingAll();
   BOOST_CHECK_EQUAL(objectsManager.getNumberPublishedObjects(), 0);
   BOOST_CHECK_NO_THROW(objectsManager.stopPublishingAll());
+
+  // unpublish after deletion
+  auto s2 = new TObjString("content");
+  objectsManager.startPublishing(s2);
+  BOOST_CHECK_EQUAL(objectsManager.getNumberPublishedObjects(), 1);
+  delete s2;
+  objectsManager.stopPublishing(s2);
+  BOOST_CHECK_EQUAL(objectsManager.getNumberPublishedObjects(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(getters_test)


### PR DESCRIPTION
Effectively, this allows to use stopPublishing on an object allocated on heap after it has been deleted, but still having the pointer, which may avoid some segmentation faults. Unfortunately, this will not avoid segfaults when re-registering an object, since then TObject::GetName has to be called as the only source of the object name.