### PR TITLE
Common: improve reference run handling in checker

### DIFF
--- a/Modules/Common/include/Common/ReferenceComparatorCheck.h
+++ b/Modules/Common/include/Common/ReferenceComparatorCheck.h
@@ -22,6 +22,7 @@
 #include "Common/ObjectComparatorInterface.h"
 
 #include <sstream>
+#include <unordered_map>
 
 class TPaveText;
 
@@ -56,6 +57,7 @@ class ReferenceComparatorCheck : public o2::quality_control::checker::CheckInter
   std::map<std::string, std::shared_ptr<TPaveText>> mQualityLabels;
   quality_control::core::Activity mActivity /*current*/, mReferenceActivity;
   size_t mReferenceRun;
+  std::unordered_map<std::string, std::shared_ptr<MonitorObject>> mReferencePlots;
 };
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -149,6 +149,12 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
 
   // get path of mo and ref (we have to remove the provenance)
   std::string path = RepoPathUtils::getPathNoProvenance(mo);
+
+  if (mReferenceRun == 0) {
+    message = "No reference run provided";
+    return Quality::Null;;
+  }
+
   // todo we could cache the reference plot within a run
   auto referencePlot = retrieveReference(path, mReferenceActivity);
   if (!referencePlot) {
@@ -171,11 +177,6 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
 Quality ReferenceComparatorCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
   Quality result = Quality::Null;
-
-  if (mReferenceRun == 0) {
-    result.addFlag(FlagTypeFactory::Unknown(), "No reference run provided");
-    return result;
-  }
 
   for (auto& [key, mo] : *moMap) {
     auto moName = mo->getName();

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -63,6 +63,9 @@ void ReferenceComparatorCheck::startOfActivity(const Activity& activity)
   mActivity = activity;
   mReferenceActivity = activity;
   mReferenceActivity.mId = mReferenceRun;
+
+  // clear the cache of reference plots
+  mReferencePlots.clear();
 }
 
 void ReferenceComparatorCheck::endOfActivity(const Activity& activity)
@@ -155,8 +158,12 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
     return Quality::Null;;
   }
 
-  // todo we could cache the reference plot within a run
-  auto referencePlot = retrieveReference(path, mReferenceActivity);
+  // retrieve the reference plot only once and cache it for later use
+  if (mReferencePlots.count(path) == 0) {
+    mReferencePlots[path] = retrieveReference(path, mReferenceActivity);
+  }
+
+  auto referencePlot = mReferencePlots[path];
   if (!referencePlot) {
     message = "Reference plot not found";
     return Quality::Null;

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -155,7 +155,7 @@ Quality ReferenceComparatorCheck::getSinglePlotQuality(std::shared_ptr<MonitorOb
 
   if (mReferenceRun == 0) {
     message = "No reference run provided";
-    return Quality::Null;;
+    return Quality::Null;
   }
 
   // retrieve the reference plot only once and cache it for later use


### PR DESCRIPTION
In the current code, a valid reference run is needed in all cases, even when only TCanvas objects were checked, which already have the reference plot embedded.

In order to avoid redundantly setting the reference run number both in the post-processing task and the checker when the `ReferenceComparatorTask` is used, the code is modified to only require a valid reference run number when TH1 objects are checked.

In addition, the code adds the caching of the reference plots, such that they are only loaded from QCDB once and re-used until a new activity is started.