### PR TITLE
MFT: Fix for timestamp determination for noise scan

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTDigitCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitCheck.h
@@ -57,7 +57,7 @@ class QcMFTDigitCheck : public o2::quality_control::checker::CheckInterface
 
   // noise scan check
 
-  void readNoiseMap(std::shared_ptr<MonitorObject> mo);
+  void readNoiseMap(std::shared_ptr<MonitorObject> mo, long timestamp);
   int mNoiseScan;
   int mNCycles;
   int mNCyclesNoiseMap;

--- a/Modules/MFT/src/QcMFTDigitCheck.cxx
+++ b/Modules/MFT/src/QcMFTDigitCheck.cxx
@@ -265,8 +265,7 @@ void QcMFTDigitCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkR
   }
   if (mNoiseScan == 1) {
     if (mNCycles == 1) {
-      // long timestamp = mo->getValidity().getMin();
-      long timestamp = 1714531157487;
+      long timestamp = mo->getValidity().getMin();
       readNoiseMap(mo, timestamp);
       mOldNoisyPix = mNoisyPix;
     }

--- a/Modules/MFT/src/QcMFTDigitCheck.cxx
+++ b/Modules/MFT/src/QcMFTDigitCheck.cxx
@@ -151,9 +151,8 @@ void QcMFTDigitCheck::readMaskedChips(std::shared_ptr<MonitorObject> mo)
   }
 }
 
-void QcMFTDigitCheck::readNoiseMap(std::shared_ptr<MonitorObject> mo)
+void QcMFTDigitCheck::readNoiseMap(std::shared_ptr<MonitorObject> mo, long timestamp)
 {
-  long timestamp = mo->getValidity().getMin();
   map<string, string> headers;
   map<std::string, std::string> filter;
   auto calib = UserCodeInterface::retrieveConditionAny<o2::itsmft::NoiseMap>("MFT/Calib/NoiseMap/", filter, timestamp);
@@ -266,12 +265,15 @@ void QcMFTDigitCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkR
   }
   if (mNoiseScan == 1) {
     if (mNCycles == 1) {
-      readNoiseMap(mo);
+      // long timestamp = mo->getValidity().getMin();
+      long timestamp = 1714531157487;
+      readNoiseMap(mo, timestamp);
       mOldNoisyPix = mNoisyPix;
     }
 
     if (mNCycles == mNCyclesNoiseMap) {
-      readNoiseMap(mo);
+      long timestamp = o2::ccdb::getCurrentTimestamp();
+      readNoiseMap(mo, timestamp);
       mNewNoisyPix = mNoisyPix;
 
       for (int i = 0; i < mNewNoisyPix.size(); i++) {


### PR DESCRIPTION
*Addition of new timestamp parameter in the readNoiseMap() function.

*Adding timestamps given by validity of object or current time to correctly obtain noise maps for comparison inside task.