### PR TITLE
Framework: slice labels in 1D slice trending

### DIFF
--- a/Framework/include/QualityControl/SliceTrendingTask.h
+++ b/Framework/include/QualityControl/SliceTrendingTask.h
@@ -81,7 +81,7 @@ class SliceTrendingTask : public PostProcessingInterface
   void trendValues(const Trigger& t, o2::quality_control::repository::DatabaseInterface&);
   void generatePlots();
   void drawCanvasMO(TCanvas* thisCanvas, const std::string& var,
-                    const std::string& name, const std::string& opt, const std::string& err, const std::vector<std::vector<float>>& axis, const TitleSettings& titlesettings);
+                    const std::string& name, const std::string& opt, const std::string& err, const std::vector<std::vector<float>>& axis, const std::vector<std::vector<std::string>>& sliceLabels, const TitleSettings& titlesettings);
   void getUserAxisRange(const std::string& graphAxisRange, float& limitLow, float& limitUp);
   void setUserAxisLabel(TAxis* xAxis, TAxis* yAxis, const std::string& graphAxisLabel);
   void getTrendVariables(const std::string& inputvar, std::string& sourceName, std::string& variableName, std::string& trend);
@@ -102,6 +102,7 @@ class SliceTrendingTask : public PostProcessingInterface
   std::unordered_map<std::string, std::vector<SliceInfo>*> mSources;
   std::unordered_map<std::string, int> mNumberPads;
   std::unordered_map<std::string, std::vector<std::vector<float>>> mAxisDivision;
+  std::unordered_map<std::string, std::vector<std::vector<std::string>>> mSliceLabel;
 };
 
 } // namespace o2::quality_control::postprocessing

--- a/Framework/include/QualityControl/SliceTrendingTaskConfig.h
+++ b/Framework/include/QualityControl/SliceTrendingTaskConfig.h
@@ -65,6 +65,7 @@ struct SliceTrendingTaskConfig : PostProcessingConfig {
     std::string name;
     std::string reductorName;
     std::vector<std::vector<float>> axisDivision;
+    std::vector<std::vector<std::string>> sliceLabels;
     std::string moduleName;
   };
 

--- a/Framework/postprocessing.json
+++ b/Framework/postprocessing.json
@@ -139,6 +139,7 @@
             "names": [ "example" ],
             "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
             "axisDivision": [ [ "0", "4500", "10500" ] ],
+            "sliceLabels": [ [ "Slice 1", "Slice 2" ] ],
             "moduleName": "QcCommon"
           }
         ],
@@ -185,7 +186,8 @@
             "graphErrors": "errMeanY:0.5",
             "graphYRange": "",
             "graphXRange": "",
-            "graphAxisLabel": "Mean Y:time"
+            "graphAxisLabel": "Mean Y:time",
+            "legendTextSize": "10.0"
           },
           {
             "name": "ExtendedTrending_NEntries_of_histogram",

--- a/Framework/src/SliceTrendingTaskConfig.cxx
+++ b/Framework/src/SliceTrendingTaskConfig.cxx
@@ -54,6 +54,9 @@ SliceTrendingTaskConfig::SliceTrendingTaskConfig(const std::string& id,
     std::vector<std::vector<float>> axisBoundaries;
     std::vector<float> singleAxis;
 
+    std::vector<std::vector<std::string>> sliceLabels;
+    std::vector<std::string> singleAxisLabels;
+
     if (const auto& multiAxisValues = dataSourceConfig.second.get_child_optional("axisDivision"); multiAxisValues.has_value()) {
       for (const auto& multiAxisValue : multiAxisValues.value()) {
         for (const auto& axis : multiAxisValue.second) {
@@ -61,6 +64,16 @@ SliceTrendingTaskConfig::SliceTrendingTaskConfig(const std::string& id,
         }
         axisBoundaries.push_back(singleAxis);
         singleAxis.clear();
+      }
+    }
+
+    if (const auto& multiAxisLabels = dataSourceConfig.second.get_child_optional("sliceLabels"); multiAxisLabels.has_value()) {
+      for (const auto& multiAxisLabel : multiAxisLabels.value()) {
+        for (const auto& axis : multiAxisLabel.second) {
+          singleAxisLabels.push_back(std::string(axis.second.data()));
+        }
+        sliceLabels.push_back(singleAxisLabels);
+        singleAxisLabels.clear();
       }
     }
 
@@ -72,6 +85,7 @@ SliceTrendingTaskConfig::SliceTrendingTaskConfig(const std::string& id,
                                 sourceName.second.data(),
                                 dataSourceConfig.second.get<std::string>("reductorName"),
                                 axisBoundaries,
+                                sliceLabels,
                                 dataSourceConfig.second.get<std::string>("moduleName") });
       }
     } else if (!dataSourceConfig.second.get<std::string>("name").empty()) {
@@ -81,12 +95,14 @@ SliceTrendingTaskConfig::SliceTrendingTaskConfig(const std::string& id,
                               dataSourceConfig.second.get<std::string>("name"),
                               dataSourceConfig.second.get<std::string>("reductorName"),
                               axisBoundaries,
+                              sliceLabels,
                               dataSourceConfig.second.get<std::string>("moduleName") });
     } else {
       throw std::runtime_error("No 'name' value or a 'names' vector in the path 'qc.postprocessing." + id + ".dataSources'");
     }
 
     axisBoundaries.clear();
+    sliceLabels.clear();
   }
 }
 


### PR DESCRIPTION
As requested in this [ALICE Talk ticket](https://alice-talk.web.cern.ch/t/continuing-trends-across-activities-and-legend-labels-for-multigraphtime/1549): adding the option to give a label for each slice instead of the default numerical boundaries of the slices (used e.g. in the multigraph legend). This new feature is currently limited to the one-dimensional case. 

@andreasmolander please check if this is how you wanted/imagined it. I modified `Framework/postprocessing.json` to show an example how the slice labels are passed. Example output is shown in the [qcg-test](https://qcg-test.cern.ch/?page=objectView&objectName=qc/TST/MO/ExampleTrendExtended/ExtendedTrending_meanY_of_histogram_timeMultigraph&ts=1708961728661&id=f8bfc15e-d4bc-11ee-96e4-c0a80209250c)