### PR TITLE
TRD: Load Chamber Status from CCDB every instance

### DIFF
--- a/Modules/TRD/include/TRD/DigitsTask.h
+++ b/Modules/TRD/include/TRD/DigitsTask.h
@@ -45,6 +45,7 @@ class DigitsTask final : public TaskInterface
   void monitorData(o2::framework::ProcessingContext& ctx) override;
   void endOfCycle() override;
   void endOfActivity(const Activity& activity) override;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) override;
   void reset() override;
   void buildHistograms();
   void drawLinesOnPulseHeight(TH1F* h);
@@ -84,7 +85,6 @@ class DigitsTask final : public TaskInterface
 
   // CCDB objects
   const o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
-  const std::array<int, o2::trd::constants::MAXCHAMBER>* mChamberStatus = nullptr;
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/include/TRD/TrackletsTask.h
+++ b/Modules/TRD/include/TRD/TrackletsTask.h
@@ -43,6 +43,7 @@ class TrackletsTask final : public TaskInterface
   void monitorData(o2::framework::ProcessingContext& ctx) override;
   void endOfCycle() override;
   void endOfActivity(const Activity& activity) override;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) override;
   void reset() override;
   void buildHistograms();
 
@@ -64,7 +65,6 @@ class TrackletsTask final : public TaskInterface
 
   // data to pull from CCDB
   const o2::trd::NoiseStatusMCM* mNoiseMap = nullptr;
-  const std::array<int, o2::trd::constants::MAXCHAMBER>* mChamberStatus = nullptr;
 };
 
 } // namespace o2::quality_control_modules::trd

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -146,13 +146,7 @@ void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
     mNoiseMap = ptr.get();
   }
 
-  // LB: Chamber Status cannot be loaded only once, it should always check object
   auto ptr = ctx.inputs().get<std::array<int, MAXCHAMBER>*>("fedChamberStatus");
-  mChamberStatus = ptr.get();
-  if (mChamberStatus) {
-    // LB: no half chamber distribution map for Digits, pass it as null pointer
-    TRDHelpers::drawChamberStatusOnHistograms(mChamberStatus, nullptr, mLayers, NCOLUMN);
-  }
 
   // fill histograms
   auto digits = ctx.inputs().get<gsl::span<o2::trd::Digit>>("digits");
@@ -337,6 +331,14 @@ void DigitsTask::endOfCycle()
 void DigitsTask::endOfActivity(const Activity& /*activity*/)
 {
   ILOG(Debug, Devel) << "endOfActivity" << ENDM;
+}
+
+void DigitsTask::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == o2::framework::ConcreteDataMatcher("TRD", "FCHSTATUS", 0)) {
+    // LB: no half chamber distribution map for Digits, pass it as null pointer
+    TRDHelpers::drawChamberStatusOnHistograms(static_cast<std::array<int, MAXCHAMBER>*>(obj), nullptr, mLayers, NCOLUMN);
+  }
 }
 
 void DigitsTask::reset()

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -146,16 +146,12 @@ void DigitsTask::monitorData(o2::framework::ProcessingContext& ctx)
     mNoiseMap = ptr.get();
   }
 
-  if (!mChamberStatus) {
-    auto ptr = ctx.inputs().get<std::array<int, MAXCHAMBER>*>("fedChamberStatus");
-    mChamberStatus = ptr.get();
-    // LB: only draw in plots if it is first instance, e.g. null ptr to non null ptr
-    if (mChamberStatus) {
-      // LB: no half chamber distribution map for Digits, pass it as null pointer
-      TRDHelpers::drawChamberStatusOnHistograms(mChamberStatus, nullptr, mLayers, NCOLUMN);
-    } else {
-      ILOG(Info, Support) << "Failed to retrieve ChamberStatus, so it will not show on plots" << ENDM;
-    }
+  // LB: Chamber Status cannot be loaded only once, it should always check object
+  auto ptr = ctx.inputs().get<std::array<int, MAXCHAMBER>*>("fedChamberStatus");
+  mChamberStatus = ptr.get();
+  if (mChamberStatus) {
+    // LB: no half chamber distribution map for Digits, pass it as null pointer
+    TRDHelpers::drawChamberStatusOnHistograms(mChamberStatus, nullptr, mLayers, NCOLUMN);
   }
 
   // fill histograms

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -138,15 +138,11 @@ void TrackletsTask::monitorData(o2::framework::ProcessingContext& ctx)
     mNoiseMap = ptr.get();
   }
 
-  if (!mChamberStatus) {
-    auto ptr = ctx.inputs().get<std::array<int, MAXCHAMBER>*>("fedChamberStatus");
-    mChamberStatus = ptr.get();
-    // LB: only draw in plots if it is first instance, e.g. null ptr to non null ptr
-    if (mChamberStatus) {
-      TRDHelpers::drawChamberStatusOnHistograms(mChamberStatus, mTrackletsPerHC2D, mLayers, NCOLUMN / NSECTOR);
-    } else {
-      ILOG(Info, Support) << "Failed to retrieve ChamberStatus, so it will not show on plots" << ENDM;
-    }
+  // LB: Chamber Status cannot be loaded only once, it should always take check object
+  auto ptr = ctx.inputs().get<std::array<int, MAXCHAMBER>*>("fedChamberStatus");
+  mChamberStatus = ptr.get();
+  if (mChamberStatus) {
+    TRDHelpers::drawChamberStatusOnHistograms(mChamberStatus, mTrackletsPerHC2D, mLayers, NCOLUMN / NSECTOR);
   }
 
   // Fill histograms

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -138,12 +138,7 @@ void TrackletsTask::monitorData(o2::framework::ProcessingContext& ctx)
     mNoiseMap = ptr.get();
   }
 
-  // LB: Chamber Status cannot be loaded only once, it should always take check object
   auto ptr = ctx.inputs().get<std::array<int, MAXCHAMBER>*>("fedChamberStatus");
-  mChamberStatus = ptr.get();
-  if (mChamberStatus) {
-    TRDHelpers::drawChamberStatusOnHistograms(mChamberStatus, mTrackletsPerHC2D, mLayers, NCOLUMN / NSECTOR);
-  }
 
   // Fill histograms
   auto tracklets = ctx.inputs().get<gsl::span<o2::trd::Tracklet64>>("tracklets");
@@ -198,6 +193,13 @@ void TrackletsTask::endOfCycle()
 void TrackletsTask::endOfActivity(const Activity& /*activity*/)
 {
   ILOG(Debug, Devel) << "endOfActivity" << ENDM;
+}
+
+void TrackletsTask::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == o2::framework::ConcreteDataMatcher("TRD", "FCHSTATUS", 0)) {
+    TRDHelpers::drawChamberStatusOnHistograms(static_cast<std::array<int, MAXCHAMBER>*>(obj), mTrackletsPerHC2D, mLayers, NCOLUMN / NSECTOR);
+  }
 }
 
 void TrackletsTask::reset()


### PR DESCRIPTION
## Main Goal
Minor fix to always try to get Chamber Status object from CCDB, not only once, so plots would show latest valid instance. 

Follow-up of https://github.com/AliceO2Group/QualityControl/pull/2075.

---
Relevant O2 PR: https://github.com/AliceO2Group/AliceO2/pull/12319