### PR TITLE
CcdbInspector: run number specified in CCDB queries

### DIFF
--- a/Modules/Common/src/CcdbInspectorTask.cxx
+++ b/Modules/Common/src/CcdbInspectorTask.cxx
@@ -211,7 +211,9 @@ CcdbInspectorTask::ObjectStatus CcdbInspectorTask::inspectObject(CcdbInspectorTa
 
   // get timestamps and run numberof the last available object
   auto fullObjectPath = (mDatabaseType == "qcdb" ? trigger.activity.mProvenance + "/" : "") + path;
-  auto metadata = mDatabaseType == "qcdb" ? activity_helpers::asDatabaseMetadata(trigger.activity, false) : std::map<std::string, std::string>();
+  // metadata for CCDB queries, only specifying the run number
+  std::map<std::string, std::string> metadataCcdb{ { "runNumber", std::to_string(trigger.activity.mId) } };
+  auto metadata = mDatabaseType == "qcdb" ? activity_helpers::asDatabaseMetadata(trigger.activity, false) : metadataCcdb;
   auto timestamps = getObjectInfo(path, metadata);
   auto creationTime = std::get<2>(timestamps);
   auto runNumber = std::get<3>(timestamps);


### PR DESCRIPTION
In the case of queries to the CCDB the metadata was completely empty, so the latest version of the queried object was retrieved regardless of the run number.
This leads to failures in retrieving the appropriate object in cases where the same type of object is updated by multiple parallel runs, as it is the case for example for the CTP configuration object. In such cases the object from the wrong run might be retrieved, if it was created shortly after the good one.

To avoid that this kind of corner cases leads to wrongly reported failures, the run number is now explicitly set in the metadata used for the CCDB queries, as it was already done for the QCDB ones.