### PR TITLE
QC-1137 Avoid race between storing objects and PP tasks accessing them

### DIFF
--- a/Framework/src/Triggers.cxx
+++ b/Framework/src/Triggers.cxx
@@ -201,7 +201,7 @@ TriggerFcn NewObject(const std::string& databaseUrl, const std::string& database
         // 4) The CheckRunner finishes publishing the collection of MOs
         // To avoid this scenario, a small delay is added before returning the trigger. Considerations about other
         // possible solutions are included in the commit message.
-        sleep(1);
+        std::this_thread::sleep_for(std::chrono::seconds{1});
       }
       objectActivity.mValidity = validity;
       auto timestamp = activity_helpers::isLegacyValidity(validity) ? validity.getMin() : (validity.getMax() - 1);

--- a/Framework/src/Triggers.cxx
+++ b/Framework/src/Triggers.cxx
@@ -201,7 +201,7 @@ TriggerFcn NewObject(const std::string& databaseUrl, const std::string& database
         // 4) The CheckRunner finishes publishing the collection of MOs
         // To avoid this scenario, a small delay is added before returning the trigger. Considerations about other
         // possible solutions are included in the commit message.
-        std::this_thread::sleep_for(std::chrono::seconds{1});
+        std::this_thread::sleep_for(std::chrono::seconds{ 1 });
       }
       objectActivity.mValidity = validity;
       auto timestamp = activity_helpers::isLegacyValidity(validity) ? validity.getMin() : (validity.getMax() - 1);

--- a/Framework/src/Triggers.cxx
+++ b/Framework/src/Triggers.cxx
@@ -192,6 +192,17 @@ TriggerFcn NewObject(const std::string& databaseUrl, const std::string& database
 
   return [objectActivity, config, newObjectValidity]() mutable -> Trigger {
     if (auto validity = newObjectValidity(); validity.isValid()) {
+      if (getenv("QC_DISABLE_NEWOBJECT_DELAY") == nullptr) {
+        // On rare occasions we might run into the following race condition:
+        // 1) A CheckRunner starts to publish a collection of MOs for a QC Task
+        // 2) A PostProcessing task receives a newobject trigger for a just-published object
+        // 3) The PP task tries to retrieve also other objects normally published by the same QC task, it fails
+        //    because not all were published yet.
+        // 4) The CheckRunner finishes publishing the collection of MOs
+        // To avoid this scenario, a small delay is added before returning the trigger. Considerations about other
+        // possible solutions are included in the commit message.
+        sleep(1);
+      }
       objectActivity.mValidity = validity;
       auto timestamp = activity_helpers::isLegacyValidity(validity) ? validity.getMin() : (validity.getMax() - 1);
       return { TriggerType::NewObject, false, objectActivity, timestamp, config };


### PR DESCRIPTION
On rare occasions we might run into the following race condition:
1) A CheckRunner starts to publish a collection of MOs for a QC Task
2) A PostProcessing task receives a newobject trigger for a just-published object
3) The PP task tries to retrieve also other objects normally published by the same QC task, it fails
   because not all were published yet.
4) The CheckRunner finishes publishing the collection of MOs

All of that usually takes dozens of ms. To avoid this scenario, a small delay is added before returning the trigger.

I hate this solution, but I have say this one introduces the least complexity and should be fairly effective. In the longer run, I expect this should be a non-issue when we will have postprocessing within the message passing framework, to be introduced with QC-1088.

I have considered also the following options:
1) Ask the users to use "newobject" always on the last published object for a given QC task. It is normally always the same one, but the users would have to find this out by themselves.  Also, this approach would rely on a behaviour which is not guaranteed programmatically, so it could always change.
2) Add a retry after some default delay in retrieveMO. This would still produce an error log after the first failure, since it comes from CcdbAPI, but would let the PP task survive. However, it could significantly slow down code which tries to access a lot of objects, to the point we could spend a few minutes in PostProcessingInterface::update call. The impact of having a delay in newobject is more predictable in this sense.
3) Similarly, which could have a retry mechanism in CcdbAPI, but this would bring a longer review process and discussions, while the other drawbacks of 2. would remain.
4) Have CheckRunner publish a special object after having published all the objects for a task, something like "qc/TPC/Clusters/all_objects_published". The users would have to trigger on that one in order to have guaranteed presence of all the other objects. However, this would require users to change their configuration files. It would also provoke questions about the meaning of this object, add more paths and objects, while we always try to minimize them. Lastly, this could break in cases when users have a QC task and PP task with the same name in purpose to write to the same directory in QCDB.
5) The "newobject" trigger could check for the presence of all the required objects by the user. This would also add some load on the QCDB, since we would need to make a query for each separate object. Also, it would bloat up the configuration.