### PR TITLE
MUONS: second part of QC review corrections

### DIFF
--- a/Modules/MUON/Common/src/Helpers.cxx
+++ b/Modules/MUON/Common/src/Helpers.cxx
@@ -20,7 +20,7 @@
 namespace o2::quality_control_modules::muon
 {
 template <>
-std::string getConfigurationParameter(o2::quality_control::core::CustomParameters customParameters, std::string parName, const std::string defaultValue)
+std::string getConfigurationParameter<std::string>(o2::quality_control::core::CustomParameters customParameters, std::string parName, const std::string defaultValue)
 {
   std::string result = defaultValue;
   auto parOpt = customParameters.atOptional(parName);
@@ -31,7 +31,7 @@ std::string getConfigurationParameter(o2::quality_control::core::CustomParameter
 }
 
 template <>
-std::string getConfigurationParameter(o2::quality_control::core::CustomParameters customParameters, std::string parName, const std::string defaultValue, const o2::quality_control::core::Activity& activity)
+std::string getConfigurationParameter<std::string>(o2::quality_control::core::CustomParameters customParameters, std::string parName, const std::string defaultValue, const o2::quality_control::core::Activity& activity)
 {
   auto parOpt = customParameters.atOptional(parName, activity);
   if (parOpt.has_value()) {
@@ -39,6 +39,43 @@ std::string getConfigurationParameter(o2::quality_control::core::CustomParameter
     return result;
   }
   return getConfigurationParameter<std::string>(customParameters, parName, defaultValue);
+}
+
+template <>
+bool getConfigurationParameter<bool>(o2::quality_control::core::CustomParameters customParameters, std::string parName, const bool defaultValue)
+{
+  bool result = defaultValue;
+  auto parOpt = customParameters.atOptional(parName);
+  if (parOpt.has_value()) {
+    std::string value = parOpt.value();
+    std::transform(value.begin(), value.end(), value.begin(), ::toupper);
+    if (value == "TRUE" || value == "YES" || value == "1") {
+      return true;
+    }
+    if (value == "FALSE" || value == "NO" || value == "0") {
+      return false;
+    }
+    throw std::invalid_argument(std::string("error parsing boolean configurable parameter: key=") + parName + " value=" + value);
+  }
+  return result;
+}
+
+template <>
+bool getConfigurationParameter<bool>(o2::quality_control::core::CustomParameters customParameters, std::string parName, const bool defaultValue, const o2::quality_control::core::Activity& activity)
+{
+  auto parOpt = customParameters.atOptional(parName, activity);
+  if (parOpt.has_value()) {
+    std::string value = parOpt.value();
+    std::transform(value.begin(), value.end(), value.begin(), ::toupper);
+    if (value == "TRUE" || value == "YES" || value == "1") {
+      return true;
+    }
+    if (value == "FALSE" || value == "NO" || value == "0") {
+      return false;
+    }
+    throw std::invalid_argument(std::string("error parsing boolean configurable parameter: key=") + parName + " value=" + value);
+  }
+  return getConfigurationParameter<bool>(customParameters, parName, defaultValue);
 }
 
 //_________________________________________________________________________________________

--- a/Modules/MUON/Common/src/TracksTask.cxx
+++ b/Modules/MUON/Common/src/TracksTask.cxx
@@ -86,7 +86,7 @@ void TracksTask::initialize(o2::framework::InitContext& /*ic*/)
 
 void TracksTask::createTrackHistos(const Activity& activity)
 {
-  bool fullHistos = getConfigurationParameter<int>(mCustomParameters, "fullHistos", 0, activity) == 1;
+  bool fullHistos = getConfigurationParameter<bool>(mCustomParameters, "fullHistos", false, activity);
 
   double maxTracksPerTF = getConfigurationParameter<double>(mCustomParameters, "maxTracksPerTF", 400, activity);
   double cutRAbsMin = getConfigurationParameter<double>(mCustomParameters, "cutRAbsMin", 17.6, activity);

--- a/Modules/MUON/MCH/include/MCH/DecodingCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingCheck.h
@@ -41,6 +41,7 @@ class DecodingCheck : public o2::quality_control::checker::CheckInterface
 
   // Override interface
   void configure() override;
+  void startOfActivity(const Activity& activity) override;
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;

--- a/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
@@ -21,6 +21,7 @@
 
 #include "QualityControl/PostProcessingInterface.h"
 
+#include "MCH/PostProcessingConfigMCH.h"
 #include "MCH/Helpers.h"
 #include "Common/TH2Ratio.h"
 #include "MCH/HistoOnCycle.h"
@@ -75,6 +76,8 @@ class DecodingPostProcessing : public PostProcessingInterface
 
   int64_t mRefTimeStamp;
   bool mFullHistos{ false };
+
+  PostProcessingConfigMCH mConfig;
 
   // CCDB object accessors
   std::map<std::string, CcdbObjectHelper> mCcdbObjects;

--- a/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
@@ -19,8 +19,6 @@
 #ifndef QC_MODULE_MCH_PP_DIAGNOSTICS_H
 #define QC_MODULE_MCH_PP_DIAGNOSTICS_H
 
-#include "QualityControl/PostProcessingInterface.h"
-
 #include "MCH/PostProcessingConfigMCH.h"
 #include "MCH/Helpers.h"
 #include "Common/TH2Ratio.h"
@@ -28,6 +26,7 @@
 #include "MCH/DecodingErrorsPlotter.h"
 #include "MCH/HeartBeatPacketsPlotter.h"
 #include "MCH/FECSyncStatusPlotter.h"
+#include "QualityControl/PostProcessingInterface.h"
 
 #include <memory>
 
@@ -74,7 +73,6 @@ class DecodingPostProcessing : public PostProcessingInterface
   static std::string hbPacketsSourceName() { return "hbpackets"; }
   static std::string syncStatusSourceName() { return "syncstatus"; }
 
-  int64_t mRefTimeStamp;
   bool mFullHistos{ false };
 
   PostProcessingConfigMCH mConfig;

--- a/Modules/MUON/MCH/include/MCH/DecodingTask.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingTask.h
@@ -109,19 +109,6 @@ class DecodingTask /*final*/ : public TaskInterface
   std::vector<TH1*> mAllHistograms;
 };
 
-template <typename T>
-void DecodingTask::publishObject(T* histo, std::string drawOption, std::string displayHints, bool statBox, bool isExpert)
-{
-  histo->SetOption(drawOption.c_str());
-  if (!statBox) {
-    histo->SetStats(0);
-  }
-  mAllHistograms.push_back(histo);
-  getObjectsManager()->startPublishing(histo);
-  getObjectsManager()->setDefaultDrawOptions(histo, drawOption);
-  getObjectsManager()->setDisplayHint(histo, displayHints);
-}
-
 } // namespace o2::quality_control_modules::muonchambers
 
 #endif // QC_MODULE_MCH_DECODINGTASK_H

--- a/Modules/MUON/MCH/include/MCH/DigitsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsCheck.h
@@ -20,7 +20,6 @@
 #include "MCH/Helpers.h"
 #include "QualityControl/CheckInterface.h"
 #include "QualityControl/Quality.h"
-#include "MCHRawElecMap/Mapper.h"
 #include <string>
 
 namespace o2::quality_control::core
@@ -71,10 +70,7 @@ class DigitsCheck : public o2::quality_control::checker::CheckInterface
 
   QualityChecker mQualityChecker;
 
-  o2::mch::raw::Elec2DetMapper mElec2DetMapper;
-  o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
-
-  ClassDefOverride(DigitsCheck, 1);
+  ClassDefOverride(DigitsCheck, 2);
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/DigitsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsCheck.h
@@ -44,6 +44,7 @@ class DigitsCheck : public o2::quality_control::checker::CheckInterface
 
   // Override interface
   void configure() override;
+  void startOfActivity(const Activity& activity) override;
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;

--- a/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
@@ -20,12 +20,12 @@
 #define QC_MODULE_MCH_PP_DIGITS_H
 
 #include "MCH/PostProcessingConfigMCH.h"
-#include "QualityControl/PostProcessingInterface.h"
-#include "Common/TH2Ratio.h"
 #include "MCH/HistoOnCycle.h"
 #include "MCH/RatesPlotter.h"
 #include "MCH/RatesTrendsPlotter.h"
 #include "MCH/OrbitsPlotter.h"
+#include "Common/TH2Ratio.h"
+#include "QualityControl/PostProcessingInterface.h"
 
 namespace o2::quality_control::repository
 {

--- a/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
@@ -19,6 +19,7 @@
 #ifndef QC_MODULE_MCH_PP_DIGITS_H
 #define QC_MODULE_MCH_PP_DIGITS_H
 
+#include "MCH/PostProcessingConfigMCH.h"
 #include "QualityControl/PostProcessingInterface.h"
 #include "Common/TH2Ratio.h"
 #include "MCH/HistoOnCycle.h"
@@ -61,10 +62,12 @@ class DigitsPostProcessing : public PostProcessingInterface
   static std::string orbitsSourceName() { return "orbits"; }
   static std::string orbitsSignalSourceName() { return "orbits_signal"; }
 
-  int64_t mRefTimeStamp;
+  int64_t mRefTimeStamp{ 0 };
   bool mFullHistos{ false };
-  float mChannelRateMin;
-  float mChannelRateMax;
+  float mChannelRateMin{ 0 };
+  float mChannelRateMax{ 100 };
+
+  PostProcessingConfigMCH mConfig;
 
   // CCDB object accessors
   std::map<std::string, CcdbObjectHelper> mCcdbObjects;

--- a/Modules/MUON/MCH/include/MCH/DigitsTask.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsTask.h
@@ -80,7 +80,7 @@ class DigitsTask /*final*/ : public TaskInterface // todo add back the "final" w
     }
   }
 
-  bool mDiagnostic{ false }; // publish extra diagnostics plots
+  bool mFullHistos{ false }; // publish extra diagnostics plots
 
   o2::mch::raw::Elec2DetMapper mElec2DetMapper;
   o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;

--- a/Modules/MUON/MCH/include/MCH/DigitsTask.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsTask.h
@@ -18,7 +18,6 @@
 #define QC_MODULE_MUONCHAMBERS_DIGITSTASK_H
 
 #include "QualityControl/TaskInterface.h"
-#include "MCHRawElecMap/Mapper.h"
 #ifdef HAVE_DIGIT_IN_DATAFORMATS
 #include "DataFormatsMCH/Digit.h"
 #else
@@ -26,7 +25,6 @@
 #endif
 #include "MCHDigitFiltering/DigitFilter.h"
 #include "Common/TH2Ratio.h"
-#include "MCH/Helpers.h"
 
 class TH1F;
 class TH2F;
@@ -48,9 +46,9 @@ class DigitsTask /*final*/ : public TaskInterface // todo add back the "final" w
 {
  public:
   /// \brief Constructor
-  DigitsTask();
+  DigitsTask() = default;
   /// Destructor
-  ~DigitsTask() override;
+  ~DigitsTask() override = default;
 
   // Definition of the methods for the template method pattern
   void initialize(o2::framework::InitContext& ctx) override;
@@ -67,23 +65,9 @@ class DigitsTask /*final*/ : public TaskInterface // todo add back the "final" w
   void resetOrbits();
 
   template <typename T>
-  void publishObject(T* histo, std::string drawOption, bool statBox, bool isExpert)
-  {
-    histo->SetOption(drawOption.c_str());
-    if (!statBox) {
-      histo->SetStats(0);
-    }
-    mAllHistograms.push_back(histo);
-    if (mDiagnostic || (isExpert == false)) {
-      getObjectsManager()->startPublishing(histo);
-      getObjectsManager()->setDefaultDrawOptions(histo, drawOption);
-    }
-  }
+  void publishObject(T* histo, std::string drawOption, bool statBox, bool isExpert);
 
   bool mFullHistos{ false }; // publish extra diagnostics plots
-
-  o2::mch::raw::Elec2DetMapper mElec2DetMapper;
-  o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
 
   o2::mch::DigitFilter mIsSignalDigit;
 

--- a/Modules/MUON/MCH/include/MCH/PedestalsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PedestalsCheck.h
@@ -19,10 +19,7 @@
 
 #include "MCH/Helpers.h"
 #include "QualityControl/CheckInterface.h"
-#include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
-#include "MCHRawCommon/DataFormats.h"
-#include "MCHRawElecMap/Mapper.h"
 
 namespace o2::quality_control_modules::muonchambers
 {

--- a/Modules/MUON/MCH/include/MCH/PedestalsTask.h
+++ b/Modules/MUON/MCH/include/MCH/PedestalsTask.h
@@ -85,7 +85,6 @@ class PedestalsTask final : public TaskInterface
   static constexpr int sMaxDsId = 40;
 
   o2::mch::raw::Elec2DetMapper mElec2DetMapper;
-  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
   o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
   o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
 

--- a/Modules/MUON/MCH/include/MCH/PreclustersCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersCheck.h
@@ -19,7 +19,6 @@
 #include "MCH/Helpers.h"
 #include "QualityControl/CheckInterface.h"
 #include "QualityControl/Quality.h"
-#include "MCHRawElecMap/Mapper.h"
 #include <string>
 
 namespace o2::quality_control::core
@@ -37,9 +36,9 @@ class PreclustersCheck : public o2::quality_control::checker::CheckInterface
 {
  public:
   /// Default constructor
-  PreclustersCheck();
+  PreclustersCheck() = default;
   /// Destructor
-  ~PreclustersCheck() override;
+  ~PreclustersCheck() override = default;
 
   // Override interface
   void configure() override;
@@ -65,12 +64,7 @@ class PreclustersCheck : public o2::quality_control::checker::CheckInterface
 
   QualityChecker mQualityChecker;
 
-  o2::mch::raw::Elec2DetMapper mElec2DetMapper;
-  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
-  o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
-  o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
-
-  ClassDefOverride(PreclustersCheck, 1);
+  ClassDefOverride(PreclustersCheck, 2);
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/PreclustersCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersCheck.h
@@ -43,6 +43,7 @@ class PreclustersCheck : public o2::quality_control::checker::CheckInterface
 
   // Override interface
   void configure() override;
+  void startOfActivity(const Activity& activity) override;
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::string getAcceptedType() override;

--- a/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
@@ -21,6 +21,7 @@
 
 #include "QualityControl/PostProcessingInterface.h"
 
+#include "MCH/PostProcessingConfigMCH.h"
 #include "MCH/Helpers.h"
 #include "Common/TH2Ratio.h"
 #include "MCH/HistoOnCycle.h"
@@ -73,8 +74,10 @@ class PreclustersPostProcessing : public PostProcessingInterface
   static std::string clusterSizeSourceName() { return "clsize"; }
 
   // PreclustersConfig mConfig;
-  int64_t mRefTimeStamp;
+  int64_t mRefTimeStamp{ 0 };
   bool mFullHistos{ false };
+
+  PostProcessingConfigMCH mConfig;
 
   // CCDB object accessors
   std::map<std::string, CcdbObjectHelper> mCcdbObjects;

--- a/Modules/MUON/MCH/include/MCH/PreclustersTask.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersTask.h
@@ -21,7 +21,6 @@
 #include "QualityControl/TaskInterface.h"
 #include "Common/TH1Ratio.h"
 #include "Common/TH2Ratio.h"
-#include "MCHRawElecMap/Mapper.h"
 #ifdef HAVE_DIGIT_IN_DATAFORMATS
 #include "DataFormatsMCH/Digit.h"
 #else
@@ -48,7 +47,7 @@ class PreclustersTask /*final*/ : public o2::quality_control::core::TaskInterfac
   /// \brief Constructor
   PreclustersTask() = default;
   /// Destructor
-  ~PreclustersTask() = default;
+  ~PreclustersTask() override = default;
 
   // Definition of the methods for the template method pattern
   void initialize(o2::framework::InitContext& ctx) override;
@@ -61,21 +60,9 @@ class PreclustersTask /*final*/ : public o2::quality_control::core::TaskInterfac
 
  private:
   template <typename T>
-  void publishObject(T* histo, std::string drawOption, bool statBox)
-  {
-    histo->SetOption(drawOption.c_str());
-    if (!statBox) {
-      histo->SetStats(0);
-    }
-    mAllHistograms.push_back(histo);
-    getObjectsManager()->startPublishing(histo);
-    getObjectsManager()->setDefaultDrawOptions(histo, drawOption);
-  }
+  void publishObject(T* histo, std::string drawOption, bool statBox);
 
   void plotPrecluster(const o2::mch::PreCluster& preCluster, gsl::span<const o2::mch::Digit> digits);
-
-  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
-  o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
 
   o2::mch::DigitFilter mIsSignalDigit;
 

--- a/Modules/MUON/MCH/include/MCH/RofsTask.h
+++ b/Modules/MUON/MCH/include/MCH/RofsTask.h
@@ -37,9 +37,9 @@ class RofsTask /*final*/ : public o2::quality_control::core::TaskInterface
 {
  public:
   /// \brief Constructor
-  RofsTask();
+  RofsTask() = default;
   /// Destructor
-  ~RofsTask() override;
+  ~RofsTask() override = default;
 
   void initialize(o2::framework::InitContext& ctx) override;
   void startOfActivity(const o2::quality_control::core::Activity& activity) override;
@@ -51,16 +51,7 @@ class RofsTask /*final*/ : public o2::quality_control::core::TaskInterface
 
  private:
   template <typename T>
-  void publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox)
-  {
-    histo->SetOption(drawOption.c_str());
-    if (!statBox) {
-      histo->SetStats(0);
-    }
-    mAllHistograms.push_back(histo.get());
-    getObjectsManager()->startPublishing(histo.get());
-    getObjectsManager()->setDefaultDrawOptions(histo.get(), drawOption);
-  }
+  void publishObject(std::shared_ptr<T> histo, std::string drawOption, bool statBox);
 
   void plotROF(const o2::mch::ROFRecord& rof, gsl::span<const o2::mch::Digit> digits);
 

--- a/Modules/MUON/MCH/src/DecodingCheck.cxx
+++ b/Modules/MUON/MCH/src/DecodingCheck.cxx
@@ -17,6 +17,7 @@
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCH/DecodingCheck.h"
 #include "MCH/Helpers.h"
+#include "MUONCommon/Helpers.h"
 
 // ROOT
 #include <TH1.h>
@@ -27,30 +28,25 @@
 #include <string>
 
 using namespace std;
+using namespace o2::quality_control_modules::muon;
 
 namespace o2::quality_control_modules::muonchambers
 {
 
 void DecodingCheck::configure()
 {
-  if (auto param = mCustomParameters.find("MinGoodErrorFrac"); param != mCustomParameters.end()) {
-    mMinGoodErrorFrac = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MinGoodSyncFrac"); param != mCustomParameters.end()) {
-    mMinGoodSyncFrac = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("GoodFracHistName"); param != mCustomParameters.end()) {
-    mGoodFracHistName = param->second;
-  }
-  if (auto param = mCustomParameters.find("SyncFracHistName"); param != mCustomParameters.end()) {
-    mSyncFracHistName = param->second;
-  }
-  if (auto param = mCustomParameters.find("MaxBadDE_ST12"); param != mCustomParameters.end()) {
-    mMaxBadST12 = std::stoi(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxBadDE_ST345"); param != mCustomParameters.end()) {
-    mMaxBadST345 = std::stoi(param->second);
-  }
+}
+
+void DecodingCheck::startOfActivity(const Activity& activity)
+{
+  mGoodFracHistName = getConfigurationParameter<std::string>(mCustomParameters, "GoodFracHistName", mGoodFracHistName, activity);
+  mSyncFracHistName = getConfigurationParameter<std::string>(mCustomParameters, "SyncFracHistName", mSyncFracHistName, activity);
+
+  mMinGoodErrorFrac = getConfigurationParameter<double>(mCustomParameters, "MinGoodErrorFrac", mMinGoodErrorFrac, activity);
+  mMinGoodSyncFrac = getConfigurationParameter<double>(mCustomParameters, "MinGoodSyncFrac", mMinGoodSyncFrac, activity);
+
+  mMaxBadST12 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST12", mMaxBadST12, activity);
+  mMaxBadST345 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST345", mMaxBadST345, activity);
 
   mQualityChecker.mMaxBadST12 = mMaxBadST12;
   mQualityChecker.mMaxBadST345 = mMaxBadST345;

--- a/Modules/MUON/MCH/src/DecodingPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DecodingPostProcessing.cxx
@@ -21,10 +21,8 @@
 #include "MUONCommon/Helpers.h"
 #include <MCHMappingInterface/Segmentation.h>
 #include "QualityControl/QcInfoLogger.h"
-#include "QualityControl/RootClassFactory.h"
 #include "QualityControl/DatabaseInterface.h"
 #include <TH2.h>
-#include <TDatime.h>
 
 using namespace o2::quality_control;
 using namespace o2::quality_control::core;

--- a/Modules/MUON/MCH/src/DecodingTask.cxx
+++ b/Modules/MUON/MCH/src/DecodingTask.cxx
@@ -37,11 +37,18 @@ using namespace o2::quality_control_modules::muon;
 namespace o2::quality_control_modules::muonchambers
 {
 
-using namespace o2;
-using namespace o2::framework;
-using namespace o2::mch;
-using namespace o2::mch::raw;
-using RDH = o2::header::RDHAny;
+template <typename T>
+void DecodingTask::publishObject(T* histo, std::string drawOption, std::string displayHints, bool statBox, bool isExpert)
+{
+  histo->SetOption(drawOption.c_str());
+  if (!statBox) {
+    histo->SetStats(0);
+  }
+  mAllHistograms.push_back(histo);
+  getObjectsManager()->startPublishing(histo);
+  getObjectsManager()->setDefaultDrawOptions(histo, drawOption);
+  getObjectsManager()->setDisplayHint(histo, displayHints);
+}
 
 //_____________________________________________________________________________
 
@@ -90,7 +97,6 @@ void DecodingTask::initialize(o2::framework::InitContext& /*ic*/)
 
   // expected bunch-crossing value in heart-beat packets
   mHBExpectedBc = getConfigurationParameter<int>(mCustomParameters, "HBExpectedBc", mHBExpectedBc);
-
 
   mElec2DetMapper = createElec2DetMapper<ElectronicMapperGenerated>();
 

--- a/Modules/MUON/MCH/src/DecodingTask.cxx
+++ b/Modules/MUON/MCH/src/DecodingTask.cxx
@@ -15,6 +15,7 @@
 ///
 
 #include "MCH/DecodingTask.h"
+#include "MUONCommon/Helpers.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "Framework/WorkflowSpec.h"
@@ -26,11 +27,14 @@
 #include "MCHBase/DecoderError.h"
 #include "MCHBase/HeartBeatPacket.h"
 
-namespace o2
-{
-namespace quality_control_modules
-{
-namespace muonchambers
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::mch;
+using namespace o2::mch::raw;
+using RDH = o2::header::RDHAny;
+using namespace o2::quality_control_modules::muon;
+
+namespace o2::quality_control_modules::muonchambers
 {
 
 using namespace o2;
@@ -85,9 +89,8 @@ void DecodingTask::initialize(o2::framework::InitContext& /*ic*/)
   ILOG(Debug, Devel) << "initialize DecodingErrorsTask" << ENDM;
 
   // expected bunch-crossing value in heart-beat packets
-  if (auto param = mCustomParameters.find("HBExpectedBc"); param != mCustomParameters.end()) {
-    mHBExpectedBc = std::stoi(param->second);
-  }
+  mHBExpectedBc = getConfigurationParameter<int>(mCustomParameters, "HBExpectedBc", mHBExpectedBc);
+
 
   mElec2DetMapper = createElec2DetMapper<ElectronicMapperGenerated>();
 
@@ -384,6 +387,4 @@ void DecodingTask::reset()
   }
 }
 
-} // namespace muonchambers
-} // namespace quality_control_modules
-} // namespace o2
+} // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/src/DigitsCheck.cxx
+++ b/Modules/MUON/MCH/src/DigitsCheck.cxx
@@ -15,6 +15,7 @@
 ///
 
 #include "MCH/DigitsCheck.h"
+#include "MUONCommon/Helpers.h"
 #include <MCHConstants/DetectionElements.h>
 #include <MCHRawElecMap/Mapper.h>
 #include "QualityControl/MonitorObject.h"
@@ -29,6 +30,7 @@
 #include <string>
 
 using namespace std;
+using namespace o2::quality_control_modules::muon;
 
 namespace o2::quality_control_modules::muonchambers
 {
@@ -37,47 +39,25 @@ void DigitsCheck::configure()
 {
   mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
   mFeeLink2SolarMapper = o2::mch::raw::createFeeLink2SolarMapper<o2::mch::raw::ElectronicMapperGenerated>();
+}
 
-  if (auto param = mCustomParameters.find("MeanRateHistName"); param != mCustomParameters.end()) {
-    mMeanRateHistName = param->second;
-  }
-  if (auto param = mCustomParameters.find("MeanRateRatioHistName"); param != mCustomParameters.end()) {
-    mMeanRateRatioHistName = param->second;
-  }
-  if (auto param = mCustomParameters.find("GoodChanFracHistName"); param != mCustomParameters.end()) {
-    mGoodChanFracHistName = param->second;
-  }
-  if (auto param = mCustomParameters.find("GoodChanFracRatioHistName"); param != mCustomParameters.end()) {
-    mGoodChanFracRatioHistName = param->second;
-  }
+void DigitsCheck::startOfActivity(const Activity& activity)
+{
+  mMeanRateHistName = getConfigurationParameter<std::string>(mCustomParameters, "MeanRateHistName", mMeanRateHistName, activity);
+  mMeanRateRatioHistName = getConfigurationParameter<std::string>(mCustomParameters, "MeanRateRatioHistName", mMeanRateRatioHistName, activity);
+  mGoodChanFracHistName = getConfigurationParameter<std::string>(mCustomParameters, "GoodChanFracHistName", mGoodChanFracHistName, activity);
+  mGoodChanFracRatioHistName = getConfigurationParameter<std::string>(mCustomParameters, "GoodChanFracRatioHistName", mGoodChanFracRatioHistName, activity);
 
-  if (auto param = mCustomParameters.find("MinRate"); param != mCustomParameters.end()) {
-    mMinRate = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxRate"); param != mCustomParameters.end()) {
-    mMaxRate = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxRateDelta"); param != mCustomParameters.end()) {
-    mMaxRateDelta = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MinGoodFraction"); param != mCustomParameters.end()) {
-    mMinGoodFraction = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxGoodFractionDelta"); param != mCustomParameters.end()) {
-    mMaxGoodFractionDelta = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("RatePlotScaleMin"); param != mCustomParameters.end()) {
-    mRatePlotScaleMin = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("RatePlotScaleMax"); param != mCustomParameters.end()) {
-    mRatePlotScaleMax = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxBadDE_ST12"); param != mCustomParameters.end()) {
-    mMaxBadST12 = std::stoi(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxBadDE_ST345"); param != mCustomParameters.end()) {
-    mMaxBadST345 = std::stoi(param->second);
-  }
+  mMinRate = getConfigurationParameter<double>(mCustomParameters, "MinRate", mMinRate, activity);
+  mMaxRate = getConfigurationParameter<double>(mCustomParameters, "MaxRate", mMaxRate, activity);
+  mMaxRateDelta = getConfigurationParameter<double>(mCustomParameters, "MaxRateDelta", mMaxRateDelta, activity);
+  mMinGoodFraction = getConfigurationParameter<double>(mCustomParameters, "MinGoodFraction", mMinGoodFraction, activity);
+  mMaxGoodFractionDelta = getConfigurationParameter<double>(mCustomParameters, "MaxGoodFractionDelta", mMaxGoodFractionDelta, activity);
+  mRatePlotScaleMin = getConfigurationParameter<double>(mCustomParameters, "RatePlotScaleMin", mRatePlotScaleMin, activity);
+  mRatePlotScaleMax = getConfigurationParameter<double>(mCustomParameters, "RatePlotScaleMax", mRatePlotScaleMax, activity);
+
+  mMaxBadST12 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST12", mMaxBadST12, activity);
+  mMaxBadST345 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST345", mMaxBadST345, activity);
 
   mQualityChecker.mMaxBadST12 = mMaxBadST12;
   mQualityChecker.mMaxBadST345 = mMaxBadST345;

--- a/Modules/MUON/MCH/src/DigitsCheck.cxx
+++ b/Modules/MUON/MCH/src/DigitsCheck.cxx
@@ -16,8 +16,6 @@
 
 #include "MCH/DigitsCheck.h"
 #include "MUONCommon/Helpers.h"
-#include <MCHConstants/DetectionElements.h>
-#include <MCHRawElecMap/Mapper.h>
 #include "QualityControl/MonitorObject.h"
 
 // ROOT
@@ -37,8 +35,6 @@ namespace o2::quality_control_modules::muonchambers
 
 void DigitsCheck::configure()
 {
-  mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
-  mFeeLink2SolarMapper = o2::mch::raw::createFeeLink2SolarMapper<o2::mch::raw::ElectronicMapperGenerated>();
 }
 
 void DigitsCheck::startOfActivity(const Activity& activity)

--- a/Modules/MUON/MCH/src/PedestalsCheck.cxx
+++ b/Modules/MUON/MCH/src/PedestalsCheck.cxx
@@ -16,18 +16,12 @@
 
 #include "MCH/PedestalsCheck.h"
 #include "MUONCommon/Helpers.h"
-#include "MCHMappingInterface/Segmentation.h"
-#include "MCHMappingSegContour/CathodeSegmentationContours.h"
 
-#include <fairlogger/Logger.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TCanvas.h>
 #include <TLine.h>
-#include <TList.h>
-#include <TMath.h>
 #include <TPaveText.h>
-#include <TColor.h>
 
 using namespace std;
 using namespace o2::quality_control_modules::muon;

--- a/Modules/MUON/MCH/src/PedestalsCheck.cxx
+++ b/Modules/MUON/MCH/src/PedestalsCheck.cxx
@@ -15,6 +15,7 @@
 ///
 
 #include "MCH/PedestalsCheck.h"
+#include "MUONCommon/Helpers.h"
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHMappingSegContour/CathodeSegmentationContours.h"
 
@@ -29,39 +30,23 @@
 #include <TColor.h>
 
 using namespace std;
+using namespace o2::quality_control_modules::muon;
 
 namespace o2::quality_control_modules::muonchambers
 {
 
 void PedestalsCheck::configure()
 {
-  if (auto param = mCustomParameters.find("MaxBadDE_ST12"); param != mCustomParameters.end()) {
-    mMaxBadST12 = std::stoi(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxBadDE_ST345"); param != mCustomParameters.end()) {
-    mMaxBadST345 = std::stoi(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxBadFractionPerDE"); param != mCustomParameters.end()) {
-    mMaxBadFractionPerDE = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxEmptyFractionPerDE"); param != mCustomParameters.end()) {
-    mMaxEmptyFractionPerDE = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MinStatisticsPerDE"); param != mCustomParameters.end()) {
-    mMinStatisticsPerDE = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("PedestalsPlotScaleMin"); param != mCustomParameters.end()) {
-    mPedestalsPlotScaleMin = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("PedestalsPlotScaleMax"); param != mCustomParameters.end()) {
-    mPedestalsPlotScaleMax = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("NoisePlotScaleMin"); param != mCustomParameters.end()) {
-    mNoisePlotScaleMin = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("NoisePlotScaleMax"); param != mCustomParameters.end()) {
-    mNoisePlotScaleMax = std::stof(param->second);
-  }
+  mMaxBadFractionPerDE = getConfigurationParameter<double>(mCustomParameters, "MaxBadFractionPerDE", mMaxBadFractionPerDE);
+  mMaxEmptyFractionPerDE = getConfigurationParameter<double>(mCustomParameters, "MaxEmptyFractionPerDE", mMaxEmptyFractionPerDE);
+  mMinStatisticsPerDE = getConfigurationParameter<double>(mCustomParameters, "MinStatisticsPerDE", mMinStatisticsPerDE);
+  mPedestalsPlotScaleMin = getConfigurationParameter<double>(mCustomParameters, "PedestalsPlotScaleMin", mPedestalsPlotScaleMin);
+  mPedestalsPlotScaleMax = getConfigurationParameter<double>(mCustomParameters, "PedestalsPlotScaleMax", mPedestalsPlotScaleMax);
+  mNoisePlotScaleMin = getConfigurationParameter<double>(mCustomParameters, "NoisePlotScaleMin", mNoisePlotScaleMin);
+  mNoisePlotScaleMax = getConfigurationParameter<double>(mCustomParameters, "NoisePlotScaleMax", mNoisePlotScaleMax);
+
+  mMaxBadST12 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST12", mMaxBadST12);
+  mMaxBadST345 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST345", mMaxBadST345);
 
   mQualityChecker.mMaxBadST12 = mMaxBadST12;
   mQualityChecker.mMaxBadST345 = mMaxBadST345;

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -17,6 +17,7 @@
 #include <TCanvas.h>
 #include <TFile.h>
 
+#include "MUONCommon/Helpers.h"
 #include "Headers/RAWDataHeader.h"
 #include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"
@@ -37,6 +38,7 @@
 
 using namespace std;
 using namespace o2::framework;
+using namespace o2::quality_control_modules::muon;
 
 #define MCH_FFEID_MAX (31 * 2 + 1)
 
@@ -58,12 +60,7 @@ void PedestalsTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Debug, Devel) << "initialize PedestalsTask" << ENDM;
   // flag to enable extra disagnostics plots
-  mFullHistos = false;
-  if (auto param = mCustomParameters.find("FullHistos"); param != mCustomParameters.end()) {
-    if (param->second == "true" || param->second == "True" || param->second == "TRUE") {
-      mFullHistos = true;
-    }
-  }
+  mFullHistos = getConfigurationParameter<bool>(mCustomParameters, "FullHistos", mFullHistos);
 
   mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
   mDet2ElecMapper = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();

--- a/Modules/MUON/MCH/src/PedestalsTask.cxx
+++ b/Modules/MUON/MCH/src/PedestalsTask.cxx
@@ -14,22 +14,13 @@
 /// \author Andrea Ferrero
 ///
 
-#include <TCanvas.h>
-#include <TFile.h>
-
-#include "MUONCommon/Helpers.h"
-#include "Headers/RAWDataHeader.h"
-#include "Framework/CallbackService.h"
-#include "Framework/ControlService.h"
-#include "Framework/Task.h"
-#include "DPLUtils/DPLRawParser.h"
-#include "QualityControl/QcInfoLogger.h"
 #include "MCH/PedestalsTask.h"
 #include "MCH/Helpers.h"
-#include "DataFormatsMCH/DsChannelGroup.h"
+#include "MUONCommon/Helpers.h"
+#include "Headers/RAWDataHeader.h"
+#include "DPLUtils/DPLRawParser.h"
+#include "QualityControl/QcInfoLogger.h"
 #include "MCHMappingInterface/Segmentation.h"
-#include "MCHMappingInterface/CathodeSegmentation.h"
-#include "MCHRawElecMap/Mapper.h"
 #include "MCHCalibration/PedestalChannel.h"
 #ifdef MCH_HAS_MAPPING_FACTORY
 #include "MCHMappingFactory/CreateSegmentation.h"
@@ -39,8 +30,6 @@
 using namespace std;
 using namespace o2::framework;
 using namespace o2::quality_control_modules::muon;
-
-#define MCH_FFEID_MAX (31 * 2 + 1)
 
 namespace o2
 {
@@ -63,7 +52,6 @@ void PedestalsTask::initialize(o2::framework::InitContext& /*ctx*/)
   mFullHistos = getConfigurationParameter<bool>(mCustomParameters, "FullHistos", mFullHistos);
 
   mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
-  mDet2ElecMapper = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
   mFeeLink2SolarMapper = o2::mch::raw::createFeeLink2SolarMapper<o2::mch::raw::ElectronicMapperGenerated>();
   mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
 

--- a/Modules/MUON/MCH/src/PreclustersCheck.cxx
+++ b/Modules/MUON/MCH/src/PreclustersCheck.cxx
@@ -16,8 +16,6 @@
 #include "MCH/PreclustersCheck.h"
 #include "MCH/Helpers.h"
 #include "MUONCommon/Helpers.h"
-#include <MCHConstants/DetectionElements.h>
-#include <MCHRawElecMap/Mapper.h>
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/MonitorObject.h"
 
@@ -35,16 +33,6 @@ using namespace o2::quality_control_modules::muon;
 
 namespace o2::quality_control_modules::muonchambers
 {
-
-PreclustersCheck::PreclustersCheck()
-{
-  mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
-  mDet2ElecMapper = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
-  mFeeLink2SolarMapper = o2::mch::raw::createFeeLink2SolarMapper<o2::mch::raw::ElectronicMapperGenerated>();
-  mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
-}
-
-PreclustersCheck::~PreclustersCheck() {}
 
 void PreclustersCheck::configure()
 {

--- a/Modules/MUON/MCH/src/PreclustersCheck.cxx
+++ b/Modules/MUON/MCH/src/PreclustersCheck.cxx
@@ -15,6 +15,7 @@
 
 #include "MCH/PreclustersCheck.h"
 #include "MCH/Helpers.h"
+#include "MUONCommon/Helpers.h"
 #include <MCHConstants/DetectionElements.h>
 #include <MCHRawElecMap/Mapper.h>
 #include "QualityControl/QcInfoLogger.h"
@@ -30,6 +31,7 @@
 #include <string>
 
 using namespace std;
+using namespace o2::quality_control_modules::muon;
 
 namespace o2::quality_control_modules::muonchambers
 {
@@ -46,38 +48,22 @@ PreclustersCheck::~PreclustersCheck() {}
 
 void PreclustersCheck::configure()
 {
-  if (auto param = mCustomParameters.find("MinEfficiency"); param != mCustomParameters.end()) {
-    mMinEfficiency = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxEfficiencyDelta"); param != mCustomParameters.end()) {
-    mMaxEffDelta = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("PseudoeffPlotScaleMin"); param != mCustomParameters.end()) {
-    mPseudoeffPlotScaleMin = std::stof(param->second);
-  }
-  if (auto param = mCustomParameters.find("PseudoeffPlotScaleMax"); param != mCustomParameters.end()) {
-    mPseudoeffPlotScaleMax = std::stof(param->second);
-  }
+}
 
-  if (auto param = mCustomParameters.find("MeanEffHistNameB"); param != mCustomParameters.end()) {
-    mMeanEffHistNameB = param->second;
-  }
-  if (auto param = mCustomParameters.find("MeanEffHistNameNB"); param != mCustomParameters.end()) {
-    mMeanEffHistNameNB = param->second;
-  }
+void PreclustersCheck::startOfActivity(const Activity& activity)
+{
+  mMinEfficiency = getConfigurationParameter<double>(mCustomParameters, "MinEfficiency", mMinEfficiency, activity);
+  mMaxEffDelta = getConfigurationParameter<double>(mCustomParameters, "MaxEfficiencyDelta", mMaxEffDelta, activity);
+  mPseudoeffPlotScaleMin = getConfigurationParameter<double>(mCustomParameters, "PseudoeffPlotScaleMin", mPseudoeffPlotScaleMin, activity);
+  mPseudoeffPlotScaleMax = getConfigurationParameter<double>(mCustomParameters, "PseudoeffPlotScaleMax", mPseudoeffPlotScaleMax, activity);
 
-  if (auto param = mCustomParameters.find("MeanEffRatioHistNameB"); param != mCustomParameters.end()) {
-    mMeanEffRatioHistNameB = param->second;
-  }
-  if (auto param = mCustomParameters.find("MeanEffRatioHistNameNB"); param != mCustomParameters.end()) {
-    mMeanEffRatioHistNameNB = param->second;
-  }
-  if (auto param = mCustomParameters.find("MaxBadDE_ST12"); param != mCustomParameters.end()) {
-    mMaxBadST12 = std::stoi(param->second);
-  }
-  if (auto param = mCustomParameters.find("MaxBadDE_ST345"); param != mCustomParameters.end()) {
-    mMaxBadST345 = std::stoi(param->second);
-  }
+  mMeanEffHistNameB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffHistNameB", mMeanEffHistNameB, activity);
+  mMeanEffHistNameNB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffHistNameNB", mMeanEffHistNameNB, activity);
+  mMeanEffRatioHistNameB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffRatioHistNameB", mMeanEffRatioHistNameB, activity);
+  mMeanEffRatioHistNameNB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffRatioHistNameNB", mMeanEffRatioHistNameNB, activity);
+
+  mMaxBadST12 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST12", mMaxBadST12, activity);
+  mMaxBadST345 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST345", mMaxBadST345, activity);
 
   mQualityChecker.mMaxBadST12 = mMaxBadST12;
   mQualityChecker.mMaxBadST345 = mMaxBadST345;

--- a/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
@@ -17,55 +17,17 @@
 ///
 
 #include "MCH/PreclustersPostProcessing.h"
+#include "MUONCommon/Helpers.h"
 #include "MCH/PostProcessingConfigMCH.h"
 #include "QualityControl/QcInfoLogger.h"
 #include <TDatime.h>
 
 using namespace o2::quality_control_modules::muonchambers;
+using namespace o2::quality_control_modules::muon;
 
 void PreclustersPostProcessing::configure(const boost::property_tree::ptree& config)
 {
-  PostProcessingConfigMCH mchConfig(getID(), config);
-
-  mRefTimeStamp = mchConfig.getParameter<int64_t>("ReferenceTimeStamp", -1);
-  auto refDate = mchConfig.getParameter<std::string>("ReferenceDate");
-  if (!refDate.empty()) {
-    TDatime date(refDate.c_str());
-    mRefTimeStamp = date.Convert();
-  }
-  ILOG(Info, Devel) << "Reference time stamp: " << mRefTimeStamp << "  (" << refDate << ")" << ENDM;
-
-  mFullHistos = mchConfig.getParameter<bool>("FullHistos", false);
-
-  mCcdbObjects.emplace(effSourceName(), CcdbObjectHelper());
-  mCcdbObjects.emplace(clusterChargeSourceName(), CcdbObjectHelper());
-  mCcdbObjects.emplace(clusterSizeSourceName(), CcdbObjectHelper());
-
-  if (mRefTimeStamp > 0) {
-    mCcdbObjectsRef.emplace(effSourceName(), CcdbObjectHelper());
-    mCcdbObjectsRef.emplace(clusterChargeSourceName(), CcdbObjectHelper());
-    mCcdbObjectsRef.emplace(clusterSizeSourceName(), CcdbObjectHelper());
-  }
-
-  for (const auto& source : mchConfig.dataSources) {
-    std::string sourceType, sourceName;
-    splitDataSourceName(source.name, sourceType, sourceName);
-    if (sourceType.empty()) {
-      continue;
-    }
-
-    auto obj = mCcdbObjects.find(sourceType);
-    if (obj != mCcdbObjects.end()) {
-      obj->second.mPath = source.path;
-      obj->second.mName = sourceName;
-    }
-
-    auto objRef = mCcdbObjectsRef.find(sourceType);
-    if (objRef != mCcdbObjectsRef.end()) {
-      objRef->second.mPath = source.path;
-      objRef->second.mName = sourceName;
-    }
-  }
+  mConfig = PostProcessingConfigMCH(getID(), config);
 }
 
 //_________________________________________________________________________________________
@@ -96,6 +58,7 @@ void PreclustersPostProcessing::createEfficiencyHistos(Trigger t, repository::Da
   //----------------------------------
   // Efficiency plotters
   //----------------------------------
+
   mEfficiencyPlotter.reset();
   mEfficiencyPlotter = std::make_unique<EfficiencyPlotter>("Efficiency/", hElecHistoRef, mFullHistos);
   mEfficiencyPlotter->publish(getObjectsManager());
@@ -208,7 +171,47 @@ void PreclustersPostProcessing::createClusterSizeHistos(Trigger t, repository::D
 void PreclustersPostProcessing::initialize(Trigger t, framework::ServiceRegistryRef services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
+  const auto& activity = t.activity;
 
+  mFullHistos = getConfigurationParameter<bool>(mCustomParameters, "FullHistos", mFullHistos, activity);
+
+  mRefTimeStamp = getConfigurationParameter<int64_t>(mCustomParameters, "ReferenceTimeStamp", mRefTimeStamp, activity);
+  ILOG(Info, Devel) << "Reference time stamp: " << mRefTimeStamp << ENDM;
+
+  mCcdbObjects.clear();
+  mCcdbObjects.emplace(effSourceName(), CcdbObjectHelper());
+  mCcdbObjects.emplace(clusterChargeSourceName(), CcdbObjectHelper());
+  mCcdbObjects.emplace(clusterSizeSourceName(), CcdbObjectHelper());
+
+  mCcdbObjectsRef.clear();
+  if (mRefTimeStamp > 0) {
+    mCcdbObjectsRef.emplace(effSourceName(), CcdbObjectHelper());
+    mCcdbObjectsRef.emplace(clusterChargeSourceName(), CcdbObjectHelper());
+    mCcdbObjectsRef.emplace(clusterSizeSourceName(), CcdbObjectHelper());
+  }
+
+  // set objects path from configuration
+  for (const auto& source : mConfig.dataSources) {
+    std::string sourceType, sourceName;
+    splitDataSourceName(source.name, sourceType, sourceName);
+    if (sourceType.empty()) {
+      continue;
+    }
+
+    auto obj = mCcdbObjects.find(sourceType);
+    if (obj != mCcdbObjects.end()) {
+      obj->second.mPath = source.path;
+      obj->second.mName = sourceName;
+    }
+
+    auto objRef = mCcdbObjectsRef.find(sourceType);
+    if (objRef != mCcdbObjectsRef.end()) {
+      objRef->second.mPath = source.path;
+      objRef->second.mName = sourceName;
+    }
+  }
+
+  // instantiate and publish the histograms
   createEfficiencyHistos(t, &qcdb);
   createClusterChargeHistos(t, &qcdb);
   createClusterSizeHistos(t, &qcdb);

--- a/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
@@ -18,9 +18,7 @@
 
 #include "MCH/PreclustersPostProcessing.h"
 #include "MUONCommon/Helpers.h"
-#include "MCH/PostProcessingConfigMCH.h"
 #include "QualityControl/QcInfoLogger.h"
-#include <TDatime.h>
 
 using namespace o2::quality_control_modules::muonchambers;
 using namespace o2::quality_control_modules::muon;

--- a/Modules/MUON/MCH/src/PreclustersTask.cxx
+++ b/Modules/MUON/MCH/src/PreclustersTask.cxx
@@ -23,7 +23,6 @@
 #include "MCHGlobalMapping/DsIndex.h"
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHMappingInterface/CathodeSegmentation.h"
-// #include "MCHMappingSegContour/CathodeSegmentationContours.h"
 #include <Framework/InputRecord.h>
 #include "QualityControl/QcInfoLogger.h"
 
@@ -39,14 +38,23 @@ namespace quality_control_modules
 namespace muonchambers
 {
 
+template <typename T>
+void PreclustersTask::publishObject(T* histo, std::string drawOption, bool statBox)
+{
+  histo->SetOption(drawOption.c_str());
+  if (!statBox) {
+    histo->SetStats(0);
+  }
+  mAllHistograms.push_back(histo);
+  getObjectsManager()->startPublishing(histo);
+  getObjectsManager()->setDefaultDrawOptions(histo, drawOption);
+}
+
 void PreclustersTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   ILOG(Info, Devel) << "initialize PreclustersTask" << AliceO2::InfoLogger::InfoLogger::endm;
 
   mIsSignalDigit = o2::mch::createDigitFilter(20, true, true);
-
-  mDet2ElecMapper = createDet2ElecMapper<ElectronicMapperGenerated>();
-  mSolar2FeeLinkMapper = createSolar2FeeLinkMapper<ElectronicMapperGenerated>();
 
   mHistogramPreclustersPerDE = std::make_unique<TH1DRatio>("PreclustersPerDE", "Number of pre-clusters for each DE", getNumDE(), 0, getNumDE());
   publishObject(mHistogramPreclustersPerDE.get(), "hist", false);


### PR DESCRIPTION
This PR contains a second block of code changes following the MCH QC review.
The PR is divided in two commits, for easier review:
1. the changes needed to allow the use of extended task/checks parameters
2. some cleanup to remove unneeded header files and possibly reduce compilation time