### PR TITLE
[EMCAL-657, EMCAL-846] Update EMCAL reductors

### DIFF
--- a/Modules/EMCAL/doxymodules.h
+++ b/Modules/EMCAL/doxymodules.h
@@ -1,0 +1,39 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/**
+ * @defgroup QCEMCAL EMCAL QC
+ * @brief EMCAL QualityControl
+ */
+
+/**
+ * @defgroup EMCALQCTasks EMCAL tasks
+ * @brief EMCAL QC Tasks
+ * @ingroup QCEMCAL
+ */
+
+/**
+ * @defgroup EMCALQCCheckers EMCAL checkers
+ * @brief EMCAL QC checkers
+ * @ingroup QCEMCAL
+ */
+
+/**
+ * @defgroup EMCALQCCPostprocessing EMCAL postprocessing
+ * @brief EMCAL QC post-processing
+ * @ingroup QCEMCAL
+ */
+
+/**
+ * @defgroup EMCALQCCReductors EMCAL reductors
+ * @brief EMCAL QC reductors
+ * @ingroup QCEMCAL
+ */

--- a/Modules/EMCAL/include/EMCAL/BadChannelMapReductor.h
+++ b/Modules/EMCAL/include/EMCAL/BadChannelMapReductor.h
@@ -25,45 +25,72 @@ class Geometry;
 namespace o2::quality_control_modules::emcal
 {
 
+/// \class BadChannelMapReductor
 /// \brief Dedicated reductor for EMCAL bad channel map
+/// \ingroup EMCALQCCReductors
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since November 1st, 2022
 ///
 /// Produces entries:
-/// - Bad/Dead channels for Full acceptance/Subdetector/Supermodule
-/// - Fraction Bad/Dead channels for Full acceptance/Subdetector/Supermodule
+/// - Bad/Dead/Non-good channels for Full acceptance/Subdetector/Supermodule
+/// - Fraction Bad/Dead/Non-good channels for Full acceptance/Subdetector/Supermodule
+/// - Index of the Supermodule with the highest number of Bad/Dead/Non-good channels
 class BadChannelMapReductor : public quality_control::postprocessing::ReductorTObject
 {
  public:
+  /// \brief Constructor
   BadChannelMapReductor();
+  /// \brief Destructor
   virtual ~BadChannelMapReductor() = default;
 
+  /// \brief Get branch address of structure with data
+  /// \return Branch address
   void* getBranchAddress() override;
+
+  /// \brief Get list of variables providede by reductor
+  /// \return List of variables (leaflist)
   const char* getBranchLeafList() override;
+
+  /// \brief Extract information from bad channel histogram and fill observables
+  /// \param obj Input object to get the data from
   void update(TObject* obj) override;
 
  private:
+  /// \brief Check whether a certain position is within the PHOS region
+  /// \param column Column number of the position
+  /// \param row Row number of the position
   bool isPHOSRegion(int column, int row) const;
 
-  o2::emcal::Geometry* mGeometry;
+  o2::emcal::Geometry* mGeometry; ///< EMCAL geometry
   struct {
-    Int_t mBadChannelsTotal;
-    Int_t mDeadChannelsTotal;
-    Int_t mBadChannelsEMCAL;
-    Int_t mBadChannelsDCAL;
-    Int_t mDeadChannelsEMCAL;
-    Int_t mDeadChannelsDCAL;
-    Int_t mBadChannelsSM[20];
-    Int_t mDeadChannelsSM[20];
-    Int_t mSupermoduleMaxBad;
-    Int_t mSupermoduleMaxDead;
-    Double_t mFractionBadTotal;
-    Double_t mFractionDeadTotal;
-    Double_t mFractionBadEMCAL;
-    Double_t mFractionBadDCAL;
-    Double_t mFractionDeadEMCAL;
-    Double_t mFractionDeadDCAL;
-    Double_t mFractionBadSM[20];
-    Double_t mFractionDeadSM[20];
-  } mStats;
+    Int_t mBadChannelsTotal;         ///< Total number of bad channels
+    Int_t mDeadChannelsTotal;        ///< Total number of dead channels
+    Int_t mNonGoodChannelsTotal;     ///< Total number of channels which are dead or bad
+    Int_t mBadChannelsEMCAL;         ///< Number of bad channels in EMCAL
+    Int_t mBadChannelsDCAL;          ///< Number of bad channels in DCAL
+    Int_t mDeadChannelsEMCAL;        ///< Number of dead channels in EMCAL
+    Int_t mDeadChannelsDCAL;         ///< Number of dead channels in DCAL
+    Int_t mNonGoodChannelsEMCAL;     ///< Number of channels which are dead or bad in EMCAL
+    Int_t mNonGoodChannelsDCAL;      ///< Number of channels which are dead or bad in DCAL
+    Int_t mBadChannelsSM[20];        ///< Number of bad channels per Supermodule
+    Int_t mDeadChannelsSM[20];       ///< Number of dead channels per Supermodule
+    Int_t mNonGoodChannelsSM[20];    ///< Number of channels which are dead or bad per Supermodule
+    Int_t mSupermoduleMaxBad;        ///< Index of the supermodule with the highest number of bad channels
+    Int_t mSupermoduleMaxDead;       ///< Index of the supermodule with the highest number of dead channels
+    Int_t mSupermoduleMaxNonGood;    ///< Index of the supermodule with the highest number of channels which are dead or bad
+    Double_t mFractionBadTotal;      ///< Total fraction of bad channels
+    Double_t mFractionDeadTotal;     ///< Total fraction of dead channels
+    Double_t mFractionNonGoodTotal;  ///< Total fraction of channels which are dead or bad
+    Double_t mFractionBadEMCAL;      ///< Fraction of bad channels in EMCAL
+    Double_t mFractionBadDCAL;       ///< Fraction of bad channels in DCAL
+    Double_t mFractionDeadEMCAL;     ///< Fraction of dead channels in EMCAL
+    Double_t mFractionDeadDCAL;      ///< Fraction of dead channels in DCAL
+    Double_t mFractionNonGoodEMCAL;  ///< Fraction of channels in EMCAL which are dead or bad
+    Double_t mFractionNonGoodDCAL;   ///< Fraction of channels in EMCAL which are dead or bad
+    Double_t mFractionBadSM[20];     ///< Fraction of bad channels per Supermodule
+    Double_t mFractionDeadSM[20];    ///< Fraction of dead channels per Supermodule
+    Double_t mFractionNonGoodSM[20]; ///< Fraction of channels which are dead or bad per Supermodule
+  } mStats;                          ///< Trending data point
 };
 
 } // namespace o2::quality_control_modules::emcal

--- a/Modules/EMCAL/include/EMCAL/OccupancyReductor.h
+++ b/Modules/EMCAL/include/EMCAL/OccupancyReductor.h
@@ -18,30 +18,50 @@ namespace o2
 namespace emcal
 {
 class Geometry;
-}
+} // namespace emcal
 } // namespace o2
 
 namespace o2::quality_control_modules::emcal
 {
 
+/// \class OccupancyReductor
 /// \brief Reductor for Occupancy histograms
+/// \ingroup EMCALQCCReductors
+/// \author Cristina Terrevoli
+/// \since November 2nd, 2022
 ///
-/// Extracting number of entries above 0 for each supermodule area.
+/// Extracting number of entries above 0 for each supermodule area. In addition extracting
+/// also mean and rms per supermodule, and mean and rms over all non-0 objects
 class OccupancyReductor : public quality_control::postprocessing::ReductorTObject
 {
  public:
+  /// \brief Constructor
   OccupancyReductor();
+
+  /// \brief Destructor
   virtual ~OccupancyReductor() = default;
 
+  /// \brief Get branch address of structure with data
+  /// \return Branch address
   void* getBranchAddress() override;
+
+  /// \brief Get list of variables providede by reductor
+  /// \return List of variables (leaflist)
   const char* getBranchLeafList() override;
+
+  /// \brief Calculate observables per SM and update tree
+  /// \param obj Input object to get the data from
   void update(TObject* obj) override;
 
  private:
-  o2::emcal::Geometry* mGeometry;
+  o2::emcal::Geometry* mGeometry; ///< EMCAL Geometry
   struct {
-    Double_t mCountTotal;
-    Double_t mCountSM[20];
+    Double_t mCountTotal;    ///< Total counts
+    Double_t mAverage;       ///< Average value
+    Double_t mRMS;           ///< RMS value
+    Double_t mCountSM[20];   ///< Counts per SM
+    Double_t mAverageSM[20]; ///< Average value per SM
+    Double_t mRMSSM[20];     ///< RMS value per SM
   } mStats;
 };
 

--- a/Modules/EMCAL/include/EMCAL/TimeCalibParamReductor.h
+++ b/Modules/EMCAL/include/EMCAL/TimeCalibParamReductor.h
@@ -25,7 +25,11 @@ class Geometry;
 namespace o2::quality_control_modules::emcal
 {
 
+/// \class TimeCalibParamReductor
 /// \brief Dedicated reductor for EMCAL time calibration param
+/// \ingroup EMCALQCCReductors
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since November 1st, 2022
 ///
 /// Produces entries:
 /// - Channels with failed fit for Full acceptance/Subdetector/Supermodule
@@ -35,30 +39,44 @@ namespace o2::quality_control_modules::emcal
 class TimeCalibParamReductor : public quality_control::postprocessing::ReductorTObject
 {
  public:
+  /// \brief Constructor
   TimeCalibParamReductor();
+
+  /// \brief Destructor
   virtual ~TimeCalibParamReductor() = default;
 
+  /// \brief Get branch address of structure with data
+  /// \return Branch address
   void* getBranchAddress() override;
+
+  /// \brief Get list of variables providede by reductor
+  /// \return List of variables (leaflist)
   const char* getBranchLeafList() override;
+
+  /// \brief Extract information from time calibration histogram and fill observables
+  /// \param obj Input object to get the data from
   void update(TObject* obj) override;
 
  private:
+  /// \brief Check whether a certain position is within the PHOS region
+  /// \param column Column number of the position
+  /// \param row Row number of the position
   bool isPHOSRegion(int column, int row) const;
 
-  o2::emcal::Geometry* mGeometry;
+  o2::emcal::Geometry* mGeometry; ///< EMCAL geometry
   struct {
-    Int_t mFailedParams;
-    Int_t mFailedParamsEMCAL;
-    Int_t mFailedParamsDCAL;
-    Int_t mFailedParamSM[20];
-    Int_t mSupermoduleMaxFailed;
-    Double_t mFractionFailed;
-    Double_t mFractionFailedEMCAL;
-    Double_t mFractionFailedDCAL;
-    Double_t mFractionFailedSM[20];
-    Double_t mMeanShiftGood;
-    Double_t mSigmaShiftGood;
-  } mStats;
+    Int_t mFailedParams;            ///< Total number of failed time calibration params
+    Int_t mFailedParamsEMCAL;       ///< Number of failed time calibration params in EMCAL
+    Int_t mFailedParamsDCAL;        ///< Number of failed time calibration params in DCAL
+    Int_t mFailedParamSM[20];       ///< Number of failed time calibration params per supermodule
+    Int_t mSupermoduleMaxFailed;    ///< Index of the supermodule with the largest amount of failed time calibration params
+    Double_t mFractionFailed;       ///< Total fraction of failed time calibration params
+    Double_t mFractionFailedEMCAL;  ///< Fraction of failed time calibration params in EMCAL
+    Double_t mFractionFailedDCAL;   ///< Fraction of failed time calibration params in DCAL
+    Double_t mFractionFailedSM[20]; ///< Fraction of failed time calibration params per supermodule
+    Double_t mMeanShiftGood;        ///< Mean time caliration param of good cells
+    Double_t mSigmaShiftGood;       ///< Sigma of the time calibration params of good cells
+  } mStats;                         ///< Trending data point
 };
 
 } // namespace o2::quality_control_modules::emcal

--- a/Modules/EMCAL/src/OccupancyReductor.cxx
+++ b/Modules/EMCAL/src/OccupancyReductor.cxx
@@ -9,9 +9,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <array>
+#include "TH2.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCAL/OccupancyReductor.h"
-#include "TH2.h"
+#include "MathUtils/Utils.h"
 
 using namespace o2::quality_control_modules::emcal;
 
@@ -27,22 +29,36 @@ void* OccupancyReductor::getBranchAddress()
 
 const char* OccupancyReductor::getBranchLeafList()
 {
-  return "totalCounts/D:smCounts[20]";
+  return "totalCounts/D:average:RMS:smCounts[20]:averageSM[20]:RMSSM[20]";
 }
 
 void OccupancyReductor::update(TObject* obj)
 {
   memset(mStats.mCountSM, 0, sizeof(double) * 20);
+  memset(mStats.mAverageSM, 0, sizeof(double) * 20);
+  memset(mStats.mRMSSM, 0, sizeof(double) * 20);
+  std::array<o2::math_utils::StatAccumulator, 20> statAccumulatorsSM;
   TH2* digitOccupancyHistogram = static_cast<TH2*>(obj);
+  o2::math_utils::StatAccumulator statAccumulatorTotal;
   mStats.mCountTotal = digitOccupancyHistogram->GetEntries();
   for (int icol = 0; icol < digitOccupancyHistogram->GetXaxis()->GetNbins(); icol++) {
     for (int irow = 0; irow < digitOccupancyHistogram->GetYaxis()->GetNbins(); irow++) {
       double count = digitOccupancyHistogram->GetBinContent(icol + 1, irow + 1);
       if (count) {
-        auto cellindex = mGeometry->GetCellIndexFromGlobalRowCol(irow, icol); // To implement:Cell abs ID from glob row / col
+        statAccumulatorTotal.add(count);
+        auto cellindex = mGeometry->GetCellIndexFromGlobalRowCol(irow, icol);
         auto smod = std::get<0>(cellindex);
         mStats.mCountSM[smod] += count;
+        statAccumulatorsSM[smod].add(count);
       }
     }
+  }
+  auto [mean, rms] = statAccumulatorTotal.getMeanRMS2<double>();
+  mStats.mAverage = mean;
+  mStats.mRMS = rms;
+  for (int ism = 0; ism < 20; ism++) {
+    auto [meanSM, rmsSM] = statAccumulatorsSM[ism].getMeanRMS2<double>();
+    mStats.mAverageSM[ism] = meanSM;
+    mStats.mRMSSM[ism] = rmsSM;
   }
 }


### PR DESCRIPTION
- Occupancy reductor exports also mean and RMS
  per supermodule
- Bad channel reductor exports also the observables of
  non-good channels (bad+dead)
- Added documentation in all 3 reductors
- Add basic doxygen module structure for EMCAL