### PR TITLE
QC-1155 Allow for multiple graphs in one canvas in TrendingTask

### DIFF
--- a/Framework/include/QualityControl/TrendingTask.h
+++ b/Framework/include/QualityControl/TrendingTask.h
@@ -64,7 +64,7 @@ class TrendingTask : public PostProcessingInterface
     }
   } mMetaData;
 
-  static void setUserAxisLabel(TAxis* xAxis, TAxis* yAxis, const std::string& graphAxisLabel);
+  static void setUserAxesLabels(TAxis* xAxis, TAxis* yAxis, const std::string& graphAxesLabels);
   static void setUserYAxisRange(TH1* hist, const std::string& graphYAxisRange);
   static void formatTimeXAxis(TH1* background);
   static void formatRunNumberXAxis(TH1* background);

--- a/Framework/include/QualityControl/TrendingTask.h
+++ b/Framework/include/QualityControl/TrendingTask.h
@@ -26,6 +26,7 @@
 #include <TTree.h>
 
 class TAxis;
+class TCanvas;
 
 namespace o2::quality_control::repository
 {
@@ -54,9 +55,6 @@ class TrendingTask : public PostProcessingInterface
   void update(Trigger, framework::ServiceRegistryRef) override;
   void finalize(Trigger, framework::ServiceRegistryRef) override;
 
-  static void setUserAxisLabel(TAxis* xAxis, TAxis* yAxis, const std::string& graphAxisLabel);
-  static void setUserYAxisRange(TH1* hist, const std::string& graphYAxisRange);
-
  private:
   struct {
     Long64_t runNumber = 0;
@@ -66,8 +64,15 @@ class TrendingTask : public PostProcessingInterface
     }
   } mMetaData;
 
+  static void setUserAxisLabel(TAxis* xAxis, TAxis* yAxis, const std::string& graphAxisLabel);
+  static void setUserYAxisRange(TH1* hist, const std::string& graphYAxisRange);
+  static void formatTimeXAxis(TH1* background);
+  static void formatRunNumberXAxis(TH1* background);
+  static std::string deduceGraphLegendOptions(const TrendingTaskConfig::Graph& graphConfig);
+
   void trendValues(const Trigger& t, repository::DatabaseInterface&);
   void generatePlots();
+  TCanvas* drawPlot(const TrendingTaskConfig::Plot& plotConfig);
   bool canContinueTrend(TTree* tree);
 
   TrendingTaskConfig mConfig;

--- a/Framework/include/QualityControl/TrendingTaskConfig.h
+++ b/Framework/include/QualityControl/TrendingTaskConfig.h
@@ -31,15 +31,23 @@ struct TrendingTaskConfig : PostProcessingConfig {
   TrendingTaskConfig(std::string name, const boost::property_tree::ptree& config);
   ~TrendingTaskConfig() = default;
 
-  struct Plot {
-    std::string name;
+  // this corresponds to one TTree::Draw() call, i.e. one graph or histogram drawing
+  struct Graph {
     std::string title;
     std::string varexp;
     std::string selection;
-    std::string option;
-    std::string graphErrors;
+    std::string option; // the list of possible options are documented in TGraphPainter and THistPainter
+    std::string errors;
+  };
+
+  // this corresponds to one canvas which can include multiple graphs
+  struct Plot {
+    std::string name;
+    std::string title;
     std::string graphAxisLabel;
     std::string graphYRange;
+    int colorPalette = 0;
+    std::vector<Graph> graphs;
   };
 
   struct DataSource {

--- a/Framework/postprocessing.json
+++ b/Framework/postprocessing.json
@@ -81,39 +81,59 @@
           {
             "name": "mean_of_histogram",
             "title": "Mean trend of the example histogram",
-            "varexp": "example.mean:time",
-            "selection": "",
-            "option": "*L",
-            "graphAxisLabel": "Mean X:time"
+            "graphAxisLabel": "Mean X:time",
+            "graphYRange": "0:10000",
+            "graphs" : [
+              {
+                "title": "mean trend",
+                "varexp": "example.mean:time",
+                "selection": "",
+                "option": "*L PLC PMC"
+              }, {
+                "title": "mean trend + 1000",
+                "varexp": "example.mean + 1000:time",
+                "selection": "",
+                "option": "* PMC",
+                "graphErrors": "1:200"
+              }
+            ]
           },
           {
             "name": "histogram_of_means",
             "title": "Distribution of mean values in the example histogram",
-            "varexp": "example.mean",
-            "selection": "",
-            "option": ""
+            "graphs" : [{
+                "varexp": "example.mean",
+                "selection": "",
+                "option": ""
+              }]
           },
           {
             "name": "correlation_mean_stddev",
             "title": "Correlation between the mean and stddev of the example histogram",
-            "varexp": "example.mean:example.stddev",
-            "selection": "",
-            "option": "*"
+            "graphs" : [{
+              "varexp": "example.mean:example.stddev",
+              "selection": "",
+              "option": "*"
+            }]
           },
           {
             "name": "correlation_stddev_entries",
             "title": "Correlation between the stddev and entries of the example histogram",
-            "varexp": "example.stddev:example.entries",
-            "selection": "",
-            "option": "*",
-            "graphAxisLabel": "stddev:entries"
+            "graphAxisLabel": "stddev:entries",
+            "graphs" : [{
+              "varexp": "example.stddev:example.entries",
+              "selection": "",
+              "option": "*"
+            }]
           },
           {
             "name": "example_quality",
             "title": "Trend of the example histogram's quality",
-            "varexp": "QcCheck.name:time",
-            "selection": "",
-            "option": "*"
+            "graphs" : [{
+              "varexp": "QcCheck.name:time",
+              "selection": "",
+              "option": "*"
+            }]
           }
         ],
         "initTrigger": [

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -169,16 +169,16 @@ void TrendingTask::trendValues(const Trigger& t, repository::DatabaseInterface& 
   mTrend->Fill();
 }
 
-void TrendingTask::setUserAxisLabel(TAxis* xAxis, TAxis* yAxis, const std::string& graphAxisLabel)
+void TrendingTask::setUserAxesLabels(TAxis* xAxis, TAxis* yAxis, const std::string& graphAxesLabels)
 {
   // todo if we keep adding this method to pp classes we should move it up somewhere
-  if (std::count(graphAxisLabel.begin(), graphAxisLabel.end(), ':') != 1 && graphAxisLabel != "") {
-    ILOG(Error, Support) << "In setup of graphAxisLabel yLabel:xLabel should be divided by one ':'" << ENDM;
+  if (std::count(graphAxesLabels.begin(), graphAxesLabels.end(), ':') != 1 && graphAxesLabels != "") {
+    ILOG(Error, Support) << "In setup of graphAxesLabels yLabel:xLabel should be divided by one ':'" << ENDM;
     return;
   }
-  const std::size_t posDivider = graphAxisLabel.find(':');
-  const std::string yLabel(graphAxisLabel.substr(0, posDivider));
-  const std::string xLabel(graphAxisLabel.substr(posDivider + 1));
+  const std::size_t posDivider = graphAxesLabels.find(':');
+  const std::string yLabel(graphAxesLabels.substr(0, posDivider));
+  const std::string xLabel(graphAxesLabels.substr(posDivider + 1));
 
   xAxis->SetTitle(xLabel.data());
   yAxis->SetTitle(yLabel.data());
@@ -368,7 +368,7 @@ TCanvas* TrendingTask::drawPlot(const TrendingTaskConfig::Plot& plotConfig)
     }
 
     if (!plotConfig.graphAxisLabel.empty()) {
-      setUserAxisLabel(background->GetXaxis(), background->GetYaxis(), plotConfig.graphAxisLabel);
+      setUserAxesLabels(background->GetXaxis(), background->GetYaxis(), plotConfig.graphAxisLabel);
     }
 
     if (plotConfig.graphs.back().varexp.find(":time") != std::string::npos) {

--- a/Framework/test/testTrendingTask.cxx
+++ b/Framework/test/testTrendingTask.cxx
@@ -102,9 +102,11 @@ TEST_CASE("test_trending_task")
           {
             "name": "mean_of_histogram",
             "title": "Mean trend of the testHistoTrending histogram",
-            "varexp": "testHistoTrending.mean:time",
-            "selection": "",
-            "option": "*L"
+            "graphs": [{
+              "varexp": "testHistoTrending.mean:time",
+              "selection": "",
+              "option": "*L"
+            }]
           },
           {
             "name": "quality_histogram",

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -242,7 +242,8 @@ Additionally added columns include a `time` branch and a `metadata` branch (now 
 
 The TTree is stored back to the **QC database** each time it is updated.
 In addition, the class exposes the [`TTree::Draw`](https://root.cern/doc/master/classTTree.html#a73450649dc6e54b5b94516c468523e45) interface, which allows to instantaneously generate **plots** with trends, correlations or histograms that are also sent to the QC database. 
- 
+Multiple graphs can be drawn on one plot, if needed.
+
 ![TrendingTask](images/trending-task.png)
 
 #### Configuration
@@ -311,7 +312,9 @@ The `"names"` array should point to one or more objects under a common `"path"` 
 ```
 
 Similarly, plots are defined by adding proper structures to the `"plots"` list, as shown below. The plot will be
- stored under the `"name"` value and it will have the `"title"` value shown on the top. The `"varexp"`, `"selection"` and `"option"` fields correspond to the arguments of the [`TTree::Draw`](https://root.cern/doc/master/classTTree.html#a73450649dc6e54b5b94516c468523e45) method.
+ stored under the `"name"` value and it will have the `"title"` value shown on the top.
+The `"graphs"` list can include one more objects, where the `"varexp"`, `"selection"` and `"option"` fields correspond to the arguments of the [`TTree::Draw`](https://root.cern/doc/master/classTTree.html#a73450649dc6e54b5b94516c468523e45) method.
+If there is more than one graph drawn on a plot, a legend will be automatically created.
 Optionally, one can use `"graphError"` to add x and y error bars to a graph, as in the first plot example.
 The `"name"` and `"varexp"` are the only compulsory arguments, others can be omitted to reduce configuration files size.
 `"graphAxisLabel"` allows the user to set axis labels in the form of `"Label Y axis: Label X axis"`. With `"graphYRange"` numerical values for fixed ranges of the y axis can be provided in the form of `"Min:Max"`.
@@ -322,26 +325,33 @@ The `"name"` and `"varexp"` are the only compulsory arguments, others can be omi
           {
             "name": "mean_of_histogram",
             "title": "Mean trend of the example histogram",
-            "varexp": "example.mean:time",
-            "selection": "",
-            "option": "*L",
-            "graphErrors": "5:example.stddev",
             "graphAxisLabel": "Mean X:time",
-            "graphYRange": "-2.3:6.7"
+            "graphYRange": "-2.3:6.7",
+            "graphs" : [{
+                "title": "mean trend",
+                "varexp": "example.mean:time",
+                "selection": "",
+                "option": "*L",
+                "graphErrors": "5:example.stddev"
+              }]
           },
           {
             "name": "histogram_of_means",
             "title": "Distribution of mean values in the example histogram",
-            "varexp": "example.mean",
-            "selection": "",
-            "option": ""
+            "graphs" : [{
+                "varexp": "example.mean",
+                "selection": "",
+                "option": "*L"
+              }]
           },
           {
             "name": "example_quality",
             "title": "Trend of the example histogram's quality",
-            "varexp": "QcCheck.name:time",
-            "selection": "",
-            "option": "*"
+            "graphs" : [{
+                "varexp": "QcCheck.name:time",
+                "selection": "",
+                "option": "*"
+              }]
           }
         ],
         ...


### PR DESCRIPTION
This allows to draw more than one histogram or TGraph on one plot (canvas) in TrendingTask. If more than one graph is used, a legend is automatically added to the plot.

The configuration scheme has been adapted accordingly to allow for multiple graphs. The old way is still supported, but has been removed from documentation to encourage users to move to the new scheme.

There is also a possibility to select custom color palette expected, but we will need ROOT bump to 6.32 before this can be enabled.

Some refactoring is included as well.