### PR TITLE
Common: properly handle Sumw2 in THxRatio classes

### DIFF
--- a/Modules/Common/include/Common/TH1Ratio.h
+++ b/Modules/Common/include/Common/TH1Ratio.h
@@ -70,11 +70,13 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
   Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1, Double_t c2 = 1) override;
   Bool_t Add(const TH1* h1, Double_t c1 = 1) override;
   void SetBins(Int_t nx, Double_t xmin, Double_t xmax) override;
+  void Sumw2(Bool_t flag = kTRUE) override;
 
  private:
   T* mHistoNum{ nullptr };
   T* mHistoDen{ nullptr };
   bool mUniformScaling{ true };
+  Bool_t mSumw2Enabled{ kFALSE };
   std::string mTreatMeAs{ T::Class_Name() };
 
   ClassDefOverride(TH1Ratio, 1);

--- a/Modules/Common/include/Common/TH1Ratio.h
+++ b/Modules/Common/include/Common/TH1Ratio.h
@@ -76,7 +76,7 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
   T* mHistoNum{ nullptr };
   T* mHistoDen{ nullptr };
   bool mUniformScaling{ true };
-  Bool_t mSumw2Enabled{ kFALSE };
+  Bool_t mSumw2Enabled{ kTRUE };
   std::string mTreatMeAs{ T::Class_Name() };
 
   ClassDefOverride(TH1Ratio, 1);

--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -123,12 +123,7 @@ TH1Ratio<T>::~TH1Ratio()
 template<class T>
 void TH1Ratio<T>::init()
 {
-  if (!mHistoNum || !mHistoDen) {
-    return;
-  }
-  mHistoNum->Sumw2();
-  mHistoDen->Sumw2();
-  T::Sumw2();
+  Sumw2(kTRUE);
 }
 
 template<class T>
@@ -159,7 +154,12 @@ void TH1Ratio<T>::update()
   if (mUniformScaling) {
     double entries = mHistoDen->GetBinContent(1);
     double norm = (entries > 0) ? 1.0 / entries : 0;
-    T::Scale(norm);
+    // make sure the sum-of-weights structure is not initialized if not required
+    if (mSumw2Enabled == kTRUE) {
+      T::Scale(norm);
+    } else {
+      T::Scale(norm, "nosw2");
+    }
   } else {
     if (T::GetXaxis()->GetLabels())  {
       // copy bin labels to denominator before dividing, otherwise we get a warning
@@ -277,6 +277,19 @@ void TH1Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax)
   getNum()->SetBins(nx, xmin, xmax);
   getDen()->SetBins(nx, xmin, xmax);
   T::SetBins(nx, xmin, xmax);
+}
+
+template<class T>
+void TH1Ratio<T>::Sumw2(Bool_t flag)
+{
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
+  mSumw2Enabled = flag;
+  mHistoNum->Sumw2(flag);
+  mHistoDen->Sumw2(flag);
+  T::Sumw2(flag);
 }
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/TH2Ratio.h
+++ b/Modules/Common/include/Common/TH2Ratio.h
@@ -76,7 +76,7 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
   T* mHistoNum{ nullptr };
   T* mHistoDen{ nullptr };
   bool mUniformScaling{ true };
-  Bool_t mSumw2Enabled{ kFALSE };
+  Bool_t mSumw2Enabled{ kTRUE };
   std::string mTreatMeAs{ T::Class_Name() };
 
   ClassDefOverride(TH2Ratio, 1);

--- a/Modules/Common/include/Common/TH2Ratio.h
+++ b/Modules/Common/include/Common/TH2Ratio.h
@@ -70,11 +70,13 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
   Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1, Double_t c2 = 1) override;
   Bool_t Add(const TH1* h1, Double_t c1 = 1) override;
   void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax) override;
+  void Sumw2(Bool_t flag = kTRUE) override;
 
  private:
   T* mHistoNum{ nullptr };
   T* mHistoDen{ nullptr };
   bool mUniformScaling{ true };
+  Bool_t mSumw2Enabled{ kFALSE };
   std::string mTreatMeAs{ T::Class_Name() };
 
   ClassDefOverride(TH2Ratio, 1);

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -123,12 +123,7 @@ TH2Ratio<T>::~TH2Ratio()
 template<class T>
 void TH2Ratio<T>::init()
 {
-  if (!mHistoNum || !mHistoDen) {
-    return;
-  }
-  mHistoNum->Sumw2();
-  mHistoDen->Sumw2();
-  T::Sumw2();
+  Sumw2(kTRUE);
 }
 
 template<class T>
@@ -160,7 +155,12 @@ void TH2Ratio<T>::update()
   if (mUniformScaling) {
     double entries = mHistoDen->GetBinContent(1, 1);
     double norm = (entries > 0) ? 1.0 / entries : 0;
-    T::Scale(norm);
+    // make sure the sum-of-weights structure is not initialized if not required
+    if (mSumw2Enabled == kTRUE) {
+      T::Scale(norm);
+    } else {
+      T::Scale(norm, "nosw2");
+    }
   } else {
     // copy bin labels to denominator before dividing, otherwise we get a warning
     if (T::GetXaxis()->GetLabels())  {
@@ -284,6 +284,19 @@ void TH2Ratio<T>::SetBins(Int_t nx, Double_t xmin, Double_t xmax,
   getNum()->SetBins(nx, xmin, xmax, ny, ymin, ymax);
   getDen()->SetBins(nx, xmin, xmax, ny, ymin, ymax);
   T::SetBins(nx, xmin, xmax, ny, ymin, ymax);
+}
+
+template<class T>
+void TH2Ratio<T>::Sumw2(Bool_t flag)
+{
+  if (!mHistoNum || !mHistoDen) {
+    return;
+  }
+
+  mSumw2Enabled = flag;
+  mHistoNum->Sumw2(flag);
+  mHistoDen->Sumw2(flag);
+  T::Sumw2(flag);
 }
 
 } // namespace o2::quality_control_modules::common


### PR DESCRIPTION
In the original implementation the creation of the sum-of-weights structure was forcibly enabled in the `init()` function, for both the ratio histogram and the internal numerato/denominator ones, without the possibility to disable it.
This doubles the size of the produced objects, because of the extra memory needed to store the sum-of-weights structures.

The new implementation allows to disable the sum-of-weights on a per-histogram basis, by calling `Sumw2(kFALSE)` immediately after the instantiation of the histogram ratio. This applies to both the ratio histogram and the internal numerator/denominator ones.

The sum-of-weights is still enabled by default in the `init()` function of the histogram ratio, to match the previous behavior and guarantee that errors are correctly computed and propagated at each step.

The relevant changes are the following:
- added a `Bool_t mSumw2Enabled` member variable to keep track of wether or not the sum-of-weights structure should be updated in the histogram computations
- overridden the `void Sumw2(Bool_t flag)` virtual function to propagate the flag to the internal numerator/denominator histograms
- modified the `update()` function to call `T::Scale(norm, "nosw2")` when the sum-of-weights structure is not enabled (otherwise the `Scale()` function automatically creates the structure regardless of the user settings, see [here](https://root.cern.ch/doc/master/classTH1.html#add929909dcb3745f6a52e9ae0860bfbd))