### PR TITLE
Hotfix for PID Hypothesis - switch to disable Canvas

### DIFF
--- a/Modules/TPC/run/tpcQCPID_sampled.json
+++ b/Modules/TPC/run/tpcQCPID_sampled.json
@@ -36,7 +36,7 @@
           "name": "tpc-tracks"
         },
         "taskParameters": {
-          "cutMinNCluster": "60", "cutAbsTgl": "1.", "cutMindEdxTot": "10.", "cutMaxdEdxTot": "70.", "cutMinpTPC": "0.05", "cutMaxpTPC": "20.", "cutMinpTPCMIPs": "0.45", "cutMaxpTPCMIPs": "0.55" , "CreateCanvas" : "1"
+          "cutMinNCluster": "60", "cutAbsTgl": "1.", "cutMindEdxTot": "10.", "cutMaxdEdxTot": "70.", "cutMinpTPC": "0.05", "cutMaxpTPC": "20.", "cutMinpTPCMIPs": "0.45", "cutMaxpTPCMIPs": "0.55" , "createCanvas" : "1"
         },
         "location": "remote"
       }

--- a/Modules/TPC/run/tpcQCPID_sampled.json
+++ b/Modules/TPC/run/tpcQCPID_sampled.json
@@ -36,7 +36,7 @@
           "name": "tpc-tracks"
         },
         "taskParameters": {
-          "cutMinNCluster": "60", "cutAbsTgl": "1.", "cutMindEdxTot": "10.", "cutMaxdEdxTot": "70.", "cutMinpTPC": "0.05", "cutMaxpTPC": "20.", "cutMinpTPCMIPs": "0.45", "cutMaxpTPCMIPs": "0.55"
+          "cutMinNCluster": "60", "cutAbsTgl": "1.", "cutMindEdxTot": "10.", "cutMaxdEdxTot": "70.", "cutMinpTPC": "0.05", "cutMaxpTPC": "20.", "cutMinpTPCMIPs": "0.45", "cutMaxpTPCMIPs": "0.55" , "CreateCanvas" : "1"
         },
         "location": "remote"
       }

--- a/Modules/TPC/src/PID.cxx
+++ b/Modules/TPC/src/PID.cxx
@@ -51,9 +51,10 @@ void PID::initialize(o2::framework::InitContext& /*ctx*/)
   const float cutMaxpTPC = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "cutMaxpTPC");
   const float cutMinpTPCMIPs = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "cutMinpTPCMIPs");
   const float cutMaxpTPCMIPs = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "cutMaxpTPCMIPs");
+  const int CreateCanvas = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "CreateCanvas");
 
   // set track cuts defaults are (AbsEta = 1.0, nCluster = 60, MindEdxTot  = 20)
-  mQCPID.setPIDCuts(cutMinNCluster, cutAbsTgl, cutMindEdxTot, cutMaxdEdxTot, cutMinpTPC, cutMaxpTPC, cutMinpTPCMIPs, cutMaxpTPCMIPs);
+  mQCPID.setPIDCuts(cutMinNCluster, cutAbsTgl, cutMindEdxTot, cutMaxdEdxTot, cutMinpTPC, cutMaxpTPC, cutMinpTPCMIPs, cutMaxpTPCMIPs, CreateCanvas);
   mQCPID.initializeHistograms();
   // pass map of vectors of histograms to be beautified!
 

--- a/Modules/TPC/src/PID.cxx
+++ b/Modules/TPC/src/PID.cxx
@@ -51,10 +51,11 @@ void PID::initialize(o2::framework::InitContext& /*ctx*/)
   const float cutMaxpTPC = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "cutMaxpTPC");
   const float cutMinpTPCMIPs = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "cutMinpTPCMIPs");
   const float cutMaxpTPCMIPs = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "cutMaxpTPCMIPs");
-  const int CreateCanvas = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "CreateCanvas");
+  const int createCanvas = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "createCanvas");
 
   // set track cuts defaults are (AbsEta = 1.0, nCluster = 60, MindEdxTot  = 20)
-  mQCPID.setPIDCuts(cutMinNCluster, cutAbsTgl, cutMindEdxTot, cutMaxdEdxTot, cutMinpTPC, cutMaxpTPC, cutMinpTPCMIPs, cutMaxpTPCMIPs, CreateCanvas);
+  mQCPID.setPIDCuts(cutMinNCluster, cutAbsTgl, cutMindEdxTot, cutMaxdEdxTot, cutMinpTPC, cutMaxpTPC, cutMinpTPCMIPs, cutMaxpTPCMIPs);
+  mQCPID.setCreateCanvas(createCanvas);
   mQCPID.initializeHistograms();
   // pass map of vectors of histograms to be beautified!
 


### PR DESCRIPTION
There was an issue with the last PR #2119  where TCanvas could not be merged. This PR allows to disable the TCanvas generation through the JSON file. This is paired with another PR in O2 (https://github.com/AliceO2Group/AliceO2/pull/12755).