### PR TITLE
ctpdev: removing dependencies on RunManager

### DIFF
--- a/Modules/CTP/include/CTP/CountersQcTask.h
+++ b/Modules/CTP/include/CTP/CountersQcTask.h
@@ -26,6 +26,9 @@ class TH1D;
 class TCanvas;
 
 using namespace o2::quality_control::core;
+//
+// Fake class to compile. If the task CTPCounterTask will beused it will be fixed or the whole task shall be removed.
+//
 class CTPRunManager
 {
 };

--- a/Modules/CTP/include/CTP/CountersQcTask.h
+++ b/Modules/CTP/include/CTP/CountersQcTask.h
@@ -19,7 +19,6 @@
 
 #include "QualityControl/TaskInterface.h"
 #include "DataFormatsCTP/Configuration.h"
-#include "DataFormatsCTP/RunManager.h"
 #include "TH1.h"
 
 class TH1F;
@@ -27,7 +26,9 @@ class TH1D;
 class TCanvas;
 
 using namespace o2::quality_control::core;
-
+class CTPRunManager
+{
+};
 namespace o2::quality_control_modules::ctp
 {
 
@@ -97,7 +98,7 @@ class CTPCountersTask final : public TaskInterface
   std::array<TCanvas*, 16> mTCanvasClassRates = { nullptr };
 };
 
-class CTPQcRunManager : public o2::ctp::CTPRunManager
+class CTPQcRunManager : public CTPRunManager
 {
  public:
   /// \brief Constructor

--- a/Modules/CTP/src/CTPTrendingTask.cxx
+++ b/Modules/CTP/src/CTPTrendingTask.cxx
@@ -23,7 +23,7 @@
 #include <QualityControl/ActivityHelpers.h>
 #include <CCDB/BasicCCDBManager.h>
 #include <DataFormatsCTP/Configuration.h>
-//#include "DataFormatsCTP/RunManager.h"
+// #include "DataFormatsCTP/RunManager.h"
 
 #include <TCanvas.h>
 #include <TH1.h>
@@ -51,9 +51,9 @@ void CTPTrendingTask::initCTP(Trigger& t)
   }
 
   /// the reading of the ccdb from trending was already discussed and is related with the fact that CTPconfing may not be ready at the QC starts
-  //o2::ctp::CTPRunManager::setCCDBHost(CCDBHost);
+  // o2::ctp::CTPRunManager::setCCDBHost(CCDBHost);
   bool ok;
-  //o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(t.timestamp, run, ok);
+  // o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(t.timestamp, run, ok);
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
   mgr.setURL(CCDBHost);
   map<string, string> metadata; // can be empty
@@ -135,10 +135,10 @@ void CTPTrendingTask::initCTP(Trigger& t)
   }
 
   // get the indices of the classes we want to trend
-  //std::vector<ctp::CTPClass> ctpcls = CTPconfig.getCTPClasses();
-  //std::vector<int> clslist = CTPconfig.getTriggerClassList();
+  // std::vector<ctp::CTPClass> ctpcls = CTPconfig.getCTPClasses();
+  // std::vector<int> clslist = CTPconfig.getTriggerClassList();
   std::vector<ctp::CTPClass> ctpcls = ctpconfigdb->getCTPClasses();
-  std::vector<int> clslist = ctpconfigdb->getTriggerClassList();  
+  std::vector<int> clslist = ctpconfigdb->getTriggerClassList();
   for (size_t i = 0; i < clslist.size(); i++) {
     for (size_t j = 0; j < mNumberOfClasses; j++) {
       if (ctpcls[i].name.find(mClassNames[j]) != std::string::npos) {

--- a/Modules/CTP/src/CTPTrendingTask.cxx
+++ b/Modules/CTP/src/CTPTrendingTask.cxx
@@ -23,7 +23,7 @@
 #include <QualityControl/ActivityHelpers.h>
 #include <CCDB/BasicCCDBManager.h>
 #include <DataFormatsCTP/Configuration.h>
-#include "DataFormatsCTP/RunManager.h"
+//#include "DataFormatsCTP/RunManager.h"
 
 #include <TCanvas.h>
 #include <TH1.h>
@@ -51,10 +51,22 @@ void CTPTrendingTask::initCTP(Trigger& t)
   }
 
   /// the reading of the ccdb from trending was already discussed and is related with the fact that CTPconfing may not be ready at the QC starts
-  o2::ctp::CTPRunManager::setCCDBHost(CCDBHost);
+  //o2::ctp::CTPRunManager::setCCDBHost(CCDBHost);
   bool ok;
-  o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(t.timestamp, run, ok);
-
+  //o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(t.timestamp, run, ok);
+  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+  mgr.setURL(CCDBHost);
+  map<string, string> metadata; // can be empty
+  metadata["runNumber"] = run;
+  auto ctpconfigdb = mgr.getSpecific<o2::ctp::CTPConfiguration>(o2::ctp::CCDBPathCTPConfig, t.timestamp, metadata);
+  if (ctpconfigdb == nullptr) {
+    LOG(info) << "CTP config not in database, timestamp:" << t.timestamp;
+    ok = 0;
+  } else {
+    // ctpconfigdb->printStream(std::cout);
+    LOG(info) << "CTP config found. Run:" << run;
+    ok = 1;
+  }
   if (!ok) {
     ILOG(Warning, Support) << "CTP Config not found for run:" << run << " timesamp " << t.timestamp << ENDM;
     return;
@@ -123,8 +135,10 @@ void CTPTrendingTask::initCTP(Trigger& t)
   }
 
   // get the indices of the classes we want to trend
-  std::vector<ctp::CTPClass> ctpcls = CTPconfig.getCTPClasses();
-  std::vector<int> clslist = CTPconfig.getTriggerClassList();
+  //std::vector<ctp::CTPClass> ctpcls = CTPconfig.getCTPClasses();
+  //std::vector<int> clslist = CTPconfig.getTriggerClassList();
+  std::vector<ctp::CTPClass> ctpcls = ctpconfigdb->getCTPClasses();
+  std::vector<int> clslist = ctpconfigdb->getTriggerClassList();  
   for (size_t i = 0; i < clslist.size(); i++) {
     for (size_t j = 0; j < mNumberOfClasses; j++) {
       if (ctpcls[i].name.find(mClassNames[j]) != std::string::npos) {

--- a/Modules/CTP/src/RawDataQcTask.cxx
+++ b/Modules/CTP/src/RawDataQcTask.cxx
@@ -24,7 +24,7 @@
 #include "Headers/RAWDataHeader.h"
 #include "DataFormatsCTP/Digits.h"
 #include "DataFormatsCTP/Configuration.h"
-#include "DataFormatsCTP/RunManager.h"
+//#include "DataFormatsCTP/RunManager.h"
 #include <Framework/InputRecord.h>
 #include "Framework/TimingInfo.h"
 
@@ -80,13 +80,27 @@ void CTPRawDataReaderTask::startOfActivity(const Activity& activity)
     ccdbName = "https://alice-ccdb.cern.ch";
   }
   /// the ccdb reading to be futher discussed
-  o2::ctp::CTPRunManager::setCCDBHost(ccdbName);
+  //o2::ctp::CTPRunManager::setCCDBHost(ccdbName);
   bool ok;
-  o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(mTimestamp, run, ok);
+  //o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(mTimestamp, run, ok);
+  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+  mgr.setURL(ccdbName);
+  map<string, string> metadata; // can be empty
+  metadata["runNumber"] = run;
+  auto ctpconfigdb = mgr.getSpecific<o2::ctp::CTPConfiguration>(o2::ctp::CCDBPathCTPConfig, mTimestamp, metadata);
+  if (ctpconfigdb == nullptr) {
+    LOG(info) << "CTP config not in database, timestamp:" << mTimestamp;
+    ok = 0;
+  } else {
+    // ctpconfigdb->printStream(std::cout);
+    LOG(info) << "CTP config found. Run:" << run;
+    ok = 1;
+  }
   if (ok) {
     // get the index of the MB reference class
     ILOG(Info, Support) << "CTP config found, run:" << run << ENDM;
-    std::vector<o2::ctp::CTPClass> ctpcls = CTPconfig.getCTPClasses();
+    //std::vector<o2::ctp::CTPClass> ctpcls = CTPconfig.getCTPClasses();
+    std::vector<o2::ctp::CTPClass> ctpcls = ctpconfigdb->getCTPClasses();
     for (size_t i = 0; i < ctpcls.size(); i++) {
       if (ctpcls[i].name.find(MBclassName) != std::string::npos) {
         mIndexMBclass = ctpcls[i].getIndex() + 1;

--- a/Modules/CTP/src/RawDataQcTask.cxx
+++ b/Modules/CTP/src/RawDataQcTask.cxx
@@ -24,7 +24,7 @@
 #include "Headers/RAWDataHeader.h"
 #include "DataFormatsCTP/Digits.h"
 #include "DataFormatsCTP/Configuration.h"
-//#include "DataFormatsCTP/RunManager.h"
+// #include "DataFormatsCTP/RunManager.h"
 #include <Framework/InputRecord.h>
 #include "Framework/TimingInfo.h"
 
@@ -80,9 +80,9 @@ void CTPRawDataReaderTask::startOfActivity(const Activity& activity)
     ccdbName = "https://alice-ccdb.cern.ch";
   }
   /// the ccdb reading to be futher discussed
-  //o2::ctp::CTPRunManager::setCCDBHost(ccdbName);
+  // o2::ctp::CTPRunManager::setCCDBHost(ccdbName);
   bool ok;
-  //o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(mTimestamp, run, ok);
+  // o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(mTimestamp, run, ok);
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
   mgr.setURL(ccdbName);
   map<string, string> metadata; // can be empty
@@ -99,7 +99,7 @@ void CTPRawDataReaderTask::startOfActivity(const Activity& activity)
   if (ok) {
     // get the index of the MB reference class
     ILOG(Info, Support) << "CTP config found, run:" << run << ENDM;
-    //std::vector<o2::ctp::CTPClass> ctpcls = CTPconfig.getCTPClasses();
+    // std::vector<o2::ctp::CTPClass> ctpcls = CTPconfig.getCTPClasses();
     std::vector<o2::ctp::CTPClass> ctpcls = ctpconfigdb->getCTPClasses();
     for (size_t i = 0; i < ctpcls.size(); i++) {
       if (ctpcls[i].name.find(MBclassName) != std::string::npos) {

--- a/Modules/CTP/src/RawDataReaderCheck.cxx
+++ b/Modules/CTP/src/RawDataReaderCheck.cxx
@@ -18,7 +18,7 @@
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/QcInfoLogger.h"
-#include "DataFormatsCTP/RunManager.h"
+//#include "DataFormatsCTP/RunManager.h"
 #include <DataFormatsCTP/Configuration.h>
 // ROOT
 #include <TH1.h>

--- a/Modules/CTP/src/RawDataReaderCheck.cxx
+++ b/Modules/CTP/src/RawDataReaderCheck.cxx
@@ -18,7 +18,7 @@
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/QcInfoLogger.h"
-//#include "DataFormatsCTP/RunManager.h"
+// #include "DataFormatsCTP/RunManager.h"
 #include <DataFormatsCTP/Configuration.h>
 // ROOT
 #include <TH1.h>


### PR DESCRIPTION
Removing dependency on RunManager as discussed in
https://github.com/AliceO2Group/AliceO2/pull/13224
I left old lines commented as it may be moved back after O2 update.