### PR TITLE
Uniform postprocessing task facility in IL

### DIFF
--- a/Framework/include/QualityControl/QcInfoLogger.h
+++ b/Framework/include/QualityControl/QcInfoLogger.h
@@ -44,6 +44,7 @@ namespace o2::quality_control::core
 class QcInfoLogger
 {
  public:
+  constexpr static size_t maxFacilityLength = 32;
   static AliceO2::InfoLogger::InfoLogger& GetInfoLogger()
   {
     return *instance;

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -108,9 +108,9 @@ std::string CheckRunner::createCheckRunnerName(const std::vector<CheckConfig>& c
 
 std::string CheckRunner::createCheckRunnerFacility(std::string deviceName)
 {
-  // it starts with "check/" and is followed by the unique part of the device name truncated to a maximum of 32 characters.
+  // it starts with "check/" and is followed by the unique part of the device name truncated to the maximum allowed length
   string facilityName = "check/" + deviceName.substr(CheckRunner::createCheckRunnerIdString().length() + 1, string::npos);
-  facilityName = facilityName.substr(0, 32);
+  facilityName = facilityName.substr(0, QcInfoLogger::maxFacilityLength);
   return facilityName;
 }
 

--- a/Framework/src/PostProcessingDevice.cxx
+++ b/Framework/src/PostProcessingDevice.cxx
@@ -22,6 +22,7 @@
 #include "QualityControl/PostProcessingRunnerConfig.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/HashDataDescription.h"
+#include "QualityControl/runnerUtils.h"
 
 #include <Common/Exceptions.h>
 #include <Framework/CallbackService.h>
@@ -46,6 +47,8 @@ PostProcessingDevice::PostProcessingDevice(const PostProcessingRunnerConfig& run
 
 void PostProcessingDevice::init(framework::InitContext& ctx)
 {
+  core::initInfologger(ctx, mRunnerConfig.infologgerDiscardParameters, ("post/" + mRunnerConfig.taskName).substr(0, core::QcInfoLogger::maxFacilityLength), mRunnerConfig.detectorName);
+
   if (ctx.options().isSet("configKeyValues")) {
     mRunnerConfig.configKeyValues = ctx.options().get<std::string>("configKeyValues");
   }

--- a/Framework/src/PostProcessingRunner.cxx
+++ b/Framework/src/PostProcessingRunner.cxx
@@ -68,13 +68,13 @@ void PostProcessingRunner::init(const boost::property_tree::ptree& config, core:
 
 void PostProcessingRunner::init(const PostProcessingRunnerConfig& runnerConfig, const PostProcessingConfig& taskConfig)
 {
+  QcInfoLogger::init(("post/" + taskConfig.taskName).substr(0, QcInfoLogger::maxFacilityLength), runnerConfig.infologgerDiscardParameters);
+  ILOG(Info, Support) << "Initializing PostProcessingRunner" << ENDM;
+
   mRunnerConfig = runnerConfig;
   mTaskConfig = taskConfig;
   mActivity = taskConfig.activity;
   mActivity.mValidity = gInvalidValidityInterval;
-
-  QcInfoLogger::init("post/" + mID, mRunnerConfig.infologgerDiscardParameters);
-  ILOG(Info, Support) << "Initializing PostProcessingRunner" << ENDM;
 
   root_class_factory::loadLibrary(mTaskConfig.moduleName);
   if (!ConfigParamGlo::keyValues.empty()) {


### PR DESCRIPTION
Before we suffered from having two different facility fields for logs from different parts of the code, this should fix it.