### PR TITLE
GLO:  ITS-TPC matching efficiency to th1

### DIFF
--- a/Framework/include/QualityControl/CustomParameters.h
+++ b/Framework/include/QualityControl/CustomParameters.h
@@ -123,7 +123,7 @@ class CustomParameters
    * @param defaultValue
    * @return the value for the given key, runType and beamType. If it is not found, it returns an empty string or defaultValue if provided.
    */
-  std::string atOrDefaultValue(const std::string& key, std::string defaultValue = "", const std::string& runType = "default", const std::string& beamType = "default");
+  std::string atOrDefaultValue(const std::string& key, std::string defaultValue = "", const std::string& runType = "default", const std::string& beamType = "default") const;
 
   std::string atOrDefaultValue(const std::string& key, std::string defaultValue, const Activity& activity) const;
 

--- a/Framework/src/CustomParameters.cxx
+++ b/Framework/src/CustomParameters.cxx
@@ -96,7 +96,7 @@ std::optional<std::string> CustomParameters::atOptional(const std::string& key, 
   return atOptional(key, activity.mType, activity.mBeamType);
 }
 
-std::string CustomParameters::atOrDefaultValue(const std::string& key, std::string defaultValue, const std::string& runType, const std::string& beamType)
+std::string CustomParameters::atOrDefaultValue(const std::string& key, std::string defaultValue, const std::string& runType, const std::string& beamType) const
 {
   try {
     return mCustomParameters.at(runType).at(beamType).at(key);

--- a/Modules/Common/include/Common/Utils.h
+++ b/Modules/Common/include/Common/Utils.h
@@ -25,6 +25,38 @@
 namespace o2::quality_control_modules::common
 {
 
+namespace internal
+{
+/// \brief Parses a string to a type
+/// \param params String to be cast
+/// \return Returns requested type from param
+template <typename T>
+T string_to_type(const std::string& param)
+{
+  T retVal{};
+  if constexpr (std::is_same<int, T>::value) {
+    retVal = std::stoi(param);
+  } else if constexpr (std::is_same<std::string, T>::value) {
+    retVal = param;
+  } else if constexpr (std::is_same<float, T>::value) {
+    retVal = std::stof(param);
+  } else if constexpr (std::is_same<double, T>::value) {
+    retVal = std::stod(param);
+  } else if constexpr (std::is_same<bool, T>::value) {
+    if ((param == "true") || (param == "True") || (param == "TRUE") || (param == "1")) {
+      retVal = true;
+    } else if ((param == "false") || (param == "False") || (param == "FALSE") || (param == "0")) {
+      retVal = false;
+    } else {
+      LOG(error) << "Cannot parse boolean.";
+    }
+  } else {
+    LOG(error) << "Template type not supported";
+  }
+  return retVal;
+}
+} // namespace internal
+
 /// \brief Gets a task parameter from the config file
 /// Convenience function to return a value for a taskParameter given in the config file
 /// \param params mCustomParameters from within the QualityControl/TaskInterface
@@ -38,27 +70,28 @@ T getFromConfig(const quality_control::core::CustomParameters& params, const std
     LOGP(warning, "Missing parameter. Please add '{}': '<value>' to the 'taskParameters'. Using default value {}.", name.data(), retVal);
   } else {
     const auto& param = itParam->second;
-    if constexpr (std::is_same<int, T>::value) {
-      retVal = std::stoi(param);
-    } else if constexpr (std::is_same<std::string, T>::value) {
-      retVal = param;
-    } else if constexpr (std::is_same<float, T>::value) {
-      retVal = std::stof(param);
-    } else if constexpr (std::is_same<double, T>::value) {
-      retVal = std::stod(param);
-    } else if constexpr (std::is_same<bool, T>::value) {
-      if ((param == "true") || (param == "True") || (param == "TRUE") || (param == "1")) {
-        retVal = true;
-      } else if ((param == "false") || (param == "False") || (param == "FALSE") || (param == "0")) {
-        retVal = false;
-      } else {
-        LOG(error) << fmt::format("Please provide a valid boolean value for {}.", name.data()).data();
-      }
-    } else {
-      LOG(error) << "Template type not supported";
-    }
+    return internal::string_to_type<T>(param);
   }
   return retVal;
+}
+
+/// \brief Gets a extended task parameter from the config file
+/// Convenience function to return a value for a extended taskParameter given in the config file
+/// \param activity mActivity from within the QualityControl/TaskInterface
+/// \param params mCustomParameters from within the QualityControl/TaskInterface
+/// \param name Name of the taskParameter
+/// \param retVal Default value if not specified in config, must be stringyfiable
+/// \return taskParameter converted to bool, int, float, double or std::string depending on the template type
+template <typename T>
+T getFromExtendedConfig(const quality_control::core::Activity& activity, const quality_control::core::CustomParameters& params, const std::string& name, T retVal = T{})
+{
+  std::string parameter;
+  if (auto param = params.atOptional(name, activity)) {
+    parameter = param.value();
+  } else {
+    parameter = params.atOrDefaultValue(name, std::to_string(retVal));
+  }
+  return internal::string_to_type<T>(parameter);
 }
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/Utils.h
+++ b/Modules/Common/include/Common/Utils.h
@@ -31,7 +31,7 @@ namespace internal
 /// \param params String to be cast
 /// \return Returns requested type from param
 template <typename T>
-T string_to_type(const std::string& param)
+T stringToType(const std::string& param)
 {
   T retVal{};
   if constexpr (std::is_same<int, T>::value) {
@@ -70,7 +70,7 @@ T getFromConfig(const quality_control::core::CustomParameters& params, const std
     LOGP(warning, "Missing parameter. Please add '{}': '<value>' to the 'taskParameters'. Using default value {}.", name.data(), retVal);
   } else {
     const auto& param = itParam->second;
-    return internal::string_to_type<T>(param);
+    return internal::stringToType<T>(param);
   }
   return retVal;
 }
@@ -91,7 +91,7 @@ T getFromExtendedConfig(const quality_control::core::Activity& activity, const q
   } else {
     parameter = params.atOrDefaultValue(name, std::to_string(retVal));
   }
-  return internal::string_to_type<T>(parameter);
+  return internal::stringToType<T>(parameter);
 }
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/GLO/glo-itstpc-mtch-qcmn-test.json
+++ b/Modules/GLO/glo-itstpc-mtch-qcmn-test.json
@@ -45,6 +45,7 @@
           "verbose": "false",
           "minPtCut": "0.1f",
           "etaCut": "1.4f",
+          "isSync": "true",
           "minNTPCClustersCut": "60",
           "minDCACut": "100.f",
           "minDCACutY": "10.f"
@@ -75,9 +76,9 @@
             "type": "Task",
             "name": "ITSTPCMatchingTask",
             "MOs": [
-              "mFractionITSTPCmatch_ITS",
-              "mFractionITSTPCmatchPhi_ITS",
-              "mFractionITSTPCmatchEta_ITS"
+              "mFractionITSTPCmatch_ITS_Hist",
+              "mFractionITSTPCmatchPhi_ITS_Hist",
+              "mFractionITSTPCmatchEta_ITS_Hist"
             ]
           }
         ],
@@ -85,7 +86,7 @@
           "default": {
             "default": {
               "showPt": "true",
-              "thresholdPt": "0.9",
+              "thresholdPt": "0.5",
               "showPhi": "true",
               "thresholdPhi": "0.3",
               "showEta": "1",

--- a/Modules/GLO/src/ITSTPCMatchingTask.cxx
+++ b/Modules/GLO/src/ITSTPCMatchingTask.cxx
@@ -19,6 +19,7 @@
 
 #include "QualityControl/QcInfoLogger.h"
 #include "GLO/ITSTPCMatchingTask.h"
+#include "Common/Utils.h"
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
 #include <QualityControl/stringUtils.h>
@@ -126,6 +127,39 @@ void ITSTPCMatchingTask::endOfCycle()
 {
   ILOG(Debug, Devel) << "endOfCycle" << ENDM;
   mMatchITSTPCQC.finalize();
+
+  // Sync Mode
+  if (common::getFromConfig(mCustomParameters, "isSync", false)) {
+    {
+      // Pt
+      auto hEffPt = mMatchITSTPCQC.getFractionITSTPCmatch(globaltracking::MatchITSTPCQC::ITS);
+      auto hEffPtHist = dynamic_cast<TH1*>(hEffPt->GetPassedHistogram()->Clone("mFractionITSTPCmatch_ITS_Hist"));
+      hEffPtHist->Sumw2();
+      hEffPtHist->Divide(hEffPt->GetTotalHistogram());
+      hEffPtHist->SetBit(TH1::EStatusBits::kNoStats);
+      getObjectsManager()->startPublishing(hEffPtHist);
+    }
+
+    {
+      // Eta
+      auto hEffEta = mMatchITSTPCQC.getFractionITSTPCmatchEta(globaltracking::MatchITSTPCQC::ITS);
+      auto hEffEtaHist = dynamic_cast<TH1*>(hEffEta->GetPassedHistogram()->Clone("mFractionITSTPCmatchEta_ITS_Hist"));
+      hEffEtaHist->Sumw2();
+      hEffEtaHist->Divide(hEffEta->GetTotalHistogram());
+      hEffEtaHist->SetBit(TH1::EStatusBits::kNoStats);
+      getObjectsManager()->startPublishing(hEffEtaHist);
+    }
+
+    {
+      // Phi
+      auto hEffPhi = mMatchITSTPCQC.getFractionITSTPCmatchPhi(globaltracking::MatchITSTPCQC::ITS);
+      auto hEffPhiHist = dynamic_cast<TH1*>(hEffPhi->GetPassedHistogram()->Clone("mFractionITSTPCmatchPhi_ITS_Hist"));
+      hEffPhiHist->Sumw2();
+      hEffPhiHist->Divide(hEffPhi->GetTotalHistogram());
+      hEffPhiHist->SetBit(TH1::EStatusBits::kNoStats);
+      getObjectsManager()->startPublishing(hEffPhiHist);
+    }
+  }
 }
 
 void ITSTPCMatchingTask::endOfActivity(const Activity& /*activity*/)

--- a/Modules/GLO/src/ITSTPCmatchingCheck.cxx
+++ b/Modules/GLO/src/ITSTPCmatchingCheck.cxx
@@ -18,6 +18,7 @@
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/QcInfoLogger.h"
+#include "Common/Utils.h"
 
 #include <Rtypes.h>
 #include <TH1.h>
@@ -488,56 +489,23 @@ void ITSTPCmatchingCheck::startOfActivity(const Activity& activity)
 {
   mActivity = make_shared<Activity>(activity);
 
-  // Casting function with error handling
-  auto ccast = []<typename T>(T& p, const std::string& par) -> void {
-    try {
-      if constexpr (std::is_floating_point_v<T>) {
-        p = static_cast<T>(std::stof(par));
-      } else if constexpr (std::is_integral_v<T>) {
-        if (par != "true" && par != "false") {
-          p = static_cast<T>(std::stoi(par));
-        } else {
-          p = par == "true";
-        }
-      } else {
-        p = static_cast<T>(par);
-      }
-    } catch (std::exception& err) {
-      ILOG(Error) << "Cannot cast parameter in config file " << par << " " << err.what() << "'; using default..." << ENDM;
-    }
-  };
-
-  // Parse a generic parameter
-  auto parseParam = [&]<typename T>(T& p, const std::string& name, const std::string& def) -> void {
-    std::string parameter;
-    if (auto param = mCustomParameters.atOptional(name, activity)) {
-      parameter = param.value();
-    } else {
-      parameter = mCustomParameters.atOrDefaultValue(name, def);
-    }
-    ccast(p, parameter);
-  };
-
-  // Pt
-  parseParam(mShowPt, "showPt", "true");
+  mShowPt = common::getFromExtendedConfig(activity, mCustomParameters, "showPt", true);
   if (mShowPt) {
-    parseParam(mThresholdPt, "thresholdPt", "0.5");
-    parseParam(mMinPt, "minPt", "1.0");
-    parseParam(mMaxPt, "maxPt", "1.999");
+    mThresholdPt = common::getFromExtendedConfig(activity, mCustomParameters, "thresholdPt", 0.5f);
+    mMinPt = common::getFromExtendedConfig(activity, mCustomParameters, "minPt", 1.0f);
+    mMaxPt = common::getFromExtendedConfig(activity, mCustomParameters, "maxPt", 1.999f);
   }
 
-  // Phi
-  parseParam(mShowPhi, "showPhi", "true");
-  if (mShowPhi) {
-    parseParam(mThresholdPhi, "thresholdPhi", "0.3");
+  mShowPhi = common::getFromExtendedConfig(activity, mCustomParameters, "showPhi", true);
+  if (mShowPt) {
+    mThresholdPhi = common::getFromExtendedConfig(activity, mCustomParameters, "thresholdPhi", 0.3f);
   }
 
-  // Eta
-  parseParam(mShowEta, "showEta", "false");
+  mShowEta = common::getFromExtendedConfig(activity, mCustomParameters, "showEta", false);
   if (mShowEta) {
-    parseParam(mThresholdEta, "thresholdEta", "0.4");
-    parseParam(mMinEta, "minEta", "-0.8");
-    parseParam(mMaxEta, "maxEta", "0.8");
+    mThresholdEta = common::getFromExtendedConfig(activity, mCustomParameters, "thresholdEta", 0.4f);
+    mMinEta = common::getFromExtendedConfig(activity, mCustomParameters, "minEta", -0.8f);
+    mMaxEta = common::getFromExtendedConfig(activity, mCustomParameters, "maxEta", 0.8f);
   }
 }
 

--- a/Modules/GLO/src/ITSTPCmatchingCheck.cxx
+++ b/Modules/GLO/src/ITSTPCmatchingCheck.cxx
@@ -22,7 +22,6 @@
 
 #include <Rtypes.h>
 #include <TH1.h>
-#include <TEfficiency.h>
 #include <TPaveText.h>
 #include <TMath.h>
 #include <TArrow.h>
@@ -56,8 +55,8 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
   for (auto& [moName, mo] : *moMap) {
     (void)moName;
 
-    if (mShowPt && mo->getName() == "mFractionITSTPCmatch_ITS") {
-      auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+    if (mShowPt && mo->getName() == "mFractionITSTPCmatch_ITS_Hist") {
+      auto* eff = dynamic_cast<TH1*>(mo->getObject());
       if (eff == nullptr) {
         ILOG(Error) << "Failed cast for ITSTPCmatch_ITS check!" << ENDM;
         continue;
@@ -67,18 +66,14 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
       ptQual = Quality::Good;
       result.addMetadata("checkPtQuality", "good");
       result.addMetadata("checkPtBins", "");
-      result.addMetadata("checkPtDen", "good");
-      result.addMetadata("checkPtNum", "good");
-      if (eff->GetTotalHistogram()->GetEntries() == 0) {
+      result.addMetadata("checkPt", "good");
+      if (eff->GetEntries() == 0) {
         ptQual = Quality::Null;
-        result.updateMetadata("checkPtDen", "null");
-      } else if (eff->GetPassedHistogram()->GetEntries() == 0) {
-        ptQual = Quality::Bad;
-        result.updateMetadata("checkPtNum", "bad");
+        result.updateMetadata("checkPt", "null");
       } else {
         std::vector<int> badBins;
         for (int iBin = binLow; iBin <= binUp; ++iBin) {
-          if (eff->GetEfficiency(iBin) < mThresholdPt) {
+          if (eff->GetBinContent(iBin) < mThresholdPt) {
             ptQual = Quality::Bad;
             badBins.push_back(iBin);
           }
@@ -90,7 +85,7 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
 
           std::string cBins{ "Bad matching efficiency in: " };
           for (const auto& [binLow, binUp] : ranges) {
-            float low = eff->GetPassedHistogram()->GetXaxis()->GetBinLowEdge(binLow), up = eff->GetPassedHistogram()->GetXaxis()->GetBinUpEdge(binUp);
+            float low = eff->GetXaxis()->GetBinLowEdge(binLow), up = eff->GetXaxis()->GetBinUpEdge(binUp);
             cBins += fmt::format("{:.1f}-{:.1f},", low, up);
           }
           cBins.pop_back(); // remove last `,`
@@ -100,8 +95,8 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
       }
     }
 
-    if (mShowPhi && mo->getName() == "mFractionITSTPCmatchPhi_ITS") {
-      auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+    if (mShowPhi && mo->getName() == "mFractionITSTPCmatchPhi_ITS_Hist") {
+      auto* eff = dynamic_cast<TH1*>(mo->getObject());
       if (eff == nullptr) {
         ILOG(Error) << "Failed cast for ITSTPCmatchPhi_ITS check!" << ENDM;
         continue;
@@ -110,18 +105,14 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
       phiQual = Quality::Good;
       result.addMetadata("checkPhiQuality", "good");
       result.addMetadata("checkPhiBins", "");
-      result.addMetadata("checkPhiDen", "good");
-      result.addMetadata("checkPhiNum", "good");
-      if (eff->GetTotalHistogram()->GetEntries() == 0) {
+      result.addMetadata("checkPhi", "good");
+      if (eff->GetEntries() == 0) {
         phiQual = Quality::Null;
-        result.updateMetadata("checkPhiDen", "null");
-      } else if (eff->GetPassedHistogram()->GetEntries() == 0) {
-        phiQual = Quality::Bad;
-        result.updateMetadata("checkPhiNum", "bad");
+        result.updateMetadata("checkPhi", "null");
       } else {
         std::vector<int> badBins;
-        for (int iBin{ 1 }; iBin <= eff->GetPassedHistogram()->GetNbinsX(); ++iBin) {
-          if (eff->GetEfficiency(iBin) < mThresholdPhi) {
+        for (int iBin{ 1 }; iBin <= eff->GetNbinsX(); ++iBin) {
+          if (eff->GetBinContent(iBin) < mThresholdPhi) {
             phiQual = Quality::Bad;
             badBins.push_back(iBin);
           }
@@ -133,7 +124,7 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
 
           std::string cBins{ "Bad matching efficiency in: " };
           for (const auto& [binLow, binUp] : ranges) {
-            float low = eff->GetPassedHistogram()->GetXaxis()->GetBinLowEdge(binLow), up = eff->GetPassedHistogram()->GetXaxis()->GetBinUpEdge(binUp);
+            float low = eff->GetXaxis()->GetBinLowEdge(binLow), up = eff->GetXaxis()->GetBinUpEdge(binUp);
             cBins += fmt::format("{:.1f}-{:.1f},", low, up);
           }
           cBins.pop_back(); // remove last `,`
@@ -143,8 +134,8 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
       }
     }
 
-    if (mShowEta && mo->getName() == "mFractionITSTPCmatchEta_ITS") {
-      auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+    if (mShowEta && mo->getName() == "mFractionITSTPCmatchEta_ITS_Hist") {
+      auto* eff = dynamic_cast<TH1*>(mo->getObject());
       if (eff == nullptr) {
         ILOG(Error) << "Failed cast for ITSTPCmatchEta_ITS check!" << ENDM;
         continue;
@@ -154,29 +145,25 @@ Quality ITSTPCmatchingCheck::check(std::map<std::string, std::shared_ptr<Monitor
       etaQual = Quality::Good;
       result.addMetadata("checkEtaQuality", "good");
       result.addMetadata("checkEtaBins", "");
-      result.addMetadata("checkEtaDen", "good");
-      result.addMetadata("checkEtaNum", "good");
-      if (eff->GetTotalHistogram()->GetEntries() == 0) {
-        ptQual = Quality::Null;
-        result.updateMetadata("checkEtaDen", "null");
-      } else if (eff->GetPassedHistogram()->GetEntries() == 0) {
-        ptQual = Quality::Bad;
-        result.updateMetadata("checkEtaNum", "bad");
+      result.addMetadata("checkEta", "good");
+      if (eff->GetEntries() == 0) {
+        etaQual = Quality::Null;
+        result.updateMetadata("checkEta", "null");
       } else {
         std::vector<int> badBins;
         for (int iBin = binLow; iBin <= binUp; ++iBin) {
-          if (eff->GetEfficiency(iBin) < mThresholdEta) {
-            ptQual = Quality::Bad;
+          if (eff->GetBinContent(iBin) < mThresholdEta) {
+            etaQual = Quality::Bad;
             badBins.push_back(iBin);
           }
         }
         auto ranges = findRanges(badBins);
-        if (ptQual == Quality::Bad) {
+        if (etaQual == Quality::Bad) {
           result.updateMetadata("checkEtaQuality", "bad");
 
           std::string cBins{ "Bad matching efficiency in: " };
           for (const auto& [binLow, binUp] : ranges) {
-            float low = eff->GetPassedHistogram()->GetXaxis()->GetBinLowEdge(binLow), up = eff->GetPassedHistogram()->GetXaxis()->GetBinUpEdge(binUp);
+            float low = eff->GetXaxis()->GetBinLowEdge(binLow), up = eff->GetXaxis()->GetBinUpEdge(binUp);
             cBins += fmt::format("{:.1f}-{:.1f},", low, up);
           }
           cBins.pop_back(); // remove last `,`
@@ -206,15 +193,18 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     return;
   }
 
-  if (mShowPt && mo->getName() == "mFractionITSTPCmatch_ITS") {
-    auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+  if (mShowPt && mo->getName() == "mFractionITSTPCmatch_ITS_Hist") {
+    auto* eff = dynamic_cast<TH1*>(mo->getObject());
     if (eff == nullptr) {
-      ILOG(Error) << "Failed cast for ITSTPCmatch_ITS beautify!" << ENDM;
+      ILOG(Error) << "Failed cast for ITSTPCmatch_ITS_Hist beautify!" << ENDM;
       return;
     }
+    eff->GetYaxis()->SetRangeUser(0, 1.1);
+    eff->GetYaxis()->SetBit(TAxis::EStatusBits::kDecimals);
+
     // Draw threshold lines
-    float xmin = eff->GetPassedHistogram()->GetXaxis()->GetXmin();
-    float xmax = eff->GetPassedHistogram()->GetXaxis()->GetXmax();
+    float xmin = eff->GetXaxis()->GetXmin();
+    float xmax = eff->GetXaxis()->GetXmax();
     float xminT = mMinPt;
     float xmaxT = mMaxPt;
     auto* l1 = new TLine(xmin, mThresholdPt, xmax, mThresholdPt);
@@ -229,9 +219,9 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     l3->SetLineStyle(kDashed);
     l3->SetLineWidth(4);
     l3->SetLineColor(kCyan - 7);
-    auto* tt = new TText(xminT + 0.1, 1.05, "Checked Range");
+    auto* tt = new TText(xmaxT + 0.3, 1.02, "Checked Range");
     tt->SetTextSize(0.04);
-    auto* ttt = new TText(xmaxT + 0.9, mThresholdPt + 0.012, "Threshold");
+    auto* ttt = new TText(xmax - 5.0, mThresholdPt + 0.012, "Threshold");
     auto* aa = new TArrow(xminT + 0.01, 1.02, xmaxT - 0.01, 1.02, 0.02, "<|>");
     if (checkResult.getMetadata("checkPtQuality") == "good") {
       l1->SetLineColor(kCyan - 7);
@@ -264,15 +254,14 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     bad->SetMarkerStyle(25);
     bad->SetMarkerSize(2);
     auto* leg = new TLegend(0.7, 0.13, 0.89, 0.3);
-    leg->SetNColumns(2);
     leg->SetHeader("Threshold Checks");
     leg->AddEntry(good, "Good", "P");
     leg->AddEntry(bad, "Bad", "P");
     auto binLow = eff->FindFixBin(mMinPt), binUp = eff->FindFixBin(mMaxPt);
     for (int iBin = binLow; iBin <= binUp; ++iBin) {
-      auto x = eff->GetPassedHistogram()->GetBinCenter(iBin);
-      auto y = eff->GetEfficiency(iBin);
-      if (eff->GetEfficiency(iBin) < mThresholdPt) {
+      auto x = eff->GetBinCenter(iBin);
+      auto y = eff->GetBinContent(iBin);
+      if (y < mThresholdPt) {
         bad->SetPoint(cB++, x, y);
       } else {
         good->SetPoint(cG++, x, y);
@@ -306,12 +295,15 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     eff->GetListOfFunctions()->Add(msg);
   }
 
-  if (mShowPhi && mo->getName() == "mFractionITSTPCmatchPhi_ITS") {
-    auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+  if (mShowPhi && mo->getName() == "mFractionITSTPCmatchPhi_ITS_Hist") {
+    auto* eff = dynamic_cast<TH1*>(mo->getObject());
     if (eff == nullptr) {
-      ILOG(Error) << "Failed cast for ITSTPCmatchPhi_ITS beautify!" << ENDM;
+      ILOG(Error) << "Failed cast for ITSTPCmatchPhi_ITS_Hist beautify!" << ENDM;
       return;
     }
+    eff->GetYaxis()->SetRangeUser(0, 1.1);
+    eff->GetYaxis()->SetBit(TAxis::EStatusBits::kDecimals);
+
     // Draw threshold lines
     auto* l1 = new TLine(0, mThresholdPhi, 2 * TMath::Pi(), mThresholdPhi);
     l1->SetLineStyle(kDashed);
@@ -319,7 +311,7 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     l1->SetLineColor(kCyan - 7);
     auto* tt = new TText(TMath::Pi() - 1., 1.05, "Checked Range");
     tt->SetTextSize(0.04);
-    auto* ttt = new TText(2 * TMath::Pi() - 0.9, mThresholdPhi + 0.012, "Threshold");
+    auto* ttt = new TText(2 * TMath::Pi() - 2, mThresholdPhi + 0.012, "Threshold");
     auto* aa = new TArrow(0.01, 1.02, 2 * TMath::Pi() - 0.01, 1.02, 0.02, "<|>");
     if (checkResult.getMetadata("checkPhiQuality") == "good") {
       l1->SetLineColor(kCyan - 7);
@@ -346,14 +338,13 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     bad->SetMarkerStyle(25);
     bad->SetMarkerSize(1);
     auto* leg = new TLegend(0.7, 0.13, 0.89, 0.3);
-    leg->SetNColumns(2);
     leg->SetHeader("Threshold Checks");
     leg->AddEntry(good, "Good", "P");
     leg->AddEntry(bad, "Bad", "P");
-    for (int iBin{ 1 }; iBin <= eff->GetPassedHistogram()->GetNbinsX(); ++iBin) {
-      auto x = eff->GetPassedHistogram()->GetBinCenter(iBin);
-      auto y = eff->GetEfficiency(iBin);
-      if (eff->GetEfficiency(iBin) < mThresholdPhi) {
+    for (int iBin{ 1 }; iBin <= eff->GetNbinsX(); ++iBin) {
+      auto x = eff->GetBinCenter(iBin);
+      auto y = eff->GetBinContent(iBin);
+      if (y < mThresholdPhi) {
         bad->SetPoint(cB++, x, y);
       } else {
         good->SetPoint(cG++, x, y);
@@ -386,15 +377,18 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     eff->GetListOfFunctions()->Add(msg);
   }
 
-  if (mShowEta && mo->getName() == "mFractionITSTPCmatchEta_ITS") {
-    auto* eff = dynamic_cast<TEfficiency*>(mo->getObject());
+  if (mShowEta && mo->getName() == "mFractionITSTPCmatchEta_ITS_Hist") {
+    auto* eff = dynamic_cast<TH1*>(mo->getObject());
     if (eff == nullptr) {
-      ILOG(Error) << "Failed cast for ITSTPCmatchEta_ITS beautify!" << ENDM;
+      ILOG(Error) << "Failed cast for ITSTPCmatchEta_ITS_Hist beautify!" << ENDM;
       return;
     }
+    eff->GetYaxis()->SetRangeUser(0, 1.1);
+    eff->GetYaxis()->SetBit(TAxis::EStatusBits::kDecimals);
+
     // Draw threshold lines
-    float xmin = eff->GetPassedHistogram()->GetXaxis()->GetXmin();
-    float xmax = eff->GetPassedHistogram()->GetXaxis()->GetXmax();
+    float xmin = eff->GetXaxis()->GetXmin();
+    float xmax = eff->GetXaxis()->GetXmax();
     float xminT = mMinEta;
     float xmaxT = mMaxEta;
     auto* l1 = new TLine(xmin, mThresholdEta, xmax, mThresholdEta);
@@ -411,7 +405,7 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     l3->SetLineColor(kCyan - 7);
     auto* tt = new TText(xminT + 0.1, 1.05, "Checked Range");
     tt->SetTextSize(0.04);
-    auto* ttt = new TText(xmaxT + 0.4, mThresholdEta + 0.012, "Threshold");
+    auto* ttt = new TText(xmaxT + 0.2, mThresholdEta + 0.012, "Threshold");
     auto* aa = new TArrow(xminT + 0.01, 1.02, xmaxT - 0.01, 1.02, 0.02, "<|>");
     if (checkResult.getMetadata("checkEtaQuality") == "good") {
       l1->SetLineColor(kCyan - 7);
@@ -444,15 +438,14 @@ void ITSTPCmatchingCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality ch
     bad->SetMarkerStyle(25);
     bad->SetMarkerSize(1);
     auto* leg = new TLegend(0.7, 0.13, 0.89, 0.3);
-    leg->SetNColumns(2);
     leg->SetHeader("Threshold Checks");
     leg->AddEntry(good, "Good", "P");
     leg->AddEntry(bad, "Bad", "P");
     auto binLow = eff->FindFixBin(mMinEta), binUp = eff->FindFixBin(mMaxEta);
     for (int iBin = binLow; iBin <= binUp; ++iBin) {
-      auto x = eff->GetPassedHistogram()->GetBinCenter(iBin);
-      auto y = eff->GetEfficiency(iBin);
-      if (eff->GetEfficiency(iBin) < mThresholdEta) {
+      auto x = eff->GetBinCenter(iBin);
+      auto y = eff->GetBinContent(iBin);
+      if (y < mThresholdEta) {
         bad->SetPoint(cB++, x, y);
       } else {
         good->SetPoint(cG++, x, y);


### PR DESCRIPTION
Hi @rmunzer, @Barthelemy,

as agreed in the email thread I changed TEfficiency to TH1 as it is not properly displayed for the QC shifter. Now it looks like this:

![image](https://github.com/AliceO2Group/QualityControl/assets/42321018/033961b3-6086-4714-88d3-d894d533f9ed)
![image](https://github.com/AliceO2Group/QualityControl/assets/42321018/eb2a479e-81c3-42ee-850d-06184faa0633)
(very low statistics). Now the checks are actually visible in JSROOT.

Note for the changes in the presented test-config, e.g.:
 - The name of the MO object
 - `isSync` flag for the producer, as they are not needed in async.

I changed some IMO minor things in the framework, e.g, adding `const` to one function and adding one utility function for parameter parsing. Let me know if these are unwanted.