### PR TITLE
MUON: use log binning for tracks-per-TF histogram x-axis

### DIFF
--- a/Modules/MUON/Common/include/MUONCommon/TrackPlotter.h
+++ b/Modules/MUON/Common/include/MUONCommon/TrackPlotter.h
@@ -80,6 +80,13 @@ class TrackPlotter : public HistPlotter
                                  const char* displayHints = "");
   template <typename T>
   std::unique_ptr<T> createHisto(const char* name, const char* title,
+                                 int nbins, double* xbins,
+                                 bool optional,
+                                 bool statBox = false,
+                                 const char* drawOptions = "",
+                                 const char* displayHints = "");
+  template <typename T>
+  std::unique_ptr<T> createHisto(const char* name, const char* title,
                                  int nbins, double xmin, double xmax,
                                  int nbinsy, double ymin, double ymax,
                                  bool optional,
@@ -158,6 +165,26 @@ std::unique_ptr<T> TrackPlotter::createHisto(const char* name, const char* title
   }
   std::string fullTitle = std::string("[") + GID::getSourceName(mSrc) + "] " + title;
   auto h = std::make_unique<T>(name, fullTitle.c_str(), nbins, xmin, xmax);
+  if (!statBox) {
+    h->SetStats(0);
+  }
+  histograms().emplace_back(HistInfo{ h.get(), drawOptions, displayHints });
+  return h;
+}
+
+template <typename T>
+std::unique_ptr<T> TrackPlotter::createHisto(const char* name, const char* title,
+                                             int nbins, double* xbins,
+                                             bool optional,
+                                             bool statBox,
+                                             const char* drawOptions,
+                                             const char* displayHints)
+{
+  if (optional && !mFullHistos) {
+    return nullptr;
+  }
+  std::string fullTitle = std::string("[") + GID::getSourceName(mSrc) + "] " + title;
+  auto h = std::make_unique<T>(name, fullTitle.c_str(), nbins, xbins);
   if (!statBox) {
     h->SetStats(0);
   }

--- a/Modules/MUON/Common/src/TrackPlotter.cxx
+++ b/Modules/MUON/Common/src/TrackPlotter.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "MUONCommon/TrackPlotter.h"
+#include "MUONCommon/Helpers.h"
 
 #include "DetectorsBase/GRPGeomHelper.h"
 #include <DataFormatsITSMFT/ROFRecord.h>
@@ -137,9 +138,11 @@ std::unique_ptr<TH2DRatio> TrackPlotter::createHisto(const char* name, const cha
 
 void TrackPlotter::createTrackHistos(int maxTracksPerTF, int etaBins, int phiBins, int ptBins)
 {
-  mNofTracksPerTF[0] = createHisto<TH1D>(TString::Format("%sPositive/TracksPerTF", mPath.c_str()), "Number of tracks per TimeFrame (+);Number of tracks per TF", maxTracksPerTF, 0, maxTracksPerTF, true, true, "logy");
-  mNofTracksPerTF[1] = createHisto<TH1D>(TString::Format("%sNegative/TracksPerTF", mPath.c_str()), "Number of tracks per TimeFrame (-);Number of tracks per TF", maxTracksPerTF, 0, maxTracksPerTF, true, true, "logy");
-  mNofTracksPerTF[2] = createHisto<TH1D>(TString::Format("%sTracksPerTF", mPath.c_str()), "Number of tracks per TimeFrame;Number of tracks per TF", maxTracksPerTF, 0, maxTracksPerTF, false, true, "logy");
+  int nbins = 100;
+  auto xLogBins = makeLogBinning(1, maxTracksPerTF, nbins);
+  mNofTracksPerTF[0] = createHisto<TH1D>(TString::Format("%sPositive/TracksPerTF", mPath.c_str()), "Number of tracks per TimeFrame (+);Number of tracks per TF", nbins, xLogBins.data(), true, false, "logx");
+  mNofTracksPerTF[1] = createHisto<TH1D>(TString::Format("%sNegative/TracksPerTF", mPath.c_str()), "Number of tracks per TimeFrame (-);Number of tracks per TF", nbins, xLogBins.data(), true, false, "logx");
+  mNofTracksPerTF[2] = createHisto<TH1D>(TString::Format("%sTracksPerTF", mPath.c_str()), "Number of tracks per TimeFrame;Number of tracks per TF", nbins, xLogBins.data(), false, false, "logx");
 
   mTrackChi2OverNDF[0] = createHisto<TH1DRatio>(TString::Format("%sPositive/TrackMCHChi2OverNDF", mPath.c_str()), "Track #chi^{2}/ndf (MCH +);#chi^{2}/ndf;entries/s", 500, 0, 50, true, false, "hist");
   mTrackChi2OverNDF[1] = createHisto<TH1DRatio>(TString::Format("%sNegative/TrackMCHChi2OverNDF", mPath.c_str()), "Track #chi^{2}/ndf (MCH -);#chi^{2}/ndf;entries/s", 500, 0, 50, true, false, "hist");


### PR DESCRIPTION
The log binning allows to draw the histogram with the x-axis set to log scale while keeping the bin width constant in log representation.