### PR TITLE
ZDC: Implementation of QC Review suggestion

### DIFF
--- a/Modules/ZDC/etc/zdcTaskRawData.json
+++ b/Modules/ZDC/etc/zdcTaskRawData.json
@@ -23,7 +23,7 @@
       }
     },
     "tasks": {
-      "QcZDCRawTask": {
+      "Raw": {
         "active": "true",
         "className": "o2::quality_control_modules::zdc::ZDCRawDataTask",
         "moduleName": "QcZDC",
@@ -126,7 +126,7 @@
             },
             "dataSource": [{
               "type": "Task",
-              "name": "QcZDCRawTask",
+              "name": "Raw",
               "MOs": ["hpedSummary", "hAlignPlotShift", "herrorSummary"]
             }]
           }
@@ -142,7 +142,7 @@
         {
           "condition": "random",
           "fraction": "0.1",
-          "seed": "1234"
+          "seed": "0"
         }
       ],
       "blocking": "false"

--- a/Modules/ZDC/etc/zdcTaskRecData.json
+++ b/Modules/ZDC/etc/zdcTaskRecData.json
@@ -23,7 +23,7 @@
       }
     },
     "tasks": {
-      "QcZDCRecTask": {
+      "Rec": {
         "active": "true",
         "className": "o2::quality_control_modules::zdc::ZDCRecDataTask",
         "moduleName": "QcZDC",
@@ -36,15 +36,23 @@
         },
         "taskParameters": {
           "ADC": "3025;-100;12000",
+          "ADCZEM": "3025;-100;10000",
           "ADCH": "3025;-100;12000",
           "TDCT": "2400;-25;25",
           "TDCA": "2000;-0.5;3999.5",
+          "TDCAZEM": "2000;-0.5;2999.5",
           "TDCAH": "2000;-0.5;3999.5",
           "ADCSUMvsTC": "1210;-100;12000;1210;-100;12000",
+          "ADCZEMvsADCZEM": "1210;-100;12000;1210;-100;12000",
+          "ADCZEMvsTC": "1210;-100;12000;1210;-100;12000",
           "ADCvsTDCT": "240;-25;25;1210;-100;12000",
+          "ADCZEMvsTDCT": "240;-25;25;1210;-100;12000",
           "TDCDIFF": "240;-25;25;240;-25;25",
           "TDCAvsTDCT": "240;-25;25;1000;-0.5;3999.5",
+          "TDCAZEMvsTDCT": "240;-25;25;1000;-0.5;3999.5",
           "TDCAvsTDCA": "1000;-0.5;3999.5;1000;-0.5;3999.5",
+          "TDCAZEMvsTDCAZEM": "1000;-0.5;3999.5;1000;-0.5;3999.5",
+          "TDCAZEMvsTDCA": "1000;-0.5;3999.5;1000;-0.5;3999.5",
           "CENTR_ZNA": "200;-2;2;200;-2;2",
           "CENTR_ZNC": "200;-2;2;200;-2;2",
           "CENTR_ZPA": "2240;0;22.4",
@@ -65,7 +73,7 @@
         "dataSourcesADC": [
           {
             "type": "repository",
-            "path": "ZDC/MO/QcZDCRecTask",
+            "path": "ZDC/MO/Rec",
             "names": [
               "ZNAC:h_ADC_ZNA_TC",
               "ZNA1:h_ADC_ZNA_T1",
@@ -99,7 +107,7 @@
         "dataSourcesTDC": [
           {
             "type": "repository",
-            "path": "ZDC/MO/QcZDCRecTask",
+            "path": "ZDC/MO/Rec",
             "names": [
               "ZNAC:h_TDC_ZNA_TC_V",
               "ZNAS:h_TDC_ZNA_SUM_V",
@@ -118,7 +126,7 @@
           "userorcontrol"
         ],
         "updateTrigger": [
-          "newobject:qcdb:ZDC/MO/QcZDCRecTask/h_ADC_ZNA_TC"
+          "newobject:qcdb:ZDC/MO/Rec/h_ADC_ZNA_TC"
         ],
         "stopTrigger": [
           "userorcontrol"
@@ -192,7 +200,7 @@
         {
           "condition": "random",
           "fraction": "0.3",
-          "seed": "1441"
+          "seed": "0"
         }     
       ],
       "blocking": "false"

--- a/Modules/ZDC/include/ZDC/PostProcessingConfigZDC.h
+++ b/Modules/ZDC/include/ZDC/PostProcessingConfigZDC.h
@@ -41,12 +41,6 @@ struct PostProcessingConfigZDC : PostProcessingConfig {
     return (entry != parameters.end());
   }
 
-  template <typename T>
-  const T getParameter(std::string name) const;
-
-  template <typename T>
-  const T getParameter(std::string name, T defaultValue) const;
-
   struct DataSource {
     std::string path;
     std::string name;
@@ -56,32 +50,6 @@ struct PostProcessingConfigZDC : PostProcessingConfig {
   std::vector<DataSource> dataSourcesADC;
   std::vector<DataSource> dataSourcesTDC;
 };
-
-template <typename T>
-const T PostProcessingConfigZDC::getParameter(std::string name) const
-{
-  T result{};
-  auto entry = parameters.find(name);
-  if (entry != parameters.end()) {
-    std::istringstream istr(entry->second);
-    istr >> result;
-  }
-
-  return result;
-}
-
-template <typename T>
-const T PostProcessingConfigZDC::getParameter(std::string name, T defaultValue) const
-{
-  T result = defaultValue;
-  auto entry = parameters.find(name);
-  if (entry != parameters.end()) {
-    std::istringstream istr(entry->second);
-    istr >> result;
-  }
-
-  return result;
-}
 
 } // namespace o2::quality_control_modules::zdc
 

--- a/Modules/ZDC/include/ZDC/ZDCRecDataTask.h
+++ b/Modules/ZDC/include/ZDC/ZDCRecDataTask.h
@@ -18,8 +18,6 @@
 #define QC_MODULE_ZDC_ZDCZDCRECDATATASK_H
 
 #include "QualityControl/TaskInterface.h"
-#include "ZDCBase/Constants.h"
-#include "ZDCSimulation/ZDCSimParam.h"
 #include "DataFormatsZDC/BCRecData.h"
 #include "DataFormatsZDC/RecEventFlat.h"
 #include "DataFormatsZDC/ZDCEnergy.h"
@@ -29,7 +27,6 @@
 #include "ZDCSimulation/Digitizer.h"
 #include <TH1.h>
 #include <TH2.h>
-#include <map>
 #include <string>
 #include <vector>
 
@@ -41,7 +38,7 @@ namespace o2::quality_control_modules::zdc
 {
 
 /// \brief Quality Control ZDC Rec Task
-/// \author My Name
+/// \author Carlo Puggioni
 class ZDCRecDataTask final : public TaskInterface
 {
  public:
@@ -130,8 +127,6 @@ class ZDCRecDataTask final : public TaskInterface
   int fNumBinY = 0;
   double fMinBinY = 0;
   double fMaxBinY = 0;
-  int mIdhTDC = 0;
-  int mIdhADC = 0;
   // TH1F* mHistogram = nullptr;
 };
 

--- a/Modules/ZDC/src/PostProcessingConfigZDC.cxx
+++ b/Modules/ZDC/src/PostProcessingConfigZDC.cxx
@@ -66,28 +66,4 @@ PostProcessingConfigZDC::PostProcessingConfigZDC(std::string name, const boost::
   }
 }
 
-template <>
-const std::string PostProcessingConfigZDC::getParameter(std::string name) const
-{
-  std::string result;
-  auto entry = parameters.find(name);
-  if (entry != parameters.end()) {
-    result = entry->second;
-  }
-
-  return result;
-}
-
-template <>
-const std::string PostProcessingConfigZDC::getParameter(std::string name, std::string defaultValue) const
-{
-  std::string result = defaultValue;
-  auto entry = parameters.find(name);
-  if (entry != parameters.end()) {
-    result = entry->second;
-  }
-
-  return result;
-}
-
 } // namespace o2::quality_control_modules::zdc

--- a/Modules/ZDC/src/ZDCRawDataCheck.cxx
+++ b/Modules/ZDC/src/ZDCRawDataCheck.cxx
@@ -58,6 +58,10 @@ Quality ZDCRawDataCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
       if (mo->getName() == mVectHistoCheck.at(ih).nameHisto) {
         if ((mo->getName() == "hpedSummary")) {
           auto* h = dynamic_cast<TH1*>(mo->getObject());
+          if (h == nullptr) {
+            ILOG(Error, Support) << "could not cast hpedSummary to TH1*" << ENDM;
+            return Quality::Null;
+          }
           if ((int)h->GetNbinsX() != (int)mVectHistoCheck.at(ih).paramch.size()) {
             return Quality::Null;
           }
@@ -81,6 +85,10 @@ Quality ZDCRawDataCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
           int flag_ch_empty = 1;
           int flag_all_ch_empty = 1;
           auto* h = dynamic_cast<TH2*>(mo->getObject());
+          if (h == nullptr) {
+            ILOG(Error, Support) << "could not cast hAlignPlot to TH2*" << ENDM;
+            return Quality::Null;
+          }
           if ((int)h->GetNbinsX() != (int)mVectHistoCheck.at(ih).paramch.size()) {
             return Quality::Null;
           }
@@ -117,6 +125,10 @@ Quality ZDCRawDataCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
         if (mo->getName() == "herrorSummary") {
           int flag_ch_empty = 1;
           auto* h = dynamic_cast<TH2*>(mo->getObject());
+          if (h == nullptr) {
+            ILOG(Error, Support) << "could not cast herrorSummary to TH2*" << ENDM;
+            return Quality::Null;
+          }
           if ((int)h->GetNbinsX() != (int)mVectHistoCheck.at(ih).paramch.size()) {
             return Quality::Null;
           }
@@ -177,7 +189,10 @@ void ZDCRawDataCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkR
 
     if (mo->getName() == mVectHistoCheck.at(ih).nameHisto) {
       auto* h = dynamic_cast<TH1*>(mo->getObject());
-
+      if (h == nullptr) {
+        ILOG(Error, Support) << "could not cast '" << mo->getName() << "' to TH1*" << ENDM;
+        return;
+      }
       if (mVectHistoCheck.at(ih).quality == 1) {
         std::string errorSt = getCurrentDataTime() + " Ok";
         TLatex* msg = new TLatex(mVectHistoCheck.at(ih).posMsgX, mVectHistoCheck.at(ih).posMsgY, errorSt.c_str());

--- a/Modules/ZDC/src/ZDCRawDataTask.cxx
+++ b/Modules/ZDC/src/ZDCRawDataTask.cxx
@@ -20,7 +20,6 @@
 #include "QualityControl/QcInfoLogger.h"
 #include "ZDC/ZDCRawDataTask.h"
 #include <Framework/InputRecord.h>
-#include <Framework/InputRecordWalker.h>
 #include "DPLUtils/DPLRawParser.h"
 #include <TROOT.h>
 #include <TPad.h>
@@ -45,27 +44,17 @@ namespace o2::quality_control_modules::zdc
 
 ZDCRawDataTask::~ZDCRawDataTask()
 {
-  if (fFireChannel) {
-    delete fFireChannel;
-  }
-  if (fTrasmChannel) {
-    delete fTrasmChannel;
-  }
-  if (fSummaryPedestal) {
-    delete fSummaryPedestal;
-  }
-  if (fTriggerBits) {
-    delete fTriggerBits;
-  }
-  if (fTriggerBitsHits) {
-    delete fTriggerBitsHits;
-  }
-  if (fDataLoss) {
-    delete fDataLoss;
-  }
-  if (fOverBc) {
-    delete fOverBc;
-  }
+  delete fFireChannel;
+  delete fTrasmChannel;
+  delete fDataLoss;
+  delete fTriggerBits;
+  delete fTriggerBitsHits;
+  delete fSummaryPedestal;
+  delete fSummaryRate;
+  delete fSummaryAlign;
+  delete fSummaryAlignShift;
+  delete fSummaryError;
+  delete fOverBc;
 }
 
 void ZDCRawDataTask::initialize(o2::framework::InitContext& /*ctx*/)
@@ -103,11 +92,7 @@ void ZDCRawDataTask::monitorData(o2::framework::ProcessingContext& ctx)
     auto rdhPtr = reinterpret_cast<const o2::header::RDHAny*>(it.raw());
     if (rdhPtr == nullptr || !o2::raw::RDHUtils::checkRDH(rdhPtr, true)) {
       nErr[0]++;
-      /*if (nErr[0] < 5) {
-        LOG(warning) << "ZDCDataReaderDPLSpec::run - Missing RAWDataHeader on page " << count;
-      } else if (nErr[0] == 5) {
-        LOG(warning) << "ZDCDataReaderDPLSpec::run - Missing RAWDataHeader on page " << count << " suppressing further messages";
-      }*/
+
     } else {
       if (it.data() == nullptr) {
         nErr[1]++;
@@ -191,8 +176,8 @@ void ZDCRawDataTask::reset()
   if (fTrasmChannel) {
     fTrasmChannel->Reset();
   }
-  if (fSummaryPedestal) {
-    fSummaryPedestal->Reset();
+  if (fDataLoss) {
+    fDataLoss->Reset();
   }
   if (fTriggerBits) {
     fTriggerBits->Reset();
@@ -200,17 +185,23 @@ void ZDCRawDataTask::reset()
   if (fTriggerBitsHits) {
     fTriggerBitsHits->Reset();
   }
-  if (fDataLoss) {
-    fDataLoss->Reset();
-  }
-  if (fOverBc) {
-    fOverBc->Reset();
+  if (fSummaryPedestal) {
+    fSummaryPedestal->Reset();
   }
   if (fSummaryRate) {
     fSummaryRate->Reset();
   }
   if (fSummaryAlign) {
     fSummaryAlign->Reset();
+  }
+  if (fSummaryAlignShift) {
+    fSummaryAlignShift->Reset();
+  }
+  if (fSummaryError) {
+    fSummaryError->Reset();
+  }
+  if (fOverBc) {
+    fOverBc->Reset();
   }
 }
 
@@ -633,16 +624,16 @@ int ZDCRawDataTask::process(const o2::zdc::EventChData& ch)
         } else {
           s[i] = us[i];
         }
-        if ((fMatrixHistoSignal[f.board][f.ch].at(j).condHisto.at(0).compare("AoT") == 0) && (f.Alice_3 || f.Auto_3)) {
+        if ((fMatrixHistoSignal[f.board][f.ch].at(j).condHisto.at(0) == "AoT") && (f.Alice_3 || f.Auto_3)) {
           fMatrixHistoSignal[f.board][f.ch].at(j).histo->Fill(i - 36., double(s[i]));
         }
-        if ((fMatrixHistoSignal[f.board][f.ch].at(j).condHisto.at(0).compare("AoT") == 0) && (f.Alice_2 || f.Auto_2)) {
+        if ((fMatrixHistoSignal[f.board][f.ch].at(j).condHisto.at(0) == "AoT") && (f.Alice_2 || f.Auto_2)) {
           fMatrixHistoSignal[f.board][f.ch].at(j).histo->Fill(i - 24., double(s[i]));
         }
-        if ((fMatrixHistoSignal[f.board][f.ch].at(j).condHisto.at(0).compare("AoT") == 0) && (f.Alice_1 || f.Auto_1)) {
+        if ((fMatrixHistoSignal[f.board][f.ch].at(j).condHisto.at(0) == "AoT") && (f.Alice_1 || f.Auto_1)) {
           fMatrixHistoSignal[f.board][f.ch].at(j).histo->Fill(i - 12., double(s[i]));
         }
-        if ((fMatrixHistoSignal[f.board][f.ch].at(j).condHisto.at(0).compare("AoT") == 0) && (f.Alice_0 || f.Auto_0)) {
+        if ((fMatrixHistoSignal[f.board][f.ch].at(j).condHisto.at(0) == "AoT") && (f.Alice_0 || f.Auto_0)) {
           fMatrixHistoSignal[f.board][f.ch].at(j).histo->Fill(i + 0., double(s[i]));
           if (f.Auto_0) {
             fMatrixAlign[f.board][f.ch].minSample.vSamples[i].num_entry += 1;
@@ -753,13 +744,13 @@ int ZDCRawDataTask::process(const o2::zdc::EventChData& ch)
     double bc_d = uint32_t(f.bc / 100);
     double bc_m = uint32_t(f.bc % 100);
     for (int i = 0; i < (int)fMatrixHistoBunch[f.board][f.ch].size(); i++) {
-      if (fMatrixHistoBunch[f.board][f.ch].at(i).condHisto.at(0).compare("A0oT0") == 0) {
+      if (fMatrixHistoBunch[f.board][f.ch].at(i).condHisto.at(0) == "A0oT0") {
         fMatrixHistoBunch[f.board][f.ch].at(i).histo->Fill(bc_m, -bc_d);
       }
-      if (f.Alice_0 && fMatrixHistoBunch[f.board][f.ch].at(i).condHisto.at(0).compare("A0") == 0) {
+      if (f.Alice_0 && fMatrixHistoBunch[f.board][f.ch].at(i).condHisto.at(0) == "A0") {
         fMatrixHistoBunch[f.board][f.ch].at(i).histo->Fill(bc_m, -bc_d);
       }
-      if (f.Auto_0 && fMatrixHistoBunch[f.board][f.ch].at(i).condHisto.at(0).compare("T0") == 0) {
+      if (f.Auto_0 && fMatrixHistoBunch[f.board][f.ch].at(i).condHisto.at(0) == "T0") {
         fMatrixHistoBunch[f.board][f.ch].at(i).histo->Fill(bc_m, -bc_d);
       }
     }
@@ -853,7 +844,7 @@ void ZDCRawDataTask::setNameChannel(int imod, int ich, std::string namech, int b
 
 bool ZDCRawDataTask::getModAndCh(std::string chName, int* module, int* channel)
 {
-  if (chName.compare("NONE") == 0) {
+  if (chName == "NONE") {
     return true;
   }
   if (fMapChNameModCh.find(chName) != fMapChNameModCh.end()) {
@@ -897,7 +888,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
     TString hname = TString::Format("%s", name.c_str());
     TString htit = TString::Format("%s", title.c_str());
     // BASELINE
-    if (type.compare("BASELINE") == 0) {
+    if (type == "BASELINE") {
       // Check if Histogram Exist
       if (std::find(fNameHisto.begin(), fNameHisto.end(), name) == fNameHisto.end()) {
         fNameHisto.push_back(name);
@@ -928,7 +919,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
       }
     }
     // COUNTS
-    if (type.compare("COUNTS") == 0) {
+    if (type == "COUNTS") {
       // Check if Histogram Exist
       if (std::find(fNameHisto.begin(), fNameHisto.end(), name) == fNameHisto.end()) {
         fNameHisto.push_back(name);
@@ -959,7 +950,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
       }
     }
     // SIGNAL
-    if (type.compare("SIGNAL") == 0) {
+    if (type == "SIGNAL") {
       // Check if Histogram Exist
       if (std::find(fNameHisto.begin(), fNameHisto.end(), name) == fNameHisto.end()) {
         fNameHisto.push_back(name);
@@ -990,7 +981,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
       }
     }
     // BUNCH
-    if (type.compare("BUNCH") == 0) {
+    if (type == "BUNCH") {
       // Check if Histogram Exist
       if (std::find(fNameHisto.begin(), fNameHisto.end(), name) == fNameHisto.end()) {
         fNameHisto.push_back(name);
@@ -1023,7 +1014,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
       }
     }
 
-    if (type.compare("FIRECHANNEL") == 0) {
+    if (type == "FIRECHANNEL") {
       fFireChannel = new TH2I(hname, htit, fNumBinX, fMinBinX, fMaxBinX, fNumBinY, fMinBinY, fMaxBinY);
       fFireChannel->SetStats(0);
       getObjectsManager()->startPublishing(fFireChannel);
@@ -1035,7 +1026,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
         return false;
       }
     }
-    if (type.compare("DATALOSS") == 0) {
+    if (type == "DATALOSS") {
       fDataLoss = new TH2F(hname, htit, fNumBinX, fMinBinX, fMaxBinX, fNumBinY, fMinBinY, fMaxBinY);
       getObjectsManager()->startPublishing(fDataLoss);
       try {
@@ -1046,7 +1037,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
         return false;
       }
     }
-    if (type.compare("TRASMITTEDCHANNEL") == 0) {
+    if (type == "TRASMITTEDCHANNEL") {
       fTrasmChannel = new TH2I(hname, htit, fNumBinX, fMinBinX, fMaxBinX, fNumBinY, fMinBinY, fMaxBinY);
       fTrasmChannel->SetStats(0);
       getObjectsManager()->startPublishing(fTrasmChannel);
@@ -1058,7 +1049,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
         return false;
       }
     }
-    if (type.compare("TRIGGER_BIT") == 0) {
+    if (type == "TRIGGER_BIT") {
       fTriggerBits = new TH2F(hname, htit, fNumBinX, fMinBinX, fMaxBinX, fNumBinY, fMinBinY, fMaxBinY);
       fTriggerBits->GetYaxis()->SetBinLabel(10, "Alice_3");
       fTriggerBits->GetYaxis()->SetBinLabel(9, "Alice_2");
@@ -1085,7 +1076,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
         return false;
       }
     }
-    if (type.compare("TRIGGER_BIT_HIT") == 0) {
+    if (type == "TRIGGER_BIT_HIT") {
       fTriggerBitsHits = new TH2F(hname, htit, fNumBinX, fMinBinX, fMaxBinX, fNumBinY, fMinBinY, fMaxBinY);
       fTriggerBitsHits->GetYaxis()->SetBinLabel(10, "Alice_3");
       fTriggerBitsHits->GetYaxis()->SetBinLabel(9, "Alice_2");
@@ -1112,7 +1103,7 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
         return false;
       }
     }
-    if (type.compare("OVER_BC") == 0) {
+    if (type == "OVER_BC") {
       fOverBc = new TH1F(hname, htit, fNumBinX, fMinBinX, fMaxBinX);
       for (int im = 0; im < o2::zdc::NModules; im++) {
         for (int ic = 0; ic < o2::zdc::NChPerModule; ic++) {
@@ -1130,28 +1121,28 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
       }
     }
 
-    if ((type.compare("SUMMARYBASELINE") == 0) || (type.compare("SUMMARYRATE") == 0) || (type.compare("SUMMARY_ALIGN") == 0) || (type.compare("SUMMARY_ALIGN_SHIFT") == 0) || (type.compare("SUMMARY_ERROR") == 0)) {
-      if (type.compare("SUMMARYBASELINE") == 0) {
+    if ((type == "SUMMARYBASELINE") || (type == "SUMMARYRATE") || (type == "SUMMARY_ALIGN") || (type == "SUMMARY_ALIGN_SHIFT") || (type == "SUMMARY_ERROR")) {
+      if (type == "SUMMARYBASELINE") {
         fSummaryPedestal = new TH1F(hname, htit, fNumBinX, fMinBinX, fMaxBinX);
         fSummaryPedestal->GetXaxis()->LabelsOption("v");
         fSummaryPedestal->SetStats(0);
       }
-      if (type.compare("SUMMARYRATE") == 0) {
+      if (type == "SUMMARYRATE") {
         fSummaryRate = new TH1F(hname, htit, fNumBinX, fMinBinX, fMaxBinX);
         fSummaryRate->GetXaxis()->LabelsOption("v");
         fSummaryRate->SetStats(0);
       }
-      if (type.compare("SUMMARY_ALIGN") == 0) {
+      if (type == "SUMMARY_ALIGN") {
         fSummaryAlign = new TH2D(hname, htit, fNumBinX, fMinBinX, fMaxBinX, fNumBinY, fMinBinY, fMaxBinY);
         fSummaryAlign->GetXaxis()->LabelsOption("v");
         fSummaryAlign->SetStats(0);
       }
-      if (type.compare("SUMMARY_ALIGN_SHIFT") == 0) {
+      if (type == "SUMMARY_ALIGN_SHIFT") {
         fSummaryAlignShift = new TH2D(hname, htit, fNumBinX, fMinBinX, fMaxBinX, fNumBinY, fMinBinY, fMaxBinY);
         fSummaryAlignShift->GetXaxis()->LabelsOption("v");
         fSummaryAlignShift->SetStats(0);
       }
-      if (type.compare("SUMMARY_ERROR") == 0) {
+      if (type == "SUMMARY_ERROR") {
         fSummaryError = new TH2D(hname, htit, fNumBinX, fMinBinX, fMaxBinX, fNumBinY, fMinBinY, fMaxBinY);
         fSummaryError->GetXaxis()->LabelsOption("v");
         fSummaryError->SetStats(0);
@@ -1164,74 +1155,74 @@ bool ZDCRawDataTask::addNewHisto(std::string type, std::string name, std::string
             continue;
           } else {
             i++;
-            if (type.compare("SUMMARYBASELINE") == 0) {
+            if (type == "SUMMARYBASELINE") {
               fSummaryPedestal->GetXaxis()->SetBinLabel(i, TString::Format("%s", getNameChannel(imod, ich).c_str()));
             }
-            if (type.compare("SUMMARYRATE") == 0) {
+            if (type == "SUMMARYRATE") {
               fSummaryRate->GetXaxis()->SetBinLabel(i, TString::Format("%s", getNameChannel(imod, ich).c_str()));
             }
-            if (type.compare("SUMMARY_ERROR") == 0) {
+            if (type == "SUMMARY_ERROR") {
               fSummaryError->GetXaxis()->SetBinLabel(fMatrixAlign[imod][ich].bin, TString::Format("%s", fMatrixAlign[imod][ich].name_ch.c_str()));
             }
-            if (type.compare("SUMMARY_ALIGN") == 0) {
+            if (type == "SUMMARY_ALIGN") {
               fSummaryAlign->GetXaxis()->SetBinLabel(fMatrixAlign[imod][ich].bin, TString::Format("%s", fMatrixAlign[imod][ich].name_ch.c_str()));
             }
-            if (type.compare("SUMMARY_ALIGN_SHIFT") == 0) {
+            if (type == "SUMMARY_ALIGN_SHIFT") {
               fSummaryAlignShift->GetXaxis()->SetBinLabel(fMatrixAlign[imod][ich].bin, TString::Format("%s", fMatrixAlign[imod][ich].name_ch.c_str()));
             }
             fMapBinNameIdSummaryHisto.insert(std::pair<std::string, int>(chName, i));
           }
         }
       }
-      if (type.compare("SUMMARYBASELINE") == 0) {
+      if (type == "SUMMARYBASELINE") {
         getObjectsManager()->startPublishing(fSummaryPedestal);
       }
-      if (type.compare("SUMMARYRATE") == 0) {
+      if (type == "SUMMARYRATE") {
         getObjectsManager()->startPublishing(fSummaryRate);
       }
-      if (type.compare("SUMMARY_ALIGN") == 0) {
+      if (type == "SUMMARY_ALIGN") {
         getObjectsManager()->startPublishing(fSummaryAlign);
       }
-      if (type.compare("SUMMARY_ALIGN_SHIFT") == 0) {
+      if (type == "SUMMARY_ALIGN_SHIFT") {
         getObjectsManager()->startPublishing(fSummaryAlignShift);
       }
-      if (type.compare("SUMMARY_ERROR") == 0) {
+      if (type == "SUMMARY_ERROR") {
         fSummaryError->GetYaxis()->SetBinLabel(1, TString::Format("Bit Error"));
         fSummaryError->GetYaxis()->SetBinLabel(2, TString::Format("Data Loss"));
         fSummaryError->GetYaxis()->SetBinLabel(3, TString::Format("Data Corrupted"));
         getObjectsManager()->startPublishing(fSummaryError);
       }
       try {
-        if (type.compare("SUMMARYBASELINE") == 0) {
+        if (type == "SUMMARYBASELINE") {
           getObjectsManager()->addMetadata(fSummaryPedestal->GetName(), fSummaryPedestal->GetName(), "34");
         }
-        if (type.compare("SUMMARYRATE") == 0) {
+        if (type == "SUMMARYRATE") {
           getObjectsManager()->addMetadata(fSummaryRate->GetName(), fSummaryRate->GetName(), "34");
         }
-        if (type.compare("SUMMARY_ALIGN") == 0) {
+        if (type == "SUMMARY_ALIGN") {
           getObjectsManager()->addMetadata(fSummaryAlign->GetName(), fSummaryAlign->GetName(), "34");
         }
-        if (type.compare("SUMMARY_ALIGN_SHIFT") == 0) {
+        if (type == "SUMMARY_ALIGN_SHIFT") {
           getObjectsManager()->addMetadata(fSummaryAlign->GetName(), fSummaryAlignShift->GetName(), "34");
         }
-        if (type.compare("SUMMARY_ERROR") == 0) {
+        if (type == "SUMMARY_ERROR") {
           getObjectsManager()->addMetadata(fSummaryError->GetName(), fSummaryError->GetName(), "34");
         }
         return true;
       } catch (...) {
-        if (type.compare("SUMMARYBASELINE") == 0) {
+        if (type == "SUMMARYBASELINE") {
           ILOG(Warning, Support) << "Metadata could not be added to " << fSummaryPedestal->GetName() << ENDM;
         }
-        if (type.compare("SUMMARYRATE") == 0) {
+        if (type == "SUMMARYRATE") {
           ILOG(Warning, Support) << "Metadata could not be added to " << fSummaryRate->GetName() << ENDM;
         }
-        if (type.compare("SUMMARY_ERROR") == 0) {
+        if (type == "SUMMARY_ERROR") {
           ILOG(Warning, Support) << "Metadata could not be added to " << fSummaryError->GetName() << ENDM;
         }
-        if (type.compare("SUMMARY_ALIGN") == 0) {
+        if (type == "SUMMARY_ALIGN") {
           ILOG(Warning, Support) << "Metadata could not be added to " << fSummaryAlign->GetName() << ENDM;
         }
-        if (type.compare("SUMMARY_ALIGN_SHIFT") == 0) {
+        if (type == "SUMMARY_ALIGN_SHIFT") {
           ILOG(Warning, Support) << "Metadata could not be added to " << fSummaryAlignShift->GetName() << ENDM;
         }
         return false;
@@ -1310,40 +1301,40 @@ bool ZDCRawDataTask::decodeConfLine(std::vector<std::string> TokenString, int Li
     return decodeModule(TokenString, LineNumber);
   }
   // Bin Histograms
-  if (TokenString.at(0).compare("BIN") == 0) {
+  if (TokenString.at(0) == "BIN") {
     return decodeBinHistogram(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("BASELINE") == 0) {
+  if (TokenString.at(0) == "BASELINE") {
     return decodeBaseline(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("COUNTS") == 0) {
+  if (TokenString.at(0) == "COUNTS") {
     return decodeCounts(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("SIGNAL") == 0) {
+  if (TokenString.at(0) == "SIGNAL") {
     return decodeSignal(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("BUNCH") == 0) {
+  if (TokenString.at(0) == "BUNCH") {
     return decodeBunch(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("TRASMITTEDCHANNEL") == 0) {
+  if (TokenString.at(0) == "TRASMITTEDCHANNEL") {
     return decodeTrasmittedChannel(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("FIRECHANNEL") == 0) {
+  if (TokenString.at(0) == "FIRECHANNEL") {
     return decodeFireChannel(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("DATALOSS") == 0) {
+  if (TokenString.at(0) == "DATALOSS") {
     return decodeDataLoss(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("TRIGGER_BIT") == 0) {
+  if (TokenString.at(0) == "TRIGGER_BIT") {
     return decodeTriggerBitChannel(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("TRIGGER_BIT_HIT") == 0) {
+  if (TokenString.at(0) == "TRIGGER_BIT_HIT") {
     return decodeTriggerBitHitChannel(TokenString, LineNumber);
   }
-  if (TokenString.at(0).compare("OVER_BC") == 0) {
+  if (TokenString.at(0) == "OVER_BC") {
     return decodeOverBc(TokenString, LineNumber);
   }
-  if ((TokenString.at(0).compare("SUMMARYBASELINE") == 0) || (TokenString.at(0).compare("SUMMARYRATE") == 0)) {
+  if ((TokenString.at(0) == "SUMMARYBASELINE") || (TokenString.at(0) == "SUMMARYRATE")) {
     return decodeSummary(TokenString, LineNumber);
   }
   ILOG(Error, Support) << TString::Format("ERROR Line number %d Key word %s does not exist.", LineNumber, TokenString.at(0).c_str()) << ENDM;
@@ -1519,25 +1510,25 @@ bool ZDCRawDataTask::decodeSummary(std::vector<std::string> TokenString, int Lin
 bool ZDCRawDataTask::checkCondition(std::string cond)
 {
 
-  if (cond.compare("A0") == 0) {
+  if (cond == "A0") {
     return true; // Alice Trigger 0
   }
-  if (cond.compare("T0") == 0) {
+  if (cond == "T0") {
     return true; // Auto Trigger 0
   }
-  if (cond.compare("A0eT0") == 0) {
+  if (cond == "A0eT0") {
     return true; // Alice Trigger 0 AND Auto Trigger 0
   }
-  if (cond.compare("A0oT0") == 0) {
+  if (cond == "A0oT0") {
     return true; // Alice Trigger 0 OR Auto Trigger 0
   }
-  if (cond.compare("AoT") == 0) {
+  if (cond == "AoT") {
     return true; // Alice Trigger 0 OR Auto Trigger 0
   }
-  if (cond.compare("LBC") == 0) {
+  if (cond == "LBC") {
     return true; // Last BC
   }
-  if (cond.compare("ALL") == 0) {
+  if (cond == "ALL") {
     return true; // no trigger
   }
   return false;

--- a/Modules/ZDC/src/ZDCRecDataCheck.cxx
+++ b/Modules/ZDC/src/ZDCRecDataCheck.cxx
@@ -57,6 +57,10 @@ Quality ZDCRecDataCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
     (void)moName;
     if (mo->getName() == "h_summary_ADC") {
       auto* h = dynamic_cast<TH1F*>(mo->getObject());
+      if (h == nullptr) {
+        ILOG(Error, Support) << "could not cast '" << mo->getName() << "' to TH1*" << ENDM;
+        return Quality::Null;
+      }
       // dumpVecParam((int)h->GetNbinsX(),(int)mVectParamADC.size());
       if ((int)h->GetNbinsX() != (int)mVectParamADC.size()) {
         return Quality::Null;
@@ -90,6 +94,10 @@ Quality ZDCRecDataCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
     mStringETDC = "";
     if (mo->getName() == "h_summary_TDC") {
       auto* h = dynamic_cast<TH1F*>(mo->getObject());
+      if (h == nullptr) {
+        ILOG(Error, Support) << "could not cast '" << mo->getName() << "' to TH1*" << ENDM;
+        return Quality::Null;
+      }
       // dumpVecParam((int)h->GetNbinsX(),(int)mVectParamTDC.size());
       if ((int)h->GetNbinsX() != (int)mVectParamTDC.size()) {
         return Quality::Null;
@@ -176,6 +184,10 @@ void ZDCRecDataCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkR
 void ZDCRecDataCheck::setQualityInfo(std::shared_ptr<MonitorObject> mo, int color, std::string text)
 {
   auto* h = dynamic_cast<TH1F*>(mo->getObject());
+  if (h == nullptr) {
+    ILOG(Error, Support) << "could not cast '" << mo->getName() << "' to TH1*" << ENDM;
+    return;
+  }
   TLatex* msg = new TLatex(mPosMsgADCX, mPosMsgADCY, text.c_str());
   msg->SetNDC();
   msg->SetTextSize(16);
@@ -258,10 +270,10 @@ void ZDCRecDataCheck::setChName(std::string channel, std::string type)
 {
   sCheck chCheck;
   chCheck.ch = channel;
-  if (type.compare("ADC") == 0) {
+  if (type == "ADC") {
     mVectParamADC.push_back(chCheck);
   }
-  if (type.compare("TDC") == 0) {
+  if (type == "TDC") {
     mVectParamTDC.push_back(chCheck);
   }
 }
@@ -269,7 +281,7 @@ void ZDCRecDataCheck::setChName(std::string channel, std::string type)
 void ZDCRecDataCheck::setChCheck(int index, std::string type)
 {
   std::vector<std::string> tokenString;
-  if (type.compare("ADC") == 0 && index < (int)mVectParamADC.size()) {
+  if (type == "ADC" && index < (int)mVectParamADC.size()) {
     if (const auto param = mCustomParameters.find(mVectParamADC.at(index).ch); param != mCustomParameters.end()) {
       tokenString = tokenLine(param->second, ";");
 
@@ -279,7 +291,7 @@ void ZDCRecDataCheck::setChCheck(int index, std::string type)
       mVectParamADC.at(index).maxE = atof(tokenString.at(0).c_str()) + atof(tokenString.at(2).c_str());
     }
   }
-  if (type.compare("TDC") == 0 && index < (int)mVectParamTDC.size()) {
+  if (type == "TDC" && index < (int)mVectParamTDC.size()) {
     if (const auto param = mCustomParameters.find(mVectParamTDC.at(index).ch); param != mCustomParameters.end()) {
       tokenString = tokenLine(param->second, ";");
 

--- a/Modules/ZDC/src/ZDCRecDataTask.cxx
+++ b/Modules/ZDC/src/ZDCRecDataTask.cxx
@@ -501,7 +501,7 @@ void ZDCRecDataTask::initHisto()
   addNewHisto("TDC_A_A", "h_TDC_ZPC_ZEM2", "ZNC TDC amplitude vs ZEM2 TDC amplitude", "TDCA", "ZEM2", "TDCA", "ZPCC", 0);
 
   // msg histo
-  setBinHisto2D(o2::zdc::NChannels, -0.5, o2::zdc::NChannels - 0.5, o2::zdc::MsgEnd, -0.5, o2::zdc::MsgEnd - 0.5);
+  setBinHisto2D(26, -0.5, 26.0 - 0.5, 19, -0.5, 19.0 - 0.5);
   addNewHisto("MSG_REC", "h_msg", "Reconstruction messages", "INFO", "CH", "INFO", "MSG", 0);
   int idh_msg = (int)mHisto2D.size() - 1;
   mHisto2D.at(idh_msg).histo->SetStats(0);

--- a/Modules/ZDC/src/ZDCRecDataTask.cxx
+++ b/Modules/ZDC/src/ZDCRecDataTask.cxx
@@ -20,7 +20,6 @@
 #include "QualityControl/QcInfoLogger.h"
 #include "ZDC/ZDCRecDataTask.h"
 #include <Framework/InputRecord.h>
-#include <Framework/InputRecordWalker.h>
 #include <Framework/DataRefUtils.h>
 #include <fairlogger/Logger.h>
 #include <stdio.h>
@@ -28,19 +27,15 @@
 #include <iostream>
 #include <fstream>
 #include <ctype.h>
-#include <boost/algorithm/string.hpp>
 #include <gsl/span>
 #include <vector>
-#include "DataFormatsZDC/BCData.h"
-#include "DataFormatsZDC/ChannelData.h"
-#include "DataFormatsZDC/OrbitData.h"
-#include "DataFormatsZDC/RecEvent.h"
-#include "ZDCBase/ModuleConfig.h"
+#include "ZDCBase/Constants.h"
 #include "CommonUtils/NameConf.h"
 #include "ZDCReconstruction/RecoConfigZDC.h"
 #include "ZDCReconstruction/ZDCEnergyParam.h"
 #include "ZDCReconstruction/ZDCTowerParam.h"
 #include "DataFormatsZDC/RecEventFlat.h"
+#include "ZDCSimulation/ZDCSimParam.h"
 
 using namespace o2::zdc;
 namespace o2::quality_control_modules::zdc
@@ -59,12 +54,12 @@ void ZDCRecDataTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Debug, Devel) << "initialize ZDCRecDataTask" << ENDM; // QcInfoLogger is used. FairMQ logs will go to there as well.
   init();
-  reset();
 }
 
 void ZDCRecDataTask::startOfActivity(const Activity& activity)
 {
   ILOG(Debug, Devel) << "startOfActivity " << activity.mId << ENDM;
+  reset();
 }
 
 void ZDCRecDataTask::startOfCycle()
@@ -237,36 +232,42 @@ void ZDCRecDataTask::initHisto()
   } else {
     setBinHisto1D(1051, -202.5, 4002.5);
   }
-  addNewHisto("ADC1D", "h_ADC_ZNA_TC", "ADC ZNA TC (Gev)", "ADC", "ZNAC", "", "", 1);
-  addNewHisto("ADC1D", "h_ADC_ZNA_T1", "ADC ZNA T1 (Gev)", "ADC", "ZNA1", "", "", 2);
-  addNewHisto("ADC1D", "h_ADC_ZNA_T2", "ADC ZNA T2 (Gev)", "ADC", "ZNA2", "", "", 3);
-  addNewHisto("ADC1D", "h_ADC_ZNA_T3", "ADC ZNA T3 (Gev)", "ADC", "ZNA3", "", "", 4);
-  addNewHisto("ADC1D", "h_ADC_ZNA_T4", "ADC ZNA T4 (Gev)", "ADC", "ZNA4", "", "", 5);
-  addNewHisto("ADC1D", "h_ADC_ZNA_SUM", "ADC ZNA SUM (Gev)", "ADC", "ZNAS", "", "", 6);
+  addNewHisto("ADC1D", "h_ADC_ZNA_TC", "ADC ZNA TC ", "ADC", "ZNAC", "", "", 1);
+  addNewHisto("ADC1D", "h_ADC_ZNA_T1", "ADC ZNA T1 ", "ADC", "ZNA1", "", "", 2);
+  addNewHisto("ADC1D", "h_ADC_ZNA_T2", "ADC ZNA T2 ", "ADC", "ZNA2", "", "", 3);
+  addNewHisto("ADC1D", "h_ADC_ZNA_T3", "ADC ZNA T3 ", "ADC", "ZNA3", "", "", 4);
+  addNewHisto("ADC1D", "h_ADC_ZNA_T4", "ADC ZNA T4 ", "ADC", "ZNA4", "", "", 5);
+  addNewHisto("ADC1D", "h_ADC_ZNA_SUM", "ADC ZNA SUM ", "ADC", "ZNAS", "", "", 6);
 
-  addNewHisto("ADC1D", "h_ADC_ZPA_TC", "ADC ZPA TC (Gev)", "ADC", "ZPAC", "", "", 7);
-  addNewHisto("ADC1D", "h_ADC_ZPA_T1", "ADC ZPA T1 (Gev)", "ADC", "ZPA1", "", "", 8);
-  addNewHisto("ADC1D", "h_ADC_ZPA_T2", "ADC ZPA T2 (Gev)", "ADC", "ZPA2", "", "", 9);
-  addNewHisto("ADC1D", "h_ADC_ZPA_T3", "ADC ZPA T3 (Gev)", "ADC", "ZPA3", "", "", 10);
-  addNewHisto("ADC1D", "h_ADC_ZPA_T4", "ADC ZPA T4 (Gev)", "ADC", "ZPA4", "", "", 11);
-  addNewHisto("ADC1D", "h_ADC_ZPA_SUM", "ADC ZPA SUM (Gev)", "ADC", "ZPAS", "", "", 12);
+  addNewHisto("ADC1D", "h_ADC_ZPA_TC", "ADC ZPA TC ", "ADC", "ZPAC", "", "", 7);
+  addNewHisto("ADC1D", "h_ADC_ZPA_T1", "ADC ZPA T1 ", "ADC", "ZPA1", "", "", 8);
+  addNewHisto("ADC1D", "h_ADC_ZPA_T2", "ADC ZPA T2 ", "ADC", "ZPA2", "", "", 9);
+  addNewHisto("ADC1D", "h_ADC_ZPA_T3", "ADC ZPA T3 ", "ADC", "ZPA3", "", "", 10);
+  addNewHisto("ADC1D", "h_ADC_ZPA_T4", "ADC ZPA T4 ", "ADC", "ZPA4", "", "", 11);
+  addNewHisto("ADC1D", "h_ADC_ZPA_SUM", "ADC ZPA SUM ", "ADC", "ZPAS", "", "", 12);
 
-  addNewHisto("ADC1D", "h_ADC_ZNC_TC", "ADC ZNC TC (Gev)", "ADC", "ZNCC", "", "", 15);
-  addNewHisto("ADC1D", "h_ADC_ZNC_T1", "ADC ZNC T1 (Gev)", "ADC", "ZNC1", "", "", 16);
-  addNewHisto("ADC1D", "h_ADC_ZNC_T2", "ADC ZNC T2 (Gev)", "ADC", "ZNC2", "", "", 17);
-  addNewHisto("ADC1D", "h_ADC_ZNC_T3", "ADC ZNC T3 (Gev)", "ADC", "ZNC3", "", "", 18);
-  addNewHisto("ADC1D", "h_ADC_ZNC_T4", "ADC ZNC T4 (Gev)", "ADC", "ZNC4", "", "", 19);
-  addNewHisto("ADC1D", "h_ADC_ZNC_SUM", "ADC ZNC SUM (Gev)", "ADC", "ZNCS", "", "", 20);
+  addNewHisto("ADC1D", "h_ADC_ZNC_TC", "ADC ZNC TC ", "ADC", "ZNCC", "", "", 15);
+  addNewHisto("ADC1D", "h_ADC_ZNC_T1", "ADC ZNC T1 ", "ADC", "ZNC1", "", "", 16);
+  addNewHisto("ADC1D", "h_ADC_ZNC_T2", "ADC ZNC T2 ", "ADC", "ZNC2", "", "", 17);
+  addNewHisto("ADC1D", "h_ADC_ZNC_T3", "ADC ZNC T3 ", "ADC", "ZNC3", "", "", 18);
+  addNewHisto("ADC1D", "h_ADC_ZNC_T4", "ADC ZNC T4 ", "ADC", "ZNC4", "", "", 19);
+  addNewHisto("ADC1D", "h_ADC_ZNC_SUM", "ADC ZNC SUM ", "ADC", "ZNCS", "", "", 20);
 
-  addNewHisto("ADC1D", "h_ADC_ZPC_TC", "ADC ZPC TC (Gev)", "ADC", "ZPCC", "", "", 21);
-  addNewHisto("ADC1D", "h_ADC_ZPC_T1", "ADC ZPC T1 (Gev)", "ADC", "ZPC1", "", "", 22);
-  addNewHisto("ADC1D", "h_ADC_ZPC_T2", "ADC ZPC T2 (Gev)", "ADC", "ZPC2", "", "", 23);
-  addNewHisto("ADC1D", "h_ADC_ZPC_T3", "ADC ZPC T3 (Gev)", "ADC", "ZPC3", "", "", 24);
-  addNewHisto("ADC1D", "h_ADC_ZPC_T4", "ADC ZPC T4 (Gev)", "ADC", "ZPC4", "", "", 25);
-  addNewHisto("ADC1D", "h_ADC_ZPC_SUM", "ADC ZPC SUM (Gev)", "ADC", "ZPCS", "", "", 26);
-
-  addNewHisto("ADC1D", "h_ADC_ZEM1", "ADC ZEM1 (Gev)", "ADC", "ZEM1", "", "", 13);
-  addNewHisto("ADC1D", "h_ADC_ZEM2", "ADC ZEM2 (Gev)", "ADC", "ZEM2", "", "", 14);
+  addNewHisto("ADC1D", "h_ADC_ZPC_TC", "ADC ZPC TC ", "ADC", "ZPCC", "", "", 21);
+  addNewHisto("ADC1D", "h_ADC_ZPC_T1", "ADC ZPC T1 ", "ADC", "ZPC1", "", "", 22);
+  addNewHisto("ADC1D", "h_ADC_ZPC_T2", "ADC ZPC T2 ", "ADC", "ZPC2", "", "", 23);
+  addNewHisto("ADC1D", "h_ADC_ZPC_T3", "ADC ZPC T3 ", "ADC", "ZPC3", "", "", 24);
+  addNewHisto("ADC1D", "h_ADC_ZPC_T4", "ADC ZPC T4 ", "ADC", "ZPC4", "", "", 25);
+  addNewHisto("ADC1D", "h_ADC_ZPC_SUM", "ADC ZPC SUM ", "ADC", "ZPCS", "", "", 26);
+  if (auto param = mCustomParameters.find("ADCZEM"); param != mCustomParameters.end()) {
+    ILOG(Debug, Devel) << "Custom parameter - ADCZEM: " << param->second << ENDM;
+    tokenString = tokenLine(param->second, ";");
+    setBinHisto1D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()));
+  } else {
+    setBinHisto1D(1051, -202.5, 4002.5);
+  }
+  addNewHisto("ADC1D", "h_ADC_ZEM1", "ADC ZEM1 ", "ADC", "ZEM1", "", "", 13);
+  addNewHisto("ADC1D", "h_ADC_ZEM2", "ADC ZEM2 ", "ADC", "ZEM2", "", "", 14);
 
   if (auto param = mCustomParameters.find("ADCH"); param != mCustomParameters.end()) {
     ILOG(Debug, Devel) << "Custom parameter - ADCH: " << param->second << ENDM;
@@ -275,14 +276,14 @@ void ZDCRecDataTask::initHisto()
   } else {
     setBinHisto1D(1051, -202.5, 4002.5);
   }
-  addNewHisto("ADC1D", "h_ADC_ZNA_TC_H", "ADC ZNA TC (Gev) ZOOM", "ADC", "ZNAC", "", "", 0);
-  addNewHisto("ADC1D", "h_ADC_ZNA_SUM_H", "ADC ZNA SUM (Gev) ZOOM", "ADC", "ZNAS", "", "", 0);
-  addNewHisto("ADC1D", "h_ADC_ZPA_TC_H", "ADC ZPA TC (Gev) ZOOM", "ADC", "ZPAC", "", "", 0);
-  addNewHisto("ADC1D", "h_ADC_ZPA_SUM_H", "ADC ZPA SUM (Gev) ZOOM", "ADC", "ZPAS", "", "", 0);
-  addNewHisto("ADC1D", "h_ADC_ZNC_TC_H", "ADC ZNC TC (Gev) ZOOM", "ADC", "ZNCC", "", "", 0);
-  addNewHisto("ADC1D", "h_ADC_ZNC_SUM_H", "ADC ZNC SUM (Gev) ZOOM", "ADC", "ZNCS", "", "", 0);
-  addNewHisto("ADC1D", "h_ADC_ZPC_TC_H", "ADC ZPC TC (Gev) ZOOM", "ADC", "ZPCC", "", "", 0);
-  addNewHisto("ADC1D", "h_ADC_ZPC_SUM_H", "ADC ZPC SUM (Gev) ZOOM", "ADC", "ZPCS", "", "", 0);
+  addNewHisto("ADC1D", "h_ADC_ZNA_TC_H", "ADC ZNA TC ZOOM", "ADC", "ZNAC", "", "", 0);
+  addNewHisto("ADC1D", "h_ADC_ZNA_SUM_H", "ADC ZNA SUM ZOOM", "ADC", "ZNAS", "", "", 0);
+  addNewHisto("ADC1D", "h_ADC_ZPA_TC_H", "ADC ZPA TC ZOOM", "ADC", "ZPAC", "", "", 0);
+  addNewHisto("ADC1D", "h_ADC_ZPA_SUM_H", "ADC ZPA SUM ZOOM", "ADC", "ZPAS", "", "", 0);
+  addNewHisto("ADC1D", "h_ADC_ZNC_TC_H", "ADC ZNC TC ZOOM", "ADC", "ZNCC", "", "", 0);
+  addNewHisto("ADC1D", "h_ADC_ZNC_SUM_H", "ADC ZNC SUM ZOOM", "ADC", "ZNCS", "", "", 0);
+  addNewHisto("ADC1D", "h_ADC_ZPC_TC_H", "ADC ZPC TC ZOOM", "ADC", "ZPCC", "", "", 0);
+  addNewHisto("ADC1D", "h_ADC_ZPC_SUM_H", "ADC ZPC SUM ZOOM", "ADC", "ZPCS", "", "", 0);
 
   if (auto param = mCustomParameters.find("TDCT"); param != mCustomParameters.end()) {
     ILOG(Debug, Devel) << "Custom parameter - TDCT: " << param->second << ENDM;
@@ -317,10 +318,17 @@ void ZDCRecDataTask::initHisto()
   addNewHisto("TDC1D", "h_TDC_ZNC_SUM_A", "TDC Amplitude ZNC SUM", "TDCA", "ZNCS", "", "", 0);
   addNewHisto("TDC1D", "h_TDC_ZPC_TC_A", "TDC Amplitude ZPC TC", "TDCA", "ZPCC", "", "", 0);
   addNewHisto("TDC1D", "h_TDC_ZPC_SUM_A", "TDC Amplitude ZPC SUM", "TDCA", "ZPCS", "", "", 0);
+  if (auto param = mCustomParameters.find("TDCAZEM"); param != mCustomParameters.end()) {
+    ILOG(Debug, Devel) << "Custom parameter - TDCAZEM: " << param->second << ENDM;
+    tokenString = tokenLine(param->second, ";");
+    setBinHisto1D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()));
+  } else {
+    setBinHisto1D(2000, -0.5, 3999.5);
+  }
   addNewHisto("TDC1D", "h_TDC_ZEM1_A", "TDC Amplitude ZEM1", "TDCA", "ZEM1", "", "", 0);
   addNewHisto("TDC1D", "h_TDC_ZEM2_A", "TDC Amplitude ZEM2", "TDCA", "ZEM2", "", "", 0);
   // TDC_A ZOOM
-  if (auto param = mCustomParameters.find("ADCH"); param != mCustomParameters.end()) {
+  if (auto param = mCustomParameters.find("TDCAH"); param != mCustomParameters.end()) {
     ILOG(Debug, Devel) << "Custom parameter - TDCAH: " << param->second << ENDM;
     tokenString = tokenLine(param->second, ";");
     setBinHisto1D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()));
@@ -363,19 +371,37 @@ void ZDCRecDataTask::initHisto()
   } else {
     setBinHisto2D(1051, -202.5, 4002.5, 1051, -202.5, 4002.5);
   }
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZNAS_ZNAC", "ADC (Gev) ZNA SUM vs ADC (Gev) ZNA TC", "ADC", "ZNAC", "ADC", "ZNAS", 0);
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZPAS_ZPAC", "ADC (Gev) ZPA SUM vs ADC (Gev) ZPA TC", "ADC", "ZPAC", "ADC", "ZPAS", 0);
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZNCS_ZNCC", "ADC (Gev) ZNC SUM vs ADC (Gev) ZNC TC", "ADC", "ZNCC", "ADC", "ZNCS", 0);
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZPCS_ZPCC", "ADC (Gev) ZPC SUM vs ADC (Gev) ZPC TC", "ADC", "ZPCC", "ADC", "ZPCS", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNAS_ZNAC", "ADC  ZNA SUM vs ADC  ZNA TC", "ADC", "ZNAC", "ADC", "ZNAS", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZPAS_ZPAC", "ADC  ZPA SUM vs ADC  ZPA TC", "ADC", "ZPAC", "ADC", "ZPAS", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNCS_ZNCC", "ADC  ZNC SUM vs ADC  ZNC TC", "ADC", "ZNCC", "ADC", "ZNCS", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZPCS_ZPCC", "ADC  ZPC SUM vs ADC  ZPC TC", "ADC", "ZPCC", "ADC", "ZPCS", 0);
 
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZNAC_ZPAC", "ADC (Gev) ZNA TC vs ADC (Gev) ZPA TC", "ADC", "ZPAC", "ADC", "ZNAC", 0);
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZNCC_ZPCC", "ADC (Gev) ZNC TC vs ADC (Gev) ZPC TC", "ADC", "ZPCC", "ADC", "ZNCC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNAC_ZPAC", "ADC  ZNA TC vs ADC  ZPA TC", "ADC", "ZPAC", "ADC", "ZNAC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNCC_ZPCC", "ADC  ZNC TC vs ADC  ZPC TC", "ADC", "ZPCC", "ADC", "ZNCC", 0);
+  if (auto param = mCustomParameters.find("ADCZEMvsADCZEM"); param != mCustomParameters.end()) {
+    ILOG(Debug, Devel) << "Custom parameter - ADCZEMvsADCZEM: " << param->second << ENDM;
+    tokenString = tokenLine(param->second, ";");
+    setBinHisto2D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()), atoi(tokenString.at(3).c_str()), atof(tokenString.at(4).c_str()), atof(tokenString.at(5).c_str()));
+  } else {
+    setBinHisto2D(1051, -202.5, 4002.5, 1051, -202.5, 4002.5);
+  }
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZEM1_ZEM2", "ADC  ZEM1 vs ADC  ZEM2", "ADC", "ZEM2", "ADC", "ZEM1", 0);
+  if (auto param = mCustomParameters.find("ADCZEMvsTC"); param != mCustomParameters.end()) {
+    ILOG(Debug, Devel) << "Custom parameter - ADCZEMvsTC: " << param->second << ENDM;
+    tokenString = tokenLine(param->second, ";");
+    setBinHisto2D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()), atoi(tokenString.at(3).c_str()), atof(tokenString.at(4).c_str()), atof(tokenString.at(5).c_str()));
+  } else {
+    setBinHisto2D(1051, -202.5, 4002.5, 1051, -202.5, 4002.5);
+  }
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNA_ZEM1", "ADC  ZNA TC vs ADC  ZEM1", "ADC", "ZEM1", "ADC", "ZNAC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNA_ZEM2", "ADC  ZNA TC vs ADC  ZEM2", "ADC", "ZEM2", "ADC", "ZNAC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNC_ZEM1", "ADC  ZNC TC vs ADC  ZEM1", "ADC", "ZEM1", "ADC", "ZNCC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNC_ZEM2", "ADC  ZNC TC vs ADC  ZEM2", "ADC", "ZEM2", "ADC", "ZNCC", 0);
 
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZEM1_ZEM2", "ADC (Gev) ZEM1 vs ADC (Gev) ZEM2", "ADC", "ZEM2", "ADC", "ZEM1", 0);
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZNA_ZEM1", "ADC (Gev) ZNA TC vs ADC (Gev) ZEM1", "ADC", "ZEM1", "ADC", "ZNAC", 0);
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZNA_ZEM2", "ADC (Gev) ZNA TC vs ADC (Gev) ZEM2", "ADC", "ZEM2", "ADC", "ZNAC", 0);
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZNC_ZEM1", "ADC (Gev) ZNC TC vs ADC (Gev) ZEM1", "ADC", "ZEM1", "ADC", "ZNCC", 0);
-  addNewHisto("ADCSUMvsTC", "h_ADC_ZNC_ZEM2", "ADC (Gev) ZNC TC vs ADC (Gev) ZEM2", "ADC", "ZEM2", "ADC", "ZNCC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNA_ZEM1", "ADC  ZPA TC vs ADC  ZEM1", "ADC", "ZEM1", "ADC", "ZPAC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNA_ZEM2", "ADC  ZPA TC vs ADC  ZEM2", "ADC", "ZEM2", "ADC", "ZPAC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNC_ZEM1", "ADC  ZPC TC vs ADC  ZEM1", "ADC", "ZEM1", "ADC", "ZPCC", 0);
+  addNewHisto("ADCSUMvsTC", "h_ADC_ZNC_ZEM2", "ADC  ZPC TC vs ADC  ZEM2", "ADC", "ZEM2", "ADC", "ZPCC", 0);
 
   if (auto param = mCustomParameters.find("ADCvsTDCT"); param != mCustomParameters.end()) {
     ILOG(Debug, Devel) << "Custom parameter - ADCvsTDCT: " << param->second << ENDM;
@@ -384,16 +410,23 @@ void ZDCRecDataTask::initHisto()
   } else {
     setBinHisto2D(250, -5.5, 24.5, 1051, -202.5, 4002.5);
   }
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZNAC", "ADC (Gev) ZNA TC vs TDC Time (ns)  ZNA TC", "TDCV", "ZNAC", "ADC", "ZNAC", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZNAS", "ADC (Gev) ZNA SUM vs TDC Time (ns) ZNA SUM", "TDCV", "ZNAS", "ADC", "ZNAS", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZPAC", "ADC (Gev) ZPA TC vs TDC Time (ns) ZPA TC", "TDCV", "ZPAC", "ADC", "ZPAC", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZPAS", "ADC (Gev) ZPA SUM vs TDC Time (ns) ZPA SUM", "TDCV", "ZPAS", "ADC", "ZPAS", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZNCC", "ADC (Gev) ZNC TC vs TDC Time (ns) ZNC TC", "TDCV", "ZNCC", "ADC", "ZNCC", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZNCS", "ADC (Gev) ZNC SUM vs TDC Time (ns) ZNC SUM", "TDCV", "ZNCS", "ADC", "ZNCS", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZPCC", "ADC (Gev) ZPC TC vs TDC Time (ns) ZPC TC", "TDCV", "ZPCC", "ADC", "ZPCC", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZPCS", "ADC (Gev) ZPC SUM vs TDC Time (ns) ZPC SUM", "TDCV", "ZPCS", "ADC", "ZPCS", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZEM1", "ADC (Gev) ZEM1 vs TDC Time (ns) ZEM1", "TDCV", "ZEM1", "ADC", "ZEM1", 0);
-  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZEM2", "ADC (Gev) ZEM2 vs TDC Time (ns) ZEM2", "TDCV", "ZEM2", "ADC", "ZEM2", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZNAC", "ADC  ZNA TC vs TDC Time (ns)  ZNA TC", "TDCV", "ZNAC", "ADC", "ZNAC", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZNAS", "ADC  ZNA SUM vs TDC Time (ns) ZNA SUM", "TDCV", "ZNAS", "ADC", "ZNAS", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZPAC", "ADC  ZPA TC vs TDC Time (ns) ZPA TC", "TDCV", "ZPAC", "ADC", "ZPAC", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZPAS", "ADC  ZPA SUM vs TDC Time (ns) ZPA SUM", "TDCV", "ZPAS", "ADC", "ZPAS", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZNCC", "ADC  ZNC TC vs TDC Time (ns) ZNC TC", "TDCV", "ZNCC", "ADC", "ZNCC", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZNCS", "ADC  ZNC SUM vs TDC Time (ns) ZNC SUM", "TDCV", "ZNCS", "ADC", "ZNCS", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZPCC", "ADC  ZPC TC vs TDC Time (ns) ZPC TC", "TDCV", "ZPCC", "ADC", "ZPCC", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZPCS", "ADC  ZPC SUM vs TDC Time (ns) ZPC SUM", "TDCV", "ZPCS", "ADC", "ZPCS", 0);
+  if (auto param = mCustomParameters.find("ADCZEMvsTDCT"); param != mCustomParameters.end()) {
+    ILOG(Debug, Devel) << "Custom parameter - ADCZEMvsTDCT: " << param->second << ENDM;
+    tokenString = tokenLine(param->second, ";");
+    setBinHisto2D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()), atoi(tokenString.at(3).c_str()), atof(tokenString.at(4).c_str()), atof(tokenString.at(5).c_str()));
+  } else {
+    setBinHisto2D(250, -5.5, 24.5, 1051, -202.5, 4002.5);
+  }
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZEM1", "ADC  ZEM1 vs TDC Time (ns) ZEM1", "TDCV", "ZEM1", "ADC", "ZEM1", 0);
+  addNewHisto("ADCvsTDC", "h_ADC_TDC_ZEM2", "ADC  ZEM2 vs TDC Time (ns) ZEM2", "TDCV", "ZEM2", "ADC", "ZEM2", 0);
 
   if (auto param = mCustomParameters.find("TDCDIFF"); param != mCustomParameters.end()) {
     ILOG(Debug, Devel) << "Custom parameter - TDCDIFF: " << param->second << ENDM;
@@ -419,6 +452,13 @@ void ZDCRecDataTask::initHisto()
   addNewHisto("TDC_T_A", "h_TDC_ZPAS_V_A", "ZPA SUM TDC amplitude vs time (ns)", "TDCV", "ZPAS", "TDCA", "ZPAS", 0);
   addNewHisto("TDC_T_A", "h_TDC_ZNCS_V_A", "ZNC SUM TDC amplitude vs time (ns)", "TDCV", "ZNCS", "TDCA", "ZNCS", 0);
   addNewHisto("TDC_T_A", "h_TDC_ZPCS_V_A", "ZPC SUM TDC amplitude vs time (ns)", "TDCV", "ZPCS", "TDCA", "ZPCS", 0);
+  if (auto param = mCustomParameters.find("TDCAZEMvsTDCT"); param != mCustomParameters.end()) {
+    ILOG(Debug, Devel) << "Custom parameter - TDCAZEMvsTDCT: " << param->second << ENDM;
+    tokenString = tokenLine(param->second, ";");
+    setBinHisto2D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()), atoi(tokenString.at(3).c_str()), atof(tokenString.at(4).c_str()), atof(tokenString.at(5).c_str()));
+  } else {
+    setBinHisto2D(250, -5.5, 24.5, 2000, -0.5, 3999.5);
+  }
   addNewHisto("TDC_T_A", "h_TDC_ZEM1_V_A", "ZEM1 TDC amplitude vs time (ns)", "TDCV", "ZEM1", "TDCA", "ZEM1", 0);
   addNewHisto("TDC_T_A", "h_TDC_ZEM2_V_A", "ZEM2 TDC amplitude vs time (ns)", "TDCV", "ZEM2", "TDCA", "ZEM2", 0);
   if (auto param = mCustomParameters.find("TDCAvsTDCA"); param != mCustomParameters.end()) {
@@ -431,42 +471,40 @@ void ZDCRecDataTask::initHisto()
   addNewHisto("TDC_A_A", "h_TDC_ZNA_ZPA", "ZNA TDC amplitude vs ZPA TDC amplitude", "TDCA", "ZPAC", "TDCA", "ZNAC", 0);
   addNewHisto("TDC_A_A", "h_TDC_ZNC_ZPC", "ZNC TDC amplitude vs ZPC TDC amplitude", "TDCA", "ZPCC", "TDCA", "ZNCC", 0);
 
+  addNewHisto("TDC_A_A", "h_TDC_ZNAS_ZNAC", "TDC amplitude ZNA SUM vs TDC amplitude ZNA TC", "TDCA", "ZNAC", "TDCA", "ZNAS", 0);
+  addNewHisto("TDC_A_A", "h_TDC_ZPAS_ZPAC", "TDC amplitude ZPA SUM vs TDC amplitude ZPA TC", "TDCA", "ZPAC", "TDCA", "ZPAS", 0);
+  addNewHisto("TDC_A_A", "h_TDC_ZNCS_ZNCC", "TDC amplitude ZNC SUM vs TDC amplitude ZNC TC", "TDCA", "ZNCC", "TDCA", "ZNCS", 0);
+  addNewHisto("TDC_A_A", "h_TDC_ZPCS_ZPCC", "TDC amplitude ZPC SUM vs TDC amplitude ZPC TC", "TDCA", "ZPCC", "TDCA", "ZPCS", 0);
+  if (auto param = mCustomParameters.find("TDCAZEMvsTDCAZEM"); param != mCustomParameters.end()) {
+    ILOG(Debug, Devel) << "Custom parameter - TDCAZEMvsTDCAZEM: " << param->second << ENDM;
+    tokenString = tokenLine(param->second, ";");
+    setBinHisto2D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()), atoi(tokenString.at(3).c_str()), atof(tokenString.at(4).c_str()), atof(tokenString.at(5).c_str()));
+  } else {
+    setBinHisto2D(1000, -0.5, 3999.5, 1000, -0.5, 3999.5);
+  }
   addNewHisto("TDC_A_A", "h_TDC_ZEM1_ZEM2", "ZEM1 TDC amplitude vs ZEM2 TDC amplitude", "TDCA", "ZEM2", "TDCA", "ZEM1", 0);
+  if (auto param = mCustomParameters.find("TDCAZEMvsTDCA"); param != mCustomParameters.end()) {
+    ILOG(Debug, Devel) << "Custom parameter - TDCAZEMvsTDCA: " << param->second << ENDM;
+    tokenString = tokenLine(param->second, ";");
+    setBinHisto2D(atoi(tokenString.at(0).c_str()), atof(tokenString.at(1).c_str()), atof(tokenString.at(2).c_str()), atoi(tokenString.at(3).c_str()), atof(tokenString.at(4).c_str()), atof(tokenString.at(5).c_str()));
+  } else {
+    setBinHisto2D(1000, -0.5, 3999.5, 1000, -0.5, 3999.5);
+  }
   addNewHisto("TDC_A_A", "h_TDC_ZNA_ZEM1", "ZNA TDC amplitude vs ZEM1 TDC amplitude", "TDCA", "ZEM1", "TDCA", "ZNAC", 0);
   addNewHisto("TDC_A_A", "h_TDC_ZNA_ZEM2", "ZNA TDC amplitude vs ZEM2 TDC amplitude", "TDCA", "ZEM2", "TDCA", "ZNAC", 0);
   addNewHisto("TDC_A_A", "h_TDC_ZNC_ZEM1", "ZNC TDC amplitude vs ZEM1 TDC amplitude", "TDCA", "ZEM1", "TDCA", "ZNCC", 0);
   addNewHisto("TDC_A_A", "h_TDC_ZNC_ZEM2", "ZNC TDC amplitude vs ZEM2 TDC amplitude", "TDCA", "ZEM2", "TDCA", "ZNCC", 0);
 
-  addNewHisto("TDC_A_A", "h_TDC_ZNAS_ZNAC", "TDC amplitude ZNA SUM vs TDC amplitude ZNA TC", "TDCA", "ZNAC", "TDCA", "ZNAS", 0);
-  addNewHisto("TDC_A_A", "h_TDC_ZPAS_ZPAC", "TDC amplitude ZPA SUM vs TDC amplitude ZPA TC", "TDCA", "ZPAC", "TDCA", "ZPAS", 0);
-  addNewHisto("TDC_A_A", "h_TDC_ZNCS_ZNCC", "TDC amplitude ZNC SUM vs TDC amplitude ZNC TC", "TDCA", "ZNCC", "TDCA", "ZNCS", 0);
-  addNewHisto("TDC_A_A", "h_TDC_ZPCS_ZPCC", "TDC amplitude ZPC SUM vs TDC amplitude ZPC TC", "TDCA", "ZPCC", "TDCA", "ZPCS", 0);
+  addNewHisto("TDC_A_A", "h_TDC_ZPA_ZEM1", "ZNA TDC amplitude vs ZEM1 TDC amplitude", "TDCA", "ZEM1", "TDCA", "ZPAC", 0);
+  addNewHisto("TDC_A_A", "h_TDC_ZPA_ZEM2", "ZNA TDC amplitude vs ZEM2 TDC amplitude", "TDCA", "ZEM2", "TDCA", "ZPAC", 0);
+  addNewHisto("TDC_A_A", "h_TDC_ZPC_ZEM1", "ZNC TDC amplitude vs ZEM1 TDC amplitude", "TDCA", "ZEM1", "TDCA", "ZPCC", 0);
+  addNewHisto("TDC_A_A", "h_TDC_ZPC_ZEM2", "ZNC TDC amplitude vs ZEM2 TDC amplitude", "TDCA", "ZEM2", "TDCA", "ZPCC", 0);
 
   // msg histo
-  setBinHisto2D(o2::zdc::NChannels, -0.5, (float)o2::zdc::NChannels - 0.5, o2::zdc::MsgEnd, -0.5, (float)o2::zdc::MsgEnd - 0.5);
+  setBinHisto2D(o2::zdc::NChannels, -0.5, o2::zdc::NChannels - 0.5, o2::zdc::MsgEnd, -0.5, o2::zdc::MsgEnd - 0.5);
   addNewHisto("MSG_REC", "h_msg", "Reconstruction messages", "INFO", "CH", "INFO", "MSG", 0);
   int idh_msg = (int)mHisto2D.size() - 1;
-  setBinHisto1D(10, -0.5, 9.5);
-  addNewHisto("SUMMARY_TDC", "h_summary_TDC", "Summary TDC", "TDCV", "", "", "", 0);
-  mIdhTDC = (int)mHisto1D.size() - 1;
-  setBinHisto1D(26, -0.5, 25.5);
-  addNewHisto("SUMMARY_ADC", "h_summary_ADC", "Summary ADC", "ADC", "", "", "", 0);
-  mIdhADC = (int)mHisto1D.size() - 1;
-  for (int ibx = 1; ibx <= o2::zdc::NChannels; ibx++) {
-    mHisto2D.at(idh_msg).histo->GetXaxis()->SetBinLabel(ibx, o2::zdc::ChannelNames[ibx - 1].data());
-    mHisto1D.at(mIdhADC).histo->GetXaxis()->SetBinLabel(ibx, o2::zdc::ChannelNames[ibx - 1].data());
-  }
-  for (int ibx = 0; ibx < mVecTDC.size(); ibx++) {
-    mHisto1D.at(mIdhTDC).histo->GetXaxis()->SetBinLabel(ibx + 1, mVecTDC.at(ibx).c_str());
-  }
-  for (int iby = 1; iby <= o2::zdc::MsgEnd; iby++) {
-    mHisto2D.at(idh_msg).histo->GetYaxis()->SetBinLabel(iby, o2::zdc::MsgText[iby - 1].data());
-  }
   mHisto2D.at(idh_msg).histo->SetStats(0);
-  mHisto1D.at(mIdhTDC).histo->LabelsOption("v");
-  mHisto1D.at(mIdhTDC).histo->SetStats(0);
-  mHisto1D.at(mIdhADC).histo->LabelsOption("v");
-  mHisto1D.at(mIdhADC).histo->SetStats(0);
   // Centroid ZNA
   if (auto param = mCustomParameters.find("CENTR_ZNA"); param != mCustomParameters.end()) {
     ILOG(Debug, Devel) << "Custom parameter - CENTR_ZNA: " << param->second << ENDM;
@@ -559,13 +597,13 @@ bool ZDCRecDataTask::addNewHisto(std::string typeH, std::string name, std::strin
   if (std::find(mNameHisto.begin(), mNameHisto.end(), name) == mNameHisto.end()) {
 
     // ADC 1D (ENERGY) OR TDC 1D
-    if (typeH.compare("ADC1D") == 0 || typeH.compare("TDC1D") == 0 || typeH.compare("CENTR_ZPA") == 0 || typeH.compare("CENTR_ZPC") == 0 || typeH.compare("SUMMARY_TDC") == 0 || typeH.compare("SUMMARY_ADC") == 0) {
+    if (typeH == "ADC1D" || typeH == "TDC1D" || typeH == "CENTR_ZPA" || typeH == "CENTR_ZPC") {
       if (add1DHisto(typeH, name, title, typeCh1, ch1, bin)) {
         return true;
       } else {
         return false;
       }
-    } else if (typeH.compare("ADCSUMvsTC") == 0 || typeH.compare("ADCvsTDC") == 0 || typeH.compare("TDC-DIFF") == 0 || typeH.compare("TDC_T_A") == 0 || typeH.compare("TDC_A_A") == 0 || typeH.compare("MSG_REC") == 0 || typeH.compare("CENTR_ZNA") == 0 || typeH.compare("CENTR_ZNC") == 0) {
+    } else if (typeH == "ADCSUMvsTC" || typeH == "ADCvsTDC" || typeH == "TDC-DIFF" || typeH == "TDC_T_A" || typeH == "TDC_A_A" || typeH == "MSG_REC" || typeH == "CENTR_ZNA" || typeH == "CENTR_ZNC") {
       if (add2DHisto(typeH, name, title, typeCh1, ch1, typeCh2, ch2)) {
         return true;
       } else {
@@ -591,60 +629,49 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
   mEv.init(RecBC, Energy, TDCData, Info);
   while (mEv.next()) {
     // Histo 1D
-    mHisto1D.at(mIdhADC).histo->Reset();
-    mHisto1D.at(mIdhTDC).histo->Reset();
     for (int i = 0; i < (int)mHisto1D.size(); i++) {
       // Fill ADC 1D
-      if (mHisto1D.at(i).typeh.compare("ADC1D") == 0 && mHisto1D.at(i).typech.compare("ADC") == 0) {
+      if (mHisto1D.at(i).typeh == "ADC1D" && mHisto1D.at(i).typech == "ADC") {
         mHisto1D.at(i).histo->Fill(getADCRecValue(mHisto1D.at(i).typech, mHisto1D.at(i).ch));
       }
 
       // Fill TDC 1D
-      if (mHisto1D.at(i).typeh.compare("TDC1D") == 0 && (mHisto1D.at(i).typech.compare("TDCV") == 0 || mHisto1D.at(i).typech.compare("TDCA") == 0)) {
+      if (mHisto1D.at(i).typeh == "TDC1D" && (mHisto1D.at(i).typech == "TDCV" || mHisto1D.at(i).typech == "TDCA")) {
         int tdcid = getIdTDCch(mHisto1D.at(i).typech, mHisto1D.at(i).ch);
         auto nhitv = mEv.NtdcV(tdcid);
         if (mEv.NtdcA(tdcid) == nhitv && nhitv > 0) {
           for (int ihit = 0; ihit < nhitv; ihit++) {
-            if (mHisto1D.at(i).typech.compare("TDCV") == 0) {
+            if (mHisto1D.at(i).typech == "TDCV") {
               mHisto1D.at(i).histo->Fill(mEv.tdcV(tdcid, ihit));
             }
-            if (mHisto1D.at(i).typech.compare("TDCA") == 0) {
+            if (mHisto1D.at(i).typech == "TDCA") {
               mHisto1D.at(i).histo->Fill(mEv.tdcA(tdcid, ihit));
             }
           }
         }
       }
       // Fill CENTROID ZP
-      if (mHisto1D.at(i).typeh.compare("CENTR_ZPA") == 0 && mHisto1D.at(i).typech.compare("ADC") == 0) {
+      if (mHisto1D.at(i).typeh == "CENTR_ZPA" && mHisto1D.at(i).typech == "ADC") {
         mHisto1D.at(i).histo->Fill(mEv.xZPA());
       }
-      if (mHisto1D.at(i).typeh.compare("CENTR_ZPC") == 0 && mHisto1D.at(i).typech.compare("ADC") == 0) {
+      if (mHisto1D.at(i).typeh == "CENTR_ZPC" && mHisto1D.at(i).typech == "ADC") {
         mHisto1D.at(i).histo->Fill(mEv.xZPC());
-      }
-      // Fill SUMMARY
-      if (mHisto1D.at(mIdhADC).typeh.compare("SUMMARY_ADC") == 0 && mHisto1D.at(i).typeh.compare("ADC1D") == 0 && mHisto1D.at(i).typech.compare("ADC") == 0 && i != mIdhADC) {
-        mHisto1D.at(mIdhADC).histo->SetBinContent(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMean());
-        mHisto1D.at(mIdhADC).histo->SetBinError(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMeanError());
-      }
-      if (mHisto1D.at(mIdhTDC).typeh.compare("SUMMARY_TDC") == 0 && mHisto1D.at(i).typeh.compare("TDC1D") == 0 && mHisto1D.at(i).typech.compare("TDCV") == 0 && i != mIdhTDC) {
-        mHisto1D.at(mIdhTDC).histo->SetBinContent(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMean());
-        mHisto1D.at(mIdhTDC).histo->SetBinError(mHisto1D.at(i).bin, mHisto1D.at(i).histo->GetMeanError());
       }
     } // for histo 1D
 
     // Histo 2D
     for (int i = 0; i < (int)mHisto2D.size(); i++) {
-      if (mHisto2D.at(i).typeh.compare("ADCSUMvsTC") == 0 && mHisto2D.at(i).typech1.compare("ADC") == 0 && mHisto2D.at(i).typech2.compare("ADC") == 0) {
+      if (mHisto2D.at(i).typeh == "ADCSUMvsTC" && mHisto2D.at(i).typech1 == "ADC" && mHisto2D.at(i).typech2 == "ADC") {
         mHisto2D.at(i).histo->Fill((Double_t)getADCRecValue(mHisto2D.at(i).typech1, mHisto2D.at(i).ch1), getADCRecValue(mHisto2D.at(i).typech2, mHisto2D.at(i).ch2));
       }
-      if (mHisto2D.at(i).typeh.compare("ADCvsTDC") == 0 && mHisto2D.at(i).typech1.compare("TDCV") == 0 && mHisto2D.at(i).typech2.compare("ADC") == 0) {
+      if (mHisto2D.at(i).typeh == "ADCvsTDC" && mHisto2D.at(i).typech1 == "TDCV" && mHisto2D.at(i).typech2 == "ADC") {
         int tdcid = getIdTDCch(mHisto2D.at(i).typech1, mHisto2D.at(i).ch1);
         auto nhit = mEv.NtdcV(tdcid);
         if (mEv.NtdcA(tdcid) == nhit && nhit > 0) {
           mHisto2D.at(i).histo->Fill(mEv.tdcV(tdcid, 0), getADCRecValue(mHisto2D.at(i).typech2, mHisto2D.at(i).ch2));
         }
       }
-      if (mHisto2D.at(i).typeh.compare("TDC-DIFF") == 0 && mHisto2D.at(i).typech1.compare("TDCV") == 0 && mHisto2D.at(i).typech2.compare("TDCV") == 0) {
+      if (mHisto2D.at(i).typeh == "TDC-DIFF" && mHisto2D.at(i).typech1 == "TDCV" && mHisto2D.at(i).typech2 == "TDCV") {
         int zncc_id = getIdTDCch("TDCV", "ZNCC");
         int znac_id = getIdTDCch("TDCV", "ZNAC");
         auto nhit_zncc = mEv.NtdcV(zncc_id);
@@ -655,7 +682,7 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
           mHisto2D.at(i).histo->Fill(diff, sum);
         }
       }
-      if (mHisto2D.at(i).typeh.compare("TDC_T_A") == 0 && mHisto2D.at(i).typech1.compare("TDCV") == 0 && mHisto2D.at(i).typech2.compare("TDCA") == 0) {
+      if (mHisto2D.at(i).typeh == "TDC_T_A" && mHisto2D.at(i).typech1 == "TDCV" && mHisto2D.at(i).typech2 == "TDCA") {
         int tdcid = getIdTDCch(mHisto2D.at(i).typech1, mHisto2D.at(i).ch1);
         auto nhitv = mEv.NtdcV(tdcid);
         if (mEv.NtdcA(tdcid) == nhitv && nhitv > 0) {
@@ -664,7 +691,7 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
           }
         }
       }
-      if (mHisto2D.at(i).typeh.compare("TDC_A_A") == 0 && mHisto2D.at(i).typech1.compare("TDCA") == 0 && mHisto2D.at(i).typech2.compare("TDCA") == 0) {
+      if (mHisto2D.at(i).typeh == "TDC_A_A" && mHisto2D.at(i).typech1 == "TDCA" && mHisto2D.at(i).typech2 == "TDCA") {
         int tdcid1 = getIdTDCch(mHisto2D.at(i).typech1, mHisto2D.at(i).ch1);
         auto nhitv1 = mEv.NtdcV(tdcid1);
         int tdcid2 = getIdTDCch(mHisto2D.at(i).typech2, mHisto2D.at(i).ch2);
@@ -674,7 +701,7 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
         }
       }
 
-      if (mEv.getNInfo() > 0 && mHisto2D.at(i).typech1.compare("INFO") == 0) {
+      if (mEv.getNInfo() > 0 && mHisto2D.at(i).typech1 == "INFO") {
         auto& decodedInfo = mEv.getDecodedInfo();
         for (uint16_t info : decodedInfo) {
           uint8_t ch = (info >> 10) & 0x1f;
@@ -682,11 +709,11 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
           mHisto2D.at(i).histo->Fill(ch, code);
         }
       }
-      if (mHisto2D.at(i).typeh.compare("CENTR_ZNA") == 0 && mHisto2D.at(i).typech1.compare("ADC") == 0 && mHisto2D.at(i).typech2.compare("ADC") == 0) {
+      if (mHisto2D.at(i).typeh == "CENTR_ZNA" && mHisto2D.at(i).typech1 == "ADC" && mHisto2D.at(i).typech2 == "ADC") {
         mEv.centroidZNA(x, y);
         mHisto2D.at(i).histo->Fill(x, y);
       }
-      if (mHisto2D.at(i).typeh.compare("CENTR_ZNC") == 0 && mHisto2D.at(i).typech1.compare("ADC") == 0 && mHisto2D.at(i).typech2.compare("ADC") == 0) {
+      if (mHisto2D.at(i).typeh == "CENTR_ZNC" && mHisto2D.at(i).typech1 == "ADC" && mHisto2D.at(i).typech2 == "ADC") {
         mEv.centroidZNC(x, y);
         mHisto2D.at(i).histo->Fill(x, y);
       }
@@ -697,82 +724,82 @@ int ZDCRecDataTask::process(const gsl::span<const o2::zdc::BCRecData>& RecBC,
 
 float ZDCRecDataTask::getADCRecValue(std::string typech, std::string ch)
 {
-  if (typech.compare("ADC") == 0 && ch.compare("ZNAC") == 0) {
+  if (typech == "ADC" && ch == "ZNAC") {
     return mEv.EZNAC();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNA1") == 0) {
+  if (typech == "ADC" && ch == "ZNA1") {
     return mEv.EZNA1();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNA2") == 0) {
+  if (typech == "ADC" && ch == "ZNA2") {
     return mEv.EZNA2();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNA3") == 0) {
+  if (typech == "ADC" && ch == "ZNA3") {
     return mEv.EZNA3();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNA4") == 0) {
+  if (typech == "ADC" && ch == "ZNA4") {
     return mEv.EZNA4();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNAS") == 0) {
+  if (typech == "ADC" && ch == "ZNAS") {
     return mEv.EZNASum();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPAC") == 0) {
+  if (typech == "ADC" && ch == "ZPAC") {
     return mEv.EZPAC();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPA1") == 0) {
+  if (typech == "ADC" && ch == "ZPA1") {
     return mEv.EZPA1();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPA2") == 0) {
+  if (typech == "ADC" && ch == "ZPA2") {
     return mEv.EZPA2();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPA3") == 0) {
+  if (typech == "ADC" && ch == "ZPA3") {
     return mEv.EZPA3();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPA4") == 0) {
+  if (typech == "ADC" && ch == "ZPA4") {
     return mEv.EZPA4();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPAS") == 0) {
+  if (typech == "ADC" && ch == "ZPAS") {
     return mEv.EZPASum();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNCC") == 0) {
+  if (typech == "ADC" && ch == "ZNCC") {
     return mEv.EZNCC();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNC1") == 0) {
+  if (typech == "ADC" && ch == "ZNC1") {
     return mEv.EZNC1();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNC2") == 0) {
+  if (typech == "ADC" && ch == "ZNC2") {
     return mEv.EZNC2();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNC3") == 0) {
+  if (typech == "ADC" && ch == "ZNC3") {
     return mEv.EZNC3();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNC4") == 0) {
+  if (typech == "ADC" && ch == "ZNC4") {
     return mEv.EZNC4();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZNCS") == 0) {
+  if (typech == "ADC" && ch == "ZNCS") {
     return mEv.EZNCSum();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPCC") == 0) {
+  if (typech == "ADC" && ch == "ZPCC") {
     return mEv.EZPCC();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPC1") == 0) {
+  if (typech == "ADC" && ch == "ZPC1") {
     return mEv.EZPC1();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPC2") == 0) {
+  if (typech == "ADC" && ch == "ZPC2") {
     return mEv.EZPC2();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPC3") == 0) {
+  if (typech == "ADC" && ch == "ZPC3") {
     return mEv.EZPC3();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPC4") == 0) {
+  if (typech == "ADC" && ch == "ZPC4") {
     return mEv.EZPC4();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZPCS") == 0) {
+  if (typech == "ADC" && ch == "ZPCS") {
     return mEv.EZPCSum();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZEM1") == 0) {
+  if (typech == "ADC" && ch == "ZEM1") {
     return mEv.EZEM1();
   }
-  if (typech.compare("ADC") == 0 && ch.compare("ZEM2") == 0) {
+  if (typech == "ADC" && ch == "ZEM2") {
     return mEv.EZEM2();
   }
   return 0.00;
@@ -780,34 +807,34 @@ float ZDCRecDataTask::getADCRecValue(std::string typech, std::string ch)
 
 int ZDCRecDataTask::getIdTDCch(std::string typech, std::string ch)
 {
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZNAC") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZNAC") {
     return o2::zdc::TDCZNAC;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZNAS") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZNAS") {
     return o2::zdc::TDCZNAS;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZPAC") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZPAC") {
     return o2::zdc::TDCZPAC;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZPAS") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZPAS") {
     return o2::zdc::TDCZPAS;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZNCC") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZNCC") {
     return o2::zdc::TDCZNCC;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZNCS") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZNCS") {
     return o2::zdc::TDCZNCS;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZPCC") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZPCC") {
     return o2::zdc::TDCZPCC;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZPCS") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZPCS") {
     return o2::zdc::TDCZPCS;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZEM1") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZEM1") {
     return o2::zdc::TDCZEM1;
   }
-  if ((typech.compare("TDCV") == 0 || typech.compare("TDCA") == 0) && ch.compare("ZEM2") == 0) {
+  if ((typech == "TDCV" || typech == "TDCA") && ch == "ZEM2") {
     return o2::zdc::TDCZEM2;
   }
   return 0;


### PR DESCRIPTION
- ZDCTaskRawData.json Apply QC naming convention, Apply proposed configuration changes in Consul to all the config files.
- ZDCTaskRecData.json Apply QC naming convention, Apply proposed configuration changes in Consul to all the config files. Added new parameters for ZEM
- PostProcessingConfigZDC.h remove template as suggestion during review
- PostProcessingConfigZDC.cxx remove template as suggestion during review
- ZDCRecDataTask.h remove include  as suggestion during review, remove summary plots ADC and TDC
- ZDCRecDataTask.cxx remove include as suggestion during review, Review the reset() and the start/endOfActivity in the Tasks, change title of ADC histo, Added new parameters for ZEM, Added new correlection, Added ZEM ZP correlations, remove summary plots ADC and TDC, replaced .compare(...) with == as suggestion during review
- ZDCRecDataCheck.cxx chech null pointer object as suggestion during review, replaced .compare(...) with == as suggestion during review
- ZDCRawDataTask.cxx remove include as suggestion during review, Review the reset(), and the start/endOfActivity in the Tasks, review destructor,  replaced .compare(...) with == as suggestion during review
- ZDCRawDataCheck.cxx chech null pointer object as suggestion during review, replaced .compare(...) with == as suggestion during review