### PR TITLE
MCH: add per-station distributions

### DIFF
--- a/Modules/MUON/Common/include/MUONCommon/Helpers.h
+++ b/Modules/MUON/Common/include/MUONCommon/Helpers.h
@@ -45,6 +45,10 @@ T getConfigurationParameter(o2::quality_control::core::CustomParameters customPa
   return getConfigurationParameter<T>(customParameters, parName, defaultValue);
 }
 
+// create an array of bins in a given range with log10 spacing
+std::vector<double> makeLogBinning(double xmin, double xmax, int nbins);
+
+// add lines to an histogram with specified color, style and width, using ROOT's TAttLine conventions
 TLine* addHorizontalLine(TH1& histo, double y,
                          int lineColor = 1, int lineStyle = 10,
                          int lineWidth = 1);

--- a/Modules/MUON/Common/src/Helpers.cxx
+++ b/Modules/MUON/Common/src/Helpers.cxx
@@ -17,6 +17,8 @@
 #include <regex>
 #include "QualityControl/ObjectsManager.h"
 
+#include <cmath>
+
 namespace o2::quality_control_modules::muon
 {
 template <>
@@ -80,6 +82,20 @@ bool getConfigurationParameter<bool>(o2::quality_control::core::CustomParameters
 
 //_________________________________________________________________________________________
 
+std::vector<double> makeLogBinning(double min, double max, int nbins)
+{
+  auto logMin = std::log10(min);
+  auto logMax = std::log10(max);
+  auto binWidth = (logMax - logMin) / nbins;
+  std::vector<double> bins(nbins + 1);
+  for (int i = 0; i <= nbins; i++) {
+    bins[i] = std::pow(10, logMin + i * binWidth);
+  }
+  return bins;
+}
+
+//_________________________________________________________________________________________
+
 TLine* addHorizontalLine(TH1& histo, double y,
                          int lineColor, int lineStyle,
                          int lineWidth)
@@ -106,8 +122,9 @@ TLine* addVerticalLine(TH1& histo, double x,
                        int lineColor, int lineStyle,
                        int lineWidth)
 {
+  double max = histo.GetBinContent(histo.GetMaximumBin());
   TLine* line = new TLine(x, histo.GetMinimum(),
-                          x, histo.GetMaximum());
+                          x, max * 1.05);
   line->SetLineColor(lineColor);
   line->SetLineStyle(lineStyle);
   line->SetLineWidth(lineWidth);

--- a/Modules/MUON/MCH/include/MCH/ClustersTask.h
+++ b/Modules/MUON/MCH/include/MCH/ClustersTask.h
@@ -62,6 +62,8 @@ class ClustersTask /*final*/ : public TaskInterface
   std::unique_ptr<TH1F> mNofClustersPerTrack;       ///< number of clusters per track
   std::unique_ptr<TProfile> mClusterSizePerChamber; ///< mean cluster size per chamber
   std::unique_ptr<TProfile> mNofClustersPerChamber; ///< mean number of clusters per chamber
+  ///< distribution of the cluster size in each station separately
+  std::array<std::unique_ptr<TH1F>, 5> mClusterSizeDistributionPerStation;
 
   o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
   o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;

--- a/Modules/MUON/MCH/include/MCH/PreclustersTask.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersTask.h
@@ -71,6 +71,10 @@ class PreclustersTask /*final*/ : public o2::quality_control::core::TaskInterfac
   std::unique_ptr<TH1DRatio> mHistogramPreclustersPerDE;       // number of pre-clusters per DE and per TF
   std::unique_ptr<TH1DRatio> mHistogramPreclustersSignalPerDE; // number of pre-clusters with signal per DE and per TF
 
+  ///< distribution of the cluster charge and size in each station, total and separately for each cathode
+  std::array<std::unique_ptr<TH2F>, 3> mHistogramClusterChargePerStation;
+  std::array<std::unique_ptr<TH2F>, 3> mHistogramClusterSizePerStation;
+
   std::unique_ptr<TH2F> mHistogramClusterCharge;
   std::unique_ptr<TH2F> mHistogramClusterSize;
 

--- a/Modules/MUON/MCH/include/MCH/RatesPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/RatesPlotter.h
@@ -35,7 +35,7 @@ namespace muonchambers
 class RatesPlotter : public HistPlotter
 {
  public:
-  RatesPlotter(std::string path, TH2F* hRef, float rateMin, float rateMax, bool fullPlots = false);
+  RatesPlotter(std::string path, TH2F* hRef, float rateMin, float rateMax, bool perStationPlots = false, bool fullPlots = false);
 
   void update(TH2F* hRates);
 
@@ -65,6 +65,8 @@ class RatesPlotter : public HistPlotter
   o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
 
   std::unique_ptr<TH2ElecMapReductor> mElecMapReductor;
+
+  std::unique_ptr<TH2F> mHistogramRatePerStation;
 
   std::unique_ptr<TH1F> mHistogramMeanRatePerDE;
   std::unique_ptr<TH1F> mHistogramMeanRatePerDERef;

--- a/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
@@ -75,19 +75,19 @@ void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInte
   //----------------------------------
 
   mRatesPlotter.reset();
-  mRatesPlotter = std::make_unique<RatesPlotter>("Rates/", hElecHistoRef, mChannelRateMin, mChannelRateMax, mFullHistos);
+  mRatesPlotter = std::make_unique<RatesPlotter>("Rates/", hElecHistoRef, mChannelRateMin, mChannelRateMax, true, mFullHistos);
   mRatesPlotter->publish(getObjectsManager());
 
   mRatesPlotterOnCycle.reset();
-  mRatesPlotterOnCycle = std::make_unique<RatesPlotter>("Rates/LastCycle/", hElecHistoRef, mChannelRateMin, mChannelRateMax, mFullHistos);
+  mRatesPlotterOnCycle = std::make_unique<RatesPlotter>("Rates/LastCycle/", hElecHistoRef, mChannelRateMin, mChannelRateMax, false, mFullHistos);
   mRatesPlotterOnCycle->publish(getObjectsManager());
 
   mRatesPlotterSignal.reset();
-  mRatesPlotterSignal = std::make_unique<RatesPlotter>("RatesSignal/", hElecSignalHistoRef, mChannelRateMin, mChannelRateMax, mFullHistos);
+  mRatesPlotterSignal = std::make_unique<RatesPlotter>("RatesSignal/", hElecSignalHistoRef, mChannelRateMin, mChannelRateMax, true, mFullHistos);
   mRatesPlotterSignal->publish(getObjectsManager());
 
   mRatesPlotterSignalOnCycle.reset();
-  mRatesPlotterSignalOnCycle = std::make_unique<RatesPlotter>("RatesSignal/LastCycle/", hElecSignalHistoRef, mChannelRateMin, mChannelRateMax, mFullHistos);
+  mRatesPlotterSignalOnCycle = std::make_unique<RatesPlotter>("RatesSignal/LastCycle/", hElecSignalHistoRef, mChannelRateMin, mChannelRateMax, false, mFullHistos);
   mRatesPlotterSignalOnCycle->publish(getObjectsManager());
 
   //----------------------------------

--- a/Modules/MUON/MCH/src/PreclustersTask.cxx
+++ b/Modules/MUON/MCH/src/PreclustersTask.cxx
@@ -67,12 +67,58 @@ void PreclustersTask::initialize(o2::framework::InitContext& /*ctx*/)
   mHistogramPseudoeffElec = std::make_unique<TH2FRatio>("Pseudoeff_Elec", "Pseudoeff", nElecXbins, 0, nElecXbins, 64, 0, 64);
   publishObject(mHistogramPseudoeffElec.get(), "colz", false);
 
+  //----------------------------------
+  // Charge distribution histograms
+  //----------------------------------
+
   // 256 bins, 50 ADC / bin
   mHistogramClusterCharge = std::make_unique<TH2F>("ClusterChargeHist", "Cluster Charge", getNumDE(), 0, getNumDE(), 256, 0, 256 * 50);
   publishObject(mHistogramClusterCharge.get(), "colz", false);
 
+  mHistogramClusterChargePerStation[0] = std::make_unique<TH2F>("ClusterCharge/ClusterChargeDistributionB",
+                                                                "Cluster charge distribution (B)",
+                                                                256, 0, 256 * 50, 5, 1, 6);
+  publishObject(mHistogramClusterChargePerStation[0].get(), "colz", false);
+
+  mHistogramClusterChargePerStation[1] = std::make_unique<TH2F>("ClusterCharge/ClusterChargeDistributionNB",
+                                                                "Cluster charge distribution (NB)",
+                                                                256, 0, 256 * 50, 5, 1, 6);
+  publishObject(mHistogramClusterChargePerStation[1].get(), "colz", false);
+
+  mHistogramClusterChargePerStation[2] = std::make_unique<TH2F>("ClusterCharge/ClusterChargeDistribution",
+                                                                "Cluster charge distribution",
+                                                                256, 0, 256 * 50, 5, 1, 6);
+  publishObject(mHistogramClusterChargePerStation[2].get(), "colz", false);
+
+  for (int c = 0; c < 3; c++) {
+    for (int i = 1; i <= mHistogramClusterChargePerStation[c]->GetYaxis()->GetNbins(); i++) {
+      mHistogramClusterChargePerStation[c]->GetYaxis()->SetBinLabel(i, TString::Format("ST%d", i));
+    }
+  }
+
   mHistogramClusterSize = std::make_unique<TH2F>("ClusterSizeHist", "Cluster Size", getNumDE() * 3, 0, getNumDE() * 3, 100, 0, 100);
   publishObject(mHistogramClusterSize.get(), "colz", false);
+
+  mHistogramClusterSizePerStation[0] = std::make_unique<TH2F>("ClusterSize/ClusterSizeDistributionB",
+                                                              "Cluster size distribution (B)",
+                                                              50, 0, 50, 5, 1, 6);
+  publishObject(mHistogramClusterSizePerStation[0].get(), "colz", false);
+
+  mHistogramClusterSizePerStation[1] = std::make_unique<TH2F>("ClusterSize/ClusterSizeDistributionNB",
+                                                              "Cluster size distribution (NB)",
+                                                              50, 0, 50, 5, 1, 6);
+  publishObject(mHistogramClusterSizePerStation[1].get(), "colz", false);
+
+  mHistogramClusterSizePerStation[2] = std::make_unique<TH2F>("ClusterSize/ClusterSizeDistribution",
+                                                              "Cluster size distribution",
+                                                              50, 0, 50, 5, 1, 6);
+  publishObject(mHistogramClusterSizePerStation[2].get(), "colz", false);
+
+  for (int c = 0; c < 3; c++) {
+    for (int i = 1; i <= mHistogramClusterSizePerStation[c]->GetYaxis()->GetNbins(); i++) {
+      mHistogramClusterSizePerStation[c]->GetYaxis()->SetBinLabel(i, TString::Format("ST%d", i));
+    }
+  }
 }
 
 //_________________________________________________________________________________________________
@@ -234,6 +280,12 @@ void PreclustersTask::plotPrecluster(const o2::mch::PreCluster& preCluster, gsl:
   int multiplicity[2] = { 0, 0 };
 
   int deId = preClusterDigits[0].getDetID();
+  auto chamberId = deId / 100;
+  auto stationId = ((chamberId - 1) / 2) + 1;
+
+  if (stationId < 1 || stationId > 5) {
+    return;
+  }
   const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(deId);
 
   // loop over digits and collect information on charge and multiplicity
@@ -324,9 +376,17 @@ void PreclustersTask::plotPrecluster(const o2::mch::PreCluster& preCluster, gsl:
     mHistogramClusterSize->Fill(deIndex * 3 + 1, multiplicity[1]);
     mHistogramClusterSize->Fill(deIndex * 3 + 2, multiplicity[0] + multiplicity[1]);
 
+    mHistogramClusterSizePerStation[0]->Fill(multiplicity[0], stationId);
+    mHistogramClusterSizePerStation[1]->Fill(multiplicity[1], stationId);
+    mHistogramClusterSizePerStation[2]->Fill(multiplicity[0] + multiplicity[1], stationId);
+
     // total cluster charge
     float chargeTot = chargeSum[0] + chargeSum[1];
     mHistogramClusterCharge->Fill(deIndex, chargeTot);
+
+    mHistogramClusterChargePerStation[0]->Fill(chargeSum[0], stationId);
+    mHistogramClusterChargePerStation[1]->Fill(chargeSum[1], stationId);
+    mHistogramClusterChargePerStation[2]->Fill(chargeTot, stationId);
   }
 }
 


### PR DESCRIPTION
The code adds some 1-D histograms that provide distributions of relevant quantities (hit rates, efficiencies, cluster sizes and charge) separately for each tracking station.
The plots are useful for diagnostics and comparison with reference data.

It also introduces a utility function to create a log10-spaced binning that is suitable to initialize variable-bin-sized 1-D histograms for which the X-axis should be displayed in log scale.