### PR TITLE
ReferenceComparator: allow ignoring period and pass when retrieving reference plots

### DIFF
--- a/Modules/Common/include/Common/ReferenceComparatorCheck.h
+++ b/Modules/Common/include/Common/ReferenceComparatorCheck.h
@@ -55,7 +55,9 @@ class ReferenceComparatorCheck : public o2::quality_control::checker::CheckInter
   std::unique_ptr<ObjectComparatorInterface> mComparator;
   std::map<std::string, Quality> mQualityFlags;
   std::map<std::string, std::shared_ptr<TPaveText>> mQualityLabels;
-  quality_control::core::Activity mActivity /*current*/, mReferenceActivity;
+  quality_control::core::Activity mReferenceActivity;
+  bool mIgnorePeriodForReference{ true }; /// whether to specify the period name in the reference run query
+  bool mIgnorePassForReference{ true };   /// whether to specify the pass name in the reference run query
   size_t mReferenceRun;
   std::unordered_map<std::string, std::shared_ptr<MonitorObject>> mReferencePlots;
 };

--- a/Modules/Common/include/Common/ReferenceComparatorTask.h
+++ b/Modules/Common/include/Common/ReferenceComparatorTask.h
@@ -60,8 +60,10 @@ class ReferenceComparatorTask : public quality_control::postprocessing::PostProc
   };
 
  private:
-  int mReferenceRun{ 0 };
+  size_t mReferenceRun{ 0 };
   int mNotOlderThan{ 120 };
+  bool mIgnorePeriodForReference{ true }; /// whether to specify the period name in the reference run query
+  bool mIgnorePassForReference{ true };   /// whether to specify the pass name in the reference run query
 
   /// \brief configuration parameters
   ReferenceComparatorTaskConfig mConfig;

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -50,6 +50,8 @@ void ReferenceComparatorCheck::startOfActivity(const Activity& activity)
   auto comparatorName = mCustomParameters.atOptional("comparatorName", activity).value_or("");
   double threshold = std::stof(mCustomParameters.atOptional("threshold", activity).value_or("0"));
   mReferenceRun = std::stoi(mCustomParameters.atOptional("referenceRun", activity).value_or("0"));
+  mIgnorePeriodForReference = std::stoi(mCustomParameters.atOptional("ignorePeriodForReference", activity).value_or("1")) != 0;
+  mIgnorePassForReference = std::stoi(mCustomParameters.atOptional("ignorePassForReference", activity).value_or("1")) != 0;
 
   mComparator.reset();
   if (!moduleName.empty() && !comparatorName.empty()) {
@@ -60,9 +62,14 @@ void ReferenceComparatorCheck::startOfActivity(const Activity& activity)
     mComparator->setThreshold(threshold);
   }
 
-  mActivity = activity;
   mReferenceActivity = activity;
   mReferenceActivity.mId = mReferenceRun;
+  if (mIgnorePeriodForReference) {
+    mReferenceActivity.mPeriodName = "";
+  }
+  if (mIgnorePassForReference) {
+    mReferenceActivity.mPassName = "";
+  }
 
   // clear the cache of reference plots
   mReferencePlots.clear();

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -458,6 +458,8 @@ This post-processing task draws a given set of plots in comparison with their co
 
 Currently the source of reference data is specified as a run-type and beam-type specific `referenceRun` number. This will be modified once a centralized way of accessing reference plots will become available in the framework.
 The `notOlderThan` option allows to ignore monitor objects that are older than a given number of seconds. A value of -1 means "no limit".
+The `ignorePeriodForReference` and `ignorePassForReference` boolean parameters control whether the period and/or pass names should be matched or not when querying the reference plots from the database.
+A value of `"1"` (default) means that the reference plots are not required to match the period and/or pass names of the current run, while a value of `"0"` means that the reference plot is retrieved only if the corresponding period and/or pass names match those of the current run.
 
 The input MonitorObjects to be processed are logically divided in **dataGroups**. Each group is configured via the following parameters:
 * `inputPath`: path in the QCDB where the input objects are located
@@ -504,7 +506,9 @@ In the example configuration below, the relationship between the input and outpu
           "default": {
             "default": {
               "notOlderThan" : "300",
-              "referenceRun" : "551875"
+              "referenceRun" : "551875",
+              "ignorePeriodForReference": "1",
+              "ignorePassForReference": "1"
             }
           },
           "PHYSICS": {


### PR DESCRIPTION
The period and pass names were always included in the QCDB queries for retrieving the reference plots. This means that a run from a given period and pass could not be used as reference for a different period and/or pass, which is a strong limitation that needs to be made configurable.

The new code adds two configuration parameters that control whether the period and/or pass names should be ignored or not in the queries (see documentation for details).