### PR TITLE
ITS: correct reset of GBTLink Decoding Plot

### DIFF
--- a/Modules/ITS/include/ITS/ITSDecodingErrorTask.h
+++ b/Modules/ITS/include/ITS/ITSDecodingErrorTask.h
@@ -69,6 +69,8 @@ class ITSDecodingErrorTask final : public TaskInterface
   TH1D* hAlwaysBusy;
   TH1D* mChipErrorPlots;
   TH1D* mLinkErrorPlots;
+  bool isDoLinkErrorReset = true;
+  std::map<int, std::vector<int>> DecErr_lastCycle;
   TH2D* mChipErrorVsChipid[7]; // chip ErrorVsChipid
   TH2D* mLinkErrorVsFeeid;     // link ErrorVsFeeid
   TH2D* mChipErrorVsFeeid;     // chip ErrorVsFeeid

--- a/Modules/ITS/itsDecoding.json
+++ b/Modules/ITS/itsDecoding.json
@@ -35,6 +35,7 @@
                 },
                 "location": "local",
                 "taskParameters": {
+	            "isDoLinkErrorReset": 0,
                     "mBusyViolationLimit": "0.75"
                 }
             }

--- a/Modules/ITS/itsQCTrendingError.json
+++ b/Modules/ITS/itsQCTrendingError.json
@@ -18,7 +18,7 @@
                    "number" :
                    "42",
                    "type" :
-                   "2"
+                   "NONE"
                  },
                  "monitoring" : {
                    "url" :
@@ -348,7 +348,7 @@
 
                                    ],
                                    "initTrigger" : ["userorcontrol"],
-                                                   "updateTrigger" : ["10 seconds"],
+                                                   "updateTrigger" : ["newobject:qcdb:ITS/MO/ITSDECODING/General/LinkErrorPlots"],
                                                                      "stopTrigger" : ["userorcontrol"]
       }
     }


### PR DESCRIPTION
Added option to correct reset of the GBTLink Decoding plot. Test locally, but still could be problematic, so I added also switch to exclude the new code