### PR TITLE
[EMCAL-767] added FEEDCS object histograms into the calibration task

### DIFF
--- a/Modules/EMCAL/include/EMCAL/CalibMonitoringTask.h
+++ b/Modules/EMCAL/include/EMCAL/CalibMonitoringTask.h
@@ -15,6 +15,8 @@
 // QC includes
 #include "QualityControl/PostProcessingInterface.h"
 #include "EMCALCalib/CalibDB.h"
+#include "EMCALBase/TriggerMappingV2.h"
+#include "EMCALBase/Geometry.h"
 #include <memory>
 #include <vector>
 #include <string>
@@ -72,6 +74,10 @@ class CalibMonitoringTask final : public quality_control::postprocessing::PostPr
   void reset();
 
  private:
+  int GetTRUIndexFromSTUIndex(Int_t id, Int_t detector);
+  int GetChannelForMaskRun2(int mask, int bitnumber, bool onethirdsm);
+  std::vector<int> GetAbsFastORIndexFromMask();
+
   std::vector<std::string> mCalibObjects;             ///< list of vectors of parm objects to be processed
   TH1* mTimeCalibParamHisto = nullptr;                ///< Monitor Time Calib Param
   TH2* mTimeCalibParamPosition = nullptr;             ///< Monitor time calib param as function of the position in EMCAL
@@ -83,10 +89,20 @@ class CalibMonitoringTask final : public quality_control::postprocessing::PostPr
   TH2* mNumberOfBadChannelsFEC = nullptr;             ///< Number of bad channels per FEC
   TH2* mNumberOfDeadChannelsFEC = nullptr;            ///< Number of dead channels per FEC
   TH2* mNumberOfNonGoodChannelsFEC = nullptr;         ///< Number of dead+bad channels per FEC
+  TH1* mSRUFirmwareVersion = nullptr;                 ///< The SRU Firmware version as function of supermodule ID
+  TH1* mActiveDDLs = nullptr;                         ///< Monitor which DDLs are active
+  TH1* mTRUThresholds = nullptr;                      ///< The L0 threshold vs TRU ID PHYS
+  TH1* mL0Algorithm = nullptr;                        ///< The L0 algorithm vs TRU ID
+  TH1* mRollbackSTU = nullptr;                        ///< The Rollback buffer vs TRU ID
+  TH1* mTRUMaskPosition = nullptr;                    ///< The FastOR Mask Position in Eta, Phi
   std::unique_ptr<o2::emcal::CalibDB> mCalibDB;       ///< EMCAL calibration DB handler
   std::unique_ptr<o2::emcal::MappingHandler> mMapper; ///< EMCAL mapper
   o2::emcal::BadChannelMap* mBadChannelMap;           ///< EMCAL channel map
   o2::emcal::TimeCalibrationParams* mTimeCalib;       ///< EMCAL time calib
+  o2::emcal::FeeDCS* mFeeDCS;                         ///< EMCAL FEE DCS
+
+  o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);                                  ///< Geometry for mapping position between SM and full EMCAL
+  std::unique_ptr<o2::emcal::TriggerMappingV2> mTriggerMapping = std::make_unique<o2::emcal::TriggerMappingV2>(mGeometry); ///!<! Trigger mapping
 
   //  std::vector<std::map<std::string, std::string>> mStoreMaps{};          ///< meta data to be stored with the output in the QCDB
 };

--- a/Modules/EMCAL/src/CalibMonitoringTask.cxx
+++ b/Modules/EMCAL/src/CalibMonitoringTask.cxx
@@ -108,112 +108,150 @@ void CalibMonitoringTask::initialize(Trigger, framework::ServiceRegistryRef)
   // initialize histograms to be monitored as data member
   for (const auto& obj : mCalibObjects) {
     if (obj == "TimeCalibParams") {
-      mTimeCalibParamHisto = new TH1D("timeCalibCoeff", "Time Calib Coeff", 17644, -0.5, 17643.5); //
-      mTimeCalibParamHisto->GetXaxis()->SetTitle("Cell Id");
-      mTimeCalibParamHisto->GetYaxis()->SetTitle("Time (ns)");
-      mTimeCalibParamHisto->SetStats(false);
+      if (!mTimeCalibParamHisto) {
+        mTimeCalibParamHisto = new TH1D("timeCalibCoeff", "Time Calib Coeff", 17644, -0.5, 17643.5); //
+        mTimeCalibParamHisto->GetXaxis()->SetTitle("Cell Id");
+        mTimeCalibParamHisto->GetYaxis()->SetTitle("Time (ns)");
+        mTimeCalibParamHisto->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mTimeCalibParamHisto);
 
-      mTimeCalibParamPosition = new TH2D("timeCalibPosition", "Time Calib Coeff in 2D", 96, -0.5, 95.5, 208, -0.5, 207.5);
-      mTimeCalibParamPosition->GetXaxis()->SetTitle("column (#eta)");
-      mTimeCalibParamPosition->GetYaxis()->SetTitle("row (#phi)");
-      mTimeCalibParamPosition->SetStats(false);
+      if (!mTimeCalibParamPosition) {
+        mTimeCalibParamPosition = new TH2D("timeCalibPosition", "Time Calib Coeff in 2D", 96, -0.5, 95.5, 208, -0.5, 207.5);
+        mTimeCalibParamPosition->GetXaxis()->SetTitle("column (#eta)");
+        mTimeCalibParamPosition->GetYaxis()->SetTitle("row (#phi)");
+        mTimeCalibParamPosition->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mTimeCalibParamPosition);
     }
     if (obj == "BadChannelMap") {
-      mBadChannelMapHisto = new TH2D("badChannelMap", "Pos. of Bad Channel", 96, -0.5, 95.5, 208, -0.5, 207.5);
-      mBadChannelMapHisto->GetXaxis()->SetTitle("column (#eta)");
-      mBadChannelMapHisto->GetYaxis()->SetTitle("row (#phi)");
-      mBadChannelMapHisto->SetStats(false);
+      if (!mBadChannelMapHisto) {
+        mBadChannelMapHisto = new TH2D("badChannelMap", "Pos. of Bad Channel", 96, -0.5, 95.5, 208, -0.5, 207.5);
+        mBadChannelMapHisto->GetXaxis()->SetTitle("column (#eta)");
+        mBadChannelMapHisto->GetYaxis()->SetTitle("row (#phi)");
+        mBadChannelMapHisto->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mBadChannelMapHisto);
 
       // histogram for number of bad, dead, good channels in emcal only
-      mMaskStatsEMCALHisto = new TH1D("MaskStatsEMCALHisto", "Number of Good/Dead/Bad Channels in EMCAL Only", 3, -0.5, 2.5);
-      mMaskStatsEMCALHisto->GetXaxis()->SetTitle("channel status");
-      mMaskStatsEMCALHisto->GetYaxis()->SetTitle("Number of channels");
-      mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(1, "Good cells");
-      mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
-      mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
-      mMaskStatsEMCALHisto->SetStats(false);
+      if (!mMaskStatsEMCALHisto) {
+        mMaskStatsEMCALHisto = new TH1D("MaskStatsEMCALHisto", "Number of Good/Dead/Bad Channels in EMCAL Only", 3, -0.5, 2.5);
+        mMaskStatsEMCALHisto->GetXaxis()->SetTitle("channel status");
+        mMaskStatsEMCALHisto->GetYaxis()->SetTitle("Number of channels");
+        mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(1, "Good cells");
+        mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
+        mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
+        mMaskStatsEMCALHisto->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mMaskStatsEMCALHisto);
 
       // histogram for number of bad, dead, good channels in emcal only
-      mMaskStatsDCALHisto = new TH1D("MaskStatsDCALHisto", "Number of Good/Dead/Bad Channels in DCAL Only", 3, -0.5, 2.5);
-      mMaskStatsDCALHisto->GetXaxis()->SetTitle("channel status");
-      mMaskStatsDCALHisto->GetYaxis()->SetTitle("Number of channels");
-      mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(1, "Good cells");
-      mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
-      mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
-      mMaskStatsDCALHisto->SetStats(false);
+      if (!mMaskStatsDCALHisto) {
+        mMaskStatsDCALHisto = new TH1D("MaskStatsDCALHisto", "Number of Good/Dead/Bad Channels in DCAL Only", 3, -0.5, 2.5);
+        mMaskStatsDCALHisto->GetXaxis()->SetTitle("channel status");
+        mMaskStatsDCALHisto->GetYaxis()->SetTitle("Number of channels");
+        mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(1, "Good cells");
+        mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
+        mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
+        mMaskStatsDCALHisto->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mMaskStatsDCALHisto);
 
       // histogram for number of bad, dead, good channels in all
-      mMaskStatsAllHisto = new TH1D("MaskStatsAllHisto", "Number of Good/Dead/Bad Channels in EMCAL + DCAL", 3, -0.5, 2.5);
-      mMaskStatsAllHisto->GetXaxis()->SetTitle("channel status");
-      mMaskStatsAllHisto->GetYaxis()->SetTitle("Number of channels");
-      mMaskStatsAllHisto->GetXaxis()->SetBinLabel(1, "Good cells");
-      mMaskStatsAllHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
-      mMaskStatsAllHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
-      mMaskStatsAllHisto->SetStats(false);
+      if (!mMaskStatsAllHisto) {
+        mMaskStatsAllHisto = new TH1D("MaskStatsAllHisto", "Number of Good/Dead/Bad Channels in EMCAL + DCAL", 3, -0.5, 2.5);
+        mMaskStatsAllHisto->GetXaxis()->SetTitle("channel status");
+        mMaskStatsAllHisto->GetYaxis()->SetTitle("Number of channels");
+        mMaskStatsAllHisto->GetXaxis()->SetBinLabel(1, "Good cells");
+        mMaskStatsAllHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
+        mMaskStatsAllHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
+        mMaskStatsAllHisto->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mMaskStatsAllHisto);
 
       // histogram number of bad, good and dead channels per supermodule
-      mMaskStatsSupermoduleHisto = new TH2D("MaskStatsSupermoduleHisto", "Number of Good/Dead/Bad Channels per supermodule", 3, -0.5, 2.5, 20, -0.5, 19.5);
-      mMaskStatsSupermoduleHisto->GetXaxis()->SetTitle("channel status");
-      mMaskStatsSupermoduleHisto->GetYaxis()->SetTitle("Supermodule ID");
-      mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(1, "Good cells");
-      mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
-      mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
-      mMaskStatsSupermoduleHisto->SetStats(false);
+      if (!mMaskStatsSupermoduleHisto) {
+        mMaskStatsSupermoduleHisto = new TH2D("MaskStatsSupermoduleHisto", "Number of Good/Dead/Bad Channels per supermodule", 3, -0.5, 2.5, 20, -0.5, 19.5);
+        mMaskStatsSupermoduleHisto->GetXaxis()->SetTitle("channel status");
+        mMaskStatsSupermoduleHisto->GetYaxis()->SetTitle("Supermodule ID");
+        mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(1, "Good cells");
+        mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
+        mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
+        mMaskStatsSupermoduleHisto->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mMaskStatsSupermoduleHisto);
 
-      mNumberOfBadChannelsFEC = new TH2D("NumberBadChannelsFEC", "Number of bad channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
-      mNumberOfBadChannelsFEC->GetXaxis()->SetTitle("FEC ID");
-      mNumberOfBadChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
-      mNumberOfBadChannelsFEC->SetStats(false);
+      if (!mNumberOfBadChannelsFEC) {
+        mNumberOfBadChannelsFEC = new TH2D("NumberBadChannelsFEC", "Number of bad channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
+        mNumberOfBadChannelsFEC->GetXaxis()->SetTitle("FEC ID");
+        mNumberOfBadChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
+        mNumberOfBadChannelsFEC->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mNumberOfBadChannelsFEC);
 
-      mNumberOfDeadChannelsFEC = new TH2D("NumberDeadChannelsFEC", "Number of dead channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
-      mNumberOfDeadChannelsFEC->GetXaxis()->SetTitle("FEC ID");
-      mNumberOfDeadChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
-      mNumberOfDeadChannelsFEC->SetStats(false);
+      if (!mNumberOfDeadChannelsFEC) {
+        mNumberOfDeadChannelsFEC = new TH2D("NumberDeadChannelsFEC", "Number of dead channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
+        mNumberOfDeadChannelsFEC->GetXaxis()->SetTitle("FEC ID");
+        mNumberOfDeadChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
+        mNumberOfDeadChannelsFEC->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mNumberOfDeadChannelsFEC);
 
-      mNumberOfNonGoodChannelsFEC = new TH2D("NumberNonGoodChannelsFEC", "Number of dead+bad channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
-      mNumberOfNonGoodChannelsFEC->GetXaxis()->SetTitle("FEC ID");
-      mNumberOfNonGoodChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
-      mNumberOfNonGoodChannelsFEC->SetStats(false);
+      if (!mNumberOfNonGoodChannelsFEC) {
+        mNumberOfNonGoodChannelsFEC = new TH2D("NumberNonGoodChannelsFEC", "Number of dead+bad channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
+        mNumberOfNonGoodChannelsFEC->GetXaxis()->SetTitle("FEC ID");
+        mNumberOfNonGoodChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
+        mNumberOfNonGoodChannelsFEC->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mNumberOfNonGoodChannelsFEC);
     }
     if (obj == "FeeDCS") {
-      mSRUFirmwareVersion = new TH1D("SRUFirmwareVersion", "SRUFirmwareVersion of Supermodule", 20., -0.5, 19.5);
-      mSRUFirmwareVersion->GetXaxis()->SetTitle("Supermodule ID");
-      mSRUFirmwareVersion->GetYaxis()->SetTitle("SRUFirmwareVersion");
+      if (!mSRUFirmwareVersion) {
+        mSRUFirmwareVersion = new TH1D("SRUFirmwareVersion", "SRUFirmwareVersion of Supermodule", 20., -0.5, 19.5);
+        mSRUFirmwareVersion->GetXaxis()->SetTitle("Supermodule ID");
+        mSRUFirmwareVersion->GetYaxis()->SetTitle("SRUFirmwareVersion");
+        mSRUFirmwareVersion->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mSRUFirmwareVersion);
 
-      mActiveDDLs = new TH1D("ActiveDDLs", "Active Status of DDLs", 46., -0.5, 45.5);
-      mActiveDDLs->GetXaxis()->SetTitle("DDL ID");
-      mActiveDDLs->GetYaxis()->SetTitle("Active Status");
+      if (!mActiveDDLs) {
+        mActiveDDLs = new TH1D("ActiveDDLs", "Active Status of DDLs", 46., -0.5, 45.5);
+        mActiveDDLs->GetXaxis()->SetTitle("DDL ID");
+        mActiveDDLs->GetYaxis()->SetTitle("Active Status");
+        mActiveDDLs->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mActiveDDLs);
 
-      mTRUThresholds = new TH1D("TRUThresholds", "L0 threshold of TRUs", 46., -0.5, 45.5);
-      mTRUThresholds->GetXaxis()->SetTitle("TRU ID");
-      mTRUThresholds->GetYaxis()->SetTitle("L0 threshold");
+      if (!mTRUThresholds) {
+        mTRUThresholds = new TH1D("TRUThresholds", "L0 threshold of TRUs", 46., -0.5, 45.5);
+        mTRUThresholds->GetXaxis()->SetTitle("TRU ID");
+        mTRUThresholds->GetYaxis()->SetTitle("L0 threshold");
+        mTRUThresholds->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mTRUThresholds);
 
-      mL0Algorithm = new TH1D("L0Algorithm", "L0 algorithm of TRUs", 46., -0.5, 45.5);
-      mL0Algorithm->GetXaxis()->SetTitle("TRU ID");
-      mL0Algorithm->GetYaxis()->SetTitle("L0 algorithm");
+      if (!mL0Algorithm) {
+        mL0Algorithm = new TH1D("L0Algorithm", "L0 algorithm of TRUs", 46., -0.5, 45.5);
+        mL0Algorithm->GetXaxis()->SetTitle("TRU ID");
+        mL0Algorithm->GetYaxis()->SetTitle("L0 algorithm");
+        mL0Algorithm->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mL0Algorithm);
 
-      mRollbackSTU = new TH1D("RollbackSTU", "Rollback Buffer of TRUs", 46., -0.5, 45.5);
-      mRollbackSTU->GetXaxis()->SetTitle("TRU ID");
-      mRollbackSTU->GetYaxis()->SetTitle("Rollback Buffer");
+      if (!mRollbackSTU) {
+        mRollbackSTU = new TH1D("RollbackSTU", "Rollback Buffer of TRUs", 46., -0.5, 45.5);
+        mRollbackSTU->GetXaxis()->SetTitle("TRU ID");
+        mRollbackSTU->GetYaxis()->SetTitle("Rollback Buffer");
+        mRollbackSTU->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mRollbackSTU);
 
-      mTRUMaskPosition = new TH2D("TRUMaskPosition", "TRU Mask Position", 48., -0.5, 47.5, 104, -0.5, 103.5);
-      mTRUMaskPosition->GetXaxis()->SetTitle("FastOR Abs Eta");
-      mTRUMaskPosition->GetYaxis()->SetTitle("FastOR Abs Phi");
+      if (!mTRUMaskPosition) {
+        mTRUMaskPosition = new TH2D("TRUMaskPosition", "TRU Mask Position", 48., -0.5, 47.5, 104, -0.5, 103.5);
+        mTRUMaskPosition->GetXaxis()->SetTitle("FastOR Abs Eta");
+        mTRUMaskPosition->GetYaxis()->SetTitle("FastOR Abs Phi");
+        mTRUMaskPosition->SetStats(false);
+      }
       getObjectsManager()->startPublishing(mTRUMaskPosition);
     }
   }

--- a/Modules/EMCAL/src/CalibMonitoringTask.cxx
+++ b/Modules/EMCAL/src/CalibMonitoringTask.cxx
@@ -20,6 +20,7 @@
 #include "EMCALReconstruction/Channel.h"
 #include "EMCALCalib/BadChannelMap.h"
 #include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalib/FeeDCS.h"
 // QC includes
 #include "QualityControl/QcInfoLogger.h"
 #include "EMCAL/CalibMonitoringTask.h"
@@ -37,6 +38,60 @@ using namespace o2::quality_control::core;
 namespace o2::quality_control_modules::emcal
 {
 
+int CalibMonitoringTask::GetTRUIndexFromSTUIndex(Int_t id, Int_t detector)
+{
+  Int_t kEMCAL = 0;
+  Int_t kDCAL = 1;
+
+  if ((id > 31 && detector == kEMCAL) || (id > 13 && detector == kDCAL) || id < 0) {
+    return -1; // Error Condition
+  }
+
+  if (detector == kEMCAL) {
+    return id;
+  } else if (detector == kDCAL) {
+    return 32 + ((int)(id / 4) * 6) + ((id % 4 < 2) ? (id % 4) : (id % 4 + 2));
+  }
+  return -1;
+}
+
+int CalibMonitoringTask::GetChannelForMaskRun2(int mask, int bitnumber, bool onethirdsm)
+{
+  if (onethirdsm)
+    return mask * 16 + bitnumber;
+  const int kChannelMap[6][16] = { { 8, 9, 10, 11, 20, 21, 22, 23, 32, 33, 34, 35, 44, 45, 46, 47 },     // Channels in mask0
+                                   { 56, 57, 58, 59, 68, 69, 70, 71, 80, 81, 82, 83, 92, 93, 94, 95 },   // Channels in mask1
+                                   { 4, 5, 6, 7, 16, 17, 18, 19, 28, 29, 30, 31, 40, 41, 42, 43 },       // Channels in mask2
+                                   { 52, 53, 54, 55, 64, 65, 66, 67, 76, 77, 78, 79, 88, 89, 90, 91 },   // Channels in mask3
+                                   { 0, 1, 2, 3, 12, 13, 14, 15, 24, 25, 26, 27, 36, 37, 38, 39 },       // Channels in mask4
+                                   { 48, 49, 50, 51, 60, 61, 62, 63, 72, 73, 74, 75, 84, 85, 86, 87 } }; // Channels in mask5
+  return kChannelMap[mask][bitnumber];
+}
+
+std::vector<int> CalibMonitoringTask::GetAbsFastORIndexFromMask()
+{
+  std::vector<int> maskedfastors;
+  int itru = 0;
+  for (Int_t i = 0; i < 46; i++) {
+    int localtru = itru % 32, detector = itru >= 32 ? 1 : 0,
+        globaltru = GetTRUIndexFromSTUIndex(localtru, detector);
+    bool onethirdsm = ((globaltru >= 30 && globaltru < 32) || (globaltru >= 50 && globaltru < 52));
+    for (int ipos = 0; ipos < 6; ipos++) {
+      auto regmask = mFeeDCS->getTRUDCS(i).getMaskReg(ipos);
+      std::bitset<16> bitsregmask(regmask);
+      for (int ibit = 0; ibit < 16; ibit++) {
+        if (bitsregmask.test(ibit)) {
+          auto channel = GetChannelForMaskRun2(ipos, ibit, onethirdsm);
+          int absfastor = mTriggerMapping->getAbsFastORIndexFromIndexInTRU(globaltru, channel);
+          maskedfastors.push_back(absfastor);
+        }
+      }
+    }
+    itru++;
+  }
+  return maskedfastors;
+}
+
 void CalibMonitoringTask::configure(const boost::property_tree::ptree& config)
 {
   mCalibDB = std::make_unique<o2::emcal::CalibDB>(config.get<std::string>("qc.config.conditionDB.url").data());
@@ -53,102 +108,113 @@ void CalibMonitoringTask::initialize(Trigger, framework::ServiceRegistryRef)
   // initialize histograms to be monitored as data member
   for (const auto& obj : mCalibObjects) {
     if (obj == "TimeCalibParams") {
-      if (!mTimeCalibParamHisto) {
-        mTimeCalibParamHisto = new TH1D("timeCalibCoeff", "Time Calib Coeff", 17644, -0.5, 17643.5); //
-        mTimeCalibParamHisto->GetXaxis()->SetTitle("Cell Id");
-        mTimeCalibParamHisto->GetYaxis()->SetTitle("Time (ns)");
-        mTimeCalibParamHisto->SetStats(false);
-      }
+      mTimeCalibParamHisto = new TH1D("timeCalibCoeff", "Time Calib Coeff", 17644, -0.5, 17643.5); //
+      mTimeCalibParamHisto->GetXaxis()->SetTitle("Cell Id");
+      mTimeCalibParamHisto->GetYaxis()->SetTitle("Time (ns)");
+      mTimeCalibParamHisto->SetStats(false);
       getObjectsManager()->startPublishing(mTimeCalibParamHisto);
 
-      if (!mTimeCalibParamPosition) {
-        mTimeCalibParamPosition = new TH2D("timeCalibPosition", "Time Calib Coeff in 2D", 96, -0.5, 95.5, 208, -0.5, 207.5);
-        mTimeCalibParamPosition->GetXaxis()->SetTitle("column (#eta)");
-        mTimeCalibParamPosition->GetYaxis()->SetTitle("row (#phi)");
-        mTimeCalibParamPosition->SetStats(false);
-      }
+      mTimeCalibParamPosition = new TH2D("timeCalibPosition", "Time Calib Coeff in 2D", 96, -0.5, 95.5, 208, -0.5, 207.5);
+      mTimeCalibParamPosition->GetXaxis()->SetTitle("column (#eta)");
+      mTimeCalibParamPosition->GetYaxis()->SetTitle("row (#phi)");
+      mTimeCalibParamPosition->SetStats(false);
       getObjectsManager()->startPublishing(mTimeCalibParamPosition);
     }
     if (obj == "BadChannelMap") {
-      if (!mBadChannelMapHisto) {
-        mBadChannelMapHisto = new TH2D("badChannelMap", "Pos. of Bad Channel", 96, -0.5, 95.5, 208, -0.5, 207.5);
-        mBadChannelMapHisto->GetXaxis()->SetTitle("column (#eta)");
-        mBadChannelMapHisto->GetYaxis()->SetTitle("row (#phi)");
-        mBadChannelMapHisto->SetStats(false);
-      }
+      mBadChannelMapHisto = new TH2D("badChannelMap", "Pos. of Bad Channel", 96, -0.5, 95.5, 208, -0.5, 207.5);
+      mBadChannelMapHisto->GetXaxis()->SetTitle("column (#eta)");
+      mBadChannelMapHisto->GetYaxis()->SetTitle("row (#phi)");
+      mBadChannelMapHisto->SetStats(false);
       getObjectsManager()->startPublishing(mBadChannelMapHisto);
 
       // histogram for number of bad, dead, good channels in emcal only
-      if (!mMaskStatsEMCALHisto) {
-        mMaskStatsEMCALHisto = new TH1D("MaskStatsEMCALHisto", "Number of Good/Dead/Bad Channels in EMCAL Only", 3, -0.5, 2.5);
-        mMaskStatsEMCALHisto->GetXaxis()->SetTitle("channel status");
-        mMaskStatsEMCALHisto->GetYaxis()->SetTitle("Number of channels");
-        mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(1, "Good cells");
-        mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
-        mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
-        mMaskStatsEMCALHisto->SetStats(false);
-      }
+      mMaskStatsEMCALHisto = new TH1D("MaskStatsEMCALHisto", "Number of Good/Dead/Bad Channels in EMCAL Only", 3, -0.5, 2.5);
+      mMaskStatsEMCALHisto->GetXaxis()->SetTitle("channel status");
+      mMaskStatsEMCALHisto->GetYaxis()->SetTitle("Number of channels");
+      mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(1, "Good cells");
+      mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
+      mMaskStatsEMCALHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
+      mMaskStatsEMCALHisto->SetStats(false);
       getObjectsManager()->startPublishing(mMaskStatsEMCALHisto);
 
       // histogram for number of bad, dead, good channels in emcal only
-      if (!mMaskStatsDCALHisto) {
-        mMaskStatsDCALHisto = new TH1D("MaskStatsDCALHisto", "Number of Good/Dead/Bad Channels in DCAL Only", 3, -0.5, 2.5);
-        mMaskStatsDCALHisto->GetXaxis()->SetTitle("channel status");
-        mMaskStatsDCALHisto->GetYaxis()->SetTitle("Number of channels");
-        mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(1, "Good cells");
-        mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
-        mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
-        mMaskStatsDCALHisto->SetStats(false);
-      }
+      mMaskStatsDCALHisto = new TH1D("MaskStatsDCALHisto", "Number of Good/Dead/Bad Channels in DCAL Only", 3, -0.5, 2.5);
+      mMaskStatsDCALHisto->GetXaxis()->SetTitle("channel status");
+      mMaskStatsDCALHisto->GetYaxis()->SetTitle("Number of channels");
+      mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(1, "Good cells");
+      mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
+      mMaskStatsDCALHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
+      mMaskStatsDCALHisto->SetStats(false);
       getObjectsManager()->startPublishing(mMaskStatsDCALHisto);
 
       // histogram for number of bad, dead, good channels in all
-      if (!mMaskStatsAllHisto) {
-        mMaskStatsAllHisto = new TH1D("MaskStatsAllHisto", "Number of Good/Dead/Bad Channels in EMCAL + DCAL", 3, -0.5, 2.5);
-        mMaskStatsAllHisto->GetXaxis()->SetTitle("channel status");
-        mMaskStatsAllHisto->GetYaxis()->SetTitle("Number of channels");
-        mMaskStatsAllHisto->GetXaxis()->SetBinLabel(1, "Good cells");
-        mMaskStatsAllHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
-        mMaskStatsAllHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
-        mMaskStatsAllHisto->SetStats(false);
-      }
+      mMaskStatsAllHisto = new TH1D("MaskStatsAllHisto", "Number of Good/Dead/Bad Channels in EMCAL + DCAL", 3, -0.5, 2.5);
+      mMaskStatsAllHisto->GetXaxis()->SetTitle("channel status");
+      mMaskStatsAllHisto->GetYaxis()->SetTitle("Number of channels");
+      mMaskStatsAllHisto->GetXaxis()->SetBinLabel(1, "Good cells");
+      mMaskStatsAllHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
+      mMaskStatsAllHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
+      mMaskStatsAllHisto->SetStats(false);
       getObjectsManager()->startPublishing(mMaskStatsAllHisto);
 
       // histogram number of bad, good and dead channels per supermodule
-      if (!mMaskStatsSupermoduleHisto) {
-        mMaskStatsSupermoduleHisto = new TH2D("MaskStatsSupermoduleHisto", "Number of Good/Dead/Bad Channels per supermodule", 3, -0.5, 2.5, 20, -0.5, 19.5);
-        mMaskStatsSupermoduleHisto->GetXaxis()->SetTitle("channel status");
-        mMaskStatsSupermoduleHisto->GetYaxis()->SetTitle("Supermodule ID");
-        mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(1, "Good cells");
-        mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
-        mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
-        mMaskStatsSupermoduleHisto->SetStats(false);
-      }
+      mMaskStatsSupermoduleHisto = new TH2D("MaskStatsSupermoduleHisto", "Number of Good/Dead/Bad Channels per supermodule", 3, -0.5, 2.5, 20, -0.5, 19.5);
+      mMaskStatsSupermoduleHisto->GetXaxis()->SetTitle("channel status");
+      mMaskStatsSupermoduleHisto->GetYaxis()->SetTitle("Supermodule ID");
+      mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(1, "Good cells");
+      mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(2, "Bad cells");
+      mMaskStatsSupermoduleHisto->GetXaxis()->SetBinLabel(3, "Dead cells");
+      mMaskStatsSupermoduleHisto->SetStats(false);
       getObjectsManager()->startPublishing(mMaskStatsSupermoduleHisto);
 
-      if (!mNumberOfBadChannelsFEC) {
-        mNumberOfBadChannelsFEC = new TH2D("NumberBadChannelsFEC", "Number of bad channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
-        mNumberOfBadChannelsFEC->GetXaxis()->SetTitle("FEC ID");
-        mNumberOfBadChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
-        mNumberOfBadChannelsFEC->SetStats(false);
-      }
+      mNumberOfBadChannelsFEC = new TH2D("NumberBadChannelsFEC", "Number of bad channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
+      mNumberOfBadChannelsFEC->GetXaxis()->SetTitle("FEC ID");
+      mNumberOfBadChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
+      mNumberOfBadChannelsFEC->SetStats(false);
       getObjectsManager()->startPublishing(mNumberOfBadChannelsFEC);
 
-      if (!mNumberOfDeadChannelsFEC) {
-        mNumberOfDeadChannelsFEC = new TH2D("NumberDeadChannelsFEC", "Number of dead channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
-        mNumberOfDeadChannelsFEC->GetXaxis()->SetTitle("FEC ID");
-        mNumberOfDeadChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
-        mNumberOfDeadChannelsFEC->SetStats(false);
-      }
+      mNumberOfDeadChannelsFEC = new TH2D("NumberDeadChannelsFEC", "Number of dead channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
+      mNumberOfDeadChannelsFEC->GetXaxis()->SetTitle("FEC ID");
+      mNumberOfDeadChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
+      mNumberOfDeadChannelsFEC->SetStats(false);
       getObjectsManager()->startPublishing(mNumberOfDeadChannelsFEC);
 
-      if (!mNumberOfNonGoodChannelsFEC) {
-        mNumberOfNonGoodChannelsFEC = new TH2D("NumberNonGoodChannelsFEC", "Number of dead+bad channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
-        mNumberOfNonGoodChannelsFEC->GetXaxis()->SetTitle("FEC ID");
-        mNumberOfNonGoodChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
-        mNumberOfNonGoodChannelsFEC->SetStats(false);
-      }
+      mNumberOfNonGoodChannelsFEC = new TH2D("NumberNonGoodChannelsFEC", "Number of dead+bad channels per FEC", 40, -0.5, 39.5, 20., -0.5, 19.5);
+      mNumberOfNonGoodChannelsFEC->GetXaxis()->SetTitle("FEC ID");
+      mNumberOfNonGoodChannelsFEC->GetYaxis()->SetTitle("Supermodule ID");
+      mNumberOfNonGoodChannelsFEC->SetStats(false);
       getObjectsManager()->startPublishing(mNumberOfNonGoodChannelsFEC);
+    }
+    if (obj == "FeeDCS") {
+      mSRUFirmwareVersion = new TH1D("SRUFirmwareVersion", "SRUFirmwareVersion of Supermodule", 20., -0.5, 19.5);
+      mSRUFirmwareVersion->GetXaxis()->SetTitle("Supermodule ID");
+      mSRUFirmwareVersion->GetYaxis()->SetTitle("SRUFirmwareVersion");
+      getObjectsManager()->startPublishing(mSRUFirmwareVersion);
+
+      mActiveDDLs = new TH1D("ActiveDDLs", "Active Status of DDLs", 46., -0.5, 45.5);
+      mActiveDDLs->GetXaxis()->SetTitle("DDL ID");
+      mActiveDDLs->GetYaxis()->SetTitle("Active Status");
+      getObjectsManager()->startPublishing(mActiveDDLs);
+
+      mTRUThresholds = new TH1D("TRUThresholds", "L0 threshold of TRUs", 46., -0.5, 45.5);
+      mTRUThresholds->GetXaxis()->SetTitle("TRU ID");
+      mTRUThresholds->GetYaxis()->SetTitle("L0 threshold");
+      getObjectsManager()->startPublishing(mTRUThresholds);
+
+      mL0Algorithm = new TH1D("L0Algorithm", "L0 algorithm of TRUs", 46., -0.5, 45.5);
+      mL0Algorithm->GetXaxis()->SetTitle("TRU ID");
+      mL0Algorithm->GetYaxis()->SetTitle("L0 algorithm");
+      getObjectsManager()->startPublishing(mL0Algorithm);
+
+      mRollbackSTU = new TH1D("RollbackSTU", "Rollback Buffer of TRUs", 46., -0.5, 45.5);
+      mRollbackSTU->GetXaxis()->SetTitle("TRU ID");
+      mRollbackSTU->GetYaxis()->SetTitle("Rollback Buffer");
+      getObjectsManager()->startPublishing(mRollbackSTU);
+
+      mTRUMaskPosition = new TH2D("TRUMaskPosition", "TRU Mask Position", 48., -0.5, 47.5, 104, -0.5, 103.5);
+      mTRUMaskPosition->GetXaxis()->SetTitle("FastOR Abs Eta");
+      mTRUMaskPosition->GetYaxis()->SetTitle("FastOR Abs Phi");
+      getObjectsManager()->startPublishing(mTRUMaskPosition);
     }
   }
   o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
@@ -217,6 +283,36 @@ void CalibMonitoringTask::update(Trigger t, framework::ServiceRegistryRef)
         mTimeCalibParamPosition->SetBinContent(column + 1, row + 1, hist_temp->GetBinContent(i + 1));
       }
     }
+    if (obj == "FeeDCS") {
+      mFeeDCS = mCalibDB->readFeeDCSData(o2::ccdb::getCurrentTimestamp(), metadata);
+      if (!mFeeDCS) {
+        ILOG(Info, Support) << " No FEE DCS object " << ENDM;
+        continue;
+      }
+      for (Int_t i = 0; i < mSRUFirmwareVersion->GetNbinsX(); i++) {
+        mSRUFirmwareVersion->SetBinContent(i + 1, mFeeDCS->getSRUFWversion(i));
+      }
+      for (Int_t i = 0; i < mActiveDDLs->GetNbinsX(); i++) {
+        mActiveDDLs->SetBinContent(i + 1, mFeeDCS->isDDLactive(i));
+      }
+      for (Int_t i = 0; i < mTRUThresholds->GetNbinsX(); i++) {
+        mTRUThresholds->SetBinContent(i + 1, static_cast<double>(mFeeDCS->getTRUDCS(i).getGTHRL0()));
+      }
+      for (Int_t i = 0; i < mL0Algorithm->GetNbinsX(); i++) {
+        mL0Algorithm->SetBinContent(i + 1, mFeeDCS->getTRUDCS(i).getL0SEL());
+      }
+
+      for (Int_t i = 0; i < mRollbackSTU->GetNbinsX(); i++) {
+        mRollbackSTU->SetBinContent(i + 1, mFeeDCS->getTRUDCS(i).getRLBKSTU());
+      }
+
+      auto fastORs = GetAbsFastORIndexFromMask();
+
+      for (auto fastORID : fastORs) {
+        auto [eta, phi] = mTriggerMapping->getPositionInEMCALFromAbsFastORIndex(fastORID);
+        mTRUMaskPosition->SetBinContent(eta + 1, phi + 1, 1.);
+      }
+    }
   }
 }
 
@@ -236,6 +332,14 @@ void CalibMonitoringTask::finalize(Trigger t, framework::ServiceRegistryRef)
     if (obj == "TimeCalibParams") {
       getObjectsManager()->stopPublishing(mTimeCalibParamHisto);
       getObjectsManager()->stopPublishing(mTimeCalibParamPosition);
+    }
+    if (obj == "FeeDCS") {
+      getObjectsManager()->stopPublishing(mSRUFirmwareVersion);
+      getObjectsManager()->stopPublishing(mActiveDDLs);
+      getObjectsManager()->stopPublishing(mTRUThresholds);
+      getObjectsManager()->stopPublishing(mL0Algorithm);
+      getObjectsManager()->stopPublishing(mRollbackSTU);
+      getObjectsManager()->stopPublishing(mTRUMaskPosition);
     }
   }
 }
@@ -270,6 +374,24 @@ void CalibMonitoringTask::reset()
   }
   if (mTimeCalibParamHisto) {
     mTimeCalibParamHisto->Reset();
+  }
+  if (mSRUFirmwareVersion) {
+    mSRUFirmwareVersion->Reset();
+  }
+  if (mActiveDDLs) {
+    mActiveDDLs->Reset();
+  }
+  if (mTRUThresholds) {
+    mTRUThresholds->Reset();
+  }
+  if (mL0Algorithm) {
+    mL0Algorithm->Reset();
+  }
+  if (mRollbackSTU) {
+    mRollbackSTU->Reset();
+  }
+  if (mTRUMaskPosition) {
+    mTRUMaskPosition->Reset();
   }
 }
 } // namespace o2::quality_control_modules::emcal


### PR DESCRIPTION
The histograms added are:

Link active: 1 Histogram with 46 bins
SRU Firmware version: 1 Histogram with 20 bins
TRU threshold: 1 histograms with 46 bins
L0 algorithm: 1 histogram with 46 bins
Rollback Buffer: 1 histogram with 46 bins
TRU mask: 2D histogram with 48 x 104 bins, showing the position of a mask.