### PR TITLE
since too long data description is now safe, no need to warn

### DIFF
--- a/Framework/src/HashDataDescription.cxx
+++ b/Framework/src/HashDataDescription.cxx
@@ -56,7 +56,7 @@ auto createDataDescription(const std::string& name, size_t hashLength) -> o2::he
     return description;
   } else {
     const auto descriptionWithHash = createDescriptionWithHash(name, hashLength);
-    ILOG(Warning, Devel) << "Too long data description name [" << name << "] changed to [" << descriptionWithHash << "]" << ENDM;
+    ILOG(Debug, Devel) << "Too long data description name [" << name << "] changed to [" << descriptionWithHash << "]" << ENDM;
     description.runtimeInit(descriptionWithHash.c_str());
     return description;
   }


### PR DESCRIPTION
I think it's enough to have a debug log now, the warnings generate quite a lot of noise at the moment, while "too long" description is now safe to have.