### PR TITLE
GLO: updated BigScreen task

### DIFF
--- a/Modules/Common/CMakeLists.txt
+++ b/Modules/Common/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(O2QcCommon
                        src/TRFCollectionTaskConfig.cxx
                        src/QualityTask.cxx
                        src/QualityTaskConfig.cxx
+                       src/BigScreenCanvas.cxx
                        src/BigScreen.cxx
                        src/BigScreenConfig.cxx
                        src/NonEmpty.cxx

--- a/Modules/Common/include/Common/BigScreen.h
+++ b/Modules/Common/include/Common/BigScreen.h
@@ -47,7 +47,7 @@ class BigScreen : public quality_control::postprocessing::PostProcessingInterfac
   /// \brief maximum allowed age of quality objects, in seconds (default: 10 minutes)
   int mMaxObjectTimeShift{ 600 };
   /// \brief read quality objects from all runs
-  int mIgnoreActivity{ 0 };
+  bool mIgnoreActivity{ false };
   /// \brief configuration parameters
   BigScreenConfig mConfig;
   /// \brief canvas with human-readable quality states

--- a/Modules/Common/include/Common/BigScreen.h
+++ b/Modules/Common/include/Common/BigScreen.h
@@ -20,12 +20,8 @@
 
 #include "QualityControl/PostProcessingInterface.h"
 #include "Common/BigScreenConfig.h"
+#include "Common/BigScreenCanvas.h"
 #include "QualityControl/Quality.h"
-#include <TCanvas.h>
-#include <TPaveText.h>
-#include <TText.h>
-#include <string>
-#include <map>
 
 namespace o2::quality_control_modules::common
 {
@@ -50,14 +46,8 @@ class BigScreen : public quality_control::postprocessing::PostProcessingInterfac
  private:
   /// \brief configuration parameters
   BigScreenConfig mConfig;
-  /// \brief colors associated to each quality state (Good/Medium/Bad/Null)
-  std::unordered_map<std::string, int> mColors;
-  /// \brief
-  std::map<std::string, std::unique_ptr<TText>> mLabels;
-  /// \brief
-  std::map<std::string, std::unique_ptr<TPaveText>> mPaves;
-  /// \brief canvas with human-readable quality states and messages
-  std::unique_ptr<TCanvas> mCanvas;
+  /// \brief canvas with human-readable quality states
+  std::unique_ptr<BigScreenCanvas> mCanvas;
 };
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/BigScreen.h
+++ b/Modules/Common/include/Common/BigScreen.h
@@ -44,6 +44,10 @@ class BigScreen : public quality_control::postprocessing::PostProcessingInterfac
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistryRef) override;
 
  private:
+  /// \brief maximum allowed age of quality objects, in seconds (default: 10 minutes)
+  int mMaxObjectTimeShift{ 600 };
+  /// \brief read quality objects from all runs
+  int mIgnoreActivity{ 0 };
   /// \brief configuration parameters
   BigScreenConfig mConfig;
   /// \brief canvas with human-readable quality states

--- a/Modules/Common/include/Common/BigScreenCanvas.h
+++ b/Modules/Common/include/Common/BigScreenCanvas.h
@@ -35,11 +35,16 @@ class BigScreenCanvas : public TCanvas
   ~BigScreenCanvas() = default;
 
   /// \brief add a box in the canvas at a given index, with "name" displayed above the box
-  void add(std::string name, int index);
-  /// \brief set the text message and color of the box identified by "name"
-  void set(std::string name, int color, std::string text);
+  ///
+  /// The boxes are arranged in a regular grid of mNRows x mNCols in the canvas.
+  /// The index proceeds from left to right and from top to bottom in the grid, starting from zero and up to (mNRows * mNCols - 1)
+  void addBox(std::string boxName, int index);
+  /// \brief set the text message and color of the box identified by "name".
+  ///
+  /// The color value follows the ROOT TColor indexing conventions (https://root.cern.ch/doc/master/classTColor.html)
+  void setText(std::string boxName, int color, std::string text);
   /// \brief set the text message and color of the box identified by "name", based on the specified quality flag
-  void set(std::string name, o2::quality_control::core::Quality quality);
+  void setQuality(std::string boxName, o2::quality_control::core::Quality quality);
   /// \brief refresh the canvas and draw all the boxes and labels
   void update();
 
@@ -56,7 +61,7 @@ class BigScreenCanvas : public TCanvas
   /// \brief colors associated to each quality state (Good/Medium/Bad/Null)
   std::unordered_map<std::string, int> mColors;
   /// \brief elements (colored boxes + labels) displayed in the canvas
-  std::unordered_map<std::string, std::shared_ptr<BigScreenElement>> mElements;
+  std::unordered_map<std::string, std::shared_ptr<BigScreenElement>> mBoxes;
 };
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/BigScreenCanvas.h
+++ b/Modules/Common/include/Common/BigScreenCanvas.h
@@ -1,0 +1,64 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    BigScreenCanvas.h
+/// \author  Andrea Ferrero
+/// \brief   Canvas showing the aggregated quality of configurable groups
+///
+
+#ifndef QUALITYCONTROL_BIGSCREENCANVAS_H
+#define QUALITYCONTROL_BIGSCREENCANVAS_H
+
+#include "QualityControl/Quality.h"
+#include <TCanvas.h>
+#include <string>
+#include <unordered_map>
+
+namespace o2::quality_control_modules::common
+{
+
+struct BigScreenElement;
+
+class BigScreenCanvas : public TCanvas
+{
+ public:
+  BigScreenCanvas(std::string name, std::string title, int nRows, int nCols, int borderWidth);
+  ~BigScreenCanvas() = default;
+
+  /// \brief add a box in the canvas at a given index, with "name" displayed above the box
+  void add(std::string name, int index);
+  /// \brief set the text message and color of the box identified by "name"
+  void set(std::string name, int color, std::string text);
+  /// \brief set the text message and color of the box identified by "name", based on the specified quality flag
+  void set(std::string name, o2::quality_control::core::Quality quality);
+  /// \brief refresh the canvas and draw all the boxes and labels
+  void update();
+
+ private:
+  /// \brief size of the grid of boxes in the canvas
+  int mNRows{ 1 };
+  int mNCols{ 1 };
+  /// \brief size of the border around the colored boxes
+  int mBorderWidth{ 5 };
+  /// \brief empty space between the boxes
+  float mPadding{ 0.2 };
+  /// \brief offset of the label above the boxes
+  float mLabelOffset{ 0.05 };
+  /// \brief colors associated to each quality state (Good/Medium/Bad/Null)
+  std::unordered_map<std::string, int> mColors;
+  /// \brief elements (colored boxes + labels) displayed in the canvas
+  std::unordered_map<std::string, std::shared_ptr<BigScreenElement>> mElements;
+};
+
+} // namespace o2::quality_control_modules::common
+
+#endif // QUALITYCONTROL_BIGSCREENCANVAS_H

--- a/Modules/Common/include/Common/BigScreenConfig.h
+++ b/Modules/Common/include/Common/BigScreenConfig.h
@@ -17,10 +17,9 @@
 #ifndef QUALITYCONTROL_BIGSCREENCONFIG_H
 #define QUALITYCONTROL_BIGSCREENCONFIG_H
 
-#include <vector>
-#include <map>
-#include <string>
 #include "QualityControl/PostProcessingConfig.h"
+#include <vector>
+#include <string>
 
 namespace o2::quality_control_modules::common
 {
@@ -32,19 +31,10 @@ struct BigScreenConfig : quality_control::postprocessing::PostProcessingConfig {
   BigScreenConfig(std::string name, const boost::property_tree::ptree& config);
   ~BigScreenConfig() = default;
 
-  const std::string getConfigParameter(std::string name) const;
-
   struct DataSource {
     std::string detector;
     std::string path;
   };
-
-  std::map<std::string, std::string> mConfigParameters;
-  int mNRows{ 4 };
-  int mNCols{ 5 };
-  int mBorderWidth{ 7 };
-  int mNotOlderThan{ -1 };
-  int mIgnoreActivity{ 0 };
 
   std::vector<DataSource> dataSources;
 };

--- a/Modules/Common/src/BigScreen.cxx
+++ b/Modules/Common/src/BigScreen.cxx
@@ -81,7 +81,7 @@ void BigScreen::initialize(quality_control::postprocessing::Trigger t, framework
 
   parValue = getParameter(mCustomParameters, "ignoreActivity", t.activity);
   if (!parValue.empty()) {
-    mIgnoreActivity = std::stoi(parValue);
+    mIgnoreActivity = (std::stoi(parValue) != 0);
   }
 
   // get the list of labels
@@ -99,7 +99,7 @@ void BigScreen::initialize(quality_control::postprocessing::Trigger t, framework
   // add the paves associated to each quality source
   for (auto label : labels) {
     if (!label.empty()) {
-      mCanvas->add(label, index);
+      mCanvas->addBox(label, index);
     }
     index += 1;
   }
@@ -154,15 +154,15 @@ void BigScreen::update(quality_control::postprocessing::Trigger t, framework::Se
     // a valid object is returned in the first element of the pair if the QO is found in the QCDB
     // the second element of the pair is set to true if the QO has a time stamp not older than the provided threshold
     // long notOlderThanMs = (mConfig.mNotOlderThan >= 0) ? static_cast<long>(mConfig.mNotOlderThan) * 1000 : std::numeric_limits<long>::max();
-    auto qo = getQO(qcdb, t, source, mMaxObjectTimeShift * 1000, (mIgnoreActivity != 0));
+    auto qo = getQO(qcdb, t, source, mMaxObjectTimeShift * 1000, mIgnoreActivity);
     if (qo.first) {
       if (qo.second) {
-        mCanvas->set(source.detector, qo.first->getQuality());
+        mCanvas->setQuality(source.detector, qo.first->getQuality());
       } else {
-        mCanvas->set(source.detector, kYellow, "Old");
+        mCanvas->setText(source.detector, kYellow, "Old");
       }
     } else {
-      mCanvas->set(source.detector, kGray, "NF");
+      mCanvas->setText(source.detector, kGray, "NF");
     }
   }
   mCanvas->update();

--- a/Modules/Common/src/BigScreen.cxx
+++ b/Modules/Common/src/BigScreen.cxx
@@ -34,60 +34,15 @@ void BigScreen::configure(const boost::property_tree::ptree& config)
 {
   mConfig = BigScreenConfig(getID(), config);
 
-  mColors[Quality::Null.getName()] = kViolet - 6;
-  mColors[Quality::Bad.getName()] = kRed;
-  mColors[Quality::Medium.getName()] = kOrange - 3;
-  mColors[Quality::Good.getName()] = kGreen + 2;
-
-  float dx = 1.0 / mConfig.mNCols;
-  float dy = 1.0 / mConfig.mNRows;
-  float paveHalfWidth = 0.3 * dx;
-  float paveHalfHeight = 0.3 * dy;
+  mCanvas = std::make_unique<BigScreenCanvas>("BigScreen", "QC Big Screen", mConfig.mNRows, mConfig.mNCols, mConfig.mBorderWidth);
 
   int index = 0;
   // add the paves associated to each quality source
   for (auto source : mConfig.dataSources) {
     auto detName = source.detector;
-    auto row = index / mConfig.mNCols;
-    auto col = index % mConfig.mNCols;
-
-    if (row >= mConfig.mNRows) {
-      break;
-    }
-    // put first pave on top-left
-    row = mConfig.mNRows - row - 1;
-
-    // coordinates of the center of the pave area
-    float xc = dx * (0.5 + col);
-    float yc = dy * (0.5 + row) - 0.01;
-
-    // coordinates of the pave corners
-    float x1 = xc - paveHalfWidth;
-    float x2 = xc + paveHalfWidth;
-    float y1 = yc - paveHalfHeight;
-    float y2 = yc + paveHalfHeight;
-
-    // label coordinates
-    float xl = x1;
-    float yl = y2 + 0.01;
-
-    // add pave associated to the detector
-    mLabels[detName] = std::make_unique<TText>(xl, yl, detName.c_str());
-    for (auto& l : mLabels) {
-      l.second->SetNDC();
-      l.second->SetTextAlign(11);
-      l.second->SetTextSize(0.05);
-      l.second->SetTextFont(42);
-    }
-
-    // add pave associated to the detector
-    mPaves[detName] = std::make_unique<TPaveText>(x1, y1, x2, y2);
-    mPaves[detName]->SetOption("");
-    mPaves[detName]->SetLineWidth(mConfig.mBorderWidth);
-
+    mCanvas->add(detName, index);
     index += 1;
   }
-  mCanvas = std::make_unique<TCanvas>("BigScreen", "QC Big Screen", 800, 600);
 }
 
 //_________________________________________________________________________________________
@@ -95,7 +50,6 @@ void BigScreen::configure(const boost::property_tree::ptree& config)
 void BigScreen::initialize(quality_control::postprocessing::Trigger t, framework::ServiceRegistryRef services)
 {
   mCanvas->Clear();
-  mCanvas->cd();
   getObjectsManager()->startPublishing(mCanvas.get());
 }
 
@@ -141,38 +95,23 @@ void BigScreen::update(quality_control::postprocessing::Trigger t, framework::Se
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
-  // draw messages in canvas
-  mCanvas->Clear();
-  mCanvas->cd();
-
   for (auto source : mConfig.dataSources) {
-    auto det = source.detector;
-    auto pave = mPaves[det].get();
-    if (!pave) {
-      continue;
-    }
-    auto label = mLabels[det].get();
-    if (!label) {
-      continue;
-    }
-
-    int color = kGray;
-
     // retrieve QO from CCDB, in the form of a std::pair<std::shared_ptr<QualityObject>, bool>
     // a valid object is returned in the first element of the pair if the QO is found in the QCDB
     // the second element of the pair is set to true if the QO has a time stamp not older than the provided threshold
     long notOlderThanMs = (mConfig.mNotOlderThan >= 0) ? static_cast<long>(mConfig.mNotOlderThan) * 1000 : std::numeric_limits<long>::max();
     auto qo = getQO(qcdb, t, source, notOlderThanMs, (mConfig.mIgnoreActivity != 0));
-    if (qo.first && qo.second) {
-      auto qoValue = qo.first->getQuality().getName();
-      color = mColors[qoValue];
-      pave->SetFillColor(color);
-      pave->Clear();
-      pave->AddText((std::string(" ") + qoValue + std::string(" ")).c_str());
+    if (qo.first) {
+      if (qo.second) {
+        mCanvas->set(source.detector, qo.first->getQuality());
+      } else {
+        mCanvas->set(source.detector, kYellow, "Old");
+      }
+    } else {
+      mCanvas->set(source.detector, kGray, "NF");
     }
-    pave->Draw();
-    label->Draw();
   }
+  mCanvas->update();
 }
 
 //_________________________________________________________________________________________

--- a/Modules/Common/src/BigScreenCanvas.cxx
+++ b/Modules/Common/src/BigScreenCanvas.cxx
@@ -44,6 +44,15 @@ struct BigScreenElement {
     mBox.SetLineWidth(borderWidth);
     mBox.SetFillStyle(0);
   }
+
+  void DrawInCanvas(TCanvas& c)
+  {
+    c.cd(mPadIndex);
+    mPave.Draw();
+    mBox.Draw();
+    mLabel.Draw();
+  }
+
   TText mLabel;
   TPaveText mPave;
   TBox mBox;
@@ -59,15 +68,15 @@ BigScreenCanvas::BigScreenCanvas(std::string name, std::string title, int nRows,
   mColors[Quality::Good.getName()] = kGreen + 2;
 }
 
-void BigScreenCanvas::add(std::string name, int index)
+void BigScreenCanvas::addBox(std::string boxName, int index)
 {
-  mElements[name] = std::make_shared<BigScreenElement>(name, index, mPadding, mLabelOffset, mBorderWidth);
+  mBoxes[boxName] = std::make_shared<BigScreenElement>(boxName, index, mPadding, mLabelOffset, mBorderWidth);
 }
 
-void BigScreenCanvas::set(std::string name, int color, std::string text)
+void BigScreenCanvas::setText(std::string boxName, int color, std::string text)
 {
-  auto index = mElements.find(name);
-  if (index == mElements.end()) {
+  auto index = mBoxes.find(boxName);
+  if (index == mBoxes.end()) {
     return;
   }
   auto& pave = index->second->mPave;
@@ -76,11 +85,11 @@ void BigScreenCanvas::set(std::string name, int color, std::string text)
   pave.AddText((std::string(" ") + text + std::string(" ")).c_str());
 }
 
-void BigScreenCanvas::set(std::string name, Quality quality)
+void BigScreenCanvas::setQuality(std::string boxName, Quality quality)
 {
   auto color = mColors.find(quality.getName());
   if (color != mColors.end()) {
-    set(name, color->second, quality.getName());
+    setText(boxName, color->second, quality.getName());
   }
 }
 
@@ -89,11 +98,8 @@ void BigScreenCanvas::update()
   Clear();
   Divide(mNCols, mNRows);
 
-  for (auto& [key, element] : mElements) {
-    cd(element->mPadIndex);
-    element->mPave.Draw();
-    element->mBox.Draw();
-    element->mLabel.Draw();
+  for (auto& [key, box] : mBoxes) {
+    box->DrawInCanvas(*this);
   }
 }
 

--- a/Modules/Common/src/BigScreenCanvas.cxx
+++ b/Modules/Common/src/BigScreenCanvas.cxx
@@ -1,0 +1,100 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    BigScreenCanvas.cxx
+/// \author  Andrea Ferrero
+/// \brief   Canvas showing the aggregated quality of configurable groups
+///
+
+#include "Common/BigScreenCanvas.h"
+#include <TPaveText.h>
+#include <TText.h>
+#include <TBox.h>
+
+using namespace o2::quality_control::core;
+
+namespace o2::quality_control_modules::common
+{
+
+struct BigScreenElement {
+  BigScreenElement(std::string name, int index, float padding, float labelOffset, int borderWidth)
+    : mLabel(padding, 1.0 - padding, name.c_str()),
+      mPave(padding, padding, 1.0 - padding, 1.0 - padding - labelOffset, "NB NDC"),
+      mBox(padding, padding, 1.0 - padding, 1.0 - padding - labelOffset),
+      mPadIndex(index + 1)
+  {
+    mLabel.SetNDC();
+    mLabel.SetTextAlign(11);
+    mLabel.SetTextSize(0.2);
+    mLabel.SetTextFont(42);
+
+    mPave.SetBorderSize(0);
+    mPave.SetFillColor(kWhite);
+
+    mBox.SetLineColor(kBlack);
+    mBox.SetLineWidth(borderWidth);
+    mBox.SetFillStyle(0);
+  }
+  TText mLabel;
+  TPaveText mPave;
+  TBox mBox;
+  int mPadIndex;
+};
+
+BigScreenCanvas::BigScreenCanvas(std::string name, std::string title, int nRows, int nCols, int borderWidth)
+  : TCanvas(name.c_str(), title.c_str(), 800, 600), mNRows(nRows), mNCols(nCols), mBorderWidth(borderWidth)
+{
+  mColors[Quality::Null.getName()] = kViolet - 6;
+  mColors[Quality::Bad.getName()] = kRed;
+  mColors[Quality::Medium.getName()] = kOrange - 3;
+  mColors[Quality::Good.getName()] = kGreen + 2;
+}
+
+void BigScreenCanvas::add(std::string name, int index)
+{
+  mElements[name] = std::make_shared<BigScreenElement>(name, index, mPadding, mLabelOffset, mBorderWidth);
+}
+
+void BigScreenCanvas::set(std::string name, int color, std::string text)
+{
+  auto index = mElements.find(name);
+  if (index == mElements.end()) {
+    return;
+  }
+  auto& pave = index->second->mPave;
+  pave.Clear();
+  pave.SetFillColor(color);
+  pave.AddText((std::string(" ") + text + std::string(" ")).c_str());
+}
+
+void BigScreenCanvas::set(std::string name, Quality quality)
+{
+  auto color = mColors.find(quality.getName());
+  if (color != mColors.end()) {
+    set(name, color->second, quality.getName());
+  }
+}
+
+void BigScreenCanvas::update()
+{
+  Clear();
+  Divide(mNCols, mNRows);
+
+  for (auto& [key, element] : mElements) {
+    cd(element->mPadIndex);
+    element->mPave.Draw();
+    element->mBox.Draw();
+    element->mLabel.Draw();
+  }
+}
+
+} // namespace o2::quality_control_modules::common

--- a/Modules/Common/src/BigScreenConfig.cxx
+++ b/Modules/Common/src/BigScreenConfig.cxx
@@ -31,7 +31,9 @@ BigScreenConfig::BigScreenConfig(std::string name, const boost::property_tree::p
         if (tokens.size() != 2 || tokens[0].empty()) {
           continue;
         }
-        dataSources.push_back({ tokens[0], tokens[1] });
+        const auto& sourceDet = tokens[0];
+        const auto& sourcePath = tokens[1];
+        dataSources.push_back({ sourceDet, sourcePath });
       }
     } else if (!dataSourceConfig.second.get<std::string>("name").empty()) {
       // "name" : [ "something" ] would return an empty string here
@@ -40,7 +42,9 @@ BigScreenConfig::BigScreenConfig(std::string name, const boost::property_tree::p
       if (tokens.size() != 2 || tokens[0].empty()) {
         continue;
       }
-      dataSources.push_back({ tokens[0], tokens[1] });
+      const auto& sourceDet = tokens[0];
+      const auto& sourcePath = tokens[1];
+      dataSources.push_back({ sourceDet, sourcePath });
     } else {
       throw std::runtime_error("No 'name' value or a 'names' vector in the path 'qc.postprocessing." + name + ".dataSources'");
     }

--- a/Modules/Common/src/BigScreenConfig.cxx
+++ b/Modules/Common/src/BigScreenConfig.cxx
@@ -15,19 +15,8 @@
 ///
 
 #include "Common/BigScreenConfig.h"
+#include <CommonUtils/StringUtils.h>
 #include <boost/property_tree/ptree.hpp>
-#include <chrono>
-
-static void splitDataSourceName(std::string s, std::string& det, std::string& name)
-{
-  std::string delimiter = ":";
-  size_t pos = s.find(delimiter);
-  if (pos != std::string::npos) {
-    det = s.substr(0, pos);
-    s.erase(0, pos + delimiter.length());
-  }
-  name = s;
-}
 
 namespace o2::quality_control_modules::common
 {
@@ -35,63 +24,27 @@ namespace o2::quality_control_modules::common
 BigScreenConfig::BigScreenConfig(std::string name, const boost::property_tree::ptree& config)
   : PostProcessingConfig(name, config)
 {
-  auto getParInt = [&](std::string name, int& par) {
-    if (!getConfigParameter(name).empty()) {
-      par = std::stoi(getConfigParameter(name));
-    }
-  };
-
-  // parameters
-  if (const auto& customConfigs = config.get_child_optional("qc.postprocessing." + name + ".customization"); customConfigs.has_value()) {
-    for (const auto& customConfig : customConfigs.value()) {
-      if (const auto& customNames = customConfig.second.get_child_optional("name"); customNames.has_value()) {
-        mConfigParameters.insert(std::make_pair(customConfig.second.get<std::string>("name"), customConfig.second.get<std::string>("value")));
-      }
-    }
-  }
-
-  getParInt("NRows", mNRows);
-  getParInt("NCols", mNCols);
-  getParInt("BorderWidth", mBorderWidth);
-  getParInt("NotOlderThan", mNotOlderThan);
-  getParInt("IgnoreActivity", mIgnoreActivity);
-
-  auto now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-
   for (const auto& dataSourceConfig : config.get_child("qc.postprocessing." + name + ".dataSources")) {
     if (const auto& sourceNames = dataSourceConfig.second.get_child_optional("names"); sourceNames.has_value()) {
       for (const auto& sourceName : sourceNames.value()) {
-        std::string sourceDet, sourcePath;
-        splitDataSourceName(sourceName.second.data(), sourceDet, sourcePath);
-        if (sourceDet.empty()) {
+        auto tokens = o2::utils::Str::tokenize(sourceName.second.data(), ':', false, true);
+        if (tokens.size() != 2 || tokens[0].empty()) {
           continue;
         }
-        dataSources.push_back({ sourceDet, sourcePath });
+        dataSources.push_back({ tokens[0], tokens[1] });
       }
     } else if (!dataSourceConfig.second.get<std::string>("name").empty()) {
       // "name" : [ "something" ] would return an empty string here
       auto sourceName = dataSourceConfig.second.get<std::string>("name");
-      std::string sourceDet, sourcePath;
-      splitDataSourceName(sourceName, sourceDet, sourcePath);
-      if (sourceDet.empty()) {
+      auto tokens = o2::utils::Str::tokenize(sourceName, ':', false, true);
+      if (tokens.size() != 2 || tokens[0].empty()) {
         continue;
       }
-      dataSources.push_back({ sourceDet, sourcePath });
+      dataSources.push_back({ tokens[0], tokens[1] });
     } else {
       throw std::runtime_error("No 'name' value or a 'names' vector in the path 'qc.postprocessing." + name + ".dataSources'");
     }
   }
-}
-
-const std::string BigScreenConfig::getConfigParameter(std::string name) const
-{
-  std::string result;
-  auto entry = mConfigParameters.find(name);
-  if (entry != mConfigParameters.end()) {
-    result = entry->second;
-  }
-
-  return result;
 }
 
 } // namespace o2::quality_control_modules::common

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -594,28 +594,18 @@ The task is configured as follows:
         "className": "o2::quality_control_modules::common::BigScreen",
         "moduleName": "QualityControl",
         "detectorName": "GLO",
-        "customization": [
-          {
-            "name": "NRows",
-            "value": "4"
-          },
-          {
-            "name": "NCols",
-            "value": "5"
-          },
-          {
-            "name": "BorderWidth",
-            "value": "5"
-          },
-          {
-            "name": "NotOlderThan",
-            "value": "3600"
-          },
-          {
-            "name": "IgnoreActivity",
-            "value": "0"
+        "extendedTaskParameters": {
+          "default": {      
+            "default": {      
+              "nRows": "4",
+              "nCols": "5",
+              "borderWidth": "1",
+              "maxObjectTimeShift": "10000",
+              "ignoreActivity": "0",
+              "labels": "CPV,EMC,FDD,FT0,FV0,HMP,ITS,MCH,MFT,MID,PHS,TPC,TOF,TRD,,TRK,MTK,VTX,PID"
+            }
           }
-        ],
+        },
         "dataSources": [
           {
             "names": [
@@ -658,16 +648,17 @@ The task is configured as follows:
 
 The following options allow to configure the appearence and behavior of the task:
 
-* `NRows`/`NCols`: size of the X-Y grid
-* `BorderWidth`: size of the border around the boxes
-* `NotOlderThan`: ignore quality objects that are older than a given number of seconds. A value of -1 means "no limit".
-* `IgnoreActivity`: if diferent from 0, the task will fetch objects regardless of their activity number and type.
+* `nRows`/`nCols`: size of the X-Y grid
+* `borderWidth`: size of the border around the boxes
+* `maxObjectTimeShift`: ignore quality objects that are older than a given number of seconds. A value of -1 means "no limit".
+* `ignoreActivity`: if different from 0, the task will fetch objects regardless of their activity number and type.
+* `labels`: comma-separated list of labels with boxes to be displayed in the canvas. Some places in the grid of boxes can be left empty by inserting two consecutive commas in the list, like between `TRD` and `TRK` in the example above
 
 The names in the data sources are composed of two parts, separated by a colon:
 ```
-SYSTEM_NAME:OBJECT_PATH
+LABEL:OBJECT_PATH
 ```
-The grid of colored boxes is built from the list of data sources, and the corresponding `SYSTEM_NAME` is displayed above each box.
+The `LABEL` should match one of the elements of the `labels` parameter. The quality object will be associated to the corresponding box.
 
 ## More examples
 


### PR DESCRIPTION
This PR improves and simplifies the Big Screen task:
- moved canvas object to a separate source file
- added "old" state for objects that exist for the current activity but are older than the maximum age defined in the configuration
- moved canvas publishing in the `initialize()` method
- use the extended task parameters for the configuration

The modifications are split is few commits, to hopefully simplify the review process.