### PR TITLE
Do not const_cast/modify sh.mem. objetcs from upstream procsesses

### DIFF
--- a/Modules/MUON/Common/include/MUONCommon/MuonTrack.h
+++ b/Modules/MUON/Common/include/MUONCommon/MuonTrack.h
@@ -164,9 +164,9 @@ class MuonTrack
   int mTrackIdMCH{ -1 };
   int mTrackIdMID{ -1 };
 
-  o2::mft::TrackMFT* mTrackMFT{ nullptr };
-  o2::mch::TrackMCH* mTrackMCH{ nullptr };
-  o2::mid::Track* mTrackMID{ nullptr };
+  const o2::mft::TrackMFT* mTrackMFT{ nullptr };
+  const o2::mch::TrackMCH* mTrackMCH{ nullptr };
+  const o2::mid::Track* mTrackMID{ nullptr };
 
   short mSign;
 };

--- a/Modules/MUON/Common/src/MuonTrack.cxx
+++ b/Modules/MUON/Common/src/MuonTrack.cxx
@@ -337,7 +337,7 @@ namespace o2::quality_control_modules::muon
 
 MuonTrack::MuonTrack(const o2::mch::TrackMCH* track, int trackID, const o2::globaltracking::RecoContainer& recoCont, uint32_t firstTForbit)
 {
-  mTrackMCH = const_cast<o2::mch::TrackMCH*>(track);
+  mTrackMCH = track;
 
   mTrackIdMCH = trackID;
 
@@ -385,8 +385,8 @@ MuonTrack::MuonTrack(const TrackMCHMID* track, const o2::globaltracking::RecoCon
   mTrackIdMCH = iMCH;
   mTrackIdMID = iMID;
 
-  mTrackMCH = const_cast<o2::mch::TrackMCH*>(&(tracksMCH[iMCH]));
-  mTrackMID = const_cast<o2::mid::Track*>(&(tracksMID[iMID]));
+  mTrackMCH = &(tracksMCH[iMCH]);
+  mTrackMID = &(tracksMID[iMID]);
 
   mIR = track->getIR();
   auto trackTimeMUS = track->getTimeMUS(InteractionRecord{ 0, firstTForbit }, 128, true);
@@ -458,14 +458,14 @@ MuonTrack::MuonTrack(const GlobalFwdTrack* track, const o2::globaltracking::Reco
   mTrackIdMID = iMID;
 
   if (iMFT >= 0) {
-    mTrackMFT = const_cast<o2::mft::TrackMFT*>(&(tracksMFT[iMFT]));
+    mTrackMFT = &(tracksMFT[iMFT]);
     mIRMFT = getMFTTrackIR(iMFT, recoCont);
     mTimeMFT = getMFTTrackTime(iMFT, recoCont, firstTForbit);
     mTrackParametersMFT.setZ(tracksMFT[iMFT].getOutParam().getZ());
     mTrackParametersMFT.setParameters(forwardTrackToMCHTrack(tracksMFT[iMFT].getOutParam()).getParameters());
   }
   if (iMCH >= 0) {
-    mTrackMCH = const_cast<o2::mch::TrackMCH*>(&(tracksMCH[iMCH]));
+    mTrackMCH = &(tracksMCH[iMCH]);
     auto& trackMCH = tracksMCH[iMCH];
     mTrackParametersMCH.setZ(trackMCH.getZ());
     mTrackParametersMCH.setParameters(trackMCH.getParameters());
@@ -483,7 +483,7 @@ MuonTrack::MuonTrack(const GlobalFwdTrack* track, const o2::globaltracking::Reco
     mChi2OverNDFMCH = mTrackMCH->getChi2OverNDF();
   }
   if (iMID >= 0) {
-    mTrackMID = const_cast<o2::mid::Track*>(&(tracksMID[iMID]));
+    mTrackMID = &(tracksMID[iMID]);
     mIRMID = getMIDTrackIR(iMID, recoCont);
     mTimeMID = getMIDTrackTime(iMID, recoCont, firstTForbit);
 

--- a/Modules/MUON/MCH/src/DecodingTask.cxx
+++ b/Modules/MUON/MCH/src/DecodingTask.cxx
@@ -176,7 +176,7 @@ void DecodingTask::decodeBuffer(gsl::span<const std::byte> buf)
   size_t bufSize = buf.size();
   size_t pageStart = 0;
   while (bufSize > pageStart) {
-    RDH* rdh = reinterpret_cast<RDH*>(const_cast<std::byte*>(&(buf[pageStart])));
+    const RDH* rdh = reinterpret_cast<const RDH*>(&(buf[pageStart]));
     auto rdhHeaderSize = o2::raw::RDHUtils::getHeaderSize(rdh);
     if (rdhHeaderSize != 64) {
       break;

--- a/Modules/PID/src/TaskFT0TOF.cxx
+++ b/Modules/PID/src/TaskFT0TOF.cxx
@@ -778,7 +778,8 @@ bool TaskFT0TOF::selectTrack(o2::tpc::TrackTPC const& track)
 
   math_utils::Point3D<float> v{};
   std::array<float, 2> dca;
-  if (!(const_cast<o2::tpc::TrackTPC&>(track).propagateParamToDCA(v, mBz, &dca, mMinDCAtoBeamPipeCut)) || std::abs(dca[0]) > mMinDCAtoBeamPipeCutY) {
+  o2::track::TrackPar trTmp(track);
+  if (!trTmp.propagateParamToDCA(v, mBz, &dca, mMinDCAtoBeamPipeCut) || std::abs(dca[0]) > mMinDCAtoBeamPipeCutY) {
     return false;
   }
 

--- a/Modules/TOF/src/TOFMatchedTracks.cxx
+++ b/Modules/TOF/src/TOFMatchedTracks.cxx
@@ -893,7 +893,8 @@ bool TOFMatchedTracks::selectTrack(o2::tpc::TrackTPC const& track)
 
   math_utils::Point3D<float> v{};
   std::array<float, 2> dca;
-  if (!(const_cast<o2::tpc::TrackTPC&>(track).propagateParamToDCA(v, mBz, &dca, mDCACut)) || std::abs(dca[0]) > mDCACutY) {
+  o2::track::TrackPar trTmp(track);
+  if (!trTmp.propagateParamToDCA(v, mBz, &dca, mDCACut) || std::abs(dca[0]) > mDCACutY) {
     return false;
   }
 


### PR DESCRIPTION
The tracks produced in the tracks and supposedly stored in the AOD as is were modified but the QC tasks after const_casting objects in the shared memory. It looks like only standalone TPC tracks were affected (were propagated to the DCA) so the damage was limited.