### PR TITLE
MCH: reduced memory footprint of Digits task

### DIFF
--- a/Modules/MUON/MCH/include/MCH/DigitsTask.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsTask.h
@@ -62,8 +62,6 @@ class DigitsTask /*final*/ : public TaskInterface // todo add back the "final" w
   void reset() override;
 
  private:
-  void storeOrbit(const uint64_t& orb);
-  void addDefaultOrbitsInTF();
   void plotDigit(const o2::mch::Digit& digit);
   void updateOrbits();
   void resetOrbits();
@@ -89,16 +87,11 @@ class DigitsTask /*final*/ : public TaskInterface // todo add back the "final" w
 
   o2::mch::DigitFilter mIsSignalDigit;
 
-  uint32_t mNOrbits[FecId::sFeeNum][FecId::sLinkNum];
-  uint32_t mLastOrbitSeen[FecId::sFeeNum][FecId::sLinkNum];
-  int mNOrbitsPerTF{ -1 };
+  uint32_t mNOrbits{ 0 };
 
   // 2D Histograms, using Elec view (where x and y uniquely identify each pad based on its Elec info (fee, link, de)
   std::unique_ptr<TH2FRatio> mHistogramOccupancyElec;       // Occupancy histogram (Elec view)
   std::unique_ptr<TH2FRatio> mHistogramSignalOccupancyElec; // Occupancy histogram (Elec view) for signal-like digits
-
-  // TH2F* mHistNum;
-  // TH2F* mHistDen;
 
   std::unique_ptr<TH2F> mHistogramDigitsOrbitElec;
   std::unique_ptr<TH2F> mHistogramDigitsSignalOrbitElec;

--- a/Modules/MUON/MCH/src/DigitsTask.cxx
+++ b/Modules/MUON/MCH/src/DigitsTask.cxx
@@ -73,30 +73,32 @@ void DigitsTask::initialize(o2::framework::InitContext& /*ctx*/)
   resetOrbits();
 
   // Histograms in electronics coordinates
-  mHistogramOccupancyElec = std::make_unique<TH2FRatio>("Occupancy_Elec", "Occupancy", nElecXbins, 0, nElecXbins, 64, 0, 64);
+  mHistogramOccupancyElec = std::make_unique<TH2FRatio>("Occupancy_Elec", "Occupancy", nElecXbins, 0, nElecXbins, 64, 0, 64, true);
   publishObject(mHistogramOccupancyElec.get(), "colz", false, false);
 
-  mHistogramSignalOccupancyElec = std::make_unique<TH2FRatio>("OccupancySignal_Elec", "Occupancy (signal)", nElecXbins, 0, nElecXbins, 64, 0, 64);
+  mHistogramSignalOccupancyElec = std::make_unique<TH2FRatio>("OccupancySignal_Elec", "Occupancy (signal)", nElecXbins, 0, nElecXbins, 64, 0, 64, true);
   publishObject(mHistogramSignalOccupancyElec.get(), "colz", false, false);
 
-  mHistogramDigitsOrbitElec = std::make_unique<TH2F>("DigitOrbit_Elec", "Digit orbits vs DS Id", nElecXbins, 0, nElecXbins, 768, -384, 384);
+  mHistogramDigitsOrbitElec = std::make_unique<TH2F>("DigitOrbit_Elec", "Digit orbits vs DS Id", nElecXbins, 0, nElecXbins, 130, -1, 129);
   publishObject(mHistogramDigitsOrbitElec.get(), "colz", true, false);
 
-  mHistogramDigitsSignalOrbitElec = std::make_unique<TH2F>("DigitSignalOrbit_Elec", "Digit orbits vs DS Id (signal)", nElecXbins, 0, nElecXbins, 768, -384, 384);
+  mHistogramDigitsSignalOrbitElec = std::make_unique<TH2F>("DigitSignalOrbit_Elec", "Digit orbits vs DS Id (signal)", nElecXbins, 0, nElecXbins, 130, -1, 129);
   publishObject(mHistogramDigitsSignalOrbitElec.get(), "colz", true, false);
 
-  mHistogramDigitsBcInOrbit = std::make_unique<TH2F>("Expert/DigitsBcInOrbit_Elec", "Digit BC vs DS Id", nElecXbins, 0, nElecXbins, 3600, 0, 3600);
-  publishObject(mHistogramDigitsBcInOrbit.get(), "colz", false, true);
+  if (mDiagnostic) {
+    mHistogramDigitsBcInOrbit = std::make_unique<TH2F>("Expert/DigitsBcInOrbit_Elec", "Digit BC vs DS Id", nElecXbins, 0, nElecXbins, 3600, 0, 3600);
+    publishObject(mHistogramDigitsBcInOrbit.get(), "colz", false, true);
 
-  mHistogramAmplitudeVsSamples = std::make_unique<TH2F>("Expert/AmplitudeVsSamples", "Digit amplitude vs nsamples", 1000, 0, 1000, 1000, 0, 10000);
-  publishObject(mHistogramAmplitudeVsSamples.get(), "colz", false, true);
+    mHistogramAmplitudeVsSamples = std::make_unique<TH2F>("Expert/AmplitudeVsSamples", "Digit amplitude vs nsamples", 1000, 0, 1000, 1000, 0, 10000);
+    publishObject(mHistogramAmplitudeVsSamples.get(), "colz", false, true);
 
-  // Histograms in detector coordinates
-  for (auto de : o2::mch::constants::deIdsForAllMCH) {
-    auto h = std::make_unique<TH1F>(TString::Format("Expert/%sADCamplitude_DE%03d", getHistoPath(de).c_str(), de),
-                                    TString::Format("ADC amplitude (DE%03d)", de), 5000, 0, 5000);
-    publishObject(h.get(), "hist", false, true);
-    mHistogramADCamplitudeDE.emplace(de, std::move(h));
+    // Histograms in detector coordinates
+    for (auto de : o2::mch::constants::deIdsForAllMCH) {
+      auto h = std::make_unique<TH1F>(TString::Format("Expert/%sADCamplitude_DE%03d", getHistoPath(de).c_str(), de),
+                                      TString::Format("ADC amplitude (DE%03d)", de), 5000, 0, 5000);
+      publishObject(h.get(), "hist", false, true);
+      mHistogramADCamplitudeDE.emplace(de, std::move(h));
+    }
   }
 }
 
@@ -124,59 +126,12 @@ static bool checkInput(o2::framework::ProcessingContext& ctx, std::string bindin
 
 void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  bool hasOrbits = checkInput(ctx, "orbits");
-
-  mNOrbitsPerTF = o2::base::GRPGeomHelper::instance().getNHBFPerTF();
-
-  if (hasOrbits) {
-    // if (ctx.inputs().isValid("orbits")) {
-    auto orbits = ctx.inputs().get<gsl::span<uint64_t>>("orbits");
-    if (orbits.empty()) {
-      static AliceO2::InfoLogger::InfoLogger::AutoMuteToken msgLimit(LogWarningSupport, 1, 600); // send it once every 10 minutes
-      string msg = "WARNING: empty orbits vector";
-      ILOG_INST.log(msgLimit, "%s", msg.c_str());
-      return;
-    }
-
-    for (auto& orb : orbits) {
-      storeOrbit(orb);
-    }
-  } else {
-    addDefaultOrbitsInTF();
-  }
+  static auto nOrbitsPerTF = o2::base::GRPGeomHelper::instance().getNHBFPerTF();
+  mNOrbits += nOrbitsPerTF;
 
   auto digits = ctx.inputs().get<gsl::span<o2::mch::Digit>>("digits");
   for (auto& d : digits) {
     plotDigit(d);
-  }
-}
-
-void DigitsTask::storeOrbit(const uint64_t& orb)
-{
-  uint32_t orbit = (orb & 0xFFFFFFFF);
-  uint32_t link = (orb >> 32) & 0xFF;
-  uint32_t fee = (orb >> 40) & 0xFF;
-  if (link != 15) {
-    if (orbit != mLastOrbitSeen[fee][link]) {
-      mNOrbits[fee][link] += 1;
-    }
-    mLastOrbitSeen[fee][link] = orbit;
-  } else if (link == 15) {
-    for (int li = 0; li < FecId::sLinkNum; li++) {
-      if (orbit != mLastOrbitSeen[fee][li]) {
-        mNOrbits[fee][li] += 1;
-      }
-      mLastOrbitSeen[fee][li] = orbit;
-    }
-  }
-}
-
-void DigitsTask::addDefaultOrbitsInTF()
-{
-  for (int fee = 0; fee < FecId::sFeeNum; fee++) {
-    for (int li = 0; li < FecId::sLinkNum; li++) {
-      mNOrbits[fee][li] += mNOrbitsPerTF;
-    }
   }
 }
 
@@ -211,16 +166,6 @@ void DigitsTask::plotDigit(const o2::mch::Digit& digit)
   }
 
   //--------------------------------------------------------------------------
-  // ADC amplitude plots
-  //--------------------------------------------------------------------------
-
-  auto h = mHistogramADCamplitudeDE.find(deId);
-  if ((h != mHistogramADCamplitudeDE.end()) && (h->second != NULL)) {
-    h->second->Fill(ADC);
-  }
-  mHistogramAmplitudeVsSamples->Fill(digit.getNofSamples(), ADC);
-
-  //--------------------------------------------------------------------------
   // Time plots
   //--------------------------------------------------------------------------
 
@@ -232,9 +177,22 @@ void DigitsTask::plotDigit(const o2::mch::Digit& digit)
     bc = digit.getTime() % static_cast<int32_t>(o2::constants::lhc::LHCMaxBunches);
   }
   mHistogramDigitsOrbitElec->Fill(fecId, orbit);
-  mHistogramDigitsBcInOrbit->Fill(fecId, bc);
   if (isSignal) {
     mHistogramDigitsSignalOrbitElec->Fill(fecId, orbit);
+  }
+
+  if (mDiagnostic) {
+    mHistogramDigitsBcInOrbit->Fill(fecId, bc);
+
+    //--------------------------------------------------------------------------
+    // ADC amplitude plots
+    //--------------------------------------------------------------------------
+
+    auto h = mHistogramADCamplitudeDE.find(deId);
+    if ((h != mHistogramADCamplitudeDE.end()) && (h->second != NULL)) {
+      h->second->Fill(ADC);
+    }
+    mHistogramAmplitudeVsSamples->Fill(digit.getNofSamples(), ADC);
   }
 }
 
@@ -244,59 +202,13 @@ void DigitsTask::updateOrbits()
   static constexpr double sOrbitLengthInMicroseconds = sOrbitLengthInNanoseconds / 1000;
   static constexpr double sOrbitLengthInMilliseconds = sOrbitLengthInMicroseconds / 1000;
 
-  // Fill NOrbits, in Elec view, for electronics channels associated to readout pads (in order to then compute the Occupancy in Elec view, physically meaningful because in Elec view, each bin is a physical pad)
-  for (uint16_t feeId = 0; feeId < FecId::sFeeNum; feeId++) {
-
-    // loop on FEE links and check if it corresponds to an existing SOLAR board
-    for (uint8_t linkId = 0; linkId < FecId::sLinkNum; linkId++) {
-
-      if (mNOrbits[feeId][linkId] == 0) {
-        continue;
-      }
-
-      std::optional<uint16_t> solarId = mFeeLink2SolarMapper(FeeLinkId{ feeId, linkId });
-      if (!solarId.has_value()) {
-        continue;
-      }
-
-      // loop on DS boards and check if it exists in the mapping
-      for (uint8_t dsAddr = 0; dsAddr < FecId::sDsNum; dsAddr++) {
-        uint8_t groupId = dsAddr / 5;
-        uint8_t dsAddrInGroup = dsAddr % 5;
-        std::optional<DsDetId> dsDetId = mElec2DetMapper(DsElecId{ solarId.value(), groupId, dsAddrInGroup });
-        if (!dsDetId.has_value()) {
-          continue;
-        }
-        auto deId = dsDetId->deId();
-        auto dsId = dsDetId->dsId();
-
-        int xbin = getDsIndex(DsDetId{ deId, dsId }) + 1;
-
-        // loop on DS channels and check if it is associated to a readout pad
-        for (int channel = 0; channel < 64; channel++) {
-
-          const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(deId);
-          int padId = segment.findPadByFEE(dsId, channel);
-          if (padId < 0) {
-            continue;
-          }
-
-          int ybin = channel + 1;
-          mHistogramOccupancyElec->getDen()->SetBinContent(xbin, ybin, mNOrbits[feeId][linkId] * sOrbitLengthInMilliseconds);
-          mHistogramSignalOccupancyElec->getDen()->SetBinContent(xbin, ybin, mNOrbits[feeId][linkId] * sOrbitLengthInMilliseconds);
-        }
-      }
-    }
-  }
+  mHistogramOccupancyElec->getDen()->SetBinContent(1, 1, mNOrbits * sOrbitLengthInMilliseconds);
+  mHistogramSignalOccupancyElec->getDen()->SetBinContent(1, 1, mNOrbits * sOrbitLengthInMilliseconds);
 }
 
 void DigitsTask::resetOrbits()
 {
-  for (int fee = 0; fee < FecId::sFeeNum; fee++) {
-    for (int link = 0; link < FecId::sLinkNum; link++) {
-      mNOrbits[fee][link] = mLastOrbitSeen[fee][link] = 0;
-    }
-  }
+  mNOrbits = 0;
 }
 
 void DigitsTask::endOfCycle()

--- a/Modules/MUON/MCH/src/TH2ElecMapReductor.cxx
+++ b/Modules/MUON/MCH/src/TH2ElecMapReductor.cxx
@@ -187,7 +187,9 @@ void TH2ElecMapReductor::update(TObject* obj)
 
       deNumPads[cathode][deIndex] += 1;
 
-      Float_t stat = hr->getDen()->GetBinContent(i, j);
+      // here we assume that if the number of bins differs between numerator and denominator,
+      // the denominator contains a single common scaling factor in the first bin (uniform scaling)
+      Float_t stat = (hr->getNum()->GetNcells() == hr->getDen()->GetNcells()) ? hr->getDen()->GetBinContent(i, j) : hr->getDen()->GetBinContent(1, 1);
       if (stat == 0) {
         deNumPadsNoStat[cathode][deIndex] += 1;
         continue;


### PR DESCRIPTION
- experts plots are only allocated if needed
- occupancy TH2 ratio now uses uniform scaling instead of bin-by-bin scaling
- reduced number of bins for orbits plot

This should reduce the memory footprint by approximately a factor of 3. The changes have no impcat on the contents of the generated plots, apart from the different binning of the orbits plot.