### PR TITLE
QC-1132 Correct validity in PostProcessingTasks across run restart

### DIFF
--- a/Framework/include/QualityControl/PostProcessingDevice.h
+++ b/Framework/include/QualityControl/PostProcessingDevice.h
@@ -70,7 +70,7 @@ class PostProcessingDevice : public framework::Task
   /// \brief Callback for CallbackService::Id::Start (DPL) a.k.a. RUN transition (FairMQ)
   void start(framework::ServiceRegistryRef services);
   /// \brief Callback for CallbackService::Id::Stop (DPL) a.k.a. STOP transition (FairMQ)
-  void stop() override;
+  void stop(framework::ServiceRegistryRef services);
   /// \brief Callback for CallbackService::Id::Reset (DPL) a.k.a. RESET DEVICE transition (FairMQ)
   void reset();
 

--- a/Framework/include/QualityControl/PostProcessingRunner.h
+++ b/Framework/include/QualityControl/PostProcessingRunner.h
@@ -74,7 +74,7 @@ class PostProcessingRunner
   /// \brief Start transition. Throws on errors.
   void start(framework::ServiceRegistryRef dplServices);
   /// \brief Stop transition. Throws on errors.
-  void stop();
+  void stop(framework::ServiceRegistryRef dplServices);
   /// \brief Reset transition. Throws on errors.
   void reset();
   /// \brief Runs the task over selected timestamps, performing the full start, run, stop cycle.

--- a/Framework/src/PostProcessingDevice.cxx
+++ b/Framework/src/PostProcessingDevice.cxx
@@ -56,7 +56,7 @@ void PostProcessingDevice::init(framework::InitContext& ctx)
   // registering state machine callbacks
   ctx.services().get<CallbackService>().set<CallbackService::Id::Start>([this, services = ctx.services()]() mutable { start(services); });
   ctx.services().get<CallbackService>().set<CallbackService::Id::Reset>([this]() { reset(); });
-  ctx.services().get<CallbackService>().set<CallbackService::Id::Stop>([this]() { stop(); });
+  ctx.services().get<CallbackService>().set<CallbackService::Id::Stop>([this, services = ctx.services()]() mutable { stop(services); });
 }
 
 void PostProcessingDevice::run(framework::ProcessingContext& ctx)
@@ -110,9 +110,9 @@ void PostProcessingDevice::start(ServiceRegistryRef services)
   mRunner->start(services);
 }
 
-void PostProcessingDevice::stop()
+void PostProcessingDevice::stop(ServiceRegistryRef services)
 {
-  mRunner->stop();
+  mRunner->stop(services);
 }
 
 void PostProcessingDevice::reset()

--- a/Framework/src/runPostProcessing.cxx
+++ b/Framework/src/runPostProcessing.cxx
@@ -78,12 +78,12 @@ int main(int argc, const char* argv[])
 
     PostProcessingRunner runner(taskID);
     runner.init(configTree, WorkflowType::Standalone);
+    ServiceRegistry registry;
 
     if (vm.count("timestamps")) {
       // running the PP task on a set of timestamps
       runner.runOverTimestamps(vm["timestamps"].as<std::vector<uint64_t>>());
     } else {
-      ServiceRegistry registry;
       // running the PP task with an event loop
       runner.start({ registry });
 
@@ -96,7 +96,7 @@ int main(int argc, const char* argv[])
         usleep(1000000.0 * timer.getRemainingTime());
       }
     }
-    runner.stop();
+    runner.stop({ registry });
     return 0;
   } catch (const bpo::error& ex) {
     ILOG(Error, Ops) << "Exception caught: " << ex.what() << ENDM;

--- a/Framework/src/runPostProcessingOCC.cxx
+++ b/Framework/src/runPostProcessingOCC.cxx
@@ -118,7 +118,8 @@ class PostProcessingOCCStateMachine : public RuntimeControlledObject
 
     bool success = true;
     try {
-      mRunner->stop();
+      o2::framework::ServiceRegistry registry;
+      mRunner->stop(registry);
     } catch (const std::exception& ex) {
       ILOG(Error, Support) << "Exception caught: " << ex.what() << ENDM;
       success = false;

--- a/Framework/src/runnerUtils.cxx
+++ b/Framework/src/runnerUtils.cxx
@@ -65,8 +65,8 @@ Activity computeActivity(framework::ServiceRegistryRef services, const Activity&
 {
   auto runNumber = computeActivityField<int>(services, "runNumber", fallbackActivity.mId);
   auto runType = computeActivityField<int>(services, "runType", fallbackActivity.mType);
-  auto run_start_time_ms = computeActivityField<unsigned long>(services, "runStartTimeMs", fallbackActivity.mValidity.getMin());
-  auto run_stop_time_ms = computeActivityField<unsigned long>(services, "runEndTimeMs", fallbackActivity.mValidity.getMax());
+  auto runStartTimeMs = computeActivityField<unsigned long>(services, "runStartTimeMs", fallbackActivity.mValidity.getMin());
+  auto runEndTimeMs = computeActivityField<unsigned long>(services, "runEndTimeMs", fallbackActivity.mValidity.getMax());
   auto partitionName = services.get<framework::RawDeviceService>().device()->fConfig->GetProperty<std::string>("environment_id", fallbackActivity.mPartitionName);
   auto periodName = services.get<framework::RawDeviceService>().device()->fConfig->GetProperty<std::string>("lhcPeriod", "");
   if (periodName.empty()) {
@@ -82,7 +82,7 @@ Activity computeActivity(framework::ServiceRegistryRef services, const Activity&
     periodName,
     fallbackActivity.mPassName,
     fallbackActivity.mProvenance,
-    { run_start_time_ms, run_stop_time_ms },
+    { runStartTimeMs, runEndTimeMs },
     beam_type,
     partitionName,
     fillNumber);


### PR DESCRIPTION
This makes sure that the SOR&EOR timestamps are retrieved from ECS and passed to the user task with UserOrControl trigger, but they are not used to establish the validity of produced objects. Also, we do not publish objects if the validity is going to be invalid, since they will not be stored anyway. We produce appropriate warnings in such case.

The root cause for having EOR timestamp earlier than SOR for the 2nd run was discovered to come from ECS sending incorrect values. However, with this commit, these values will not be used anyway for determining objects validity.