### PR TITLE
CTF size monitoring for synch. reco

### DIFF
--- a/Modules/Common/include/Common/Utils.h
+++ b/Modules/Common/include/Common/Utils.h
@@ -33,10 +33,8 @@ namespace o2::quality_control_modules::common
 template <typename T>
 T getFromConfig(const quality_control::core::CustomParameters& params, const std::string_view name, T retVal = T{})
 {
-  const auto last = params.end();
   const auto itParam = params.find(name.data());
-
-  if (itParam == last) {
+  if (itParam == params.end()) {
     LOGP(warning, "Missing parameter. Please add '{}': '<value>' to the 'taskParameters'. Using default value {}.", name.data(), retVal);
   } else {
     const auto& param = itParam->second;
@@ -56,8 +54,6 @@ T getFromConfig(const quality_control::core::CustomParameters& params, const std
       } else {
         LOG(error) << fmt::format("Please provide a valid boolean value for {}.", name.data()).data();
       }
-    } else if constexpr (std::is_same<std::string, T>::value) {
-      retVal = param;
     } else {
       LOG(error) << "Template type not supported";
     }

--- a/Modules/GLO/CMakeLists.txt
+++ b/Modules/GLO/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(O2QcGLO)
 
-target_sources(O2QcGLO PRIVATE src/MeanVertexPostProcessing.cxx src/MeanVertexCheck.cxx src/VertexingQcTask.cxx src/ITSTPCMatchingTask.cxx src/DataCompressionQcTask.cxx)
+target_sources(O2QcGLO PRIVATE src/MeanVertexPostProcessing.cxx src/MeanVertexCheck.cxx src/VertexingQcTask.cxx src/ITSTPCMatchingTask.cxx src/DataCompressionQcTask.cxx src/CTFSizeTask.cxx)
 
 target_include_directories(
   O2QcGLO
@@ -45,6 +45,7 @@ add_root_dictionary(O2QcGLO
   include/GLO/VertexingQcTask.h
   include/GLO/ITSTPCMatchingTask.h
   include/GLO/DataCompressionQcTask.h
+  include/GLO/CTFSizeTask.h
                     LINKDEF include/GLO/LinkDef.h)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/GLO
@@ -66,4 +67,3 @@ foreach(test ${TEST_SRCS})
     PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
   set_tests_properties(${test_name} PROPERTIES TIMEOUT 20)
 endforeach()
-

--- a/Modules/GLO/include/GLO/CTFSizeTask.h
+++ b/Modules/GLO/include/GLO/CTFSizeTask.h
@@ -1,0 +1,62 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CTFSizeTask.h
+/// \author Ole Schmidt
+///
+
+#ifndef QC_MODULE_GLO_CTFSIZETASK_H
+#define QC_MODULE_GLO_CTFSIZETASK_H
+
+#include "QualityControl/TaskInterface.h"
+#include <DetectorsCommonDataFormats/DetID.h>
+
+#include <tuple>
+#include <array>
+#include <string>
+
+class TH1F;
+
+using namespace o2::quality_control::core;
+
+namespace o2::quality_control_modules::glo
+{
+
+class CTFSize final : public TaskInterface
+{
+ public:
+  /// \brief Constructor
+  CTFSize() = default;
+  /// Destructor
+  ~CTFSize() override;
+
+  std::tuple<int, float, float> getBinningFromConfig(o2::detectors::DetID::ID iDet, const Activity& activity) const;
+
+  // Definition of the methods for the template method pattern
+  void initialize(o2::framework::InitContext& ctx) override;
+  void startOfActivity(const Activity& activity) override;
+  void startOfCycle() override;
+  void monitorData(o2::framework::ProcessingContext& ctx) override;
+  void endOfCycle() override;
+  void endOfActivity(const Activity& activity) override;
+  void reset() override;
+
+ private:
+  std::array<TH1F*, o2::detectors::DetID::CTP + 1> mHistSizes{ nullptr };       // CTF size per TF for each detector with different binning per detector
+  std::array<TH1F*, o2::detectors::DetID::CTP + 1> mHistSizesLog{ nullptr };    // CTF size per TF with same axis scale for all detectors
+  std::array<std::string, o2::detectors::DetID::CTP + 1> mDefaultBinning{ "" }; // default number of bins and limits for mHistSizes (customizable)
+  bool mPublishingDone{ false };
+};
+
+} // namespace o2::quality_control_modules::glo
+
+#endif // QC_MODULE_GLO_CTFSIZETASK_H

--- a/Modules/GLO/include/GLO/LinkDef.h
+++ b/Modules/GLO/include/GLO/LinkDef.h
@@ -10,4 +10,5 @@
 #pragma link C++ class o2::quality_control_modules::glo::MeanVertexPostProcessing + ;
 
 #pragma link C++ class o2::quality_control_modules::glo::MeanVertexCheck + ;
+#pragma link C++ class o2::quality_control_modules::glo::CTFSize + ;
 #endif

--- a/Modules/GLO/src/CTFSizeTask.cxx
+++ b/Modules/GLO/src/CTFSizeTask.cxx
@@ -119,10 +119,14 @@ void CTFSize::endOfActivity(const Activity& /*activity*/)
 void CTFSize::reset()
 {
   for (auto h : mHistSizes) {
-    h->Reset();
+    if (h) {
+      h->Reset();
+    }
   }
   for (auto h : mHistSizesLog) {
-    h->Reset();
+    if (h) {
+      h->Reset();
+    }
   }
 }
 

--- a/Modules/GLO/src/CTFSizeTask.cxx
+++ b/Modules/GLO/src/CTFSizeTask.cxx
@@ -1,0 +1,129 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   CTFSizeTask.cxx
+/// \author Ole Schmidt
+///
+
+#include <TH1F.h>
+#include <TMath.h>
+#include "QualityControl/QcInfoLogger.h"
+#include "GLO/CTFSizeTask.h"
+#include <Framework/InputRecord.h>
+
+using namespace o2::detectors;
+
+namespace o2::quality_control_modules::glo
+{
+
+CTFSize::~CTFSize()
+{
+}
+
+std::tuple<int, float, float> CTFSize::getBinningFromConfig(o2::detectors::DetID::ID iDet, const Activity& activity) const
+{
+  std::string cfKey = "binning";
+  cfKey += DetID::getName(iDet);
+  std::string binning = mCustomParameters.atOptional(cfKey, activity).value_or(mDefaultBinning[iDet]);
+  auto nBins = std::stoi(binning.substr(0, binning.find(",")));
+  binning.erase(0, binning.find(",") + 1);
+  auto xMin = std::stof(binning.substr(0, binning.find(",")));
+  binning.erase(0, binning.find(",") + 1);
+  auto xMax = std::stof(binning.substr(0, binning.find(",")));
+  return std::make_tuple(nBins, xMin, xMax);
+}
+
+void CTFSize::initialize(o2::framework::InitContext& /*ctx*/)
+{
+  // default lower limit from pp run 549884 and upper limit from PbPb run 543918, each limit with some margin
+  mDefaultBinning[DetID::ITS] = "1000, 1e2, 1e5";
+  mDefaultBinning[DetID::TPC] = "1000, 1e3, 1e6";
+  mDefaultBinning[DetID::TRD] = "1000, 1e2, 1e5";
+  mDefaultBinning[DetID::TOF] = "1000, 10, 1e4";
+  mDefaultBinning[DetID::PHS] = "100, 10, 1e3";
+  mDefaultBinning[DetID::CPV] = "100, 10, 3e4";
+  mDefaultBinning[DetID::EMC] = "1000, 100, 5e5";
+  mDefaultBinning[DetID::HMP] = "100, 1, 300";
+  mDefaultBinning[DetID::MFT] = "1000, 1e2, 1e4";
+  mDefaultBinning[DetID::MCH] = "100, 1e3, 5e4";
+  mDefaultBinning[DetID::MID] = "100, 10, 500";
+  mDefaultBinning[DetID::ZDC] = "100, 1e3, 1e4";
+  mDefaultBinning[DetID::FT0] = "100, 1, 500";
+  mDefaultBinning[DetID::FV0] = "100, 1, 400";
+  mDefaultBinning[DetID::FDD] = "100, 1, 100";
+  mDefaultBinning[DetID::CTP] = "100, 1, 100";
+  mDefaultBinning[DetID::TST] = "1, 0, 1";
+
+  constexpr int nLogBins = 100;
+  float xBins[nLogBins + 1];
+  float xBinLogMin = 0.f;
+  float xBinLogMax = 11.f;
+  float logBinWidth = (xBinLogMax - xBinLogMin) / nLogBins;
+  for (int iBin = 0; iBin <= nLogBins; ++iBin) {
+    xBins[iBin] = TMath::Power(10, xBinLogMin + iBin * logBinWidth);
+  }
+  for (int iDet = 0; iDet < DetID::CTP + 1; ++iDet) {
+    mHistSizesLog[iDet] = new TH1F(Form("hSizeLog_%s", DetID::getName(iDet)), Form("%s CTF size per TF;Byte;counts", DetID::getName(iDet)), nLogBins, xBins);
+    getObjectsManager()->startPublishing(mHistSizesLog[iDet]);
+    getObjectsManager()->setDefaultDrawOptions(mHistSizesLog[iDet]->GetName(), "logx");
+  }
+}
+
+void CTFSize::startOfActivity(const Activity& activity)
+{
+  if (!mPublishingDone) {
+    for (int iDet = 0; iDet < DetID::CTP + 1; ++iDet) {
+      auto binning = getBinningFromConfig(iDet, activity);
+      std::string unit = (iDet == DetID::EMC || iDet == DetID::CPV) ? "B" : "kB";
+      mHistSizes[iDet] = new TH1F(Form("hSize_%s", DetID::getName(iDet)), Form("%s CTF size per TF;%s;counts", DetID::getName(iDet), unit.c_str()), std::get<0>(binning), std::get<1>(binning), std::get<2>(binning));
+      getObjectsManager()->startPublishing(mHistSizes[iDet]);
+    }
+    mPublishingDone = true;
+  }
+  reset();
+}
+
+void CTFSize::startOfCycle()
+{
+  // reset();
+}
+
+void CTFSize::monitorData(o2::framework::ProcessingContext& ctx)
+{
+  const auto sizes = ctx.inputs().get<std::array<size_t, DetID::CTP + 1>>("ctfSizes");
+  for (int iDet = 0; iDet <= DetID::CTP; ++iDet) {
+    std::cout << DetID::getName(iDet) << ": " << sizes[iDet] << std::endl;
+    float conversion = (iDet == DetID::EMC || iDet == DetID::CPV) ? 1.f : 1024.f; // EMC and CPV can sent <1kB per CTF
+    mHistSizes[iDet]->Fill(sizes[iDet] / conversion);
+    mHistSizesLog[iDet]->Fill(sizes[iDet]);
+  }
+}
+
+void CTFSize::endOfCycle()
+{
+}
+
+void CTFSize::endOfActivity(const Activity& /*activity*/)
+{
+}
+
+void CTFSize::reset()
+{
+  for (auto h : mHistSizes) {
+    h->Reset();
+  }
+  for (auto h : mHistSizesLog) {
+    h->Reset();
+  }
+}
+
+} // namespace o2::quality_control_modules::glo


### PR DESCRIPTION
- Adding `CTFSizeTask` which picks up the CTF size in bytes per detector from the CTF writer and creates two histograms per detector, one with constant bin size set differently for each detector and one with a logarithmic axis which has the same binning for all detectors
- Missing is a trending task which should plot the mean values of each histogram multiplied by the TF rate in seconds to get to the CTF size in Bytes/second