### PR TITLE
Common: bumped ClassDefOverride version of THxRatio objects

### DIFF
--- a/Modules/Common/include/Common/TH1Ratio.h
+++ b/Modules/Common/include/Common/TH1Ratio.h
@@ -79,7 +79,7 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
   Bool_t mSumw2Enabled{ kTRUE };
   std::string mTreatMeAs{ T::Class_Name() };
 
-  ClassDefOverride(TH1Ratio, 1);
+  ClassDefOverride(TH1Ratio, 2);
 };
 
 typedef TH1Ratio<TH1F> TH1FRatio;

--- a/Modules/Common/include/Common/TH2Ratio.h
+++ b/Modules/Common/include/Common/TH2Ratio.h
@@ -79,7 +79,7 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
   Bool_t mSumw2Enabled{ kTRUE };
   std::string mTreatMeAs{ T::Class_Name() };
 
-  ClassDefOverride(TH2Ratio, 1);
+  ClassDefOverride(TH2Ratio, 2);
 };
 
 typedef TH2Ratio<TH2F> TH2FRatio;


### PR DESCRIPTION
The bump is needed due to the addition of the `mSumw2Enabled` member.