### PR TITLE
[EMCAL-527] Adjustable bunch min. amp checker

### DIFF
--- a/Modules/EMCAL/include/EMCAL/RawCheck.h
+++ b/Modules/EMCAL/include/EMCAL/RawCheck.h
@@ -59,6 +59,13 @@ class RawCheck final : public o2::quality_control::checker::CheckInterface
   double mNsigmaFECMaxPayload = 2.; ///< Number of sigmas used in the FEC max payload check
   double mNsigmaPayloadSize = 2.;   ///< Number of sigmas used in the payload size check
 
+  /************************************************
+   * Settings for bunch min. amp checker          *
+   ************************************************/
+
+  int mBunchMinCheckMinEntries = 0;          ///< Min. number of entries for bunch min. amplitude in evaluation region
+  double mBunchMinCheckFractionSignal = 0.5; ///< Fraction of entries in signal region for bunch min. amp checker
+
   ClassDefOverride(RawCheck, 2);
 };
 


### PR DESCRIPTION
- Require min. anount of counts in evaluation region in
  order not having single counts being interpreted as
  pedestal peak
- Fraction of counts in signal region configurable