### PR TITLE
GLO: Add ITS-TPC/ITS Check for QC

### DIFF
--- a/Modules/GLO/CMakeLists.txt
+++ b/Modules/GLO/CMakeLists.txt
@@ -1,8 +1,9 @@
 # ---- Library ----
 
+# add_compile_options(-O0 -g -fPIC)
 add_library(O2QcGLO)
 
-target_sources(O2QcGLO PRIVATE src/MeanVertexPostProcessing.cxx src/MeanVertexCheck.cxx src/VertexingQcTask.cxx src/ITSTPCMatchingTask.cxx src/DataCompressionQcTask.cxx src/CTFSizeTask.cxx)
+target_sources(O2QcGLO PRIVATE src/ITSTPCmatchingCheck.cxx  src/MeanVertexPostProcessing.cxx src/MeanVertexCheck.cxx src/VertexingQcTask.cxx src/ITSTPCMatchingTask.cxx src/DataCompressionQcTask.cxx src/CTFSizeTask.cxx)
 
 target_include_directories(
   O2QcGLO
@@ -46,7 +47,8 @@ add_root_dictionary(O2QcGLO
   include/GLO/ITSTPCMatchingTask.h
   include/GLO/DataCompressionQcTask.h
   include/GLO/CTFSizeTask.h
-                    LINKDEF include/GLO/LinkDef.h)
+  include/GLO/ITSTPCmatchingCheck.h
+                  LINKDEF include/GLO/LinkDef.h)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/GLO
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/QualityControl")

--- a/Modules/GLO/glo-itstpc-mtch-qcmn-test.json
+++ b/Modules/GLO/glo-itstpc-mtch-qcmn-test.json
@@ -74,13 +74,24 @@
           {
             "type": "Task",
             "name": "ITSTPCMatchingTask",
-            "MOs": ["mFractionITSTPCmatch_ITS"]
+            "MOs": [
+              "mFractionITSTPCmatch_ITS",
+              "mFractionITSTPCmatchPhi_ITS",
+              "mFractionITSTPCmatchEta_ITS"
+            ]
           }
         ],
-        "checkParameters": {
-          "threshold": "0.5",
-          "minPt": "1.0",
-          "maxPt": "1.999"
+        "extendedCheckParameters": {
+          "default": {
+            "default": {
+              "showPt": "true",
+              "thresholdPt": "0.9",
+              "showPhi": "true",
+              "thresholdPhi": "0.3",
+              "showEta": "1",
+              "thresholdEta": "0.4"
+            }
+          }
         }
       }
     }

--- a/Modules/GLO/glo-itstpc-mtch-qcmn-test.json
+++ b/Modules/GLO/glo-itstpc-mtch-qcmn-test.json
@@ -1,0 +1,88 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable",
+        "maxObjectSize": "20000000"
+      },
+      "Activity": {
+        "number": "43",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": ""
+      },
+      "conditionDB": {
+        "url": "alice-ccdb.cern.ch"
+      },
+      "infologger": {
+        "filterDiscardDebug": "false",
+        "filterDiscardLevel": "0"
+      }
+    },
+    "tasks": {
+      "ITSTPCMatchingTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::glo::ITSTPCMatchingTask",
+        "moduleName": "QcGLO",
+        "detectorName": "GLO",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "direct",
+          "query_comment": "checking every matched track",
+          "query": "trackITSTPC:GLO/TPCITS/0;trackITSTPCABREFS:GLO/TPCITSAB_REFS/0;trackITSTPCABCLID:GLO/TPCITSAB_CLID/0;trackTPC:TPC/TRACKS;trackTPCClRefs:TPC/CLUSREFS;trackITS:ITS/TRACKS/0;trackITSROF:ITS/ITSTrackROF/0;trackITSClIdx:ITS/TRACKCLSID/0;alpparITS:ITS/ALPIDEPARAM/0?lifetime=condition&ccdb-path=ITS/Config/AlpideParam"
+        },
+        "taskParameters": {
+          "GID": "ITS-TPC,ITS",
+          "verbose": "false",
+          "minPtCut": "0.1f",
+          "etaCut": "1.4f",
+          "minNTPCClustersCut": "60",
+          "minDCACut": "100.f",
+          "minDCACutY": "10.f"
+        },
+        "grpGeomRequest": {
+          "geomRequest": "None",
+          "askGRPECS": "false",
+          "askGRPLHCIF": "false",
+          "askGRPMagField": "true",
+          "askMatLUT": "false",
+          "askTime": "false",
+          "askOnceAllButField": "true",
+          "needPropagatorD": "false"
+        },
+        "saveObjectsToFile": "ITSTPCmatched.root",
+        "": "For debugging, path to the file where to save. If empty or missing it won't save."
+      }
+    },
+    "checks": {
+      "ITSTPCMatchingCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::glo::ITSTPCmatchingCheck",
+        "moduleName": "QcGLO",
+        "policy": "OnAny",
+        "detectorName": "GLO",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "ITSTPCMatchingTask",
+            "MOs": ["mFractionITSTPCmatch_ITS"]
+          }
+        ],
+        "checkParameters": {
+          "threshold": "0.5",
+          "minPt": "1.0",
+          "maxPt": "1.999"
+        }
+      }
+    }
+  }
+}

--- a/Modules/GLO/include/GLO/ITSTPCmatchingCheck.h
+++ b/Modules/GLO/include/GLO/ITSTPCmatchingCheck.h
@@ -18,6 +18,7 @@
 #define QC_MODULE_GLO_GLOITSTPCMATCHINGCHECK_H
 
 #include "QualityControl/CheckInterface.h"
+#include "QualityControl/Quality.h"
 
 #include <vector>
 #include <tuple>
@@ -30,27 +31,29 @@ namespace o2::quality_control_modules::glo
 class ITSTPCmatchingCheck : public o2::quality_control::checker::CheckInterface
 {
  public:
-  /// Default constructor
-  ITSTPCmatchingCheck() = default;
-  /// Destructor
-  ~ITSTPCmatchingCheck() override = default;
-
-  // Override interface
-  void configure() override;
   Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
-  std::string getAcceptedType() override;
-  void reset() override;
   void startOfActivity(const Activity& activity) override;
-  void endOfActivity(const Activity& activity) override;
 
  private:
   std::vector<std::pair<int, int>> findRanges(const std::vector<int>& nums);
   std::shared_ptr<Activity> mActivity;
 
+  // Pt
+  bool mShowPt{ true };
   float mMinPt{ 1. };
   float mMaxPt{ 1.999 };
-  float mThreshold{ 0.5 };
+  float mThresholdPt{ 0.5 };
+
+  // Phi
+  bool mShowPhi{ true };
+  float mThresholdPhi{ 0.3 };
+
+  // Eta
+  bool mShowEta{ false };
+  float mThresholdEta{ 0.4 };
+  float mMinEta{ -0.8 };
+  float mMaxEta{ 0.8 };
 
   ClassDefOverride(ITSTPCmatchingCheck, 1);
 };

--- a/Modules/GLO/include/GLO/ITSTPCmatchingCheck.h
+++ b/Modules/GLO/include/GLO/ITSTPCmatchingCheck.h
@@ -1,0 +1,60 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ITSTPCmatchingCheck.h
+/// \author felix.schlepper@cern.ch
+///
+
+#ifndef QC_MODULE_GLO_GLOITSTPCMATCHINGCHECK_H
+#define QC_MODULE_GLO_GLOITSTPCMATCHINGCHECK_H
+
+#include "QualityControl/CheckInterface.h"
+
+#include <vector>
+#include <tuple>
+
+namespace o2::quality_control_modules::glo
+{
+
+/// \brief  Example QC Check
+/// \author My Name
+class ITSTPCmatchingCheck : public o2::quality_control::checker::CheckInterface
+{
+ public:
+  /// Default constructor
+  ITSTPCmatchingCheck() = default;
+  /// Destructor
+  ~ITSTPCmatchingCheck() override = default;
+
+  // Override interface
+  void configure() override;
+  Quality check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap) override;
+  void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
+  std::string getAcceptedType() override;
+  void reset() override;
+  void startOfActivity(const Activity& activity) override;
+  void endOfActivity(const Activity& activity) override;
+
+ private:
+  std::vector<std::pair<int, int>> findRanges(const std::vector<int>& nums);
+  std::shared_ptr<Activity> mActivity;
+
+  float mMinPt{ 1. };
+  float mMaxPt{ 1.999 };
+  float mThreshold{ 0.5 };
+
+  ClassDefOverride(ITSTPCmatchingCheck, 1);
+};
+
+} // namespace o2::quality_control_modules::glo
+
+#endif // QC_MODULE_GLO_GLOITSTPCMATCHINGCHECK_H

--- a/Modules/GLO/include/GLO/ITSTPCmatchingCheck.h
+++ b/Modules/GLO/include/GLO/ITSTPCmatchingCheck.h
@@ -25,8 +25,8 @@
 namespace o2::quality_control_modules::glo
 {
 
-/// \brief  Example QC Check
-/// \author My Name
+/// \brief  Check for ITS-TPC sync. matching efficiency
+/// \author felix.schlepper@cern.ch
 class ITSTPCmatchingCheck : public o2::quality_control::checker::CheckInterface
 {
  public:

--- a/Modules/GLO/include/GLO/LinkDef.h
+++ b/Modules/GLO/include/GLO/LinkDef.h
@@ -10,5 +10,11 @@
 #pragma link C++ class o2::quality_control_modules::glo::MeanVertexPostProcessing + ;
 
 #pragma link C++ class o2::quality_control_modules::glo::MeanVertexCheck + ;
+<<<<<<< HEAD
 #pragma link C++ class o2::quality_control_modules::glo::CTFSize + ;
+||||||| parent of 6bfa8fdc (GLO: Add ITS-TPC/ITS Check)
+=======
+#pragma link C++ class o2::quality_control_modules::glo::ITSTPCmatchingCheck + ;
+
+>>>>>>> 6bfa8fdc (GLO: Add ITS-TPC/ITS Check)
 #endif

--- a/Modules/GLO/include/GLO/LinkDef.h
+++ b/Modules/GLO/include/GLO/LinkDef.h
@@ -10,11 +10,7 @@
 #pragma link C++ class o2::quality_control_modules::glo::MeanVertexPostProcessing + ;
 
 #pragma link C++ class o2::quality_control_modules::glo::MeanVertexCheck + ;
-<<<<<<< HEAD
 #pragma link C++ class o2::quality_control_modules::glo::CTFSize + ;
-||||||| parent of 6bfa8fdc (GLO: Add ITS-TPC/ITS Check)
-=======
 #pragma link C++ class o2::quality_control_modules::glo::ITSTPCmatchingCheck + ;
 
->>>>>>> 6bfa8fdc (GLO: Add ITS-TPC/ITS Check)
 #endif

--- a/Modules/GLO/src/ITSTPCmatchingCheck.cxx
+++ b/Modules/GLO/src/ITSTPCmatchingCheck.cxx
@@ -188,7 +188,8 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
   auto isWorse = [](Quality const& a, Quality const& b) {
     return a.isWorseThan(b) ? a : b;
   };
-  auto findWorst = [&]<typename T, typename... Args>(const T& first, Args... args) {
+  auto findWorst = [&]<typename T, typename... Args>(const T& first, Args... args)
+  {
     return isWorse(first, isWorse(args...));
   };
   result.set(findWorst(ptQual, etaQual, phiQual));

--- a/Modules/GLO/src/ITSTPCmatchingCheck.cxx
+++ b/Modules/GLO/src/ITSTPCmatchingCheck.cxx
@@ -293,9 +293,6 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
       msg->AddText("Not-handled Quality flag, don't panic...");
     }
     eff->GetListOfFunctions()->Add(msg);
-
-    TFile f("testPt.root", "RECREATE");
-    f.WriteObject(eff, "qcplotPt");
   }
 
   if (mShowPhi && mo->getName() == "mFractionITSTPCmatchPhi_ITS") {
@@ -376,9 +373,6 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
       msg->AddText("Not-handled Quality flag, don't panic...");
     }
     eff->GetListOfFunctions()->Add(msg);
-
-    TFile f("testPhi.root", "RECREATE");
-    f.WriteObject(eff, "qcplotPhi");
   }
 
   if (mShowEta && mo->getName() == "mFractionITSTPCmatchEta_ITS") {
@@ -477,9 +471,6 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
       msg->AddText("Not-handled Quality flag, don't panic...");
     }
     eff->GetListOfFunctions()->Add(msg);
-
-    TFile f("testEta.root", "RECREATE");
-    f.WriteObject(eff, "qcplotEta");
   }
 }
 

--- a/Modules/GLO/src/ITSTPCmatchingCheck.cxx
+++ b/Modules/GLO/src/ITSTPCmatchingCheck.cxx
@@ -1,0 +1,250 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ITSTPCmatchingCheck.cxx
+/// \author felix.schlepper@cern.ch
+///
+
+#include "GLO/ITSTPCmatchingCheck.h"
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/Quality.h"
+#include "QualityControl/QcInfoLogger.h"
+
+#include <Rtypes.h>
+#include <TH1.h>
+#include <TEfficiency.h>
+#include <TPaveText.h>
+#include <TArrow.h>
+#include <TText.h>
+#include <TBox.h>
+#include <TLine.h>
+#include <TLegend.h>
+#include <TFile.h>
+#include <TPolyMarker.h>
+
+#include <DataFormatsQualityControl/FlagReasons.h>
+#include "fmt/format.h"
+
+using namespace std;
+using namespace o2::quality_control;
+
+namespace o2::quality_control_modules::glo
+{
+
+void ITSTPCmatchingCheck::configure()
+{
+  if (auto param = mCustomParameters.find("minPt"); param != mCustomParameters.end()) {
+    try {
+      mMinPt = stof(param->second);
+    } catch (const std::exception& e) {
+      ILOG(Error) << "Cannot convert param minPt '" << e.what() << "'; using default...";
+    }
+  }
+
+  if (auto param = mCustomParameters.find("maxPt"); param != mCustomParameters.end()) {
+    try {
+      mMaxPt = stof(param->second);
+    } catch (const std::exception& e) {
+      ILOG(Error) << "Cannot convert param maxPt '" << e.what() << "'; using default...";
+    }
+  }
+
+  if (auto param = mCustomParameters.find("threshold"); param != mCustomParameters.end()) {
+    try {
+      mThreshold = stof(param->second);
+    } catch (const std::exception& e) {
+      ILOG(Error) << "Cannot convert param threshold '" << e.what() << "'; using default...";
+    }
+  }
+}
+
+Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
+{
+  Quality result = Quality::Null;
+
+  for (auto& [moName, mo] : *moMap) {
+    (void)moName;
+
+    if (mo->getName() == "mFractionITSTPCmatch_ITS") {
+      auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+      auto binLow = eff->FindFixBin(mMinPt), binUp = eff->FindFixBin(mMaxPt);
+
+      result = Quality::Good;
+
+      if (eff->GetTotalHistogram()->GetEntries() == 0) {
+        result = Quality::Bad;
+        result.addReason(FlagReasonFactory::Unknown(), "No ITS tracks in denumerator!");
+      } else if (eff->GetPassedHistogram()->GetEntries() == 0) {
+        result = Quality::Bad;
+        result.addReason(FlagReasonFactory::Unknown(), "No ITS-TPC tracks in numerator!");
+      } else {
+        std::vector<int> badBins;
+        for (int iBin = binLow; iBin <= binUp; ++iBin) {
+          if (eff->GetEfficiency(iBin) < mThreshold) {
+            result = Quality::Bad;
+            badBins.push_back(iBin);
+          }
+        }
+        auto ranges = findRanges(badBins);
+        if (result == Quality::Bad) {
+          result.addReason(FlagReasonFactory::BadTracking(), "Check vdrift online calibration and ITS/TPC QC");
+
+          std::string cBins{ "Bad matching efficiency in: " };
+          for (const auto& [binLow, binUp] : ranges) {
+            float low = eff->GetPassedHistogram()->GetXaxis()->GetBinLowEdge(binLow), up = eff->GetPassedHistogram()->GetXaxis()->GetBinUpEdge(binUp);
+            cBins += fmt::format("{:.1f}-{:.1f},", low, up);
+          }
+          cBins.pop_back(); // remove last `,`
+          cBins += " (GeV/c)";
+          result.addReason(FlagReasonFactory::BadTracking(), cBins);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+std::string ITSTPCmatchingCheck::getAcceptedType() { return "TH1"; }
+
+void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
+{
+  if (mo->getName() == "mFractionITSTPCmatch_ITS") {
+    auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+    // Draw threshold lines
+    float xmin = eff->GetPassedHistogram()->GetXaxis()->GetXmin();
+    float xmax = eff->GetPassedHistogram()->GetXaxis()->GetXmax();
+    float xminT = mMinPt;
+    float xmaxT = mMaxPt;
+    auto* l1 = new TLine(xmin, mThreshold, xmax, mThreshold);
+    l1->SetLineStyle(kDashed);
+    l1->SetLineWidth(4);
+    l1->SetLineColor(kCyan - 7);
+    auto* l2 = new TLine(xminT, 0, xminT, 1.1);
+    l2->SetLineStyle(kDashed);
+    l2->SetLineWidth(4);
+    l2->SetLineColor(kCyan - 7);
+    auto* l3 = new TLine(xmaxT, 0, xmaxT, 1.1);
+    l3->SetLineStyle(kDashed);
+    l3->SetLineWidth(4);
+    l3->SetLineColor(kCyan - 7);
+    auto* tt = new TText(xminT + 0.1, 1.05, "Checked Range");
+    tt->SetTextSize(0.04);
+    auto* ttt = new TText(xmaxT + 0.9, mThreshold + 0.01, "Threshold");
+    auto* aa = new TArrow(xminT + 0.01, 1.02, xmaxT - 0.01, 1.02, 0.02, "<|>");
+    if (checkResult == Quality::Good) {
+      l1->SetLineColor(kCyan - 7);
+      l2->SetLineColor(kCyan - 7);
+      l3->SetLineColor(kCyan - 7);
+      aa->SetFillColor(kCyan - 7);
+      aa->SetLineColor(kCyan - 7);
+    } else {
+      l1->SetLineColor(kRed - 4);
+      l2->SetLineColor(kRed - 4);
+      l3->SetLineColor(kRed - 4);
+      aa->SetFillColor(kRed - 4);
+      aa->SetLineColor(kRed - 4);
+    }
+    eff->GetListOfFunctions()->Add(l1);
+    eff->GetListOfFunctions()->Add(l2);
+    eff->GetListOfFunctions()->Add(l3);
+    eff->GetListOfFunctions()->Add(tt);
+    eff->GetListOfFunctions()->Add(ttt);
+    eff->GetListOfFunctions()->Add(aa);
+
+    // Color Bins in Window
+    int cG{ 0 }, cB{ 0 };
+    auto* good = new TPolyMarker();
+    good->SetMarkerColor(kGreen);
+    good->SetMarkerStyle(25);
+    good->SetMarkerSize(2);
+    auto* bad = new TPolyMarker();
+    bad->SetMarkerColor(kRed);
+    bad->SetMarkerStyle(25);
+    bad->SetMarkerSize(2);
+    auto* leg = new TLegend(0.7, 0.13, 0.89, 0.3);
+    leg->SetNColumns(2);
+    leg->SetHeader("Threshold Checks");
+    leg->AddEntry(good, "Good", "P");
+    leg->AddEntry(bad, "Bad", "P");
+    auto binLow = eff->FindFixBin(mMinPt), binUp = eff->FindFixBin(mMaxPt);
+    for (int iBin = binLow; iBin <= binUp; ++iBin) {
+      auto x = eff->GetPassedHistogram()->GetBinCenter(iBin);
+      auto y = eff->GetEfficiency(iBin);
+      if (eff->GetEfficiency(iBin) < mThreshold) {
+        bad->SetPoint(++cB, x, y);
+      } else {
+        good->SetPoint(++cG, x, y);
+      }
+    }
+    eff->GetListOfFunctions()->Add(good);
+    eff->GetListOfFunctions()->Add(bad);
+    eff->GetListOfFunctions()->Add(leg);
+
+    // Quality
+    auto* msg = new TPaveText(0.12, 0.12, 0.5, 0.3, "NDC;NB");
+    msg->AddText(Form("Quality: %s", checkResult.getName().c_str()));
+    if (checkResult == Quality::Good) {
+      msg->SetFillColor(kGreen);
+    } else {
+      msg->SetFillColor(kRed);
+      for (const auto& [_, desc] : checkResult.getReasons()) {
+        msg->AddText(Form("%s", desc.c_str()));
+      }
+      msg->SetTextColor(kWhite);
+    }
+    eff->GetListOfFunctions()->Add(msg);
+
+    if constexpr (false) {
+      TFile f("test.root", "RECREATE");
+      f.WriteObject(eff, "qcplot");
+    }
+  }
+}
+
+void ITSTPCmatchingCheck::reset()
+{
+  ILOG(Debug, Devel) << "ITSTPCmatchingCheck::reset" << ENDM;
+}
+
+void ITSTPCmatchingCheck::startOfActivity(const Activity& activity)
+{
+  ILOG(Debug, Devel) << "ITSTPCmatchingCheck::start : " << activity.mId << ENDM;
+  mActivity = make_shared<Activity>(activity);
+}
+
+void ITSTPCmatchingCheck::endOfActivity(const Activity& activity)
+{
+  ILOG(Debug, Devel) << "ITSTPCmatchingCheck::end : " << activity.mId << ENDM;
+}
+
+std::vector<std::pair<int, int>> ITSTPCmatchingCheck::findRanges(const std::vector<int>& nums)
+{
+  std::vector<std::pair<int, int>> ranges;
+  if (nums.empty())
+    return ranges;
+
+  int start = nums[0];
+  int end = start;
+
+  for (size_t i = 1; i < nums.size(); ++i) {
+    if (nums[i] == end + 1) {
+      end = nums[i];
+    } else {
+      ranges.push_back(std::make_pair(start, end));
+      start = end = nums[i];
+    }
+  }
+  ranges.push_back(std::make_pair(start, end)); // Add the last range
+  return ranges;
+}
+
+} // namespace o2::quality_control_modules::glo

--- a/Modules/GLO/src/ITSTPCmatchingCheck.cxx
+++ b/Modules/GLO/src/ITSTPCmatchingCheck.cxx
@@ -185,6 +185,14 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
   }
 
   // Overall Quality
+  auto isWorse = [](Quality const& a, Quality const& b) {
+    return a.isWorseThan(b) ? a : b;
+  };
+  auto findWorst = [&]<typename T, typename... Args>(const T& first, Args... args) {
+    return isWorse(first, isWorse(args...));
+  };
+  result.set(findWorst(ptQual, etaQual, phiQual));
+
   return result;
 }
 

--- a/Modules/GLO/src/ITSTPCmatchingCheck.cxx
+++ b/Modules/GLO/src/ITSTPCmatchingCheck.cxx
@@ -46,7 +46,7 @@ void ITSTPCmatchingCheck::configure()
     try {
       mMinPt = stof(param->second);
     } catch (const std::exception& e) {
-      ILOG(Error) << "Cannot convert param minPt '" << e.what() << "'; using default...";
+      ILOG(Error) << "Cannot convert param minPt '" << e.what() << "'; using default..." << ENDM;
     }
   }
 
@@ -54,7 +54,7 @@ void ITSTPCmatchingCheck::configure()
     try {
       mMaxPt = stof(param->second);
     } catch (const std::exception& e) {
-      ILOG(Error) << "Cannot convert param maxPt '" << e.what() << "'; using default...";
+      ILOG(Error) << "Cannot convert param maxPt '" << e.what() << "'; using default..." << ENDM;
     }
   }
 
@@ -62,7 +62,7 @@ void ITSTPCmatchingCheck::configure()
     try {
       mThreshold = stof(param->second);
     } catch (const std::exception& e) {
-      ILOG(Error) << "Cannot convert param threshold '" << e.what() << "'; using default...";
+      ILOG(Error) << "Cannot convert param threshold '" << e.what() << "'; using default..." << ENDM;
     }
   }
 }
@@ -76,6 +76,10 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
 
     if (mo->getName() == "mFractionITSTPCmatch_ITS") {
       auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+      if (eff == nullptr) {
+        ILOG(Error) << "Failed cast for ITSTPCmatch_ITS check!" << ENDM;
+        continue;
+      }
       auto binLow = eff->FindFixBin(mMinPt), binUp = eff->FindFixBin(mMaxPt);
 
       result = Quality::Good;
@@ -117,8 +121,17 @@ std::string ITSTPCmatchingCheck::getAcceptedType() { return "TH1"; }
 
 void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
+  if (mo == nullptr) {
+    ILOG(Error) << "Received nullptr from upstream, returning..." << ENDM;
+    return;
+  }
+
   if (mo->getName() == "mFractionITSTPCmatch_ITS") {
     auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+    if (eff == nullptr) {
+      ILOG(Error) << "Failed cast for ITSTPCmatch_ITS beautify!" << ENDM;
+      return;
+    }
     // Draw threshold lines
     float xmin = eff->GetPassedHistogram()->GetXaxis()->GetXmin();
     float xmax = eff->GetPassedHistogram()->GetXaxis()->GetXmax();


### PR DESCRIPTION
This PR adds a check for the ITS-TPC/ITS matching efficiency. 

Configurable values are:
 - minPt ---> minimum Pt for checked range
 - maxPt ---> maximum Pt for checked range
 - threshold ---> conservative Threshold value

Below are two example plots for very low MC statistics, where the only difference is the set threshold.
[good.pdf](https://github.com/AliceO2Group/QualityControl/files/14981460/good.pdf)
[bad.pdf](https://github.com/AliceO2Group/QualityControl/files/14981468/bad.pdf)
P.S. Also the line extending past the canvas is an artefact of low statistics shown here.