### PR TITLE
BigScreen: changed message severity to Info

### DIFF
--- a/Modules/Common/src/BigScreen.cxx
+++ b/Modules/Common/src/BigScreen.cxx
@@ -116,7 +116,7 @@ static std::pair<std::shared_ptr<QualityObject>, bool> getQO(repository::Databas
   if (objectValidity.isValid()) {
     timestamp = objectValidity.getMax() - 1;
   } else {
-    ILOG(Warning, Devel) << "Could not find an object '" << objFullPath << "' for activity " << activity << ENDM;
+    ILOG(Info, Support) << "Could not find an object '" << objFullPath << "' for activity " << activity << ENDM;
     return { nullptr, false };
   }
 


### PR DESCRIPTION
The message about missing QCDB objects does not need to be a Warning, since the corresponding box is painted in grey in this case.

The severity has been changed to `(Info, Support)` to avoid spamming the InfoLogger with unnecessary warnings.