### PR TITLE
FIT: add RecPoint test configs and update digit test configs

### DIFF
--- a/Modules/FIT/FDD/CMakeLists.txt
+++ b/Modules/FIT/FDD/CMakeLists.txt
@@ -45,6 +45,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/FDD
 
 install(FILES etc/fdd-digits.json
               etc/fdd-post-processing.json
+              etc/fdd-recpoints.json
         DESTINATION Modules/FIT/FDD/etc)
 
 # ---- Test(s) ----

--- a/Modules/FIT/FDD/etc/fdd-post-processing.json
+++ b/Modules/FIT/FDD/etc/fdd-post-processing.json
@@ -32,7 +32,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsTrg"
             ]
@@ -52,7 +52,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsFeeModulesForVtxTrg"
             ]
@@ -72,7 +72,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "TimeInWindowFraction"
             ]
@@ -97,7 +97,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "CFD_efficiency"
             ]
@@ -122,7 +122,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "TrgValidation"
             ]
@@ -147,7 +147,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "AmpSaturation"
             ]
@@ -164,8 +164,105 @@
         }
       }
     },
+    "aggregators": {
+      "GlobalQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QcCommon",
+        "policy": "OnAll",
+        "detectorName": "FDD",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "OutOfBunchCollCheck"
+          },
+          {
+            "type": "Check",
+            "name": "CFDinTimeGateCheck"
+          },
+          {
+            "type": "Check",
+            "name": "CFDinADCgateCheck"
+          },
+          {
+            "type": "Check",
+            "name": "TrgValidationCheck"
+          },
+          {
+            "type": "Check",
+            "name": "ChargeSaturationCheck"
+          }
+        ]
+      }
+    },
     "postprocessing": {
-      "PostProcTask": {
+      "Quality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QcCommon",
+        "detectorName": "FDD",
+        "qualityGroups": [
+          {
+            "name": "Global",
+            "title": "GLOBAL FDD QUALITY",
+            "path": "FDD/QO",
+            "ignoreQualitiesDetails": [
+              "Null",
+              "Good",
+              "Medium",
+              "Bad"
+            ],
+            "inputObjects": [
+              {
+                "name": "GlobalQuality/GlobalQuality",
+                "title": "FDD Quality",
+                "messageBad": "Inform the FIT on-call immediately",
+                "messageMedium": "Follow individual check instructions",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty, inform the FIT on-call immediately"
+              }
+            ]
+          },
+          {
+            "name": "Details",
+            "title": "FDD DETAILS",
+            "path": "FDD/QO",
+            "ignoreQualitiesDetails": [],
+            "inputObjects": [
+              {
+                "name": "OutOfBunchCollCheck",
+                "title": "Out of bunch collisions"
+              },
+              {
+                "name": "CFDinTimeGateCheck",
+                "title": "CFD in time gate"
+              },
+              {
+                "name": "CFDinADCgateCheck",
+                "title": "CFD in ADC gate"
+              },
+              {
+                "name": "TrgValidationCheck",
+                "title": "Trigger validation"
+              },
+              {
+                "name": "ChargeSaturationCheck",
+                "title": "Charge saturation"
+              }
+            ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:FDD/QO/GlobalQuality/GlobalQuality"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "PostProc": {
         "active": "true",
         "className": "o2::quality_control_modules::fdd::PostProcTask",
         "moduleName": "QcFDD",
@@ -173,19 +270,20 @@
         "custom": {
           "numOrbitsInTF": "32",
           "cycleDurationMoName": "CycleDurationNTF",
-          "timestampSourceLhcIf": "metadata"
+          "timestampSourceLhcIf": "metadata",
+          "pathDigitQcTask": "FDD/MO/Digits"
         },
         "initTrigger": [
           "userorcontrol"
         ],
         "updateTrigger": [
-          "newobject:qcdb:FDD/MO/DigitQcTask/TriggersCorrelation"
+          "newobject:qcdb:FDD/MO/Digits/TriggersCorrelation"
         ],
         "stopTrigger": [
           "userorcontrol"
         ]
       },
-      "TrendingTask": {
+      "Trending": {
         "active": "true",
         "className": "o2::quality_control::postprocessing::TrendingTask",
         "moduleName": "QcFDD",
@@ -193,7 +291,7 @@
         "dataSources": [
           {
             "type": "repository",
-            "path": "FDD/MO/DigitQcTask",
+            "path": "FDD/MO/Digits",
             "names": [
               "Amp_channel0",
               "Time_channel0",
@@ -268,7 +366,7 @@
           "userorcontrol"
         ],
         "updateTrigger": [
-          "newobject:qcdb:FDD/MO/DigitQcTask/TriggersCorrelation"
+          "newobject:qcdb:FDD/MO/Digits/TriggersCorrelation"
         ],
         "stopTrigger": [
           "userorcontrol"

--- a/Modules/FIT/FDD/etc/fdd-recpoints.json
+++ b/Modules/FIT/FDD/etc/fdd-recpoints.json
@@ -23,31 +23,16 @@
       }
     },
     "tasks": {
-      "Digits": {
+      "RecPoints": {
         "active": "true",
-        "className": "o2::quality_control_modules::fdd::DigitQcTask",
+        "className": "o2::quality_control_modules::fdd::RecPointsQcTask",
         "moduleName": "QcFDD",
         "detectorName": "FDD",
         "cycleDurationSeconds": "60",
         "resetAfterCycles": "1",
         "dataSource": {
           "type": "direct",
-          "query": "digits:FDD/DIGITSBC/0;channels:FDD/DIGITSCH/0"
-        },
-        "taskParameters": {
-          "ChannelIDs": "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15",
-          "ChannelIDsAmpVsTime": "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15",
-          "trgThresholdTimeLow": "-250",
-          "trgThresholdTimeHigh": "250",
-          "trgModeSide": "A&C",
-          "trgModeThresholdVar": "Ampl",
-          "trgThresholdCenA": "40",
-          "trgThresholdSCenA": "20",
-          "trgThresholdCenC": "20",
-          "trgThresholdSCenC": "10",
-          "trgOrGate": "153",
-          "trgChargeLevelLow": "0",
-          "trgChargeLevelHigh": "4095"
+          "query": "recpoints:FDD/RECPOINTS/0;channels:FDD/RECCHDATA/0"
         }
       }
     }

--- a/Modules/FIT/FT0/CMakeLists.txt
+++ b/Modules/FIT/FT0/CMakeLists.txt
@@ -48,6 +48,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/FT0
 
 install(FILES etc/ft0-digits.json
               etc/ft0-post-processing.json
+              etc/ft0-recpoints.json
         DESTINATION Modules/FIT/FT0/etc)
 
 # ---- Executables ----

--- a/Modules/FIT/FT0/etc/ft0-digits.json
+++ b/Modules/FIT/FT0/etc/ft0-digits.json
@@ -23,13 +23,12 @@
       }
     },
     "tasks": {
-      "DigitQcTask": {
+      "Digits": {
         "active": "true",
         "className": "o2::quality_control_modules::ft0::DigitQcTask",
         "moduleName": "QcFT0",
         "detectorName": "FT0",
         "cycleDurationSeconds": "60",
-        "maxNumberCycles": "-1",
         "resetAfterCycles": "1",
         "dataSource": {
           "type": "direct",
@@ -42,8 +41,8 @@
           "trgThresholdTimeHigh": "100",
           "trgModeSide": "A+C",
           "trgModeThresholdVar": "Ampl",
-          "trgThresholdSCenA": "35",
-          "trgThresholdCenA": "1433",
+          "trgThresholdSCenA": "20",
+          "trgThresholdCenA": "40",
           "trgOrGate": "153",
           "trgChargeLevelLow": "0",
           "trgChargeLevelHigh": "4095"

--- a/Modules/FIT/FT0/etc/ft0-post-processing.json
+++ b/Modules/FIT/FT0/etc/ft0-post-processing.json
@@ -32,7 +32,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsTrg"
             ]
@@ -52,7 +52,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "TimeInWindowFraction"
             ]
@@ -77,7 +77,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "CFD_efficiency"
             ]
@@ -102,7 +102,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "ChannelID_outOfBC"
             ]
@@ -127,7 +127,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "TrgValidation"
             ]
@@ -144,8 +144,105 @@
         }
       }
     },
+    "aggregators": {
+      "GlobalQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QcCommon",
+        "policy": "OnAll",
+        "detectorName": "FT0",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "OutOfBunchCollCheck"
+          },
+          {
+            "type": "Check",
+            "name": "CFDinTimeGateCheck"
+          },
+          {
+            "type": "Check",
+            "name": "CFDinADCgateCheck"
+          },
+          {
+            "type": "Check",
+            "name": "ChannelOutOfBunchCheck"
+          },
+          {
+            "type": "Check",
+            "name": "TrgValidationCheck"
+          }
+        ]
+      }
+    },
     "postprocessing": {
-      "PostProcTask": {
+      "Quality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QualityControl",
+        "detectorName": "FT0",
+        "qualityGroups": [
+          {
+            "name": "Global",
+            "title": "GLOBAL FT0 QUALITY",
+            "path": "FT0/QO/GlobalQuality",
+            "ignoreQualitiesDetails": [
+              "Null",
+              "Good",
+              "Medium",
+              "Bad"
+            ],
+            "inputObjects": [
+              {
+                "name": "GlobalQuality",
+                "title": "Global FT0 Quality",
+                "messageBad": "Inform the FIT on-call immediately",
+                "messageMedium": "Follow individual check instructions",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty, inform the FIT on-call immediately"
+              }
+            ]
+          },
+          {
+            "name": "Details",
+            "title": "FT0 DETAILS",
+            "path": "FT0/QO",
+            "ignoreQualitiesDetails": [],
+            "inputObjects": [
+              {
+                "name": "OutOfBunchCollCheck",
+                "title": "Out of bunch collisions"
+              },
+              {
+                "name": "CFDinTimeGateCheck",
+                "title": "CFD in time gate"
+              },
+              {
+                "name": "CFDinADCgateCheck",
+                "title": "CDF in ADC gate"
+              },
+              {
+                "name": "ChannelOutOfBunchCheck",
+                "title": "Channels out of bunch collisions"
+              },
+              {
+                "name": "TrgValidationCheck",
+                "title": "Trigger validation"
+              }
+            ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:FT0/QO/GlobalQuality/GlobalQuality"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "PostProc": {
         "active": "true",
         "className": "o2::quality_control_modules::ft0::PostProcTask",
         "moduleName": "QcFT0",
@@ -153,19 +250,20 @@
         "custom": {
           "numOrbitsInTF": "32",
           "cycleDurationMoName": "CycleDurationNTF",
-          "timestampSourceLhcIf": "metadata"
+          "timestampSourceLhcIf": "metadata",
+          "pathDigitQcTask": "FT0/MO/Digits"
         },
         "initTrigger": [
           "userorcontrol"
         ],
         "updateTrigger": [
-          "newobject:qcdb:FT0/MO/DigitQcTask/TriggersCorrelation"
+          "newobject:qcdb:FT0/MO/Digits/TriggersCorrelation"
         ],
         "stopTrigger": [
           "userorcontrol"
         ]
       },
-      "TrendingTask": {
+      "Trending": {
         "active": "true",
         "className": "o2::quality_control::postprocessing::TrendingTask",
         "moduleName": "QcFT0",
@@ -173,7 +271,7 @@
         "dataSources": [
           {
             "type": "repository",
-            "path": "FT0/MO/DigitQcTask",
+            "path": "FT0/MO/Digits",
             "names": [
               "CycleDuration",
               "CycleDurationNTF",
@@ -225,7 +323,7 @@
           "userorcontrol"
         ],
         "updateTrigger": [
-          "newobject:qcdb:FT0/MO/DigitQcTask/TriggersCorrelation"
+          "newobject:qcdb:FT0/MO/Digits/TriggersCorrelation"
         ],
         "stopTrigger": [
           "userorcontrol"

--- a/Modules/FIT/FT0/etc/ft0-recpoints.json
+++ b/Modules/FIT/FT0/etc/ft0-recpoints.json
@@ -1,0 +1,40 @@
+{
+    "qc": {
+      "config": {
+        "database": {
+          "implementation": "CCDB",
+          "host": "ccdb-test.cern.ch:8080",
+          "#host": "http://localhost:8080",
+          "username": "not_applicable",
+          "password": "not_applicable",
+          "name": "not_applicable"
+        },
+        "monitoring": {
+            "url": "infologger:///debug?qc"
+          },
+          "consul": {
+            "url": ""
+          },
+          "conditionDB": {
+            "url": "alice-ccdb.cern.ch"
+          },
+          "bookkeeping": {
+            "url": ""
+          }
+      },
+      "tasks": {
+        "RecPoints": {
+          "active": "true",
+          "className": "o2::quality_control_modules::ft0::RecPointsQcTask",
+          "moduleName": "QcFT0",
+          "detectorName": "FT0",
+          "cycleDurationSeconds": "60",
+          "resetAfterCycles": "1",
+          "dataSource": {
+              "type": "direct",
+              "query": "recpoints:FT0/RECPOINTS/0;channels:FT0/RECCHDATA/0"
+             }
+        }
+      }
+    }
+}

--- a/Modules/FIT/FV0/etc/fv0-digits.json
+++ b/Modules/FIT/FV0/etc/fv0-digits.json
@@ -23,13 +23,12 @@
       }
     },
     "tasks": {
-      "DigitQcTask": {
+      "Digits": {
         "active": "true",
         "className": "o2::quality_control_modules::fv0::DigitQcTask",
         "moduleName": "QcFV0",
         "detectorName": "FV0",
         "cycleDurationSeconds": "60",
-        "maxNumberCycles": "-1",
         "resetAfterCycles": "1",
         "dataSource": {
           "type": "direct",
@@ -40,10 +39,10 @@
           "ChannelIDsAmpVsTime": "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48",
           "trgModeInnerOuterThresholdVar": "Ampl",
           "trgThresholdNChannels": "2",
-          "trgThresholdCharge": "1080",
+          "trgThresholdCharge": "8",
           "trgThresholdChargeInner": "4",
           "trgThresholdChargeOuter": "4",
-          "trgChargeLevelLow": "10",
+          "trgChargeLevelLow": "6",
           "trgChargeLevelHigh": "4095",
           "minGateTimeForRatioHistogram": "-192",
           "maxGateTimeForRatioHistogram": "192"

--- a/Modules/FIT/FV0/etc/fv0-post-processing.json
+++ b/Modules/FIT/FV0/etc/fv0-post-processing.json
@@ -32,7 +32,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsTrg"
             ]
@@ -53,7 +53,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsFeeModules"
             ]
@@ -73,7 +73,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsFeeModulesForChargeTrg"
             ]
@@ -93,7 +93,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsFeeModulesForNChanTrg"
             ]
@@ -113,7 +113,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsFeeModulesForOrATrg"
             ]
@@ -133,7 +133,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsFeeModulesForOrAInTrg"
             ]
@@ -153,7 +153,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "OutOfBunchColl_BCvsFeeModulesForOrAOutTrg"
             ]
@@ -173,7 +173,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "TimeInWindowFraction"
             ]
@@ -198,7 +198,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "CFD_efficiency"
             ]
@@ -223,7 +223,7 @@
         "dataSource": [
           {
             "type": "PostProcessing",
-            "name": "PostProcTask",
+            "name": "PostProc",
             "MOs": [
               "TrgValidation"
             ]
@@ -240,8 +240,97 @@
         }
       }
     },
+    "aggregators": {
+      "GlobalQuality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::WorstOfAllAggregator",
+        "moduleName": "QcCommon",
+        "policy": "OnAll",
+        "detectorName": "FV0",
+        "dataSource": [
+          {
+            "type": "Check",
+            "name": "OutOfBunchCollCheck"
+          },
+          {
+            "type": "Check",
+            "name": "CFDinTimeGateCheck"
+          },
+          {
+            "type": "Check",
+            "name": "CFDinADCgateCheck"
+          },
+          {
+            "type": "Check",
+            "name": "TrgValidationCheck"
+          }
+        ]
+      }
+    },
     "postprocessing": {
-      "PostProcTask": {
+      "Quality": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::QualityTask",
+        "moduleName": "QualityControl",
+        "detectorName": "FV0",
+        "qualityGroups": [
+          {
+            "name": "Global",
+            "title": "GLOBAL FV0 QUALITY",
+            "path": "FV0/QO/GlobalQuality",
+            "ignoreQualitiesDetails": [
+              "Null",
+              "Good",
+              "Medium",
+              "Bad"
+            ],
+            "inputObjects": [
+              {
+                "name": "GlobalQuality",
+                "title": "Global FV0 Quality",
+                "messageBad": "Inform the FIT on-call immediately",
+                "messageMedium": "Follow individual check instructions",
+                "messageGood": "All checks are OK",
+                "messageNull": "Some histograms are empty, inform the FIT on-call immediately"
+              }
+            ]
+          },
+          {
+            "name": "Details",
+            "title": "FV0 DETAILS",
+            "path": "FV0/QO",
+            "ignoreQualitiesDetails": [],
+            "inputObjects": [
+              {
+                "name": "OutOfBunchCollCheck",
+                "title": "Out of bunch collisions"
+              },
+              {
+                "name": "CFDinTimeGateCheck",
+                "title": "CFD in time gate"
+              },
+              {
+                "name": "CFDinADCgateCheck",
+                "title": "CDF in ADC gate"
+              },
+              {
+                "name": "TrgValidationCheck",
+                "title": "Trigger validation"
+              }
+            ]
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:FV0/QO/GlobalQuality/GlobalQuality"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "PostProc": {
         "active": "true",
         "className": "o2::quality_control_modules::fv0::PostProcTask",
         "moduleName": "QcFV0",
@@ -249,19 +338,20 @@
         "custom": {
           "numOrbitsInTF": "32",
           "cycleDurationMoName": "CycleDurationNTF",
-          "timestampSourceLhcIf": "metadata"
+          "timestampSourceLhcIf": "metadata",
+          "pathDigitQcTask": "FV0/MO/Digits"
         },
         "initTrigger": [
           "userorcontrol"
         ],
         "updateTrigger": [
-          "newobject:qcdb:FV0/MO/DigitQcTask/TriggersCorrelation"
+          "newobject:qcdb:FV0/MO/Digits/TriggersCorrelation"
         ],
         "stopTrigger": [
           "userorcontrol"
         ]
       },
-      "TrendingTask": {
+      "Trending": {
         "active": "true",
         "className": "o2::quality_control::postprocessing::TrendingTask",
         "moduleName": "QcFV0",
@@ -269,7 +359,7 @@
         "dataSources": [
           {
             "type": "repository",
-            "path": "FV0/MO/DigitQcTask",
+            "path": "FV0/MO/Digits",
             "names": [
               "CycleDuration",
               "CycleDurationNTF",
@@ -327,7 +417,7 @@
           "userorcontrol"
         ],
         "updateTrigger": [
-          "newobject:qcdb:FV0/MO/DigitQcTask/TriggersCorrelation"
+          "newobject:qcdb:FV0/MO/Digits/TriggersCorrelation"
         ],
         "stopTrigger": [
           "userorcontrol"


### PR DESCRIPTION
- Example configuration for FT0 and FDD RecPoint QC added
- Digit (incl. post-processing) QC example configs updated for all FIT