### PR TITLE
Set log to Devel for "Too long data description" warning

### DIFF
--- a/Framework/src/HashDataDescription.cxx
+++ b/Framework/src/HashDataDescription.cxx
@@ -56,7 +56,7 @@ auto createDataDescription(const std::string& name, size_t hashLength) -> o2::he
     return description;
   } else {
     const auto descriptionWithHash = createDescriptionWithHash(name, hashLength);
-    ILOG(Warning) << "Too long data description name [" << name << "] changed to [" << descriptionWithHash << "]" << ENDM;
+    ILOG(Warning, Devel) << "Too long data description name [" << name << "] changed to [" << descriptionWithHash << "]" << ENDM;
     description.runtimeInit(descriptionWithHash.c_str());
     return description;
   }


### PR DESCRIPTION
This is a safe situation now, so there is no need for it to be at Support level.