### PR TITLE
Common: fix computation of output quality for ReferenceComparatorCheck

### DIFF
--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -210,8 +210,8 @@ Quality ReferenceComparatorCheck::check(std::map<std::string, std::shared_ptr<Mo
       continue;
     }
 
-    // update the overall quality
-    if (quality.isWorseThan(result)) {
+    // initialize or update the overall quality
+    if (result == Quality::Null || quality.isWorseThan(result)) {
       result.set(quality);
     }
 


### PR DESCRIPTION
The new code fixes a bug that forces the output quality to be always Null, because the initial Null value is always not better than any other quality from the plots.