### PR TITLE
Fix attempt for sporadic TrendingTask test failure on mac

### DIFF
--- a/Framework/test/testTrendingTask.cxx
+++ b/Framework/test/testTrendingTask.cxx
@@ -210,6 +210,7 @@ TEST_CASE("test_trending_task")
   auto histo2 = dynamic_cast<TCanvas*>(histo2MO->getObject());
   REQUIRE(histo2 != nullptr);
   CHECK(std::strcmp(histo2->GetName(), "quality_histogram") == 0);
+  objectManager->stopPublishing(PublicationPolicy::Once);
 
   // test finalize()
   REQUIRE_NOTHROW(task.finalize({ TriggerType::UserOrControl, true }, services));


### PR DESCRIPTION
Just guessing that it could have been a problem, looking at the stacktrace:
```
o2::quality_control::core::ObjectsManager::startPublishing(TObject*, o2::quality_control::core::PublicationPolicy) /Users/aldaqci/alice-jenkins-master/sw/SOURCES/QualityControl/master/0/Framework/src/ObjectsManager.cxx:69
2024-05-29@09:18:29:DEBUG:O2Suite:QualityControl:0: [/Users/aldaqci/alice-jenkins-master/sw/BUILD/af86d61d45abb76e1bc8477739f4e2d598a1ee60/QualityControl/lib/libO2QualityControl.dylib] o2::quality_control::postprocessing::TrendingTask::generatePlots() /Users/aldaqci/alice-jenkins-master/sw/SOURCES/QualityControl/master/0/Framework/src/TrendingTask.cxx:301
2024-05-29@09:18:29:DEBUG:O2Suite:QualityControl:0: [/Users/aldaqci/alice-jenkins-master/sw/BUILD/af86d61d45abb76e1bc8477739f4e2d598a1ee60/QualityControl/lib/libO2QualityControl.dylib] o2::quality_control::postprocessing::TrendingTask::finalize(o2::quality_control::
```
When a task is ran with PostProcessingRunner, the added line is always executed and removes objects which should have been published just once. This being said, the framework should survive replacing the objects, but maybe ROOT does something behind the scenes which breaks that.