### PR TITLE
QC-1105 Avoid "Unable to find object" at 2nd STOP in (Slice)TrendingTask

### DIFF
--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -47,6 +47,16 @@ void SliceTrendingTask::configure(const boost::property_tree::ptree& config)
 
 void SliceTrendingTask::initialize(Trigger, framework::ServiceRegistryRef services)
 {
+  // removing leftovers from any previous runs
+  mTrend.reset();
+  for (auto [name, object] : mPlots) {
+    getObjectsManager()->stopPublishing(object);
+    delete object;
+  }
+  mPlots.clear();
+  mReductors.clear();
+  mSources.clear();
+
   // Prepare the data structure of the trending TTree.
   if (mConfig.resumeTrend) {
     ILOG(Info, Support) << "Trying to retrieve an existing TTree for this task to continue the trend." << ENDM;
@@ -169,7 +179,7 @@ void SliceTrendingTask::generatePlots()
   for (const auto& plot : mConfig.plots) {
     // Delete the existing plots before regenerating them.
     if (mPlots.count(plot.name)) {
-      getObjectsManager()->stopPublishing(plot.name);
+      getObjectsManager()->stopPublishing(mPlots[plot.name]);
       delete mPlots[plot.name];
     }
 

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -80,6 +80,15 @@ bool TrendingTask::canContinueTrend(TTree* tree)
 
 void TrendingTask::initialize(Trigger, framework::ServiceRegistryRef services)
 {
+  // removing leftovers from any previous runs
+  mTrend.reset();
+  for (auto [name, object] : mPlots) {
+    getObjectsManager()->stopPublishing(object);
+    delete object;
+  }
+  mPlots.clear();
+  mReductors.clear();
+
   // Preparing data structure of TTree
   if (mConfig.resumeTrend) {
     ILOG(Info, Support) << "Trying to retrieve an existing TTree for this task to continue the trend." << ENDM;
@@ -208,7 +217,7 @@ void TrendingTask::generatePlots()
     // Before we generate any new plots, we have to delete existing under the same names.
     // It seems that ROOT cannot handle an existence of two canvases with a common name in the same process.
     if (mPlots.count(plot.name)) {
-      getObjectsManager()->stopPublishing(plot.name);
+      getObjectsManager()->stopPublishing(mPlots[plot.name]);
       delete mPlots[plot.name];
     }
 


### PR DESCRIPTION
Done so by proper cleanup before initializing objects in initialize(). Also, we reset the trend, so the 2nd run will start from an empty trend, just as the 1st would and should. Picking up an existing trend still is still a possibility of course.