### PR TITLE
Separation power for Pions and Electrons

### DIFF
--- a/Modules/TPC/include/TPC/PID.h
+++ b/Modules/TPC/include/TPC/PID.h
@@ -52,6 +52,8 @@ class PID final : public TaskInterface
 
  private:
   o2::tpc::qc::PID mQCPID{};
+  TCanvas* mSeparationPower;
+  std::vector<double> mTrendingParameters;
 };
 
 } // namespace o2::quality_control_modules::tpc

--- a/Modules/TPC/run/tpcQCPID_sampled.json
+++ b/Modules/TPC/run/tpcQCPID_sampled.json
@@ -28,7 +28,7 @@
         "className": "o2::quality_control_modules::tpc::PID",
         "moduleName": "QcTPC",
         "detectorName": "TPC",
-        "cycleDurationSeconds": "10",
+        "cycleDurationSeconds": "60",
         "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
         "dataSource": {
           "type": "dataSamplingPolicy",

--- a/Modules/TPC/src/PID.cxx
+++ b/Modules/TPC/src/PID.cxx
@@ -18,12 +18,15 @@
 #include <TCanvas.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TF1.h>
+#include <TPaveText.h>
 
 // O2 includes
 #include "Framework/ProcessingContext.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "TPCQC/Helpers.h"
 #include <Framework/InputRecord.h>
+#include "TPC/Utility.h"
 
 // QC includes
 #include "QualityControl/QcInfoLogger.h"
@@ -71,7 +74,10 @@ void PID::initialize(o2::framework::InitContext& /*ctx*/)
       getObjectsManager()->startPublishing(canv.get());
     }
   }
-}
+  mSeparationPower = mQCPID.getSeparationPowerCanvas();
+  getObjectsManager()->startPublishing(mSeparationPower);
+
+} // namespace o2::quality_control_modules::tpc
 
 void PID::startOfActivity(const Activity& /*activity*/)
 {
@@ -97,7 +103,47 @@ void PID::monitorData(o2::framework::ProcessingContext& ctx)
 
 void PID::endOfCycle()
 {
+  // ===| Fitting Histogram for separation Power |============================================================
+  std::unique_ptr<TF1> fitFunc = std::make_unique<TF1>("fitFunc", "[0]*exp(-0.5*((x-[1])/[2])^2) + [3]*exp(-0.5*((x-[4])/[5])^2)", 0, 100);
+
+  for (auto const& pair : mQCPID.getMapOfHisto()) {
+    for (auto& hist : pair.second) {
+      //      if (std::static_cast<string>(pair.first).compare("hdEdxMaxMIP") == 0) {
+      if (pair.first.compare("hdEdxMaxMIP") == 0) {
+        mTrendingParameters.clear();
+        // Define fitting function: sum of two Gaussians with an offset
+        // Set initial parameters for the fit
+        fitFunc->SetParameter(0, 3000); // Amplitude of the first Gaussian
+        fitFunc->SetParameter(1, 50);   // Mean of the first Gaussian
+        fitFunc->SetParLimits(1, 45, 55);
+        fitFunc->SetParameter(2, 2);   // Sigma of the first Gaussian
+        fitFunc->SetParameter(3, 100); // Amplitude of the second Gaussian
+        fitFunc->SetParameter(4, 75);  // Mean of the second Gaussian
+        fitFunc->SetParLimits(4, 60, 90);
+        fitFunc->SetParameter(5, 10); // Sigma of the second Gaussian
+
+        // Fit the histogram with the fitting function
+        hist->Fit(fitFunc.get(), "QR");
+
+        // Retrieve parameters of the fitted function
+        mTrendingParameters.emplace_back(fitFunc->GetParameter(1)); // Mean pion
+        mTrendingParameters.emplace_back(fitFunc->GetParameter(2)); // sigma pion
+        mTrendingParameters.emplace_back(fitFunc->GetParameter(4)); // Mean electron
+        mTrendingParameters.emplace_back(fitFunc->GetParameter(5)); // sigma electro
+      }
+    }
+  }
+
   ILOG(Debug, Devel) << "endOfCycle" << ENDM;
+
+  TPaveText* pSeparationPower = new TPaveText(.05, .05, .95, .95);
+  pSeparationPower->AddText(fmt::format("Mean Pi: {:.3}", mTrendingParameters[0]).c_str());
+  pSeparationPower->AddText(fmt::format("Sigma Pi: {:.3}", mTrendingParameters[1]).c_str());
+  pSeparationPower->AddText(fmt::format("Mean El: {:.3}", mTrendingParameters[2]).c_str());
+  pSeparationPower->AddText(fmt::format("Sigma El: {:.3}", mTrendingParameters[3]).c_str());
+  pSeparationPower->AddText(fmt::format("separationPower: {:.3}", (mTrendingParameters[2] - mTrendingParameters[0]) / (mTrendingParameters[1] / 2. + mTrendingParameters[3] / 2.)).c_str());
+  mSeparationPower->cd();
+  pSeparationPower->Draw();
 }
 
 void PID::endOfActivity(const Activity& /*activity*/)


### PR DESCRIPTION
This PR adds the separation power that can be trended for pions and electrons at the MIP point.
This is related to the O2 PR https://github.com/AliceO2Group/AliceO2/pull/12988
