### PR TITLE
ctpqc: opening CCDB in update

### DIFF
--- a/Modules/CTP/include/CTP/CTPTrendingTask.h
+++ b/Modules/CTP/include/CTP/CTPTrendingTask.h
@@ -49,7 +49,7 @@ class CTPTrendingTask : public PostProcessingInterface
   void initialize(Trigger, framework::ServiceRegistryRef) override;
   void update(Trigger, framework::ServiceRegistryRef) override;
   void finalize(Trigger, framework::ServiceRegistryRef) override;
-  void initCTP(Trigger &t);
+  void initCTP(Trigger& t);
 
  private:
   struct MetaData {

--- a/Modules/CTP/include/CTP/CTPTrendingTask.h
+++ b/Modules/CTP/include/CTP/CTPTrendingTask.h
@@ -49,6 +49,7 @@ class CTPTrendingTask : public PostProcessingInterface
   void initialize(Trigger, framework::ServiceRegistryRef) override;
   void update(Trigger, framework::ServiceRegistryRef) override;
   void finalize(Trigger, framework::ServiceRegistryRef) override;
+  void initCTP(Trigger &t);
 
  private:
   struct MetaData {

--- a/Modules/CTP/src/CTPTrendingTask.cxx
+++ b/Modules/CTP/src/CTPTrendingTask.cxx
@@ -41,10 +41,8 @@ void CTPTrendingTask::configure(const boost::property_tree::ptree& config)
 {
   mConfig = TrendingConfigCTP(getID(), config);
 }
-
-void CTPTrendingTask::initialize(Trigger t, framework::ServiceRegistryRef services)
+void CTPTrendingTask::initCTP(Trigger& t)
 {
-  // // read out the CTPConfiguration
   std::string run = std::to_string(t.activity.mId);
   CTPRunManager::setCCDBHost("https://alice-ccdb.cern.ch");
   mCTPconfig = CTPRunManager::getConfigFromCCDB(t.timestamp, run);
@@ -77,14 +75,22 @@ void CTPTrendingTask::initialize(Trigger t, framework::ServiceRegistryRef servic
     reductor->SetTVXPHOIndex(mClassIndex[4]);
     mTrend->Branch(sourceName.c_str(), reductor->getBranchAddress(), reductor->getBranchLeafList());
   }
-
   getObjectsManager()->startPublishing(mTrend.get());
+}
+void CTPTrendingTask::initialize(Trigger t, framework::ServiceRegistryRef services)
+{
+  // // read out the CTPConfiguration
+  // initCCTP(); - too eraly here ?
 }
 
 void CTPTrendingTask::update(Trigger t, framework::ServiceRegistryRef services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
-
+  static bool init = 1;
+  if(init) {
+    initCTP(t);
+    init = 0;
+  }
   trendValues(t, qcdb);
   generatePlots();
 }

--- a/Modules/CTP/src/CTPTrendingTask.cxx
+++ b/Modules/CTP/src/CTPTrendingTask.cxx
@@ -87,7 +87,7 @@ void CTPTrendingTask::update(Trigger t, framework::ServiceRegistryRef services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
   static bool init = 1;
-  if(init) {
+  if (init) {
     initCTP(t);
     init = 0;
   }


### PR DESCRIPTION
In the first tests it appeared that when initialize is called CTPConfig is not yet in CCDB. Therefore initalisation was moved to first call of update.