### PR TITLE
QC-1202 Improve naming of canvas elements created by TrendingTask

### DIFF
--- a/Framework/include/QualityControl/TrendingTaskConfig.h
+++ b/Framework/include/QualityControl/TrendingTaskConfig.h
@@ -33,6 +33,7 @@ struct TrendingTaskConfig : PostProcessingConfig {
 
   // this corresponds to one TTree::Draw() call, i.e. one graph or histogram drawing
   struct Graph {
+    std::string name;
     std::string title;
     std::string varexp;
     std::string selection;

--- a/Framework/postprocessing.json
+++ b/Framework/postprocessing.json
@@ -85,11 +85,13 @@
             "graphYRange": "0:10000",
             "graphs" : [
               {
+                "name": "mean_trend",
                 "title": "mean trend",
                 "varexp": "example.mean:time",
                 "selection": "",
                 "option": "*L PLC PMC"
               }, {
+                "name": "mean_trend_1000",
                 "title": "mean trend + 1000",
                 "varexp": "example.mean + 1000:time",
                 "selection": "",

--- a/Framework/src/TrendingTask.cxx
+++ b/Framework/src/TrendingTask.cxx
@@ -337,22 +337,26 @@ TCanvas* TrendingTask::drawPlot(const TrendingTaskConfig::Plot& plotConfig)
         mTrend->Draw(varexpWithErrors.c_str(), graphConfig.selection.c_str(), "goff");
         graphErrors = new TGraphErrors(mTrend->GetSelectedRows(), mTrend->GetVal(1), mTrend->GetVal(0),
                                        mTrend->GetVal(2), mTrend->GetVal(3));
+        graphErrors->SetName((graphConfig.name + "_errors").c_str());
+        graphErrors->SetTitle((graphConfig.title + " errors").c_str());
         // We draw on the same plotConfig as the main graphConfig, but only error bars
         graphErrors->Draw("SAME E");
       }
     }
 
     if (auto graph = dynamic_cast<TGraph*>(c->FindObject("Graph"))) {
+      graph->SetName(graphConfig.name.c_str());
       graph->SetTitle(graphConfig.title.c_str());
-      graph->SetName(graphConfig.title.c_str());
       legend->AddEntry(graph, graphConfig.title.c_str(), deduceGraphLegendOptions(graphConfig).c_str());
     }
     if (auto htemp = dynamic_cast<TH1*>(c->FindObject("htemp"))) {
-      htemp->SetTitle(graphConfig.title.c_str());
-      htemp->SetName(graphConfig.title.c_str());
       if (plotOrder == 1) {
+        htemp->SetName(graphConfig.name.c_str());
+        htemp->SetTitle(graphConfig.title.c_str());
         legend->AddEntry(htemp, graphConfig.title.c_str(), "lpf");
       } else {
+        htemp->SetName("background");
+        htemp->SetTitle("background");
         // htemp was used by TTree::Draw only to draw axes and title, not to plot data, no need to add it to legend
       }
       // QCG doesn't empty the buffers before visualizing the plotConfig, nor does ROOT when saving the file,

--- a/Framework/src/TrendingTaskConfig.cxx
+++ b/Framework/src/TrendingTaskConfig.cxx
@@ -31,14 +31,18 @@ TrendingTaskConfig::TrendingTaskConfig(std::string id, const boost::property_tre
     std::vector<Graph> graphs;
     if (const auto& graphsConfig = plotConfig.get_child_optional("graphs"); graphsConfig.has_value()) {
       for (const auto& [_, graphConfig] : graphsConfig.value()) {
-        graphs.push_back({ graphConfig.get<std::string>("title", ""),
+        // first we use name of the graph, if absent, we use graph title, if absent, we use plot (object) name.
+        const auto& name = graphConfig.get<std::string>("name", graphConfig.get<std::string>("title", plotConfig.get<std::string>("name")));
+        graphs.push_back({ name,
+                           graphConfig.get<std::string>("title", ""),
                            graphConfig.get<std::string>("varexp"),
                            graphConfig.get<std::string>("selection", ""),
                            graphConfig.get<std::string>("option", ""),
                            graphConfig.get<std::string>("graphErrors", "") });
       }
     } else {
-      graphs.push_back({ plotConfig.get<std::string>("title", ""),
+      graphs.push_back({ plotConfig.get<std::string>("name", ""),
+                         plotConfig.get<std::string>("title", ""),
                          plotConfig.get<std::string>("varexp"),
                          plotConfig.get<std::string>("selection", ""),
                          plotConfig.get<std::string>("option", ""),


### PR DESCRIPTION
As it turned out, some TPC Checks were relying on the default naming used by TTree::Draw when drawing the trends, i.e. "Graph" and "htemp". When implementing QC-1155, we could not keep them default to allow for drawing a legend in case we had multiple trends on one canvas.

This commit changes the following:
- It adds an optional "name" field to graphs. If it's absent, "title" is used. If that is absent as well, the main "name" of the plot is used.
- In case that "htemp" is used by TTree::Draw only to draw the axes, title, etc, it is renamed to "background". In case that the plot is 1D, "htemp" is renamed to the plot "name"
- In case that errors are drawn, the object is renamed to "name" suffixed with "_errors"