### PR TITLE
MCH: disabled sum-of-weights for histogram ratios

### DIFF
--- a/Modules/MUON/MCH/src/DecodingTask.cxx
+++ b/Modules/MUON/MCH/src/DecodingTask.cxx
@@ -76,13 +76,16 @@ void DecodingTask::createHeartBeatHistos()
 
   // Heart-beat packets time distribution and synchronization errors
   mHistogramHBTimeFEC = std::make_unique<TH2FRatio>("HBTime_Elec", "HB time vs. FEC ID", nElecXbins, 0, nElecXbins, 40, mHBExpectedBc - 20, mHBExpectedBc + 20);
+  mHistogramHBTimeFEC->Sumw2(kFALSE);
   publishObject(mHistogramHBTimeFEC.get(), "colz", "logz", false, false);
 
   uint64_t max = ((static_cast<uint64_t>(0x100000) / 100) + 1) * 100;
   mHistogramHBCoarseTimeFEC = std::make_unique<TH2FRatio>("HBCoarseTime_Elec", "HB time vs. FEC ID (coarse)", nElecXbins, 0, nElecXbins, 100, 0, max);
+  mHistogramHBCoarseTimeFEC->Sumw2(kFALSE);
   publishObject(mHistogramHBCoarseTimeFEC.get(), "colz", "", false, false);
 
   mSyncStatusFEC = std::make_unique<TH2FRatio>("SyncStatus_Elec", "Heart-beat status vs. FEC ID", nElecXbins, 0, nElecXbins, 3, 0, 3);
+  mSyncStatusFEC->Sumw2(kFALSE);
   mSyncStatusFEC->GetYaxis()->SetBinLabel(1, "OK");
   mSyncStatusFEC->GetYaxis()->SetBinLabel(2, "Out-of-sync");
   mSyncStatusFEC->GetYaxis()->SetBinLabel(3, "Missing");

--- a/Modules/MUON/MCH/src/DigitsTask.cxx
+++ b/Modules/MUON/MCH/src/DigitsTask.cxx
@@ -65,15 +65,17 @@ void DigitsTask::initialize(o2::framework::InitContext& /*ctx*/)
   // flag to enable extra disagnostics plots; it also enables on-cycle plots
   mFullHistos = getConfigurationParameter<bool>(mCustomParameters, "FullHistos", mFullHistos);
 
-  const uint32_t nElecXbins = NumberOfDualSampas;
-
   resetOrbits();
+
+  const uint32_t nElecXbins = NumberOfDualSampas;
 
   // Histograms in electronics coordinates
   mHistogramOccupancyElec = std::make_unique<TH2FRatio>("Occupancy_Elec", "Occupancy", nElecXbins, 0, nElecXbins, 64, 0, 64, true);
+  mHistogramOccupancyElec->Sumw2(kFALSE);
   publishObject(mHistogramOccupancyElec.get(), "colz", false, false);
 
   mHistogramSignalOccupancyElec = std::make_unique<TH2FRatio>("OccupancySignal_Elec", "Occupancy (signal)", nElecXbins, 0, nElecXbins, 64, 0, 64, true);
+  mHistogramSignalOccupancyElec->Sumw2(kFALSE);
   publishObject(mHistogramSignalOccupancyElec.get(), "colz", false, false);
 
   mHistogramDigitsOrbitElec = std::make_unique<TH2F>("DigitOrbit_Elec", "Digit orbits vs DS Id", nElecXbins, 0, nElecXbins, 130, -1, 129);

--- a/Modules/MUON/MCH/src/PreclustersTask.cxx
+++ b/Modules/MUON/MCH/src/PreclustersTask.cxx
@@ -65,6 +65,7 @@ void PreclustersTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   // Histograms in electronics coordinates
   mHistogramPseudoeffElec = std::make_unique<TH2FRatio>("Pseudoeff_Elec", "Pseudoeff", nElecXbins, 0, nElecXbins, 64, 0, 64);
+  mHistogramPseudoeffElec->Sumw2(kFALSE);
   publishObject(mHistogramPseudoeffElec.get(), "colz", false);
 
   //----------------------------------


### PR DESCRIPTION
The histogram ratio plots do not require accurate errors, disabling the sum-of-weights allows to reduce by a factor of two the size of the objects stored in the QCDB.

For proper size reduction it requires https://github.com/AliceO2Group/QualityControl/pull/2322