### PR TITLE
GLO: improved mean vertex post-processing

### DIFF
--- a/Modules/GLO/CMakeLists.txt
+++ b/Modules/GLO/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(O2QcGLO)
 
-target_sources(O2QcGLO PRIVATE src/MeanVertexPostProcessing.cxx  src/VertexingQcTask.cxx src/ITSTPCMatchingTask.cxx src/DataCompressionQcTask.cxx)
+target_sources(O2QcGLO PRIVATE src/MeanVertexPostProcessing.cxx src/MeanVertexCheck.cxx src/VertexingQcTask.cxx src/ITSTPCMatchingTask.cxx src/DataCompressionQcTask.cxx)
 
 target_include_directories(
   O2QcGLO
@@ -41,6 +41,7 @@ install(FILES ITSTPCmatchedTracks_external.json
 add_root_dictionary(O2QcGLO
                     HEADERS
   include/GLO/MeanVertexPostProcessing.h
+  include/GLO/MeanVertexCheck.h
   include/GLO/VertexingQcTask.h
   include/GLO/ITSTPCMatchingTask.h
   include/GLO/DataCompressionQcTask.h

--- a/Modules/GLO/glo-mean-vtx-post-processing.json
+++ b/Modules/GLO/glo-mean-vtx-post-processing.json
@@ -47,62 +47,6 @@
 		"CcdbURL": "http://ccdb-test.cern.ch:8080"
 	    }
 	]
-      },
-      "MeanVtxTrending": {
-        "active": "true",
-        "className": "o2::quality_control::postprocessing::TrendingTask",
-        "moduleName": "QualityControl",
-        "detectorName": "GLO",
-        "dataSources": [
-          {
-            "type": "repository",
-            "path": "GLO/MO/MeanVertexCalib",
-            "names": [
-		"mMeanVtxX",
-		"mMeanVtxY",
-		"mMeanVtxZ",
-		"mStartValidity"
-            ],
-            "reductorName": "o2::quality_control_modules::common::TH1Reductor",
-            "moduleName": "QcCommon"
-          }
-        ],
-        "plots": [
-          {
-            "name": "meanVtx_X",
-            "title": "Mean vertex position, X",
-            "varexp": "mMeanVtxX.mean:mStartValidity.mean",
-            "selection": "",
-            "option": "*L",
-            "graphAxisLabel": "MeanVtx, X (cm):StartValidy (ms)"
-          },
-	  {
-            "name": "meanVtx_Y",
-            "title": "Mean vertex position, Y",
-            "varexp": "mMeanVtxY.mean:mStartValidity.mean",
-            "selection": "",
-            "option": "*L",
-            "graphAxisLabel": "MeanVtx, Y (cm):StartValidy (ms)"
-          },
-	  {
-            "name": "meanVtx_Z",
-            "title": "Mean vertex position, Z",
-            "varexp": "mMeanVtxZ.mean:mStartValidity.mean",
-            "selection": "",
-            "option": "*L",
-            "graphAxisLabel": "MeanVtx, Z (cm):StartValidy (ms)"
-          }
-        ],
-        "initTrigger": [
-          "userorcontrol"
-        ],
-        "updateTrigger": [
-          "newobject:qcdb:GLO/MO/MeanVertexCalib/mMeanVtxX"
-        ],
-        "stopTrigger": [
-          "userorcontrol",
-          "10 minutes"
-        ]
       }
     }
   }

--- a/Modules/GLO/glo-mean-vtx-post-processing.json
+++ b/Modules/GLO/glo-mean-vtx-post-processing.json
@@ -46,7 +46,43 @@
         ],
         "stopTrigger": [
           "userorcontrol"
-	]
+        ]
+      }
+    },
+    "checks": {
+      "MeanVertexCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::glo::MeanVertexCheck",
+        "moduleName": "QcGLO",
+        "detectorName": "GLO",
+        "policy": "OnAll",
+        "extendedCheckParameters": {
+          "default": {
+            "default": {
+              "nPointsToCheck": "10",
+              "range:MeanVtxXTrending": "-0.1,0.1",
+              "range:MeanVtxYTrending": "-0.1,0.1",
+              "range:MeanVtxZTrending": "-1.0,1.0",
+              "range:MeanVtxSigmaXTrending": "-0.1,0.1",
+              "range:MeanVtxSigmaYTrending": "-0.1,0.1",
+              "range:MeanVtxSigmaZTrending": "-10.0,10.0"
+            }
+          }
+        },
+        "dataSource": [
+          {
+            "type": "PostProcessing",
+            "name": "MeanVertexCalib",
+             "MOs" : [
+               "MeanVtxXTrending",
+               "MeanVtxYTrending",
+               "MeanVtxZTrending",
+               "MeanVtxSigmaXTrending",
+               "MeanVtxSigmaYTrending",
+               "MeanVtxSigmaZTrending"
+            ]
+          }
+        ]
       }
     }
   }

--- a/Modules/GLO/glo-mean-vtx-post-processing.json
+++ b/Modules/GLO/glo-mean-vtx-post-processing.json
@@ -33,6 +33,11 @@
         "className": "o2::quality_control_modules::glo::MeanVertexPostProcessing",
         "moduleName": "QcGLO",
         "detectorName": "GLO",
+        "customization": [
+          {
+            "CcdbURL": "http://ccdb-test.cern.ch:8080"
+          }
+        ],
         "initTrigger": [
           "userorcontrol"
         ],
@@ -41,11 +46,6 @@
         ],
         "stopTrigger": [
           "userorcontrol"
-        ],
-	"customization": [
-	    {
-		"CcdbURL": "http://ccdb-test.cern.ch:8080"
-	    }
 	]
       }
     }

--- a/Modules/GLO/include/GLO/LinkDef.h
+++ b/Modules/GLO/include/GLO/LinkDef.h
@@ -8,4 +8,6 @@
 #pragma link C++ class o2::quality_control_modules::glo::DataCompressionQcTask + ;
 
 #pragma link C++ class o2::quality_control_modules::glo::MeanVertexPostProcessing + ;
+
+#pragma link C++ class o2::quality_control_modules::glo::MeanVertexCheck + ;
 #endif

--- a/Modules/GLO/include/GLO/MeanVertexCheck.h
+++ b/Modules/GLO/include/GLO/MeanVertexCheck.h
@@ -1,0 +1,63 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   MeanVertexCheck.h
+/// \author Andrea Ferrero
+///
+
+#ifndef QC_MODULE_GLO_MEANVERTEXCHECK_H
+#define QC_MODULE_GLO_MEANVERTEXCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+
+#include <map>
+
+class TH1;
+class TEfficiency;
+
+namespace o2::quality_control_modules::glo
+{
+
+/// \brief  Check whether the matching efficiency is within some configurable limits
+///
+/// \author Andrea Ferrero
+class MeanVertexCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  MeanVertexCheck() = default;
+  /// Destructor
+  ~MeanVertexCheck() override = default;
+
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+
+  void startOfActivity(const Activity& activity) override;
+  void endOfActivity(const Activity& activity) override;
+
+  ClassDefOverride(MeanVertexCheck, 1);
+
+ private:
+  void initRange(std::string key);
+  std::optional<std::pair<double, double>> getRange(std::string key);
+
+  Activity mActivity;
+  int mNPointsToCheck{ 1 };
+  std::map<std::string, std::pair<double, double>> mRanges;
+  std::map<std::string, Quality> mQualities;
+};
+
+} // namespace o2::quality_control_modules::glo
+
+#endif // QC_MODULE_GLO_MEANVERTEXCHECK_H

--- a/Modules/GLO/include/GLO/MeanVertexPostProcessing.h
+++ b/Modules/GLO/include/GLO/MeanVertexPostProcessing.h
@@ -54,7 +54,7 @@ class MeanVertexPostProcessing final : public quality_control::postprocessing::P
   /// \brief Constructor
   MeanVertexPostProcessing() = default;
   /// \brief Destructor
-  ~MeanVertexPostProcessing() override;
+  ~MeanVertexPostProcessing() override = default;
 
   /// \brief Configuration of a post-processing task.
   /// Configuration of a post-processing task. Can be overridden if user wants to retrieve the configuration of the task.
@@ -96,10 +96,6 @@ class MeanVertexPostProcessing final : public quality_control::postprocessing::P
   std::unique_ptr<TrendGraph> mGraphSigmaX;
   std::unique_ptr<TrendGraph> mGraphSigmaY;
   std::unique_ptr<TrendGraph> mGraphSigmaZ;
-  TH1F* mX = nullptr;
-  TH1F* mY = nullptr;
-  TH1F* mZ = nullptr;
-  TH1F* mStartValidity = nullptr;
   o2::ccdb::CcdbApi mCcdbApi;
   std::string mCcdbUrl = "https://alice-ccdb.cern.ch";
 };

--- a/Modules/GLO/include/GLO/MeanVertexPostProcessing.h
+++ b/Modules/GLO/include/GLO/MeanVertexPostProcessing.h
@@ -11,7 +11,7 @@
 
 ///
 /// \file   MeanVertexPostProcessing.h
-/// \author Chiara Zampolli
+/// \author Chiara Zampolli, Andrea Ferrero
 ///
 
 #ifndef QUALITYCONTROL_MEANVERTEXPOSTPROCESSING_H
@@ -20,31 +20,10 @@
 #include "QualityControl/PostProcessingInterface.h"
 #include "CCDB/CcdbApi.h"
 
-#include <TLine.h>
-#include <TH1F.h>
-#include <TGraph.h>
-#include <TCanvas.h>
-
 namespace o2::quality_control_modules::glo
 {
 
-class TrendGraph : public TCanvas
-{
- public:
-  TrendGraph(std::string name, std::string title, std::string label, float rangeMin, float rangeMax);
-
-  ~TrendGraph() override {}
-
-  void update(uint64_t time, float val);
-
- private:
-  float mRangeMin;
-  float mRangeMax;
-  std::string mAxisLabel;
-  std::unique_ptr<TGraph> mGraph;
-  std::unique_ptr<TGraph> mGraphHist;
-  std::array<std::unique_ptr<TLine>, 2> mLines;
-};
+class TrendGraph;
 
 /// \brief Postprocessing Task for Mean Vertex calibration
 
@@ -83,19 +62,12 @@ class MeanVertexPostProcessing final : public quality_control::postprocessing::P
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistryRef) override;
 
  private:
-  float mRangeX{ 0.1 };
-  float mRangeY{ 0.1 };
-  float mRangeZ{ 1.0 };
-  float mRangeSigmaX{ 1.0 };
-  float mRangeSigmaY{ 1.0 };
-  float mRangeSigmaZ{ 10.0 };
-  bool mResetHistos{ false };
-  std::unique_ptr<TrendGraph> mGraphX;
-  std::unique_ptr<TrendGraph> mGraphY;
-  std::unique_ptr<TrendGraph> mGraphZ;
-  std::unique_ptr<TrendGraph> mGraphSigmaX;
-  std::unique_ptr<TrendGraph> mGraphSigmaY;
-  std::unique_ptr<TrendGraph> mGraphSigmaZ;
+  std::shared_ptr<TrendGraph> mGraphX;
+  std::shared_ptr<TrendGraph> mGraphY;
+  std::shared_ptr<TrendGraph> mGraphZ;
+  std::shared_ptr<TrendGraph> mGraphSigmaX;
+  std::shared_ptr<TrendGraph> mGraphSigmaY;
+  std::shared_ptr<TrendGraph> mGraphSigmaZ;
   o2::ccdb::CcdbApi mCcdbApi;
   std::string mCcdbUrl = "https://alice-ccdb.cern.ch";
 };

--- a/Modules/GLO/src/MeanVertexCheck.cxx
+++ b/Modules/GLO/src/MeanVertexCheck.cxx
@@ -1,0 +1,227 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   MeanVertexCheck.cxx
+/// \author Andrea Ferrero
+///
+
+#include "GLO/MeanVertexCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
+#include <CommonUtils/StringUtils.h>
+#include <TMath.h>
+#include <TGraph.h>
+#include <TH1.h>
+#include <TCanvas.h>
+#include <TLine.h>
+
+namespace o2::quality_control_modules::glo
+{
+void MeanVertexCheck::configure() {}
+
+void MeanVertexCheck::startOfActivity(const Activity& activity)
+{
+  mActivity = activity;
+
+  std::string parKey = std::string("nPointsToCheck");
+  // search in extended parameters first
+  auto parOpt = mCustomParameters.atOptional(parKey, mActivity);
+  if (parOpt.has_value()) {
+    if (parOpt.value() == "all") {
+      mNPointsToCheck = 0;
+    } else {
+      mNPointsToCheck = std::stoi(parOpt.value());
+    }
+  } else {
+    // search in standard parameters if key not found in extended ones
+    parOpt = mCustomParameters.atOptional(parKey);
+    if (parOpt.value() == "all") {
+      mNPointsToCheck = 0;
+    } else {
+      mNPointsToCheck = std::stoi(parOpt.value());
+    }
+  }
+  ILOG(Info, Support) << "MeanVertexCheck: checking at most " << mNPointsToCheck << " points " << ENDM;
+}
+
+void MeanVertexCheck::endOfActivity(const Activity& activity)
+{
+  mActivity = Activity{};
+  mRanges.clear();
+  mQualities.clear();
+}
+
+static std::string getBaseName(std::string name)
+{
+  auto pos = name.rfind("/");
+  return ((pos < std::string::npos) ? name.substr(pos + 1) : name);
+}
+
+void MeanVertexCheck::initRange(std::string key)
+{
+  // Get acceptable range for this histogram
+  auto iter = mRanges.find(key);
+  if (iter != mRanges.end()) {
+    return;
+  }
+
+  // get configuration parameter associated to the key
+  std::string parKey = std::string("range:") + key;
+  std::string parValue;
+  // search in extended parameters first
+  auto parOpt = mCustomParameters.atOptional(parKey, mActivity);
+  if (parOpt.has_value()) {
+    parValue = parOpt.value();
+  } else {
+    // search in standard parameters if key not found in extended ones
+    parOpt = mCustomParameters.atOptional(parKey);
+    if (parOpt.has_value()) {
+      parValue = parOpt.value();
+    }
+  }
+
+  // extract the minimum and maximum values from the configurable parameter
+  auto range = o2::utils::Str::tokenize(parValue, ',', false, true);
+  if (range.size() == 2) {
+    double min = std::stod(range[0]);
+    double max = std::stod(range[1]);
+    mRanges.insert(std::pair{ key, std::make_pair(min, max) });
+    ILOG(Info, Support) << "MeanVertexCheck: range for " << key << " set to [" << min << "," << max << "]" << ENDM;
+  }
+}
+
+std::optional<std::pair<double, double>> MeanVertexCheck::getRange(std::string key)
+{
+  std::optional<std::pair<double, double>> result;
+
+  // Get acceptable range for this histogram
+  auto iter = mRanges.find(key);
+  if (iter != mRanges.end()) {
+    result = iter->second;
+  }
+
+  return result;
+}
+
+Quality MeanVertexCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  for (auto& [moKey, mo] : *moMap) {
+
+    auto moName = mo->getName();
+    auto key = getBaseName(moName);
+
+    // get acceptable range for the current plot
+    initRange(key);
+    auto range = getRange(key);
+    if (!range) {
+      continue;
+    }
+
+    // check that the object is a TGraph
+    TGraph* graph = dynamic_cast<TGraph*>(mo->getObject());
+    if (!graph) {
+      continue;
+    }
+
+    // Quality is good by default, unless one of the points is outside the acceptable range
+    mQualities[moName] = Quality::Good;
+
+    // loop over points in reverse order
+    int nChecked = 0;
+    int nPoints = graph->GetN();
+    for (int p = nPoints - 1; p >= 0; p--) {
+      double value = graph->GetPointY(p);
+      // check that the value is within the acceptable range
+      if (value < range->first || value > range->second) {
+        mQualities[moName] = Quality::Bad;
+        break;
+      }
+
+      nChecked += 1;
+      // stop if we already checked enough points
+      if (mNPointsToCheck > 0 && nChecked >= mNPointsToCheck) {
+        break;
+      }
+    }
+  }
+
+  // compute overall quality
+  Quality result = mQualities.empty() ? Quality::Null : Quality::Good;
+  for (auto& [key, q] : mQualities) {
+    if (q.isWorseThan(result)) {
+      result = q;
+    }
+  }
+
+  return result;
+}
+
+std::string MeanVertexCheck::getAcceptedType() { return "TObject"; }
+
+void MeanVertexCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  auto moName = mo->getName();
+  Quality quality = mQualities[moName];
+
+  // get acceptable range for plot, to draw the horizontal lines
+  auto key = getBaseName(moName);
+  auto range = getRange(key);
+  if (!range) {
+    return;
+  }
+
+  // check that the object is a TGraph
+  auto graph = dynamic_cast<TGraph*>(mo->getObject());
+  if (!graph || graph->GetN() < 1) {
+    return;
+  }
+
+  // draw the graph in red if the quality is Bad
+  if (quality == Quality::Bad) {
+    graph->SetLineColor(kRed);
+    graph->SetMarkerColor(kRed);
+  }
+
+  // Compute vertical axis range
+  double min = TMath::Min(range->first, TMath::MinElement(graph->GetN(), graph->GetY()));
+  double max = TMath::Max(range->second, TMath::MaxElement(graph->GetN(), graph->GetY()));
+  // put 10% of margin above and below the limits
+  auto delta = max - min;
+  min -= 0.1 * delta;
+  max += 0.1 * delta;
+
+  graph->SetMinimum(min);
+  graph->SetMaximum(max);
+
+  // add horizontal lines delimiting the acceptable range
+  double xmin = graph->GetXaxis()->GetXmin();
+  double xmax = graph->GetXaxis()->GetXmax();
+  TLine* l1 = new TLine(xmin, range->first, xmax, range->first);
+  TLine* l2 = new TLine(xmin, range->second, xmax, range->second);
+
+  l1->SetLineStyle(kDotted);
+  l2->SetLineStyle(kDotted);
+
+  if (quality == Quality::Bad) {
+    l1->SetLineColor(kRed);
+    l2->SetLineColor(kRed);
+  } else {
+    l1->SetLineColor(kBlue);
+    l2->SetLineColor(kBlue);
+  }
+
+  graph->GetListOfFunctions()->Add(l1);
+  graph->GetListOfFunctions()->Add(l2);
+}
+
+} // namespace o2::quality_control_modules::glo

--- a/Modules/GLO/src/MeanVertexPostProcessing.cxx
+++ b/Modules/GLO/src/MeanVertexPostProcessing.cxx
@@ -71,10 +71,8 @@ void MeanVertexPostProcessing::configure(const boost::property_tree::ptree& conf
   }
   ILOG(Info, Support) << "MeanVertexCalib post-processing: CCDB url will be set to: " << mCcdbUrl << ENDM;
   mCcdbApi.init(mCcdbUrl);
-}
 
-void MeanVertexPostProcessing::initialize(Trigger, framework::ServiceRegistryRef)
-{
+  // create the graphs
   mGraphX = std::make_shared<TrendGraph>("MeanVtxXTrending", "Mean Vertex X", "cm");
   mGraphY = std::make_shared<TrendGraph>("MeanVtxYTrending", "Mean Vertex Y", "cm");
   mGraphZ = std::make_shared<TrendGraph>("MeanVtxZTrending", "Mean Vertex Z", "cm");
@@ -82,7 +80,11 @@ void MeanVertexPostProcessing::initialize(Trigger, framework::ServiceRegistryRef
   mGraphSigmaX = std::make_shared<TrendGraph>("MeanVtxSigmaXTrending", "Mean Vertex #sigma_{X}", "cm");
   mGraphSigmaY = std::make_shared<TrendGraph>("MeanVtxSigmaYTrending", "Mean Vertex #sigma_{Y}", "cm");
   mGraphSigmaZ = std::make_shared<TrendGraph>("MeanVtxSigmaZTrending", "Mean Vertex #sigma_{Z}", "cm");
+}
 
+void MeanVertexPostProcessing::initialize(Trigger, framework::ServiceRegistryRef)
+{
+  // publish the graphs
   getObjectsManager()->startPublishing(mGraphX.get());
   getObjectsManager()->startPublishing(mGraphY.get());
   getObjectsManager()->startPublishing(mGraphZ.get());
@@ -131,14 +133,6 @@ void MeanVertexPostProcessing::update(Trigger t, framework::ServiceRegistryRef)
 
 void MeanVertexPostProcessing::finalize(Trigger, framework::ServiceRegistryRef)
 {
-  // Only if you don't want it to be published after finalisation.
-  getObjectsManager()->stopPublishing(mGraphX.get());
-  getObjectsManager()->stopPublishing(mGraphY.get());
-  getObjectsManager()->stopPublishing(mGraphZ.get());
-
-  getObjectsManager()->stopPublishing(mGraphSigmaX.get());
-  getObjectsManager()->stopPublishing(mGraphSigmaY.get());
-  getObjectsManager()->stopPublishing(mGraphSigmaZ.get());
 }
 
 } // namespace o2::quality_control_modules::glo

--- a/Modules/GLO/src/MeanVertexPostProcessing.cxx
+++ b/Modules/GLO/src/MeanVertexPostProcessing.cxx
@@ -14,13 +14,16 @@
 /// \author Chiara Zampolli, Andrea Ferrero
 ///
 
+#include "GLO/MeanVertexPostProcessing.h"
+#include "QualityControl/QcInfoLogger.h"
 #include "DataFormatsCalibration/MeanVertexObject.h"
 #include "CCDB/CCDBTimeStampUtils.h"
 
-#include "GLO/MeanVertexPostProcessing.h"
-#include "QualityControl/QcInfoLogger.h"
-
+// ROOT
+#include <TGraph.h>
+#include <TAxis.h>
 #include <TMath.h>
+
 #include <boost/property_tree/ptree.hpp>
 
 using namespace o2::quality_control::postprocessing;
@@ -98,8 +101,7 @@ void MeanVertexPostProcessing::initialize(Trigger, framework::ServiceRegistryRef
 
 void MeanVertexPostProcessing::update(Trigger t, framework::ServiceRegistryRef)
 {
-  ILOG(Info, Support) << "Trigger type is: " << t.triggerType << ", the timestamp is " << t.timestamp << ENDM;
-  std::map<std::string, std::string> md, headers;
+  std::map<std::string, std::string> md;
   auto* meanVtx = mCcdbApi.retrieveFromTFileAny<o2::dataformats::MeanVertexObject>("GLO/Calib/MeanVertex", md, t.timestamp);
   if (!meanVtx) {
     ILOG(Info, Support) << "MeanVertexCalib post-processing: null object received for " << t.timestamp << ENDM;
@@ -115,10 +117,11 @@ void MeanVertexPostProcessing::update(Trigger t, framework::ServiceRegistryRef)
   auto sz = meanVtx->getSigmaZ();
 
   // get time stamp
+  std::map<std::string, std::string> headers;
   headers = mCcdbApi.retrieveHeaders("GLO/Calib/MeanVertex", md, t.timestamp);
   const auto validFrom = headers.find("Valid-From");
   long startVal = std::stol(validFrom->second);
-  ILOG(Info, Support) << "MeanVertexCalib post-processing: startValidity = " << startVal << " X = " << x << " Y = " << y << " Z = " << z << ENDM;
+  ILOG(Debug, Support) << "MeanVertexCalib post-processing: startValidity = " << startVal << " X = " << x << " Y = " << y << " Z = " << z << ENDM;
 
   // ROOT expects time in seconds
   startVal /= 1000;


### PR DESCRIPTION
Some improvements to the MeanVertexPostProcessing task:
- added title to graphs
- moved TrendGraph declaration into source file
- adapted code for START/STOP/START compatibility
- removed obsolete histograms with vertex position 
    - the `MeanVtxTrending` task will have to be removed as well from all configurations
- added checker for vertex trending plots

The PR is split in few separate commits to simplify the review.