### PR TITLE
TRD raw check make nHBFPerTF configurable parameter

### DIFF
--- a/Modules/TRD/include/TRD/RawDataCheck.h
+++ b/Modules/TRD/include/TRD/RawDataCheck.h
@@ -49,6 +49,7 @@ class RawDataCheckStats : public o2::quality_control::checker::CheckInterface
   float mReadoutRate;
   float mMaxReadoutRate;
   float mMinCalTriggerRate;
+  int mNHBFperTF;
 
   ClassDefOverride(RawDataCheckStats, 1);
 };


### PR DESCRIPTION
Would be great to have this in the next release, as without it the check cannot be enabled at P2