### PR TITLE
MFT: new checker for empty ladders

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTClusterCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterCheck.h
@@ -43,18 +43,22 @@ class QcMFTClusterCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
-  int mZoneThresholdMedium;
-  int mZoneThresholdBad;
+  int mLadderThresholdMedium;
+  int mLadderThresholdBad;
+
+  // ladder checker
+  bool mIsEmpty;
+  bool mAdjacentLadders;
+  int mEmptyCount;
+  int mAdjacentCount;
 
   // masked chips part
   bool mFirstCall;
   std::vector<int> mMaskedChips;
   std::vector<string> mChipMapName;
-  std::vector<string> mOutsideAccName;
 
   void readMaskedChips(std::shared_ptr<MonitorObject> mo);
   void createMaskedChipsNames();
-  void createOutsideAccNames();
 
   // to form the name of the masked chips histograms
   int mHalf[936] = { 0 };

--- a/Modules/MFT/include/MFT/QcMFTDigitCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitCheck.h
@@ -42,18 +42,22 @@ class QcMFTDigitCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
-  int mZoneThresholdMedium;
-  int mZoneThresholdBad;
+  int mLadderThresholdMedium;
+  int mLadderThresholdBad;
+
+  // ladder checker
+  bool mIsEmpty;
+  bool mAdjacentLadders;
+  int mEmptyCount;
+  int mAdjacentCount;
 
   // masked chips part
   bool mFirstCall;
   std::vector<int> mMaskedChips;
   std::vector<string> mChipMapName;
-  std::vector<string> mOutsideAccName;
 
   void readMaskedChips(std::shared_ptr<MonitorObject> mo);
   void createMaskedChipsNames();
-  void createOutsideAccNames();
 
   // noise scan check
 

--- a/Modules/MFT/include/MFT/QcMFTUtilTables.h
+++ b/Modules/MFT/include/MFT/QcMFTUtilTables.h
@@ -352,6 +352,52 @@ class QcMFTUtilTables
     { 17, -14, 14, 5, 0, 15 },
   };
 
+  // names for occupancy maps (for outside acceptance and ladder checker)
+  string mDigitChipMapNames[20] = {
+    "ChipOccupancyMaps/Half_0/Disk_0/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_0/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_1/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_1/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_2/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_2/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_3/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_3/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_4/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_4/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_0/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_0/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_1/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_1/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_2/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_2/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_3/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_3/Face_1/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_4/Face_0/mDigitChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_4/Face_1/mDigitChipOccupancyMap"
+  };
+
+  string mClusterChipMapNames[20] = {
+    "ChipOccupancyMaps/Half_0/Disk_0/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_0/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_1/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_1/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_2/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_2/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_3/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_3/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_4/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_0/Disk_4/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_0/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_0/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_1/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_1/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_2/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_2/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_3/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_3/Face_1/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_4/Face_0/mClusterChipOccupancyMap",
+    "ChipOccupancyMaps/Half_1/Disk_4/Face_1/mClusterChipOccupancyMap"
+  };
   // binX for outside acceptance (-1 due to uneven number of empty bins different parts of the detector)
   int mBinX[20][21] = {
     // half0

--- a/Modules/MFT/mft-clusters.json
+++ b/Modules/MFT/mft-clusters.json
@@ -85,8 +85,8 @@
           ]
         } ],
         "checkParameters" : {
-          "ZoneThresholdMedium" : "2",
-          "ZoneThresholdBad" : "5"
+          "LadderThresholdMedium" : "1",
+          "LadderThresholdBad" : "2"
         },
         "className" : "o2::quality_control_modules::mft::QcMFTClusterCheck",
         "moduleName" : "QcMFT",

--- a/Modules/MFT/mft-digits.json
+++ b/Modules/MFT/mft-digits.json
@@ -63,8 +63,8 @@
         "detectorName" : "MFT",
         "policy" : "OnEachSeparately",
         "checkParameters" : {
-          "ZoneThresholdMedium" : "2",
-          "ZoneThresholdBad" : "5",
+          "LadderThresholdMedium" : "1",
+          "LadderThresholdBad" : "2",
           "NoiseScan" : "1",
           "NCyclesNoiseMap" : "3"
         },

--- a/Modules/MFT/src/QcMFTClusterCheck.cxx
+++ b/Modules/MFT/src/QcMFTClusterCheck.cxx
@@ -122,8 +122,8 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
         return Quality::Null;
       }
     }
-    
-    //checker for empty ladders
+
+    // checker for empty ladders
     QcMFTUtilTables MFTTable;
     for (int i = 0; i < 20; i++) {
       if (mo->getName() == MFTTable.mClusterChipMapNames[i]) {
@@ -138,10 +138,10 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
           mIsEmpty = true;
           for (int iBinY = 0; iBinY < hClusterChipOccupancyMap->GetNbinsY(); iBinY++) {
             if (hClusterChipOccupancyMap->GetBinContent(iBinX + 1, iBinY + 1) != 0) {
-              mIsEmpty = false; //if there is an unempty bin, the ladder is not empty
+              mIsEmpty = false; // if there is an unempty bin, the ladder is not empty
               break;
             } else {
-                // check if empty ladders are masked
+              // check if empty ladders are masked
               for (int i = 0; i < mMaskedChips.size(); i++) {
                 if (mo->getName().find(mChipMapName[i]) != std::string::npos) {
                   if (iBinX + 1 == hClusterChipOccupancyMap->GetXaxis()->FindBin(mX[mMaskedChips[i]]) && iBinY + 1 == hClusterChipOccupancyMap->GetYaxis()->FindBin(mY[mMaskedChips[i]])) {

--- a/Modules/MFT/src/QcMFTClusterCheck.cxx
+++ b/Modules/MFT/src/QcMFTClusterCheck.cxx
@@ -53,17 +53,21 @@ void QcMFTClusterCheck::configure()
 {
 
   // this is how to get access to custom parameters defined in the config file at qc.tasks.<task_name>.taskParameters
-  if (auto param = mCustomParameters.find("ZoneThresholdMedium"); param != mCustomParameters.end()) {
-    ILOG(Info, Support) << "Custom parameter - ZoneThresholdMedium: " << param->second << ENDM;
-    mZoneThresholdMedium = stoi(param->second);
+  if (auto param = mCustomParameters.find("LadderThresholdMedium"); param != mCustomParameters.end()) {
+    ILOG(Info, Support) << "Custom parameter - LadderThresholdMedium: " << param->second << ENDM;
+    mLadderThresholdMedium = stoi(param->second);
   }
-  if (auto param = mCustomParameters.find("ZoneThresholdBad"); param != mCustomParameters.end()) {
-    ILOG(Info, Support) << "Custom parameter - ZoneThresholdBad: " << param->second << ENDM;
-    mZoneThresholdBad = stoi(param->second);
+  if (auto param = mCustomParameters.find("LadderThresholdBad"); param != mCustomParameters.end()) {
+    ILOG(Info, Support) << "Custom parameter - LadderThresholdBad: " << param->second << ENDM;
+    mLadderThresholdBad = stoi(param->second);
   }
 
   // no call to beautifier yet
   mFirstCall = true;
+  mIsEmpty = true;
+  mAdjacentLadders = false;
+
+  mEmptyCount = 0;
 }
 
 Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
@@ -73,6 +77,13 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
   for (auto& [moName, mo] : *moMap) {
 
     (void)moName;
+
+    if (mFirstCall) {
+      mFirstCall = false;
+      readMaskedChips(mo);
+      getChipMapData();
+      createMaskedChipsNames();
+    }
 
     if (mo->getName() == "mClusterOccupancy") {
       auto* hClusterOccupancy = dynamic_cast<TH1F*>(mo->getObject());
@@ -111,6 +122,49 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
         return Quality::Null;
       }
     }
+    QcMFTUtilTables MFTTable;
+    for (int i = 0; i < 20; i++) {
+      if (mo->getName() == MFTTable.mClusterChipMapNames[i]) {
+        mAdjacentCount = 0;
+        auto* hClusterChipOccupancyMap = dynamic_cast<TH2F*>(mo->getObject());
+        if (hClusterChipOccupancyMap == nullptr) {
+          ILOG(Error, Support) << "Could not cast mClusterChipMap to TH2F." << ENDM;
+          return Quality::Null;
+        }
+
+        for (int iBinX = 0; iBinX < hClusterChipOccupancyMap->GetNbinsX(); iBinX++) {
+          mIsEmpty = true;
+          for (int iBinY = 0; iBinY < hClusterChipOccupancyMap->GetNbinsY(); iBinY++) {
+            if (hClusterChipOccupancyMap->GetBinContent(iBinX + 1, iBinY + 1) != 0) {
+              mIsEmpty = false;
+              break;
+            } else {
+              for (int i = 0; i < mMaskedChips.size(); i++) {
+                if (mo->getName().find(mChipMapName[i]) != std::string::npos) {
+                  if (iBinX + 1 == hClusterChipOccupancyMap->GetXaxis()->FindBin(mX[mMaskedChips[i]]) && iBinY + 1 == hClusterChipOccupancyMap->GetYaxis()->FindBin(mY[mMaskedChips[i]])) {
+                    mIsEmpty = false;
+                  } else {
+                    mIsEmpty = true;
+                  }
+                }
+              }
+            }
+          }
+
+          if (mIsEmpty) {
+            mEmptyCount++;
+            mAdjacentCount++;
+          } else {
+            mAdjacentCount = 0;
+          }
+          if (mAdjacentCount >= mLadderThresholdBad) {
+            if (!mAdjacentLadders) {
+              mAdjacentLadders = true;
+            }
+          }
+        }
+      }
+    }
 
     if (mo->getName() == "mClusterOccupancySummary") {
       auto* hClusterOccupancySummary = dynamic_cast<TH2F*>(mo->getObject());
@@ -119,23 +173,13 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
         return Quality::Null;
       }
 
-      float nEmptyBins = 0; // number of empty zones
-
-      for (int iBinX = 0; iBinX < hClusterOccupancySummary->GetNbinsX(); iBinX++) {
-        for (int iBinY = 0; iBinY < hClusterOccupancySummary->GetNbinsY(); iBinY++) {
-          if ((hClusterOccupancySummary->GetBinContent(iBinX + 1, iBinY + 1)) == 0) {
-            nEmptyBins = nEmptyBins + 1;
-          }
-        }
-      }
-
-      if (nEmptyBins <= mZoneThresholdMedium) {
+      if (!mAdjacentLadders && mEmptyCount < mLadderThresholdMedium) {
         result = Quality::Good;
       }
-      if (nEmptyBins > mZoneThresholdMedium && nEmptyBins <= mZoneThresholdBad) {
+      if (!mAdjacentLadders && mEmptyCount >= mLadderThresholdMedium) {
         result = Quality::Medium;
       }
-      if (nEmptyBins > mZoneThresholdBad) {
+      if (mAdjacentLadders) {
         result = Quality::Bad;
       }
     }
@@ -190,28 +234,9 @@ void QcMFTClusterCheck::createMaskedChipsNames()
   }
 }
 
-void QcMFTClusterCheck::createOutsideAccNames()
-{
-  for (int iHalf = 0; iHalf < 2; iHalf++) {
-    for (int iDisk = 0; iDisk < 5; iDisk++) {
-      for (int iFace = 0; iFace < 2; iFace++) {
-        mOutsideAccName.push_back(Form("ChipOccupancyMaps/Half_%d/Disk_%d/Face_%d/mClusterChipOccupancyMap",
-                                       iHalf, iDisk, iFace));
-      }
-    }
-  }
-}
-
 void QcMFTClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  // set up masking of dead chips once
-  if (mFirstCall) {
-    mFirstCall = false;
-    readMaskedChips(mo);
-    getChipMapData();
-    createMaskedChipsNames();
-    createOutsideAccNames();
-  }
+
   // print skull in maps to display dead chips
   int nMaskedChips = mMaskedChips.size();
   for (int i = 0; i < nMaskedChips; i++) {
@@ -233,7 +258,7 @@ void QcMFTClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality chec
     for (int iDisk = 0; iDisk < 5; iDisk++) {
       for (int iFace = 0; iFace < 2; iFace++) {
         int idx = (iDisk * 2 + iFace) + (10 * iHalf);
-        if (mo->getName().find(mOutsideAccName[idx]) != std::string::npos) {
+        if (mo->getName().find(MFTTable.mClusterChipMapNames[idx]) != std::string::npos) {
           auto* h = dynamic_cast<TH2F*>(mo->getObject());
           for (int i = 0; i < 21; i++) {
             int binX = MFTTable.mBinX[idx][i];

--- a/Modules/MFT/src/QcMFTClusterCheck.cxx
+++ b/Modules/MFT/src/QcMFTClusterCheck.cxx
@@ -122,6 +122,8 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
         return Quality::Null;
       }
     }
+    
+    //checker for empty ladders
     QcMFTUtilTables MFTTable;
     for (int i = 0; i < 20; i++) {
       if (mo->getName() == MFTTable.mClusterChipMapNames[i]) {
@@ -131,14 +133,15 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
           ILOG(Error, Support) << "Could not cast mClusterChipMap to TH2F." << ENDM;
           return Quality::Null;
         }
-
+        // loop over bins in each chip map
         for (int iBinX = 0; iBinX < hClusterChipOccupancyMap->GetNbinsX(); iBinX++) {
           mIsEmpty = true;
           for (int iBinY = 0; iBinY < hClusterChipOccupancyMap->GetNbinsY(); iBinY++) {
             if (hClusterChipOccupancyMap->GetBinContent(iBinX + 1, iBinY + 1) != 0) {
-              mIsEmpty = false;
+              mIsEmpty = false; //if there is an unempty bin, the ladder is not empty
               break;
             } else {
+                // check if empty ladders are masked
               for (int i = 0; i < mMaskedChips.size(); i++) {
                 if (mo->getName().find(mChipMapName[i]) != std::string::npos) {
                   if (iBinX + 1 == hClusterChipOccupancyMap->GetXaxis()->FindBin(mX[mMaskedChips[i]]) && iBinY + 1 == hClusterChipOccupancyMap->GetYaxis()->FindBin(mY[mMaskedChips[i]])) {
@@ -150,13 +153,14 @@ Quality QcMFTClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorOb
               }
             }
           }
-
+          // count empty ladders
           if (mIsEmpty) {
             mEmptyCount++;
             mAdjacentCount++;
           } else {
             mAdjacentCount = 0;
           }
+          // set bool for adjacent ladders
           if (mAdjacentCount >= mLadderThresholdBad) {
             if (!mAdjacentLadders) {
               mAdjacentLadders = true;

--- a/Modules/MFT/src/QcMFTDigitCheck.cxx
+++ b/Modules/MFT/src/QcMFTDigitCheck.cxx
@@ -110,8 +110,8 @@ Quality QcMFTDigitCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
         }
       }
     }
-      
-//checker for empty ladders
+
+    // checker for empty ladders
     QcMFTUtilTables MFTTable;
     for (int i = 0; i < 20; i++) {
       if (mo->getName() == MFTTable.mDigitChipMapNames[i]) {
@@ -126,10 +126,10 @@ Quality QcMFTDigitCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
           mIsEmpty = true;
           for (int iBinY = 0; iBinY < hDigitChipOccupancyMap->GetNbinsY(); iBinY++) {
             if (hDigitChipOccupancyMap->GetBinContent(iBinX + 1, iBinY + 1) != 0) {
-              mIsEmpty = false; //if there is an unempty bin, the ladder is not empty
+              mIsEmpty = false; // if there is an unempty bin, the ladder is not empty
               break;
             } else {
-             // check if empty ladders are masked
+              // check if empty ladders are masked
               for (int i = 0; i < mMaskedChips.size(); i++) {
                 if (mo->getName().find(mChipMapName[i]) != std::string::npos) {
                   if (iBinX + 1 == hDigitChipOccupancyMap->GetXaxis()->FindBin(mX[mMaskedChips[i]]) && iBinY + 1 == hDigitChipOccupancyMap->GetYaxis()->FindBin(mY[mMaskedChips[i]])) {

--- a/Modules/MFT/src/QcMFTDigitCheck.cxx
+++ b/Modules/MFT/src/QcMFTDigitCheck.cxx
@@ -110,7 +110,8 @@ Quality QcMFTDigitCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
         }
       }
     }
-
+      
+//checker for empty ladders
     QcMFTUtilTables MFTTable;
     for (int i = 0; i < 20; i++) {
       if (mo->getName() == MFTTable.mDigitChipMapNames[i]) {
@@ -120,14 +121,15 @@ Quality QcMFTDigitCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
           ILOG(Error, Support) << "Could not cast mDigitChipMap to TH2F." << ENDM;
           return Quality::Null;
         }
-
+        // loop over bins in each chip map
         for (int iBinX = 0; iBinX < hDigitChipOccupancyMap->GetNbinsX(); iBinX++) {
           mIsEmpty = true;
           for (int iBinY = 0; iBinY < hDigitChipOccupancyMap->GetNbinsY(); iBinY++) {
             if (hDigitChipOccupancyMap->GetBinContent(iBinX + 1, iBinY + 1) != 0) {
-              mIsEmpty = false;
+              mIsEmpty = false; //if there is an unempty bin, the ladder is not empty
               break;
             } else {
+             // check if empty ladders are masked
               for (int i = 0; i < mMaskedChips.size(); i++) {
                 if (mo->getName().find(mChipMapName[i]) != std::string::npos) {
                   if (iBinX + 1 == hDigitChipOccupancyMap->GetXaxis()->FindBin(mX[mMaskedChips[i]]) && iBinY + 1 == hDigitChipOccupancyMap->GetYaxis()->FindBin(mY[mMaskedChips[i]])) {
@@ -139,13 +141,14 @@ Quality QcMFTDigitCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
               }
             }
           }
-
+          // count empty ladders
           if (mIsEmpty) {
             mEmptyCount++;
             mAdjacentCount++;
           } else {
             mAdjacentCount = 0;
           }
+          // set bool for adjacent ladders
           if (mAdjacentCount >= 2) {
             if (!mAdjacentLadders) {
               mAdjacentLadders = true;


### PR DESCRIPTION
New checker for empty ladders

- check implemented both for digits and clusters
- checks for empty ladders (if at least 1 ladder empty -> quality medium, if at least 2 adjacent ladders empty -> quality bad)
- in addition new array was added to the MFTUtilTable for elimination of use of unnecessary vectors and functions
- previous checker for number of empty zones in DigitOccupancySummary was replaced by this checker