### PR TITLE
Avoid usage of uninitialized value

### DIFF
--- a/Framework/include/QualityControl/ServiceDiscovery.h
+++ b/Framework/include/QualityControl/ServiceDiscovery.h
@@ -66,7 +66,7 @@ class ServiceDiscovery
   const std::string mName;          ///< Instance (service) Name
   const std::string mId;            ///< Instance (service) ID
   std::string mHealthUrl;           ///< hostname of health check endpoint
-  size_t mHealthPort;               ///< Port of the health check endpoint
+  size_t mHealthPort = 0;           ///< Port of the health check endpoint
   std::mutex mHealthPortMutex;      ///< Mutex for the port
   std::condition_variable mHealthPortCV; ///< Condition varaible for the port
   std::atomic<bool> mHealthPortAssigned; ///< Port of the health check is ready.


### PR DESCRIPTION
in principle, it could have been printed by IL before anything was set there. not a real issue, but one less valgrind warning in QC