### PR TITLE
TRD fix data matcher for CCDB object of sampled input

### DIFF
--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -335,7 +335,7 @@ void DigitsTask::endOfActivity(const Activity& /*activity*/)
 
 void DigitsTask::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
-  if (matcher == o2::framework::ConcreteDataMatcher("TRD", "FCHSTATUS", 0)) {
+  if (matcher == o2::framework::ConcreteDataMatcher("TRD", "FCHSTATUS", 0) || matcher == o2::framework::ConcreteDataMatcher("DS", "trdall4", 0)) {
     // LB: no half chamber distribution map for Digits, pass it as null pointer
     TRDHelpers::drawChamberStatusOnHistograms(static_cast<std::array<int, MAXCHAMBER>*>(obj), nullptr, mLayers, NCOLUMN);
   }

--- a/Modules/TRD/src/TrackletsTask.cxx
+++ b/Modules/TRD/src/TrackletsTask.cxx
@@ -197,7 +197,7 @@ void TrackletsTask::endOfActivity(const Activity& /*activity*/)
 
 void TrackletsTask::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
-  if (matcher == o2::framework::ConcreteDataMatcher("TRD", "FCHSTATUS", 0)) {
+  if (matcher == o2::framework::ConcreteDataMatcher("TRD", "FCHSTATUS", 0) || matcher == o2::framework::ConcreteDataMatcher("DS", "trdall4", 0)) {
     TRDHelpers::drawChamberStatusOnHistograms(static_cast<std::array<int, MAXCHAMBER>*>(obj), mTrackletsPerHC2D, mLayers, NCOLUMN / NSECTOR);
   }
 }


### PR DESCRIPTION
It is a bit stupid, but I don't have a better idea at the moment. In case we are using direct data sampling the data spec has the expected name `TRD/FCHSTATUS/0`. But when we use data sampling (as it is done online) then the data spec receives a new name `DS` for data sampling, `trdall` for the sampling policy name and a number based on the position in the query string. The problem is of course that like this the chamber status always needs to be in the correct position of the query string, otherwise the task will segfault.