### PR TITLE
MFT: Implementation of QC Review suggestion

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -77,7 +77,6 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   std::vector<std::unique_ptr<TH1F>> mClusterRinLayer;
 
   std::unique_ptr<TH1F> mClustersROFSize = nullptr;
-  std::unique_ptr<TH1F> mNOfClustersTime = nullptr;
   std::unique_ptr<TH1F> mClustersBC = nullptr;
 
   std::vector<o2::BaseCluster<float>> mClustersGlobal;

--- a/Modules/MFT/include/MFT/QcMFTReadoutTask.h
+++ b/Modules/MFT/include/MFT/QcMFTReadoutTask.h
@@ -89,8 +89,6 @@ class QcMFTReadoutTask /*final*/ : public TaskInterface // todo add back the "fi
   float mY[936] = { 0 };
 
   // histos
-  std::unique_ptr<TH1F> mRDHSummary = nullptr;
-  std::unique_ptr<TH1F> mDDWSummary = nullptr;
   std::unique_ptr<TH1F> mSummaryChipOk = nullptr;
   std::unique_ptr<TH1F> mSummaryChipWarning = nullptr;
   std::unique_ptr<TH1F> mSummaryChipError = nullptr;

--- a/Modules/MFT/mft-clusters.json
+++ b/Modules/MFT/mft-clusters.json
@@ -29,7 +29,6 @@
         "moduleName" : "QcMFT",
         "detectorName" : "MFT",
         "cycleDurationSeconds" : "60",
-        "maxNumberCycles" : "-1",
         "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource" : {
           "type" : "dataSamplingPolicy",

--- a/Modules/MFT/mft-digits.json
+++ b/Modules/MFT/mft-digits.json
@@ -29,7 +29,6 @@
         "moduleName" : "QcMFT",
         "detectorName" : "MFT",
         "cycleDurationSeconds" : "60",
-        "maxNumberCycles" : "-1",
         "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource" : {
           "type" : "dataSamplingPolicy",

--- a/Modules/MFT/mft-readout.json
+++ b/Modules/MFT/mft-readout.json
@@ -29,7 +29,6 @@
         "moduleName" : "QcMFT",
         "detectorName" : "MFT",
         "cycleDurationSeconds" : "60",
-        "maxNumberCycles" : "-1",
         "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
           "type": "direct",

--- a/Modules/MFT/mft-readout.json
+++ b/Modules/MFT/mft-readout.json
@@ -58,7 +58,7 @@
         "dataSource" : [ {
           "type" : "Task",
           "name" : "Readout",
-            "MOs"  : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mZoneSummaryChipWarning", "mZoneSummaryChipError", "mZoneSummaryChipFault", "mRDHSummary"]
+            "MOs"  : ["mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mZoneSummaryChipWarning", "mZoneSummaryChipError", "mZoneSummaryChipFault"]
         } ]
       }
     },

--- a/Modules/MFT/mft-tracks-mc.json
+++ b/Modules/MFT/mft-tracks-mc.json
@@ -29,7 +29,6 @@
           "moduleName" : "QcMFT",
           "detectorName" : "MFT",
           "cycleDurationSeconds" : "30",
-          "maxNumberCycles" : "-1",
           "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
           "dataSource" : {
             "type" : "dataSamplingPolicy",

--- a/Modules/MFT/mft-tracks.json
+++ b/Modules/MFT/mft-tracks.json
@@ -29,7 +29,6 @@
         "moduleName" : "QcMFT",
         "detectorName" : "MFT",
         "cycleDurationSeconds" : "60",
-        "maxNumberCycles" : "-1",
         "dataSource_comment" : "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource" : {
           "type" : "dataSamplingPolicy",

--- a/Modules/MFT/src/QcMFTClusterCheck.cxx
+++ b/Modules/MFT/src/QcMFTClusterCheck.cxx
@@ -40,6 +40,7 @@
 #include "QualityControl/QcInfoLogger.h"
 #include "MFT/QcMFTUtilTables.h"
 #include "QualityControl/UserCodeInterface.h"
+#include "QualityControl/CustomParameters.h"
 
 using namespace std;
 
@@ -72,68 +73,88 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
     (void)moName;
 
     if (mo->getName() == "mClusterOccupancy") {
-      auto* hChipOccupancy = dynamic_cast<TH1F*>(mo->getObject());
+      auto* hClusterOccupancy = dynamic_cast<TH1F*>(mo->getObject());
+      if (hClusterOccupancy == nullptr) {
+        ILOG(Error, Support) << "Could not cast mClusterOccupancy to TH1F." << ENDM;
+        return Quality::Null;
+      }
 
-      float den = hChipOccupancy->GetBinContent(0); // normalisation stored in the uderflow bin
+      float den = hClusterOccupancy->GetBinContent(0); // normalisation stored in the uderflow bin
 
-      for (int iBin = 0; iBin < hChipOccupancy->GetNbinsX(); iBin++) {
-        if (hChipOccupancy->GetBinContent(iBin + 1) == 0) {
-          hChipOccupancy->Fill(937); // number of chips with zero clusters stored in the overflow bin
+      for (int iBin = 0; iBin < hClusterOccupancy->GetNbinsX(); iBin++) {
+        if (hClusterOccupancy->GetBinContent(iBin + 1) == 0) {
+          hClusterOccupancy->Fill(937); // number of chips with zero clusters stored in the overflow bin
         }
-        float num = hChipOccupancy->GetBinContent(iBin + 1);
+        float num = hClusterOccupancy->GetBinContent(iBin + 1);
         float ratio = (den > 0) ? (num / den) : 0.0;
-        hChipOccupancy->SetBinContent(iBin + 1, ratio);
+        hClusterOccupancy->SetBinContent(iBin + 1, ratio);
       }
     }
 
     if (mo->getName() == "mClusterPatternIndex") {
-      auto* hChipPattern = dynamic_cast<TH1F*>(mo->getObject());
+      auto* hClusterPatternIndex = dynamic_cast<TH1F*>(mo->getObject());
+      if (hClusterPatternIndex == nullptr) {
+        ILOG(Error, Support) << "Could not cast mClusterPatternIndex to TH1F." << ENDM;
+        return Quality::Null;
+      }
 
-      float den = hChipPattern->GetBinContent(0); // normalisation stored in the uderflow bin
+      float den = hClusterPatternIndex->GetBinContent(0); // normalisation stored in the uderflow bin
 
-      for (int iBin = 0; iBin < hChipPattern->GetNbinsX(); iBin++) {
-        float num = hChipPattern->GetBinContent(iBin + 1);
+      for (int iBin = 0; iBin < hClusterPatternIndex->GetNbinsX(); iBin++) {
+        float num = hClusterPatternIndex->GetBinContent(iBin + 1);
         float ratio = (den > 0) ? (num / den) : 0.0;
-        hChipPattern->SetBinContent(iBin + 1, ratio);
+        hClusterPatternIndex->SetBinContent(iBin + 1, ratio);
       }
     }
 
     if (mo->getName() == "mClusterSizeSummary") {
-      auto* hClusterSizePixels = dynamic_cast<TH1F*>(mo->getObject());
+      auto* hClusterSizeSummary = dynamic_cast<TH1F*>(mo->getObject());
+      if (hClusterSizeSummary == nullptr) {
+        ILOG(Error, Support) << "Could not cast hClusterSizeSummary to TH1F." << ENDM;
+        return Quality::Null;
+      }
 
-      float den = hClusterSizePixels->GetBinContent(0); // normalisation stored in the uderflow bin
+      float den = hClusterSizeSummary->GetBinContent(0); // normalisation stored in the uderflow bin
 
-      for (int iBin = 0; iBin < hClusterSizePixels->GetNbinsX(); iBin++) {
-        float num = hClusterSizePixels->GetBinContent(iBin + 1);
+      for (int iBin = 0; iBin < hClusterSizeSummary->GetNbinsX(); iBin++) {
+        float num = hClusterSizeSummary->GetBinContent(iBin + 1);
         float ratio = (den > 0) ? (num / den) : 0.0;
-        hClusterSizePixels->SetBinContent(iBin + 1, ratio);
+        hClusterSizeSummary->SetBinContent(iBin + 1, ratio);
       }
     }
 
     if (mo->getName() == "mGroupedClusterSizeSummary") {
-      auto* hGroupedClusterSizePixels = dynamic_cast<TH1F*>(mo->getObject());
+      auto* hGroupedClusterSizeSummary = dynamic_cast<TH1F*>(mo->getObject());
+      if (hGroupedClusterSizeSummary == nullptr) {
+        ILOG(Error, Support) << "Could not cast hGroupedClusterSizeSummary to TH1F." << ENDM;
+        return Quality::Null;
+      }
 
-      float den = hGroupedClusterSizePixels->GetBinContent(0); // normalisation stored in the uderflow bin
+      float den = hGroupedClusterSizeSummary->GetBinContent(0); // normalisation stored in the uderflow bin
 
-      for (int iBin = 0; iBin < hGroupedClusterSizePixels->GetNbinsX(); iBin++) {
-        float num = hGroupedClusterSizePixels->GetBinContent(iBin + 1);
+      for (int iBin = 0; iBin < hGroupedClusterSizeSummary->GetNbinsX(); iBin++) {
+        float num = hGroupedClusterSizeSummary->GetBinContent(iBin + 1);
         float ratio = (den > 0) ? (num / den) : 0.0;
-        hGroupedClusterSizePixels->SetBinContent(iBin + 1, ratio);
+        hGroupedClusterSizeSummary->SetBinContent(iBin + 1, ratio);
       }
     }
 
     if (mo->getName() == "mClusterOccupancySummary") {
-      auto* histogram = dynamic_cast<TH2F*>(mo->getObject());
+      auto* hClusterOccupancySummary = dynamic_cast<TH2F*>(mo->getObject());
+      if (hClusterOccupancySummary == nullptr) {
+        ILOG(Error, Support) << "Could not cast hClusterOccupancySummary to TH2F." << ENDM;
+        return Quality::Null;
+      }
 
-      float den = histogram->GetBinContent(0, 0); // normalisation stored in the uderflow bin
-      float nEmptyBins = 0;                       // number of empty zones stored here
+      float den = hClusterOccupancySummary->GetBinContent(0, 0); // normalisation stored in the uderflow bin
+      float nEmptyBins = 0;                                      // number of empty zones stored here
 
-      for (int iBinX = 0; iBinX < histogram->GetNbinsX(); iBinX++) {
-        for (int iBinY = 0; iBinY < histogram->GetNbinsY(); iBinY++) {
-          float num = histogram->GetBinContent(iBinX + 1, iBinY + 1);
+      for (int iBinX = 0; iBinX < hClusterOccupancySummary->GetNbinsX(); iBinX++) {
+        for (int iBinY = 0; iBinY < hClusterOccupancySummary->GetNbinsY(); iBinY++) {
+          float num = hClusterOccupancySummary->GetBinContent(iBinX + 1, iBinY + 1);
           float ratio = (den > 0) ? (num / den) : 0.0;
-          histogram->SetBinContent(iBinX + 1, iBinY + 1, ratio);
-          if ((histogram->GetBinContent(iBinX + 1, iBinY + 1)) == 0) {
+          hClusterOccupancySummary->SetBinContent(iBinX + 1, iBinY + 1, ratio);
+          if ((hClusterOccupancySummary->GetBinContent(iBinX + 1, iBinY + 1)) == 0) {
             nEmptyBins = nEmptyBins + 1;
           }
         }
@@ -161,6 +182,10 @@ void QcMFTClusterCheck::readMaskedChips(std::shared_ptr<MonitorObject> mo)
   map<string, string> headers;
   map<std::string, std::string> filter;
   auto calib = UserCodeInterface::retrieveConditionAny<o2::itsmft::NoiseMap>("MFT/Calib/DeadMap/", filter, timestamp);
+  if (calib == nullptr) {
+    ILOG(Error, Support) << "Could not retrieve deadmap from CCDB." << ENDM;
+    return;
+  }
   for (int i = 0; i < calib->size(); i++) {
     if (calib->isFullChipMasked(i)) {
       mMaskedChips.push_back(i);
@@ -240,14 +265,13 @@ void QcMFTClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality chec
       for (int iFace = 0; iFace < 2; iFace++) {
         int idx = (iDisk * 2 + iFace) + (10 * iHalf);
         if (mo->getName().find(mOutsideAccName[idx]) != std::string::npos) {
-          // LOGF(info, "Name: %s", mo->getName());
           auto* h = dynamic_cast<TH2F*>(mo->getObject());
-          // TBox *b = new TBox();
           for (int i = 0; i < 21; i++) {
             int binX = MFTTable.mBinX[idx][i];
             int binY = MFTTable.mBinY[idx][i];
-            if (binX == -1 || binY == -1)
+            if (binX == -1 || binY == -1) {
               continue;
+            }
             TBox* b = new TBox(h->GetXaxis()->GetBinLowEdge(binX), h->GetYaxis()->GetBinLowEdge(binY), h->GetXaxis()->GetBinWidth(binX) + h->GetXaxis()->GetBinLowEdge(binX), h->GetYaxis()->GetBinWidth(binY) + h->GetYaxis()->GetBinLowEdge(binY));
             b->SetFillStyle(4055);
             b->SetFillColor(15);

--- a/Modules/MFT/src/QcMFTReadoutCheck.cxx
+++ b/Modules/MFT/src/QcMFTReadoutCheck.cxx
@@ -73,20 +73,12 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
 
     (void)moName;
 
-    if (mo->getName() == "mDDWSummary") {
-      // get the histogram
-      auto* hDDW = dynamic_cast<TH1F*>(mo->getObject());
-      // normalise it using the underflow bin as normalisation factor
-      float den = hDDW->GetBinContent(0);
-      for (int i = 1; i < 4; i++) {
-        float num = hDDW->GetBinContent(i);
-        float ratio = (den > 0) ? (num / den) : 0.0;
-        hDDW->SetBinContent(i, ratio);
-      }
-    }
-
     if (mo->getName() == "mSummaryChipOk") {
       auto* hOK = dynamic_cast<TH1F*>(mo->getObject());
+      if (hOK == nullptr) {
+        ILOG(Error, Support) << "Could not cast mSummaryChipOK to TH1F." << ENDM;
+        return Quality::Null;
+      }
       float den = hOK->GetBinContent(0); // normalisation stored in the uderflow bin
 
       for (int iBin = 0; iBin < hOK->GetNbinsX(); iBin++) {
@@ -99,6 +91,10 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
     if (mo->getName() == "mSummaryChipFault") {
       resetVector(mVectorOfFaultBins);
       auto* hFault = dynamic_cast<TH1F*>(mo->getObject());
+      if (hFault == nullptr) {
+        ILOG(Error, Support) << "Could not cast mSummaryChipFault to TH1F." << ENDM;
+        return Quality::Null;
+      }
       float den = hFault->GetBinContent(0); // normalisation stored in the uderflow bin
 
       for (int iBin = 0; iBin < hFault->GetNbinsX(); iBin++) {
@@ -116,6 +112,10 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
     if (mo->getName() == "mSummaryChipError") {
       resetVector(mVectorOfErrorBins);
       auto* hError = dynamic_cast<TH1F*>(mo->getObject());
+      if (hError == nullptr) {
+        ILOG(Error, Support) << "Could not cast mSummaryChipError to TH1F." << ENDM;
+        return Quality::Null;
+      }
       float den = hError->GetBinContent(0); // normalisation stored in the uderflow bin
 
       for (int iBin = 0; iBin < hError->GetNbinsX(); iBin++) {
@@ -133,6 +133,10 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
     if (mo->getName() == "mSummaryChipWarning") {
       resetVector(mVectorOfWarningBins);
       auto* hWarning = dynamic_cast<TH1F*>(mo->getObject());
+      if (hWarning == nullptr) {
+        ILOG(Error, Support) << "Could not cast mSummaryChipWarning to TH1F." << ENDM;
+        return Quality::Null;
+      }
       float den = hWarning->GetBinContent(0); // normalisation stored in the uderflow bin
 
       for (int iBin = 0; iBin < hWarning->GetNbinsX(); iBin++) {
@@ -149,6 +153,10 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
 
     if (mo->getName() == "mZoneSummaryChipWarning") {
       auto* hWarningSummary = dynamic_cast<TH2F*>(mo->getObject());
+      if (hWarningSummary == nullptr) {
+        ILOG(Error, Support) << "Could not cast mZoneSummaryChipWarning to TH2F." << ENDM;
+        return Quality::Null;
+      }
 
       float den = hWarningSummary->GetBinContent(0, 0); // normalisation stored in the underflow bin
 
@@ -163,6 +171,10 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
 
     if (mo->getName() == "mZoneSummaryChipError") {
       auto* hErrorSummary = dynamic_cast<TH2F*>(mo->getObject());
+      if (hErrorSummary == nullptr) {
+        ILOG(Error, Support) << "Could not cast mZoneSummaryChipError to TH2F." << ENDM;
+        return Quality::Null;
+      }
 
       float den = hErrorSummary->GetBinContent(0, 0); // normalisation stored in the underflow bin
 
@@ -177,6 +189,10 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
 
     if (mo->getName() == "mZoneSummaryChipFault") {
       auto* hFaultSummary = dynamic_cast<TH2F*>(mo->getObject());
+      if (hFaultSummary == nullptr) {
+        ILOG(Error, Support) << "Could not cast mZoneSummaryChipFault to TH2F." << ENDM;
+        return Quality::Null;
+      }
 
       float den = hFaultSummary->GetBinContent(0, 0); // normalisation stored in the underflow bin
 
@@ -186,17 +202,6 @@ Quality QcMFTReadoutCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
           float ratio = (den > 0) ? (num / den) : 0.0;
           hFaultSummary->SetBinContent(iBinX + 1, iBinY + 1, ratio);
         }
-      }
-    }
-
-    if (mo->getName() == "mRDHSummary") {
-      auto* hSLS = dynamic_cast<TH1F*>(mo->getObject());
-      float den = hSLS->GetBinContent(0); // normalisation stored in the uderflow bin
-
-      for (int iBin = 0; iBin < hSLS->GetNbinsX(); iBin++) {
-        float num = hSLS->GetBinContent(iBin + 1);
-        float ratio = (den > 0) ? (num / den) : 0.0;
-        hSLS->SetBinContent(iBin + 1, ratio);
       }
     }
 
@@ -258,20 +263,26 @@ Quality QcMFTReadoutCheck::checkQualityStatus(TH1F* histo, std::vector<int>& vec
       result = Quality::Good;
   }
   if (strcmp(histo->GetName(), "mSummaryChipError") == 0) {
-    if (vector.size() > mErrorThresholdBad)
+    if (vector.size() > mErrorThresholdBad) {
       result = Quality::Bad;
-    if (vector.size() > mErrorThresholdMedium && vector.size() <= mErrorThresholdBad)
+    }
+    if (vector.size() > mErrorThresholdMedium && vector.size() <= mErrorThresholdBad) {
       result = Quality::Medium;
-    if (vector.size() <= mErrorThresholdMedium)
+    }
+    if (vector.size() <= mErrorThresholdMedium) {
       result = Quality::Good;
+    }
   }
   if (strcmp(histo->GetName(), "mSummaryChipWarning") == 0) {
-    if (vector.size() > mWarningThresholdBad)
+    if (vector.size() > mWarningThresholdBad) {
       result = Quality::Bad;
-    if (vector.size() > mWarningThresholdMedium && vector.size() <= mWarningThresholdBad)
+    }
+    if (vector.size() > mWarningThresholdMedium && vector.size() <= mWarningThresholdBad) {
       result = Quality::Medium;
-    if (vector.size() <= mWarningThresholdMedium)
+    }
+    if (vector.size() <= mWarningThresholdMedium) {
       result = Quality::Good;
+    }
   }
 
   return result;

--- a/Modules/MFT/src/QcMFTTrackCheck.cxx
+++ b/Modules/MFT/src/QcMFTTrackCheck.cxx
@@ -15,7 +15,8 @@
 /// \author Guillermo Contreras
 /// \author Diana Maria Krupova
 /// \author Katarina Krizkova Gajdosova
-
+// C++
+#include <string>
 // Fair
 #include <fairlogger/Logger.h>
 // ROOT

--- a/Modules/MFT/src/QcMFTTrackTask.cxx
+++ b/Modules/MFT/src/QcMFTTrackTask.cxx
@@ -16,24 +16,30 @@
 /// \author Diana Maria Krupova
 /// \author Katarina Krizkova Gajdosova
 /// \author David Grund
-
+// C++
+#include <string>
+#include <gsl/span>
 // ROOT
 #include <TH1.h>
 #include <TH2.h>
+#include <TString.h>
 // O2
 #include <DataFormatsMFT/TrackMFT.h>
 #include <MFTTracking/TrackCA.h>
 #include <Framework/InputRecord.h>
-#include <Framework/TimingInfo.h>
 #include <DataFormatsITSMFT/ROFRecord.h>
 #include <DataFormatsITSMFT/Cluster.h>
 #include <DataFormatsITSMFT/CompCluster.h>
+#include <CommonConstants/LHCConstants.h>
+#include <Framework/ProcessingContext.h>
 // Quality Control
 #include "QualityControl/QcInfoLogger.h"
 #include "MFT/QcMFTTrackTask.h"
 #include "Common/TH1Ratio.h"
 #include "Common/TH2Ratio.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+#include "QualityControl/CustomParameters.h"
+#include "QualityControl/ObjectsManager.h"
 
 namespace o2::quality_control_modules::mft
 {
@@ -206,8 +212,17 @@ void QcMFTTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
 
   // get the tracks
   const auto tracks = ctx.inputs().get<gsl::span<o2::mft::TrackMFT>>("tracks");
+  if (tracks.empty()) {
+    return;
+  }
   const auto tracksrofs = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("tracksrofs");
+  if (tracksrofs.empty()) {
+    return;
+  }
   const auto clustersrofs = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clustersrofs");
+  if (clustersrofs.empty()) {
+    return;
+  }
 
   // fill the tracks histogram
 


### PR DESCRIPTION
Implementation of QC review suggestions and code clean-up:
- headers updated according to include-what-you-use
- implementing formatting suggestions from QC module review (addition of object checkers and brackets for if statements)
- empty or not used QC objects deleted (mDDWSummary, mRDHSummary, mNOfClustersTime) 
- "maxNumberCycles" removed from json files
- unification of object naming in cluster and digit check