### PR TITLE
[QC-1125] Avoid MonitorObjectCollection to grow in size

### DIFF
--- a/Framework/src/ObjectsManager.cxx
+++ b/Framework/src/ObjectsManager.cxx
@@ -131,6 +131,7 @@ void ObjectsManager::stopPublishing(const string& objectName)
 {
   auto* mo = dynamic_cast<MonitorObject*>(getMonitorObject(objectName));
   mMonitorObjects->Remove(mo);
+  mMonitorObjects->Compress();
 }
 
 void ObjectsManager::stopPublishingAll()


### PR DESCRIPTION
Currently the published objects are inserted in the `MonitorObjectCollection` via the `TObjArray::Add()` method, which always appends new elements at the end of the array.

When un-publishing objects, they are removed via the `TObjArray::Remove()` method, which does not reduce the size of the TObjArray. Instead, the removed slots are set to `nullptr`.

The proposed solution is to replace `TObjArray::Add()` with `TObjArray::AddAtFree()` in `ObjectsManager::startPublishing()`, which will re-use NULL slots instead of systematically appending new ones at the end.