### PR TITLE
added missing output to aggregator generator

### DIFF
--- a/Framework/src/AggregatorRunnerFactory.cxx
+++ b/Framework/src/AggregatorRunnerFactory.cxx
@@ -43,7 +43,7 @@ DataProcessorSpec AggregatorRunnerFactory::create(const core::CommonSpec& common
   DataProcessorSpec newAggregatorRunner{
     aggregatorRunner.getDeviceName(),
     aggregatorRunner.getInputs(),
-    Outputs{},
+    aggregatorRunner.getOutputs(),
     AlgorithmSpec{},
     aggRunnerConfig.options
   };

--- a/Framework/test/testInfrastructureGenerator.cxx
+++ b/Framework/test/testInfrastructureGenerator.cxx
@@ -205,7 +205,7 @@ TEST_CASE("qc_factory_remote_test")
     [](const DataProcessorSpec& d) {
       return d.name == "qc-aggregator" &&
              d.inputs.size() == 4 &&
-             d.outputs.size() == 0;
+             d.outputs.size() == 4;
     });
   CHECK(aggregator != workflow.end());
 }
@@ -278,7 +278,7 @@ TEST_CASE("qc_factory_standalone_test")
     [](const DataProcessorSpec& d) {
       return d.name == "qc-aggregator" &&
              d.inputs.size() == 4 &&
-             d.outputs.size() == 0;
+             d.outputs.size() == 4;
     });
   CHECK(aggregator != workflow.end());
 }
@@ -408,7 +408,7 @@ TEST_CASE("qc_infrastructure_remote_batch_test")
     [](const DataProcessorSpec& d) {
       return d.name == "qc-aggregator" &&
              d.inputs.size() == 4 &&
-             d.outputs.size() == 0;
+             d.outputs.size() == 4;
     });
   CHECK(aggregator != workflow.end());
 }


### PR DESCRIPTION
Issue QC-1193 was missing assigning outputs to Aggregators. This small PR is meant to fix that.

However there is one more issue. When @knopers8 was merging mentioned PR all tests were green, but when I run `o2-qc-run-producer | o2-qc --config json://.....basic-aggregator.json` it showed missing outputs for Aggregator (actor does not have privilege to write to XXX). This means that there is missing test that simply runs the workflow created by generator (eg. similar to one described `basic-aggregator.json`)