### PR TITLE
QC-1100 Warn if objects are published at SOR, but not unpublished at EOR

### DIFF
--- a/Framework/include/QualityControl/TaskRunner.h
+++ b/Framework/include/QualityControl/TaskRunner.h
@@ -159,6 +159,7 @@ class TaskRunner : public framework::Task
   uint64_t mDataReceivedInCycle = 0;
   AliceO2::Common::Timer mTimerTotalDurationActivity;
   AliceO2::Common::Timer mTimerDurationCycle;
+  int mNumberObjectsRegisteredAtStart = 0;
 };
 
 } // namespace o2::quality_control::core


### PR DESCRIPTION
This commit is to (adamantly) warn module developers when they use startPublishing on objects in startOfActivity, but do not use stopPublishing in endOfActivity. We warn them because we have no way of reliably replace a deleted object known to ObjectManager with a new one at the 2nd when startOfActivity is invoked (i.e. during START->STOP->START sequence). ObjectManager creates observer pointers to objects owned by user tasks and uses their TObject::GetName to identify them. Thus, when an object is deleted, we lose a way to know what is the object we are storing and we cannot remove the right one from ObjectManager. Also, we have no way of knowing when the observed object is deleted by looking at the observer pointer.

I investigated some other ways to circumvent this, none of those were satisfying:

- We could store the object name in MonitorObject in addition and return it when MonitorObject::GetObject is invoked. However, if someone uses TObject::SetName() on the observed object, these two names become different. There is no (known to me) way to synchronize these reliably.

- TObject::IsZombie() can say whether the object for a pointer was deleted. However, if there is another pointer to the same object, calling IsZombie() on it will not return the adequate value if a different one was used to delete the object.

- TObject::IsDestructed() seems to support the case which not supported by the previous method, but if we allocate a new object and it happens to land in the same piece of memory, it returns a wrong value.

- For the same reasons, checking pointer validity with dynamic_cast<TObject*>() will not work if a new object is allocated at the ruins of the old one. I don't even know if this is a defined behaviour anyway.

- We cannot easily use a combination of std::shared_ptr and std::weak_ptr, because it would require adapting all the user code and refactoring how we store our observer pointers in ObjectManager. Serializing std::shared_ptr is not supported by ROOT, thus we would need to make a shallow copy of mMonitorObjects each time we want to publish them. Doable, but a lot of effort as a whole.