### PR TITLE
ITS: fix of wrong vector size infologger message

### DIFF
--- a/Modules/ITS/include/ITS/ITSHelpers.h
+++ b/Modules/ITS/include/ITS/ITSHelpers.h
@@ -24,6 +24,8 @@ std::vector<T> convertToArray(std::string input)
 
     if constexpr (std::is_same_v<T, int>) {
       result.push_back(std::stoi(token));
+    } else if constexpr (std::is_same_v<T, float>) {
+      result.push_back(std::strtof(token.c_str(), NULL));
     } else if constexpr (std::is_same_v<T, std::string>) {
       result.push_back(token);
     }

--- a/Modules/ITS/itsDecoding.json
+++ b/Modules/ITS/itsDecoding.json
@@ -48,9 +48,9 @@
                 "policy": "OnEachSeparately",
                 "detectorName": "ITS",
                 "checkParameters": {
-                      "DecLinkErrorLimits": "1, 1, 1, 1, 1, 1000, 1000, 1000, 1000, 1000, 1000, 1, 1, 1000, 1000, 1, 1, 1, 1, 1000, 1000, 50, 50",
-                      "DecLinkErrorLimitsRatio": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
-                      "DecLinkErrorType": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
+                      "DecLinkErrorLimits": "5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, -1",
+                      "DecLinkErrorLimitsRatio": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1",
+                      "DecLinkErrorType": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
                       "plotWithTextMessage": "",
                       "textMessage": ""
                 },

--- a/Modules/ITS/src/ITSDecodingErrorCheck.cxx
+++ b/Modules/ITS/src/ITSDecodingErrorCheck.cxx
@@ -38,7 +38,7 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
   }
   std::vector<int> vDecErrorLimits = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "DecLinkErrorLimits", ""));
   if (vDecErrorLimits.size() != o2::itsmft::GBTLinkDecodingStat::NErrorsDefined) {
-    ILOG(Error, Support) << "Incorrect vector with DecodingError limits, check .json" << ENDM;
+    ILOG(Error, Support) << "Incorrect vector with DecodingError limits, check .json"<< ENDM;
     doFlatCheck = true;
   }
   std::vector<float> vDecErrorLimitsRatio = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "DecLinkErrorLimitsRatio", ""));

--- a/Modules/ITS/src/ITSDecodingErrorCheck.cxx
+++ b/Modules/ITS/src/ITSDecodingErrorCheck.cxx
@@ -38,7 +38,7 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
   }
   std::vector<int> vDecErrorLimits = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "DecLinkErrorLimits", ""));
   if (vDecErrorLimits.size() != o2::itsmft::GBTLinkDecodingStat::NErrorsDefined) {
-    ILOG(Error, Support) << "Incorrect vector with DecodingError limits, check .json"<< ENDM;
+    ILOG(Error, Support) << "Incorrect vector with DecodingError limits, check .json" << ENDM;
     doFlatCheck = true;
   }
   std::vector<float> vDecErrorLimitsRatio = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "DecLinkErrorLimitsRatio", ""));


### PR DESCRIPTION
Added template for float variables in string parser which should fix problematic vector size error messages