### PR TITLE
[QC-885] Modify reference check to also accept a TH1 …

### DIFF
--- a/Framework/include/QualityControl/Check.h
+++ b/Framework/include/QualityControl/Check.h
@@ -19,8 +19,10 @@
 // O2
 #include <Framework/DataProcessorSpec.h>
 // QC
+#include "QualityControl/DatabaseInterface.h"
 #include "QualityControl/QualityObject.h"
 #include "QualityControl/CheckConfig.h"
+#include "QualityControl/CheckInterface.h"
 
 namespace o2::quality_control::core
 {
@@ -91,6 +93,10 @@ class Check
   // todo: probably make CheckFactory
   static CheckConfig extractConfig(const core::CommonSpec&, const CheckSpec&);
   static framework::OutputSpec createOutputSpec(const std::string& detector, const std::string& checkName);
+
+  void setDatabase(std::shared_ptr<o2::quality_control::repository::DatabaseInterface> database) {
+    mCheckInterface->setDatabase(database);
+  }
 
  private:
   void beautify(std::map<std::string, std::shared_ptr<core::MonitorObject>>& moMap, const core::Quality& quality);

--- a/Framework/include/QualityControl/Check.h
+++ b/Framework/include/QualityControl/Check.h
@@ -94,7 +94,8 @@ class Check
   static CheckConfig extractConfig(const core::CommonSpec&, const CheckSpec&);
   static framework::OutputSpec createOutputSpec(const std::string& detector, const std::string& checkName);
 
-  void setDatabase(std::shared_ptr<o2::quality_control::repository::DatabaseInterface> database) {
+  void setDatabase(std::shared_ptr<o2::quality_control::repository::DatabaseInterface> database)
+  {
     mCheckInterface->setDatabase(database);
   }
 

--- a/Framework/include/QualityControl/CheckInterface.h
+++ b/Framework/include/QualityControl/CheckInterface.h
@@ -94,7 +94,12 @@ class CheckInterface : public core::UserCodeInterface
 
   /// \brief Retrieve a reference plot at the provided path, matching the give activity and for the provided run.
   /// the activity is the current one, while the run number is the reference run.
-  std::shared_ptr<MonitorObject> retrieveReference(std::string path, int referenceRun, Activity activity);
+  ///
+  /// \param path path to the object (no provenance)
+  /// \param referenceRun Run number of the reference data
+  /// \param activity Current activity (necessary for the provenance and the pass)
+  /// \return
+  std::shared_ptr<MonitorObject> retrieveReference(std::string path, size_t referenceRun, Activity activity);
 
  private:
   std::shared_ptr<o2::quality_control::repository::DatabaseInterface> mDatabase;

--- a/Framework/include/QualityControl/CheckInterface.h
+++ b/Framework/include/QualityControl/CheckInterface.h
@@ -83,7 +83,8 @@ class CheckInterface : public core::UserCodeInterface
   virtual void startOfActivity(const core::Activity& activity); // not fully abstract because we don't want to change all the existing subclasses
   virtual void endOfActivity(const core::Activity& activity);   // not fully abstract because we don't want to change all the existing subclasses
 
-  void setDatabase(std::shared_ptr<o2::quality_control::repository::DatabaseInterface> database) {
+  void setDatabase(std::shared_ptr<o2::quality_control::repository::DatabaseInterface> database)
+  {
     mDatabase = database;
   }
 

--- a/Framework/include/QualityControl/CheckInterface.h
+++ b/Framework/include/QualityControl/CheckInterface.h
@@ -96,10 +96,9 @@ class CheckInterface : public core::UserCodeInterface
   /// the activity is the current one, while the run number is the reference run.
   ///
   /// \param path path to the object (no provenance)
-  /// \param referenceRun Run number of the reference data
-  /// \param activity Current activity (necessary for the provenance and the pass)
+  /// \param referenceActivity Reference activity (usually a copy of the current activity with a different run number)
   /// \return
-  std::shared_ptr<MonitorObject> retrieveReference(std::string path, size_t referenceRun, Activity activity);
+  std::shared_ptr<MonitorObject> retrieveReference(std::string path, Activity referenceActivity);
 
  private:
   std::shared_ptr<o2::quality_control::repository::DatabaseInterface> mDatabase;

--- a/Framework/include/QualityControl/CheckInterface.h
+++ b/Framework/include/QualityControl/CheckInterface.h
@@ -17,6 +17,7 @@
 #ifndef QC_CHECKER_CHECKINTERFACE_H
 #define QC_CHECKER_CHECKINTERFACE_H
 
+#include "QualityControl/DatabaseInterface.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/UserCodeInterface.h"
 #include "QualityControl/Activity.h"
@@ -82,9 +83,20 @@ class CheckInterface : public core::UserCodeInterface
   virtual void startOfActivity(const core::Activity& activity); // not fully abstract because we don't want to change all the existing subclasses
   virtual void endOfActivity(const core::Activity& activity);   // not fully abstract because we don't want to change all the existing subclasses
 
+  void setDatabase(std::shared_ptr<o2::quality_control::repository::DatabaseInterface> database) {
+    mDatabase = database;
+  }
+
  protected:
   /// \brief Called each time mCustomParameters is updated.
   virtual void configure() override;
+
+  /// \brief Retrieve a reference plot at the provided path, matching the give activity and for the provided run.
+  /// the activity is the current one, while the run number is the reference run.
+  std::shared_ptr<MonitorObject> retrieveReference(std::string path, int referenceRun, Activity activity);
+
+ private:
+  std::shared_ptr<o2::quality_control::repository::DatabaseInterface> mDatabase;
 
   ClassDef(CheckInterface, 6)
 };

--- a/Framework/include/QualityControl/ReferenceUtils.h
+++ b/Framework/include/QualityControl/ReferenceUtils.h
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ReferenceComparatorUtils.h
+/// \author Andrea Ferrero and Barthelemy von Haller
+///
+
+#ifndef QUALITYCONTROL_ReferenceComparatorUtils_H
+#define QUALITYCONTROL_ReferenceComparatorUtils_H
+
+#include <memory>
+#include "QualityControl/MonitorObject.h"
+#include "QualityControl/DatabaseInterface.h"
+#include "QualityControl/Activity.h"
+#include "QualityControl/ActivityHelpers.h"
+#include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/RepoPathUtils.h"
+
+namespace o2::quality_control_modules::common
+{
+
+//_________________________________________________________________________________________
+//
+// Get the reference plot for a given MonitorObject path
+
+static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(quality_control::repository::DatabaseInterface* qcdb, std::string& fullPath, uint32_t referenceRun, quality_control::core::Activity activity)
+{
+  uint64_t timeStamp = 0;
+  activity.mId = referenceRun;
+  const auto filterMetadata = quality_control::core::activity_helpers::asDatabaseMetadata(activity, false);
+  const auto objectValidity = qcdb->getLatestObjectValidity(activity.mProvenance + "/" + fullPath, filterMetadata);
+  if (objectValidity.isValid()) {
+    timeStamp = objectValidity.getMax() - 1;
+  } else {
+    ILOG(Warning, Devel) << "Could not find the object '" << fullPath << "' for run " << activity.mId << ENDM;
+    return nullptr;
+  }
+
+  std::string path;
+  std::string name;
+  if (!o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath, path, name)) {
+    return nullptr;
+  }
+  // retrieve MO from CCDB
+  auto mo = qcdb->retrieveMO(path, name, timeStamp, activity);
+
+  return mo;
+}
+
+} // namespace o2::quality_control_modules::common
+
+#endif // QUALITYCONTROL_ReferenceComparatorUtils_H

--- a/Framework/include/QualityControl/ReferenceUtils.h
+++ b/Framework/include/QualityControl/ReferenceUtils.h
@@ -32,7 +32,7 @@ namespace o2::quality_control::checker
 //
 // Get the reference plot for a given MonitorObject path
 
-static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(quality_control::repository::DatabaseInterface* qcdb, std::string& fullPath, uint32_t referenceRun, quality_control::core::Activity activity)
+static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(quality_control::repository::DatabaseInterface* qcdb, std::string& fullPath, int referenceRun, quality_control::core::Activity activity)
 {
   uint64_t timeStamp = 0;
   activity.mId = referenceRun;

--- a/Framework/include/QualityControl/ReferenceUtils.h
+++ b/Framework/include/QualityControl/ReferenceUtils.h
@@ -33,24 +33,13 @@ namespace o2::quality_control::checker
 // Get the reference plot for a given MonitorObject path
 
 static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(quality_control::repository::DatabaseInterface* qcdb, std::string& fullPath,
-                                                                              int referenceRun, quality_control::core::Activity activity)
+                                                                              size_t referenceRun, core::Activity activity)
 {
-  uint64_t timeStamp = 0;
-  activity.mId = referenceRun;
-  const auto filterMetadata = quality_control::core::activity_helpers::asDatabaseMetadata(activity, false);
-  const auto objectValidity = qcdb->getLatestObjectValidity(activity.mProvenance + "/" + fullPath, filterMetadata);
-  if (objectValidity.isValid()) {
-    timeStamp = objectValidity.getMax() - 1;
-  } else {
-    ILOG(Warning, Devel) << "Could not find the object '" << fullPath << "' for run " << activity.mId << ENDM;
-    return nullptr;
-  }
-
   auto [success, path, name] = o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath);
   if (!success) {
     return nullptr;
   }
-  return qcdb->retrieveMO(path, name, timeStamp, activity);
+  return qcdb->retrieveMO(path, name, repository::DatabaseInterface::Timestamp::Latest, activity);
 }
 
 } // namespace o2::quality_control::checker

--- a/Framework/include/QualityControl/ReferenceUtils.h
+++ b/Framework/include/QualityControl/ReferenceUtils.h
@@ -32,7 +32,8 @@ namespace o2::quality_control::checker
 //
 // Get the reference plot for a given MonitorObject path
 
-static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(quality_control::repository::DatabaseInterface* qcdb, std::string& fullPath, int referenceRun, quality_control::core::Activity activity)
+static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(quality_control::repository::DatabaseInterface* qcdb, std::string& fullPath,
+                                                                              int referenceRun, quality_control::core::Activity activity)
 {
   uint64_t timeStamp = 0;
   activity.mId = referenceRun;
@@ -45,9 +46,8 @@ static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(qu
     return nullptr;
   }
 
-  std::string path;
-  std::string name;
-  if (!o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath, path, name)) {
+  auto [success, path, name] = o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath);
+  if (!success) {
     return nullptr;
   }
   return qcdb->retrieveMO(path, name, timeStamp, activity);

--- a/Framework/include/QualityControl/ReferenceUtils.h
+++ b/Framework/include/QualityControl/ReferenceUtils.h
@@ -50,10 +50,7 @@ static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(qu
   if (!o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath, path, name)) {
     return nullptr;
   }
-  // retrieve MO from CCDB
-  auto mo = qcdb->retrieveMO(path, name, timeStamp, activity);
-
-  return mo;
+  return qcdb->retrieveMO(path, name, timeStamp, activity);
 }
 
 } // namespace o2::quality_control_modules::common

--- a/Framework/include/QualityControl/ReferenceUtils.h
+++ b/Framework/include/QualityControl/ReferenceUtils.h
@@ -33,13 +33,13 @@ namespace o2::quality_control::checker
 // Get the reference plot for a given MonitorObject path
 
 static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(quality_control::repository::DatabaseInterface* qcdb, std::string& fullPath,
-                                                                              size_t referenceRun, core::Activity activity)
+                                                                              core::Activity referenceActivity)
 {
   auto [success, path, name] = o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath);
   if (!success) {
     return nullptr;
   }
-  return qcdb->retrieveMO(path, name, repository::DatabaseInterface::Timestamp::Latest, activity);
+  return qcdb->retrieveMO(path, name, repository::DatabaseInterface::Timestamp::Latest, referenceActivity);
 }
 
 } // namespace o2::quality_control::checker

--- a/Framework/include/QualityControl/ReferenceUtils.h
+++ b/Framework/include/QualityControl/ReferenceUtils.h
@@ -14,8 +14,8 @@
 /// \author Andrea Ferrero and Barthelemy von Haller
 ///
 
-#ifndef QUALITYCONTROL_ReferenceComparatorUtils_H
-#define QUALITYCONTROL_ReferenceComparatorUtils_H
+#ifndef QUALITYCONTROL_ReferenceUtils_H
+#define QUALITYCONTROL_ReferenceUtils_H
 
 #include <memory>
 #include "QualityControl/MonitorObject.h"
@@ -53,6 +53,6 @@ static std::shared_ptr<quality_control::core::MonitorObject> getReferencePlot(qu
   return qcdb->retrieveMO(path, name, timeStamp, activity);
 }
 
-} // namespace o2::quality_control_modules::common
+} // namespace o2::quality_control::checker
 
-#endif // QUALITYCONTROL_ReferenceComparatorUtils_H
+#endif // QUALITYCONTROL_ReferenceUtils_H

--- a/Framework/include/QualityControl/ReferenceUtils.h
+++ b/Framework/include/QualityControl/ReferenceUtils.h
@@ -25,7 +25,7 @@
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/RepoPathUtils.h"
 
-namespace o2::quality_control_modules::common
+namespace o2::quality_control::checker
 {
 
 //_________________________________________________________________________________________

--- a/Framework/include/QualityControl/RepoPathUtils.h
+++ b/Framework/include/QualityControl/RepoPathUtils.h
@@ -129,17 +129,24 @@ class RepoPathUtils
   static constexpr auto allowedProvenancesMessage = R"(Allowed provenances are "qc" (real data processed synchronously), "qc_async" (real data processed asynchronously) and "qc_mc" (simulated data).)";
   static bool isProvenanceAllowed(const std::string& provenance);
 
-  static bool splitObjectPath(const std::string& fullPath, std::string& path, std::string& name)
+  /**
+   * Splits the provided path and returns both the base path and the object name.
+   * @param fullPath
+   * @return A tuple with 1. a boolean to specify if we succeeded (i.e. whether we found a `/`)
+   *                      2. the path
+   *                      3. the object name
+   */
+  static std::tuple<bool, std::string, std::string> splitObjectPath(const std::string& fullPath)
   {
     std::string delimiter = "/";
     std::string det;
     size_t pos = fullPath.rfind(delimiter);
     if (pos == std::string::npos) {
-      return false;
+      return {false, "", ""};
     }
-    path = fullPath.substr(0, pos);
-    name = fullPath.substr(pos + 1);
-    return true;
+    std::string path = fullPath.substr(0, pos);
+    std::string name = fullPath.substr(pos + 1);
+    return {true, path, name};
   }
 };
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/RepoPathUtils.h
+++ b/Framework/include/QualityControl/RepoPathUtils.h
@@ -142,11 +142,11 @@ class RepoPathUtils
     std::string det;
     size_t pos = fullPath.rfind(delimiter);
     if (pos == std::string::npos) {
-      return {false, "", ""};
+      return { false, "", "" };
     }
     std::string path = fullPath.substr(0, pos);
     std::string name = fullPath.substr(pos + 1);
-    return {true, path, name};
+    return { true, path, name };
   }
 };
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/RepoPathUtils.h
+++ b/Framework/include/QualityControl/RepoPathUtils.h
@@ -148,6 +148,16 @@ class RepoPathUtils
     std::string name = fullPath.substr(pos + 1);
     return { true, path, name };
   }
+
+  static std::string getPathNoProvenance(std::shared_ptr<MonitorObject> mo)
+  {
+    std::string path = mo->getPath();
+    size_t pos = path.find('/');
+    if (pos != std::string::npos) {
+      path = path.substr(pos + 1);
+    }
+    return path;
+  }
 };
 } // namespace o2::quality_control::core
 

--- a/Framework/include/QualityControl/RepoPathUtils.h
+++ b/Framework/include/QualityControl/RepoPathUtils.h
@@ -128,6 +128,19 @@ class RepoPathUtils
 
   static constexpr auto allowedProvenancesMessage = R"(Allowed provenances are "qc" (real data processed synchronously), "qc_async" (real data processed asynchronously) and "qc_mc" (simulated data).)";
   static bool isProvenanceAllowed(const std::string& provenance);
+
+  static bool splitObjectPath(const std::string& fullPath, std::string& path, std::string& name)
+  {
+    std::string delimiter = "/";
+    std::string det;
+    size_t pos = fullPath.rfind(delimiter);
+    if (pos == std::string::npos) {
+      return false;
+    }
+    path = fullPath.substr(0, pos);
+    name = fullPath.substr(pos + 1);
+    return true;
+  }
 };
 } // namespace o2::quality_control::core
 

--- a/Framework/src/CheckInterface.cxx
+++ b/Framework/src/CheckInterface.cxx
@@ -60,9 +60,9 @@ void CheckInterface::endOfActivity(const Activity& activity)
   // noop, override it if you want.
 }
 
-shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, size_t referenceRun, Activity activity)
+shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, Activity referenceActivity)
 {
-  return o2::quality_control::checker::getReferencePlot(mDatabase.get(), path, referenceRun, activity);
+  return o2::quality_control::checker::getReferencePlot(mDatabase.get(), path, referenceActivity);
 }
 
 } // namespace o2::quality_control::checker

--- a/Framework/src/CheckInterface.cxx
+++ b/Framework/src/CheckInterface.cxx
@@ -15,6 +15,7 @@
 ///
 
 #include "QualityControl/CheckInterface.h"
+#include "QualityControl/ReferenceUtils.h"
 #include "QualityControl/MonitorObject.h"
 
 #include <TClass.h>
@@ -57,6 +58,11 @@ void CheckInterface::startOfActivity(const Activity& activity)
 void CheckInterface::endOfActivity(const Activity& activity)
 {
   // noop, override it if you want.
+}
+
+shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, int referenceRun, Activity activity)
+{
+  return quality_control_modules::common::getReferencePlot(mDatabase.get(), path, referenceRun, activity);
 }
 
 } // namespace o2::quality_control::checker

--- a/Framework/src/CheckInterface.cxx
+++ b/Framework/src/CheckInterface.cxx
@@ -60,7 +60,7 @@ void CheckInterface::endOfActivity(const Activity& activity)
   // noop, override it if you want.
 }
 
-shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, int referenceRun, Activity activity)
+shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, size_t referenceRun, Activity activity)
 {
   return o2::quality_control::checker::getReferencePlot(mDatabase.get(), path, referenceRun, activity);
 }

--- a/Framework/src/CheckInterface.cxx
+++ b/Framework/src/CheckInterface.cxx
@@ -62,7 +62,7 @@ void CheckInterface::endOfActivity(const Activity& activity)
 
 shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, int referenceRun, Activity activity)
 {
-  return quality_control_modules::common::getReferencePlot(mDatabase.get(), path, referenceRun, activity);
+  return o2::quality_control::checker::getReferencePlot(mDatabase.get(), path, referenceRun, activity);
 }
 
 } // namespace o2::quality_control::checker

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -231,6 +231,7 @@ void CheckRunner::init(framework::InitContext& iCtx)
     updatePolicyManager.reset();
     for (auto& [checkName, check] : mChecks) {
       check.init();
+      check.setDatabase(mDatabase);
       updatePolicyManager.addPolicy(check.getName(), check.getUpdatePolicyType(), check.getObjectsNames(), check.getAllObjectsOption(), false);
     }
   } catch (...) {

--- a/Modules/Common/include/Common/ReferenceComparatorCheck.h
+++ b/Modules/Common/include/Common/ReferenceComparatorCheck.h
@@ -54,7 +54,7 @@ class ReferenceComparatorCheck : public o2::quality_control::checker::CheckInter
   std::unique_ptr<ObjectComparatorInterface> mComparator;
   std::map<std::string, Quality> mQualityFlags;
   std::map<std::string, std::shared_ptr<TPaveText>> mQualityLabels;
-  quality_control::core::Activity mActivity;
+  quality_control::core::Activity mActivity /*current*/, mReferenceActivity;
   size_t mReferenceRun;
 };
 

--- a/Modules/Common/include/Common/ReferenceComparatorCheck.h
+++ b/Modules/Common/include/Common/ReferenceComparatorCheck.h
@@ -49,9 +49,12 @@ class ReferenceComparatorCheck : public o2::quality_control::checker::CheckInter
   void endOfActivity(const Activity& activity) override;
 
  private:
+  Quality getSinglePlotQuality(std::shared_ptr<MonitorObject> mo, std::string& message);
+
   std::unique_ptr<ObjectComparatorInterface> mComparator;
   std::map<std::string, Quality> mQualityFlags;
   std::map<std::string, std::shared_ptr<TPaveText>> mQualityLabels;
+  quality_control::core::Activity mActivity;
 };
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/ReferenceComparatorCheck.h
+++ b/Modules/Common/include/Common/ReferenceComparatorCheck.h
@@ -55,6 +55,7 @@ class ReferenceComparatorCheck : public o2::quality_control::checker::CheckInter
   std::map<std::string, Quality> mQualityFlags;
   std::map<std::string, std::shared_ptr<TPaveText>> mQualityLabels;
   quality_control::core::Activity mActivity;
+  size_t mReferenceRun;
 };
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/ReferenceComparatorTask.h
+++ b/Modules/Common/include/Common/ReferenceComparatorTask.h
@@ -24,7 +24,6 @@
 #include <TH1.h>
 #include <TPad.h>
 #include <TCanvas.h>
-#include <TPaveText.h>
 #include <TText.h>
 #include <string>
 #include <map>

--- a/Modules/Common/include/Common/ReferenceComparatorTask.h
+++ b/Modules/Common/include/Common/ReferenceComparatorTask.h
@@ -19,10 +19,8 @@
 #define QUALITYCONTROL_REFERENCECOMPARATORTASK_H
 
 #include "Common/ReferenceComparatorTaskConfig.h"
-#include "Common/BigScreenCanvas.h"
 #include "QualityControl/PostProcessingInterface.h"
 #include "QualityControl/DatabaseInterface.h"
-#include "QualityControl/Quality.h"
 #include <TH1.h>
 #include <TPad.h>
 #include <TCanvas.h>
@@ -63,8 +61,6 @@ class ReferenceComparatorTask : public quality_control::postprocessing::PostProc
   };
 
  private:
-  std::shared_ptr<o2::quality_control::core::MonitorObject> getReferencePlot(o2::quality_control::repository::DatabaseInterface& qcdb, std::string fullPath, o2::quality_control::core::Activity activity);
-
   int mReferenceRun{ 0 };
   int mNotOlderThan{ 120 };
 

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -137,6 +137,10 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
 {
   // retrieve the reference plot and compare
   auto* th1 = dynamic_cast<TH1*>(mo->getObject());
+  if (th1 == nullptr) {
+    message = "The MonitorObject is not a TH1";
+    return Quality::Null;
+  }
   auto referenceRun = std::stoi(mCustomParameters.atOptional("referenceRun").value_or("0"));
 
   // get path of mo and ref (we have to remove the provenance)

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -150,11 +150,7 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
   auto referenceRun = std::stoi(mCustomParameters.at("referenceRun"));
 
   // get path of mo and ref (we have to remove the provenance)
-  string path = mo->getPath();
-  size_t pos = path.find('/');
-  if (pos != std::string::npos) {
-    path = path.substr(pos + 1);
-  }
+  std::string path = RepoPathUtils::getPathNoProvenance(mo);
 
   auto referencePlot = retrieveReference(path, referenceRun, mActivity);
   if (!referencePlot) {

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -284,7 +284,6 @@ void ReferenceComparatorCheck::beautify(std::shared_ptr<MonitorObject> mo, Quali
     setQualityLabel(canvas, quality);
   }
   auto* th1 = dynamic_cast<TH1*>(mo->getObject());
-  std::cout << "th1 : " << th1 << std::endl;
   if (th1) {
     auto* qualityLabel = new TPaveText(0.75, 0.65, 0.98, 0.75, "brNDC");
     updateQualityLabel(qualityLabel, quality);

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -181,7 +181,7 @@ Quality ReferenceComparatorCheck::check(std::map<std::string, std::shared_ptr<Mo
       // We got a plot, we have to find the reference before calling the comparator
       quality = getSinglePlotQuality(mo, message);
     } else {
-      ILOG(Warning, Ops) << "mo is not a TCanvas or a TH1" << ENDM;
+      ILOG(Warning, Ops) << "Compared Monitor Object '" << mo->getName() << "' is not a TCanvas or a TH1, the detector QC responsible should review the configuration" << ENDM;
       continue;
     }
 

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -61,6 +61,8 @@ void ReferenceComparatorCheck::startOfActivity(const Activity& activity)
   }
 
   mActivity = activity;
+  mReferenceActivity = activity;
+  mReferenceActivity.mId = mReferenceRun;
 }
 
 void ReferenceComparatorCheck::endOfActivity(const Activity& activity)
@@ -147,8 +149,8 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
 
   // get path of mo and ref (we have to remove the provenance)
   std::string path = RepoPathUtils::getPathNoProvenance(mo);
-
-  auto referencePlot = retrieveReference(path, mReferenceRun, mActivity);
+  // todo we could cache the reference plot within a run
+  auto referencePlot = retrieveReference(path, mReferenceActivity);
   if (!referencePlot) {
     message = "Reference plot not found";
     return Quality::Null;

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -133,7 +133,6 @@ static Quality compare(TCanvas* canvas, ObjectComparatorInterface* comparator, s
   return comparator->compare(plots.first, plots.second, message);
 }
 
-
 Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorObject> mo, std::string& message)
 {
   // retrieve the reference plot and compare

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -143,7 +143,11 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
     message = "The MonitorObject is not a TH1";
     return Quality::Null;
   }
-  auto referenceRun = std::stoi(mCustomParameters.atOptional("referenceRun").value_or("0"));
+  if (mCustomParameters.count("referenceRun") == 0) {
+    message = "No reference run provided";
+    return Quality::Null;
+  }
+  auto referenceRun = std::stoi(mCustomParameters.at("referenceRun"));
 
   // get path of mo and ref (we have to remove the provenance)
   string path = mo->getPath();
@@ -154,7 +158,7 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
 
   auto referencePlot = retrieveReference(path, referenceRun, mActivity);
   if (!referencePlot) {
-    message = "The reference plot is empty";
+    message = "Reference plot not found";
     return Quality::Null;
   }
   auto* ref = dynamic_cast<TH1*>(referencePlot->getObject());

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -27,6 +27,8 @@
 
 #include <Framework/ServiceRegistryRef.h>
 
+#include <TClass.h>
+
 // ROOT
 #include <TH1.h>
 #include <TCanvas.h>

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -268,7 +268,6 @@ static void setQualityLabel(TCanvas* canvas, const Quality& quality)
 
 void ReferenceComparatorCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  std::cout << "beautify" << std::endl;
   // get the quality associated to the current MO
   auto moName = mo->getName();
   auto quality = mQualityFlags[moName];

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -286,7 +286,7 @@ void ReferenceComparatorCheck::beautify(std::shared_ptr<MonitorObject> mo, Quali
   }
   auto* th1 = dynamic_cast<TH1*>(mo->getObject());
   std::cout << "th1 : " << th1 << std::endl;
-  if(th1) {
+  if (th1) {
     auto* qualityLabel = new TPaveText(0.75, 0.65, 0.98, 0.75, "brNDC");
     updateQualityLabel(qualityLabel, quality);
     th1->GetListOfFunctions()->Add(qualityLabel);

--- a/Modules/Common/src/ReferenceComparatorTask.cxx
+++ b/Modules/Common/src/ReferenceComparatorTask.cxx
@@ -119,7 +119,9 @@ void ReferenceComparatorTask::initialize(quality_control::postprocessing::Trigge
       auto fullOutPath = group.outputPath + "/" + path;
 
       // retrieve the reference MO
-      auto referencePlot = o2::quality_control::checker::getReferencePlot(&qcdb, fullRefPath, mReferenceRun, trigger.activity);
+      auto referenceActivity = trigger.activity;
+      referenceActivity.mId = mReferenceRun;
+      auto referencePlot = o2::quality_control::checker::getReferencePlot(&qcdb, fullRefPath, referenceActivity);
       if (!referencePlot) {
         continue;
       }

--- a/Modules/Common/src/ReferenceComparatorTask.cxx
+++ b/Modules/Common/src/ReferenceComparatorTask.cxx
@@ -120,7 +120,7 @@ void ReferenceComparatorTask::initialize(quality_control::postprocessing::Trigge
       auto fullOutPath = group.outputPath + "/" + path;
 
       // retrieve the reference MO
-      auto referencePlot = getReferencePlot(&qcdb, fullRefPath, mReferenceRun, trigger.activity);
+      auto referencePlot = o2::quality_control::checker::getReferencePlot(&qcdb, fullRefPath, mReferenceRun, trigger.activity);
       if (!referencePlot) {
         continue;
       }

--- a/Modules/Common/src/ReferenceComparatorTask.cxx
+++ b/Modules/Common/src/ReferenceComparatorTask.cxx
@@ -52,9 +52,8 @@ static std::pair<std::shared_ptr<MonitorObject>, bool> getMO(repository::Databas
     return { nullptr, false };
   }
 
-  std::string path;
-  std::string name;
-  if (!o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath, path, name)) {
+  auto [success, path, name] = o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath);
+  if (!success) {
     return { nullptr, false };
   }
   // retrieve QO from CCDB - do not associate to trigger activity if ignoreActivity is true

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1322,13 +1322,11 @@ To retrieve a reference plot in your Check, use
 - `referenceRun` : the run of reference
 - `activity` : the current activity
 
-If the reference is not found it will return a `nullptr` and issue a warning. 
+If the reference is not found it will return a `nullptr` and the quality is `Null`.
 
 ### Compare to a reference plot
 
 The check `ReferenceComparatorCheck` in `Common` compares objects to their reference. 
-
-TODO beautify
 
 The configuration looks like 
 ```
@@ -1371,6 +1369,8 @@ Three comparator are provided:
 3. `o2::quality_control_modules::common::ObjectComparatorKolmogorov`: comparison based on a standard Kolmogorov test between the current and reference histograms; the `threshold` parameter represent in this case the minimum allowed Kolmogorov probability
 
 Note that you can easily specify different reference runs for different run types and beam types. 
+
+The plot is beautified by the addition of a `TPaveText` containing the quality and the reason for the quality. 
 
 ### Generate a canvas combining both the current and reference ratio histogram
 

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1309,10 +1309,73 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 ```
 
 ## Reference data
-TODO
-- PP task -> pointer
-- Checker -> if PP -> pointer
-- Checker on TH1 -> describe here
+
+A reference object is an object from a previous run. It is usually used as a point of comparison. 
+
+### Get a reference plot
+
+To retrieve a reference plot in your Check, use 
+```
+  std::shared_ptr<MonitorObject> retrieveReference(std::string path, int referenceRun, Activity activity);
+```
+- `path` : the path of the object _without the provenance (e.g. `qc`)
+- `referenceRun` : the run of reference
+- `activity` : the current activity
+
+If the reference is not found it will return a `nullptr` and issue a warning. 
+
+### Compare to a reference plot
+
+The check `ReferenceComparatorCheck` in `Common` compares objects to their reference. 
+
+TODO beautify
+
+The configuration looks like 
+```
+      "QcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::ReferenceComparatorCheck",
+        "moduleName": "QcCommon",
+        "policy": "OnAny",
+        "detectorName": "TST",
+        "dataSource": [{
+          "type": "Task",
+          "name": "QcTask",
+          "MOs": ["example"]
+        }],
+        "extendedCheckParameters": {
+          "default": {
+            "default": {
+              "referenceRun" : "500",
+              "moduleName" : "QualityControl",
+              "comparatorName" : "o2::quality_control_modules::common::ObjectComparatorChi2",
+              "threshold" : "0.5"
+            }
+          },
+          "PHYSICS": {
+            "PROTON-PROTON": {
+              "referenceRun" : "551890"
+            }
+          }
+        }
+      }
+```
+The check needs the following parameters
+- `referenceRun` to specify what is the run of reference and retrieve the reference data. 
+- `comparatorName` to decide how to compare, see below for their descriptions.
+- `threshold` to specifie the value used to discriminate between good and bad matches between the histograms.
+
+Three comparator are provided:
+1. `o2::quality_control_modules::common::ObjectComparatorDeviation`: comparison based on the average relative deviation between the bins of the current and reference histograms; the `threshold` parameter represent in this case the maximum allowed deviation
+2. `o2::quality_control_modules::common::ObjectComparatorChi2`: comparison based on a standard chi2 test between the current and reference histograms; the `threshold` parameter represent in this case the minimum allowed chi2 probability
+3. `o2::quality_control_modules::common::ObjectComparatorKolmogorov`: comparison based on a standard Kolmogorov test between the current and reference histograms; the `threshold` parameter represent in this case the minimum allowed Kolmogorov probability
+
+Note that you can easily specify different reference runs for different run types and beam types. 
+
+### Generate a canvas combining both the current and reference ratio histogram
+
+The postprocessing task ReferenceComparatorTask draws a given set of plots in comparison with their corresponding references, both as superimposed histograms and as current/reference ratio histograms.
+See the details [here](https://github.com/AliceO2Group/QualityControl/blob/master/doc/PostProcessing.md#the-referencecomparatortask-class).
 
 ## Configuration files details
 

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1453,7 +1453,7 @@ The check needs the following parameters
 - `comparatorName` to decide how to compare, see below for their descriptions.
 - `threshold` to specifie the value used to discriminate between good and bad matches between the histograms.
 
-Three comparator are provided:
+Three comparators are provided:
 1. `o2::quality_control_modules::common::ObjectComparatorDeviation`: comparison based on the average relative deviation between the bins of the current and reference histograms; the `threshold` parameter represent in this case the maximum allowed deviation
 2. `o2::quality_control_modules::common::ObjectComparatorChi2`: comparison based on a standard chi2 test between the current and reference histograms; the `threshold` parameter represent in this case the minimum allowed chi2 probability
 3. `o2::quality_control_modules::common::ObjectComparatorKolmogorov`: comparison based on a standard Kolmogorov test between the current and reference histograms; the `threshold` parameter represent in this case the minimum allowed Kolmogorov probability

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1308,6 +1308,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 }
 ```
 
+## Reference data
+TODO
+- PP task -> pointer
+- Checker -> if PP -> pointer
+- Checker on TH1 -> describe here
+
 ## Configuration files details
 
 The QC requires a number of configuration items. An example config file is

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1406,11 +1406,10 @@ A reference object is an object from a previous run. It is usually used as a poi
 
 To retrieve a reference plot in your Check, use 
 ```
-  std::shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, int referenceRun, Activity activity);
+  std::shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, Activity referenceActivity);
 ```
 - `path` : the path of the object _without the provenance (e.g. `qc`)_
-- `referenceRun` : the run of reference
-- `activity` : the current activity
+- `referenceActivity` : the activity of reference (usually the current activity with a different run number)
 
 If the reference is not found it will return a `nullptr` and the quality is `Null`.
 

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1406,7 +1406,7 @@ A reference object is an object from a previous run. It is usually used as a poi
 
 To retrieve a reference plot in your Check, use 
 ```
-  std::shared_ptr<MonitorObject> retrieveReference(std::string path, int referenceRun, Activity activity);
+  std::shared_ptr<MonitorObject> CheckInterface::retrieveReference(std::string path, int referenceRun, Activity activity);
 ```
 - `path` : the path of the object _without the provenance (e.g. `qc`)_
 - `referenceRun` : the run of reference

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1312,13 +1312,13 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 A reference object is an object from a previous run. It is usually used as a point of comparison. 
 
-### Get a reference plot
+### Get a reference plot in a check
 
 To retrieve a reference plot in your Check, use 
 ```
   std::shared_ptr<MonitorObject> retrieveReference(std::string path, int referenceRun, Activity activity);
 ```
-- `path` : the path of the object _without the provenance (e.g. `qc`)
+- `path` : the path of the object _without the provenance (e.g. `qc`)_
 - `referenceRun` : the run of reference
 - `activity` : the current activity
 

--- a/doc/DevelopersTips.md
+++ b/doc/DevelopersTips.md
@@ -143,6 +143,10 @@ firewall-cmd --reload
 10. Set the monitoring url to `"url": "stdout://?qc,influxdb-udp://flptest1.cern.ch:8089"`
 11. Once the dashboard is ready, tell Adam.
 
+ALTERNATIVELY
+
+use http://alio2-bld4-mx-dev01-gpn:3000/?orgId=1 (admin and pwd like above)
+
 ### Monitoring setup for building the grafana dashboard with prod data
 
 1. Go to http://pcald24.cern.ch:3000/?orgId=1

--- a/doc/DevelopersTips.md
+++ b/doc/DevelopersTips.md
@@ -143,10 +143,6 @@ firewall-cmd --reload
 10. Set the monitoring url to `"url": "stdout://?qc,influxdb-udp://flptest1.cern.ch:8089"`
 11. Once the dashboard is ready, tell Adam.
 
-ALTERNATIVELY
-
-use http://alio2-bld4-mx-dev01-gpn:3000/?orgId=1 (admin and pwd like above)
-
 ### Monitoring setup for building the grafana dashboard with prod data
 
 1. Go to http://pcald24.cern.ch:3000/?orgId=1


### PR DESCRIPTION
… instead of a Canvas

- also pass the database object from CheckRunner to CheckInterface and use it to implement a new method `retrieveReference`.