### PR TITLE
QC-1104 Reset sh. ptr before creating a new histogram in MCH PP

### DIFF
--- a/Modules/MUON/MCH/src/DecodingPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DecodingPostProcessing.cxx
@@ -76,6 +76,7 @@ void DecodingPostProcessing::createDecodingErrorsHistos(Trigger t, repository::D
 
   auto obj = mCcdbObjects.find(errorsSourceName());
   if (obj != mCcdbObjects.end()) {
+    mErrorsOnCycle.reset();
     mErrorsOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
   }
 
@@ -83,9 +84,11 @@ void DecodingPostProcessing::createDecodingErrorsHistos(Trigger t, repository::D
   // Decoding errors plotters
   //----------------------------------
 
+  mErrorsPlotter.reset();
   mErrorsPlotter = std::make_unique<DecodingErrorsPlotter>("DecodingErrors/");
   mErrorsPlotter->publish(getObjectsManager());
 
+  mErrorsPlotterOnCycle.reset();
   mErrorsPlotterOnCycle = std::make_unique<DecodingErrorsPlotter>("DecodingErrors/LastCycle/");
   mErrorsPlotterOnCycle->publish(getObjectsManager());
 }
@@ -100,6 +103,7 @@ void DecodingPostProcessing::createHeartBeatPacketsHistos(Trigger t, repository:
 
   auto obj = mCcdbObjects.find(hbPacketsSourceName());
   if (obj != mCcdbObjects.end()) {
+    mHBPacketsOnCycle.reset();
     mHBPacketsOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
   }
 
@@ -107,9 +111,11 @@ void DecodingPostProcessing::createHeartBeatPacketsHistos(Trigger t, repository:
   // HeartBeat packets plotters
   //----------------------------------
 
+  mHBPacketsPlotter.reset();
   mHBPacketsPlotter = std::make_unique<HeartBeatPacketsPlotter>("HeartBeatPackets/", mFullHistos);
   mHBPacketsPlotter->publish(getObjectsManager());
 
+  mHBPacketsPlotterOnCycle.reset();
   mHBPacketsPlotterOnCycle = std::make_unique<HeartBeatPacketsPlotter>("HeartBeatPackets/LastCycle/", mFullHistos);
   mHBPacketsPlotterOnCycle->publish(getObjectsManager());
 }
@@ -124,6 +130,7 @@ void DecodingPostProcessing::createSyncStatusHistos(Trigger t, repository::Datab
 
   auto obj = mCcdbObjects.find(syncStatusSourceName());
   if (obj != mCcdbObjects.end()) {
+    mSyncStatusOnCycle.reset();
     mSyncStatusOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
   }
 
@@ -131,9 +138,11 @@ void DecodingPostProcessing::createSyncStatusHistos(Trigger t, repository::Datab
   // Sync status  plotters
   //----------------------------------
 
+  mSyncStatusPlotter.reset();
   mSyncStatusPlotter = std::make_unique<FECSyncStatusPlotter>("SyncErrors/");
   mSyncStatusPlotter->publish(getObjectsManager());
 
+  mSyncStatusPlotterOnCycle.reset();
   mSyncStatusPlotterOnCycle = std::make_unique<FECSyncStatusPlotter>("SyncErrors/LastCycle/");
   mSyncStatusPlotterOnCycle->publish(getObjectsManager());
 }

--- a/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
@@ -83,11 +83,13 @@ void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInte
 
   auto obj = mCcdbObjects.find(rateSourceName());
   if (obj != mCcdbObjects.end()) {
+    mElecMapOnCycle.reset();
     mElecMapOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
   }
 
   obj = mCcdbObjects.find(rateSignalSourceName());
   if (obj != mCcdbObjects.end()) {
+    mElecMapSignalOnCycle.reset();
     mElecMapSignalOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
   }
 
@@ -118,15 +120,19 @@ void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInte
   // Rate plotters
   //----------------------------------
 
+  mRatesPlotter.reset();
   mRatesPlotter = std::make_unique<RatesPlotter>("Rates/", hElecHistoRef, mChannelRateMin, mChannelRateMax, mFullHistos);
   mRatesPlotter->publish(getObjectsManager());
 
+  mRatesPlotterOnCycle.reset();
   mRatesPlotterOnCycle = std::make_unique<RatesPlotter>("Rates/LastCycle/", hElecHistoRef, mChannelRateMin, mChannelRateMax, mFullHistos);
   mRatesPlotterOnCycle->publish(getObjectsManager());
 
+  mRatesPlotterSignal.reset();
   mRatesPlotterSignal = std::make_unique<RatesPlotter>("RatesSignal/", hElecSignalHistoRef, mChannelRateMin, mChannelRateMax, mFullHistos);
   mRatesPlotterSignal->publish(getObjectsManager());
 
+  mRatesPlotterSignalOnCycle.reset();
   mRatesPlotterSignalOnCycle = std::make_unique<RatesPlotter>("RatesSignal/LastCycle/", hElecSignalHistoRef, mChannelRateMin, mChannelRateMax, mFullHistos);
   mRatesPlotterSignalOnCycle->publish(getObjectsManager());
 
@@ -134,9 +140,11 @@ void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInte
   // Rate trends
   //----------------------------------
 
+  mRatesTrendsPlotter.reset();
   mRatesTrendsPlotter = std::make_unique<RatesTrendsPlotter>("Trends/Rates/", hElecHistoRef, mFullHistos);
   mRatesTrendsPlotter->publish(getObjectsManager());
 
+  mRatesTrendsPlotterSignal.reset();
   mRatesTrendsPlotterSignal = std::make_unique<RatesTrendsPlotter>("Trends/RatesSignal/", hElecSignalHistoRef, mFullHistos);
   mRatesTrendsPlotterSignal->publish(getObjectsManager());
 }
@@ -151,11 +159,13 @@ void DigitsPostProcessing::createOrbitHistos(Trigger t, repository::DatabaseInte
 
   auto obj = mCcdbObjects.find(orbitsSourceName());
   if (obj != mCcdbObjects.end()) {
+    mDigitsOrbitsOnCycle.reset();
     mDigitsOrbitsOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
   }
 
   obj = mCcdbObjects.find(orbitsSignalSourceName());
   if (obj != mCcdbObjects.end()) {
+    mDigitsSignalOrbitsOnCycle.reset();
     mDigitsSignalOrbitsOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
   }
 
@@ -163,15 +173,19 @@ void DigitsPostProcessing::createOrbitHistos(Trigger t, repository::DatabaseInte
   // Orbit plotters
   //----------------------------------
 
+  mOrbitsPlotter.reset();
   mOrbitsPlotter = std::make_unique<OrbitsPlotter>("Orbits/");
   mOrbitsPlotter->publish(getObjectsManager());
 
+  mOrbitsPlotterOnCycle.reset();
   mOrbitsPlotterOnCycle = std::make_unique<OrbitsPlotter>("Orbits/LastCycle/");
   mOrbitsPlotterOnCycle->publish(getObjectsManager());
 
+  mOrbitsPlotterSignal.reset();
   mOrbitsPlotterSignal = std::make_unique<OrbitsPlotter>("OrbitsSignal/");
   mOrbitsPlotterSignal->publish(getObjectsManager());
 
+  mOrbitsPlotterSignalOnCycle.reset();
   mOrbitsPlotterSignalOnCycle = std::make_unique<OrbitsPlotter>("OrbitsSignal/LastCycle/");
   mOrbitsPlotterSignalOnCycle->publish(getObjectsManager());
 }
@@ -189,6 +203,7 @@ void DigitsPostProcessing::initialize(Trigger t, framework::ServiceRegistryRef s
   // Detector quality histogram
   //--------------------------------------------------
 
+  mHistogramQualityPerDE.reset();
   mHistogramQualityPerDE = std::make_unique<TH2F>("QualityFlagPerDE", "Quality Flag vs DE", getNumDE(), 0, getNumDE(), 3, 0, 3);
   mHistogramQualityPerDE->GetYaxis()->SetBinLabel(1, "Bad");
   mHistogramQualityPerDE->GetYaxis()->SetBinLabel(2, "Medium");

--- a/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
@@ -96,10 +96,11 @@ void PreclustersPostProcessing::createEfficiencyHistos(Trigger t, repository::Da
   //----------------------------------
   // Efficiency plotters
   //----------------------------------
-
+  mEfficiencyPlotter.reset();
   mEfficiencyPlotter = std::make_unique<EfficiencyPlotter>("Efficiency/", hElecHistoRef, mFullHistos);
   mEfficiencyPlotter->publish(getObjectsManager());
 
+  mEfficiencyPlotterOnCycle.reset();
   mEfficiencyPlotterOnCycle = std::make_unique<EfficiencyPlotter>("Efficiency/LastCycle/", hElecHistoRef, mFullHistos);
   mEfficiencyPlotterOnCycle->publish(getObjectsManager());
 
@@ -107,6 +108,7 @@ void PreclustersPostProcessing::createEfficiencyHistos(Trigger t, repository::Da
   // Efficiency trends
   //----------------------------------
 
+  mEfficiencyTrendsPlotter.reset();
   mEfficiencyTrendsPlotter = std::make_unique<EfficiencyTrendsPlotter>("Trends/", hElecHistoRef, mFullHistos);
   mEfficiencyTrendsPlotter->publish(getObjectsManager());
 }
@@ -121,6 +123,7 @@ void PreclustersPostProcessing::createClusterChargeHistos(Trigger t, repository:
 
   auto obj = mCcdbObjects.find(clusterChargeSourceName());
   if (obj != mCcdbObjects.end()) {
+    mClusterChargeOnCycle.reset();
     mClusterChargeOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
   }
 
@@ -138,9 +141,11 @@ void PreclustersPostProcessing::createClusterChargeHistos(Trigger t, repository:
   // Cluster charge plotters
   //----------------------------------
 
+  mClusterChargePlotter.reset();
   mClusterChargePlotter = std::make_unique<ClusterChargePlotter>("ClusterCharge/", histoRef, mFullHistos);
   mClusterChargePlotter->publish(getObjectsManager());
 
+  mClusterChargePlotterOnCycle.reset();
   mClusterChargePlotterOnCycle = std::make_unique<ClusterChargePlotter>("ClusterCharge/LastCycle/", histoRef, mFullHistos);
   mClusterChargePlotterOnCycle->publish(getObjectsManager());
 
@@ -148,6 +153,7 @@ void PreclustersPostProcessing::createClusterChargeHistos(Trigger t, repository:
   // Cluster charge trends
   //----------------------------------
 
+  mClusterChargeTrendsPlotter.reset();
   mClusterChargeTrendsPlotter = std::make_unique<ClusterChargeTrendsPlotter>("Trends/", histoRef, mFullHistos);
   mClusterChargeTrendsPlotter->publish(getObjectsManager());
 }
@@ -162,6 +168,7 @@ void PreclustersPostProcessing::createClusterSizeHistos(Trigger t, repository::D
 
   auto obj = mCcdbObjects.find(clusterSizeSourceName());
   if (obj != mCcdbObjects.end()) {
+    mClusterSizeOnCycle.reset();
     mClusterSizeOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
   }
 
@@ -179,9 +186,11 @@ void PreclustersPostProcessing::createClusterSizeHistos(Trigger t, repository::D
   // Cluster size plotters
   //----------------------------------
 
+  mClusterSizePlotter.reset();
   mClusterSizePlotter = std::make_unique<ClusterSizePlotter>("ClusterSize/", histoRef, mFullHistos);
   mClusterSizePlotter->publish(getObjectsManager());
 
+  mClusterSizePlotterOnCycle.reset();
   mClusterSizePlotterOnCycle = std::make_unique<ClusterSizePlotter>("ClusterSize/LastCycle/", histoRef, mFullHistos);
   mClusterSizePlotterOnCycle->publish(getObjectsManager());
 
@@ -189,6 +198,7 @@ void PreclustersPostProcessing::createClusterSizeHistos(Trigger t, repository::D
   // Cluster size trends
   //----------------------------------
 
+  mClusterSizeTrendsPlotter.reset();
   mClusterSizeTrendsPlotter = std::make_unique<ClusterSizeTrendsPlotter>("Trends/", histoRef, mFullHistos);
   mClusterSizeTrendsPlotter->publish(getObjectsManager());
 }
@@ -207,6 +217,7 @@ void PreclustersPostProcessing::initialize(Trigger t, framework::ServiceRegistry
   // Detector quality histogram
   //--------------------------------------------------
 
+  mHistogramQualityPerDE.reset();
   mHistogramQualityPerDE = std::make_unique<TH2F>("QualityFlagPerDE", "Quality Flag vs DE", getNumDE(), 0, getNumDE(), 3, 0, 3);
   mHistogramQualityPerDE->GetYaxis()->SetBinLabel(1, "Bad");
   mHistogramQualityPerDE->GetYaxis()->SetBinLabel(2, "Medium");


### PR DESCRIPTION
This makes sure that the old object are deleted before the new ones are created, which prevents us from potentially sharing the same resources with both old and new, and prevents ROOT from producing warnings about histograms with duplicate names and potential memory leaks.