### PR TITLE
Common: use extended parameters in ReferenceComparatorTask

### DIFF
--- a/Modules/Common/src/ReferenceComparatorTask.cxx
+++ b/Modules/Common/src/ReferenceComparatorTask.cxx
@@ -135,7 +135,22 @@ void ReferenceComparatorTask::configure(const boost::property_tree::ptree& confi
 
 //_________________________________________________________________________________________
 
-void ReferenceComparatorTask::initialize(quality_control::postprocessing::Trigger t, framework::ServiceRegistryRef services)
+static std::string getCustomParameter(const o2::quality_control::core::CustomParameters& customParameters, const std::string& key, const Activity& activity, const std::string& defaultValue)
+{
+  std::string value;
+  auto valueOptional = customParameters.atOptional(key, activity);
+  if (valueOptional.has_value()) {
+    value = valueOptional.value();
+  } else {
+    value = customParameters.atOptional(key).value_or(defaultValue);
+  }
+
+  return value;
+}
+
+//_________________________________________________________________________________________
+
+void ReferenceComparatorTask::initialize(quality_control::postprocessing::Trigger trigger, framework::ServiceRegistryRef services)
 {
   // reset all existing objects
   mPlotNames.clear();
@@ -143,8 +158,10 @@ void ReferenceComparatorTask::initialize(quality_control::postprocessing::Trigge
   mHistograms.clear();
 
   auto& qcdb = services.get<repository::DatabaseInterface>();
-  mNotOlderThan = std::stoi(mCustomParameters.atOptional("notOlderThan").value_or("120"));
-  mReferenceRun = std::stoi(mCustomParameters.atOptional("referenceRun").value_or("0"));
+  mNotOlderThan = std::stoi(getCustomParameter(mCustomParameters, "notOlderThan", trigger.activity, "120"));
+  mReferenceRun = std::stoi(getCustomParameter(mCustomParameters, "referenceRun", trigger.activity, "0"));
+
+  ILOG(Info, Devel) << "Reference run set to '" << mReferenceRun << "' for activity " << trigger.activity << ENDM;
 
   // load and initialize the input groups
   for (auto group : mConfig.dataGroups) {
@@ -156,7 +173,7 @@ void ReferenceComparatorTask::initialize(quality_control::postprocessing::Trigge
       auto fullOutPath = group.outputPath + "/" + path;
 
       // retrieve the reference MO
-      auto referencePlot = getReferencePlot(qcdb, fullRefPath, t.activity);
+      auto referencePlot = getReferencePlot(qcdb, fullRefPath, trigger.activity);
       if (!referencePlot) {
         continue;
       }

--- a/Modules/Common/src/ReferenceComparatorTask.cxx
+++ b/Modules/Common/src/ReferenceComparatorTask.cxx
@@ -55,6 +55,7 @@ static bool splitObjectPath(const std::string& fullPath, std::string& path, std:
 
 static std::shared_ptr<MonitorObject> getMOFromRun(repository::DatabaseInterface* qcdb, const std::string& fullPath, uint32_t run, Activity activity)
 {
+  ILOG(Info, Devel) << "Loading object '" << fullPath << "' for reference run '" << run << "' and activity " << activity << ENDM;
   uint64_t timeStamp = 0;
   activity.mId = run;
   const auto filterMetadata = activity_helpers::asDatabaseMetadata(activity, false);
@@ -62,7 +63,7 @@ static std::shared_ptr<MonitorObject> getMOFromRun(repository::DatabaseInterface
   if (objectValidity.isValid()) {
     timeStamp = objectValidity.getMax() - 1;
   } else {
-    ILOG(Warning, Devel) << "Could not find the object '" << fullPath << "' for run " << activity.mId << ENDM;
+    ILOG(Warning, Devel) << "Could not find the object '" << fullPath << "' for reference run " << activity.mId << ENDM;
     return nullptr;
   }
 


### PR DESCRIPTION
The access to the custom parameters is modified to make use of the extended version, such that the reference run number can be configured separately for different run and beam types.