### PR TITLE
MCH: fixed access to invalid map iterator

### DIFF
--- a/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
@@ -103,9 +103,6 @@ void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInte
     ILOG(Info, Devel) << "Loaded reference plot \"" << obj->second.mObject->getName() << "\", time stamp " << mRefTimeStamp
                       << AliceO2::InfoLogger::InfoLogger::endm;
     hElecHistoRef = obj->second.get<TH2F>();
-  } else {
-    ILOG(Info, Devel) << "Could not load reference plot \"" << obj->second.mPath << "/" << obj->second.mName << "\", time stamp " << mRefTimeStamp
-                      << AliceO2::InfoLogger::InfoLogger::endm;
   }
 
   TH2F* hElecSignalHistoRef{ nullptr };


### PR DESCRIPTION
The code was using by mistake `mCcdbObjectsRef.end()` in some Infologger printout, in the case when the reference plots are not loaded.