### PR TITLE
O2-4728 Delete any pointers in FIT PP before creating new smart pointers

### DIFF
--- a/Modules/FIT/FDD/src/PostProcTask.cxx
+++ b/Modules/FIT/FDD/src/PostProcTask.cxx
@@ -40,6 +40,10 @@ PostProcTask::~PostProcTask()
 {
   delete mAmpl;
   delete mTime;
+  for (auto& [_, histo] : mMapTrgHistBC) {
+    delete histo;
+    histo = nullptr;
+  }
 }
 
 void PostProcTask::configure(const boost::property_tree::ptree& config)
@@ -110,6 +114,38 @@ void PostProcTask::configure(const boost::property_tree::ptree& config)
 
 void PostProcTask::initialize(Trigger, framework::ServiceRegistryRef services)
 {
+  // delete any objects from previous runs
+  mRateOrA.reset();
+  mRateOrC.reset();
+  mRateVertex.reset();
+  mRateCentral.reset();
+  mRateSemiCentral.reset();
+  mHistChDataNegBits.reset();
+  mHistTriggers.reset();
+
+  mHistTimeInWindow.reset();
+  mHistCFDEff.reset();
+  mHistTrgValidation.reset();
+  mHistAmpSaturation.reset();
+  mRatesCanv.reset();
+
+  delete mAmpl;
+  mAmpl = nullptr;
+  delete mTime;
+  mTime = nullptr;
+
+  mHistBcPattern.reset();
+  mHistBcPatternFee.reset();
+  mHistBcTrgOutOfBunchColl.reset();
+  mHistBcFeeOutOfBunchCollForVtxTrg.reset();
+
+  for (auto& [_, histo] : mMapTrgHistBC) {
+    delete histo;
+    histo = nullptr;
+  }
+  mMapTrgHistBC.clear();
+
+  // start initialization
   mDatabase = &services.get<o2::quality_control::repository::DatabaseInterface>();
   mCcdbApi.init(mCcdbUrl);
 

--- a/Modules/FIT/FT0/src/PostProcTask.cxx
+++ b/Modules/FIT/FT0/src/PostProcTask.cxx
@@ -44,6 +44,10 @@ PostProcTask::~PostProcTask()
 {
   delete mAmpl;
   delete mTime;
+  for (auto& [_, histo] : mMapTrgHistBC) {
+    delete histo;
+    histo = nullptr;
+  }
 }
 
 void PostProcTask::configure(const boost::property_tree::ptree& config)
@@ -65,6 +69,30 @@ void PostProcTask::configure(const boost::property_tree::ptree& config)
 
 void PostProcTask::initialize(Trigger, framework::ServiceRegistryRef services)
 {
+  // delete any objects from previous runs
+  mRateOrA.reset();
+  mRateOrC.reset();
+  mRateVertex.reset();
+  mRateCentral.reset();
+  mRateSemiCentral.reset();
+  delete mAmpl;
+  mAmpl = nullptr;
+  delete mTime;
+  mTime = nullptr;
+  mHistChDataNegBits.reset();
+  mHistTriggers.reset();
+  mHistBcTrgOutOfBunchColl.reset();
+  mHistBcPattern.reset();
+  mHistTimeInWindow.reset();
+  mHistCFDEff.reset();
+  mHistChannelID_outOfBC.reset();
+  mHistTrgValidation.reset();
+  for (auto& [_, histo] : mMapTrgHistBC) {
+    delete histo;
+    histo = nullptr;
+  }
+
+  // start initialization
   mDatabase = &services.get<o2::quality_control::repository::DatabaseInterface>();
   mCcdbApi.init(mCcdbUrl);
 

--- a/Modules/FIT/FT0/src/PostProcTask.cxx
+++ b/Modules/FIT/FT0/src/PostProcTask.cxx
@@ -91,6 +91,7 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistryRef services)
     delete histo;
     histo = nullptr;
   }
+  mMapTrgHistBC.clear();
 
   // start initialization
   mDatabase = &services.get<o2::quality_control::repository::DatabaseInterface>();

--- a/Modules/FIT/FV0/src/PostProcTask.cxx
+++ b/Modules/FIT/FV0/src/PostProcTask.cxx
@@ -43,6 +43,10 @@ PostProcTask::~PostProcTask()
 {
   delete mAmpl;
   delete mTime;
+  for (auto& [_, histo] : mMapTrgHistBC) {
+    delete histo;
+    histo = nullptr;
+  }
 }
 
 void PostProcTask::configure(const boost::property_tree::ptree& config)
@@ -112,6 +116,42 @@ void PostProcTask::configure(const boost::property_tree::ptree& config)
 
 void PostProcTask::initialize(Trigger, framework::ServiceRegistryRef services)
 {
+  // delete any objects from previous runs
+  mRateOrA.reset();
+  mRateOrAout.reset();
+  mRateOrAin.reset();
+  mRateTrgCharge.reset();
+  mRateTrgNchan.reset();
+  mHistChDataNegBits.reset();
+  mHistTriggers.reset();
+
+  mHistTimeInWindow.reset();
+  mHistCFDEff.reset();
+  mHistTrgValidation.reset();
+
+  mRatesCanv.reset();
+  delete mAmpl;
+  mAmpl = nullptr;
+  delete mTime;
+  mTime = nullptr;
+
+  mHistBcPattern.reset();
+  mHistBcPatternFee.reset();
+  mHistBcTrgOutOfBunchColl.reset();
+  mHistBcFeeOutOfBunchColl.reset();
+  mHistBcFeeOutOfBunchCollForOrATrg.reset();
+  mHistBcFeeOutOfBunchCollForOrAOutTrg.reset();
+  mHistBcFeeOutOfBunchCollForNChanTrg.reset();
+  mHistBcFeeOutOfBunchCollForChargeTrg.reset();
+  mHistBcFeeOutOfBunchCollForOrAInTrg.reset();
+
+  for (auto& [_, histo] : mMapTrgHistBC) {
+    delete histo;
+    histo = nullptr;
+  }
+  mMapTrgHistBC.clear();
+
+  // start initialization
   mDatabase = &services.get<o2::quality_control::repository::DatabaseInterface>();
   mCcdbApi.init(mCcdbUrl);
 


### PR DESCRIPTION
This is because ROOT is sometimes not happy with having objects with the same name in one process and gives us some warnings about it and may potentially crash.

This should hopefully address FIT postprocessing crashing from time to time during SSS sequence.