### PR TITLE
GLO: Change to TH1Ratio plot

### DIFF
--- a/Modules/GLO/include/GLO/ITSTPCMatchingTask.h
+++ b/Modules/GLO/include/GLO/ITSTPCMatchingTask.h
@@ -19,8 +19,7 @@
 
 #include "QualityControl/TaskInterface.h"
 #include "GLOQC/MatchITSTPCQC.h"
-
-#include "TH1.h"
+#include "Common/TH1Ratio.h"
 
 #include <memory>
 
@@ -51,9 +50,9 @@ class ITSTPCMatchingTask final : public TaskInterface
  private:
   o2::gloqc::MatchITSTPCQC mMatchITSTPCQC;
 
-  std::unique_ptr<TH1> mHEffPt;
-  std::unique_ptr<TH1> mHEffEta;
-  std::unique_ptr<TH1> mHEffPhi;
+  std::unique_ptr<common::TH1FRatio> mEffPt;
+  std::unique_ptr<common::TH1FRatio> mEffEta;
+  std::unique_ptr<common::TH1FRatio> mEffPhi;
 };
 
 } // namespace o2::quality_control_modules::glo

--- a/Modules/GLO/src/ITSTPCMatchingTask.cxx
+++ b/Modules/GLO/src/ITSTPCMatchingTask.cxx
@@ -167,26 +167,6 @@ void ITSTPCMatchingTask::endOfCycle()
       }
       ratio->Sumw2();
       ratio->update();
-
-      // Calculate binominal errors for efficiency, taken from ROOT
-      for (Int_t iBin = 0; iBin < ratio->GetNcells(); ++iBin) {
-        const Double_t b1 = ratio->getNum()->GetBinContent(iBin);
-        const Double_t b2 = ratio->getDen()->GetBinContent(iBin);
-        if (b2 == 0) {
-          ratio->SetBinError(iBin, 0);
-          continue;
-        }
-        const Double_t b1sq = b1 * b1;
-        const Double_t b2sq = b2 * b2;
-        const Double_t e1 = ratio->getNum()->GetBinError(iBin), e1sq = e1 * e1;
-        const Double_t e2 = ratio->getDen()->GetBinError(iBin), e2sq = e2 * e2;
-        if (b1 != b2) {
-          ratio->SetBinError(iBin, TMath::Sqrt(TMath::Abs(((1. - 2. * b1 / b2) * e1sq + b1sq * e2sq / b2sq) / b2sq)));
-        } else {
-          ratio->SetBinError(iBin, 0);
-        }
-      }
-
       return ratio;
     };
 

--- a/Modules/GLO/src/ITSTPCMatchingTask.cxx
+++ b/Modules/GLO/src/ITSTPCMatchingTask.cxx
@@ -151,45 +151,57 @@ void ITSTPCMatchingTask::endOfCycle()
 
   // Sync Mode
   if (common::getFromConfig(mCustomParameters, "isSync", false)) {
-    { // Pt
-      auto hEffPt = mMatchITSTPCQC.getFractionITSTPCmatch(gloqc::MatchITSTPCQC::ITS);
-      mHEffPt.reset();
-      mHEffPt.reset(dynamic_cast<TH1*>(hEffPt->GetPassedHistogram()->Clone("mFractionITSTPCmatch_ITS_Hist")));
-      if (mHEffPt) {
-        mHEffPt->Divide(hEffPt->GetPassedHistogram(), hEffPt->GetTotalHistogram(), 1.0, 1.0, "B");
-        mHEffPt->SetBit(TH1::EStatusBits::kNoStats);
-        getObjectsManager()->startPublishing(mHEffPt.get(), PublicationPolicy::Once);
-        getObjectsManager()->setDefaultDrawOptions(mHEffPt->GetName(), "logx");
-      } else {
-        ILOG(Error) << "Failed cast for hEffPtHist, will not publish!" << ENDM;
+    auto makeRatio = [](TEfficiency* eff) {
+      std::string name = eff->GetName();
+      name += "_Hist";
+      auto ratio = std::make_unique<common::TH1FRatio>(name.c_str(), eff->GetTitle(),
+                                                       eff->GetPassedHistogram()->GetXaxis()->GetNbins(),
+                                                       eff->GetPassedHistogram()->GetXaxis()->GetXmin(),
+                                                       eff->GetPassedHistogram()->GetXaxis()->GetXmax());
+      ratio->SetBit(TH1::EStatusBits::kNoStats);
+      if (!ratio->getNum()->Add(eff->GetPassedHistogram())) {
+        ILOG(Error) << "Add operation for numerator histogram of " << name << " failed; efficiency will be skewed" << ENDM;
       }
-    }
+      if (!ratio->getDen()->Add(eff->GetTotalHistogram())) {
+        ILOG(Error) << "Add operation for denominator histogram of " << name << " failed; efficiency will be skewed" << ENDM;
+      }
+      ratio->Sumw2();
+      ratio->update();
 
-    { // Eta
-      auto hEffEta = mMatchITSTPCQC.getFractionITSTPCmatchEta(gloqc::MatchITSTPCQC::ITS);
-      mHEffEta.reset();
-      mHEffEta.reset(dynamic_cast<TH1*>(hEffEta->GetPassedHistogram()->Clone("mFractionITSTPCmatchEta_ITS_Hist")));
-      if (mHEffEta) {
-        mHEffEta->Divide(hEffEta->GetPassedHistogram(), hEffEta->GetTotalHistogram(), 1.0, 1.0, "B");
-        mHEffEta->SetBit(TH1::EStatusBits::kNoStats);
-        getObjectsManager()->startPublishing(mHEffEta.get(), PublicationPolicy::Once);
-      } else {
-        ILOG(Error) << "Failed cast for hEffEtaHist, will not publish!" << ENDM;
+      // Calculate binominal errors for efficiency, taken from ROOT
+      for (Int_t iBin = 0; iBin < ratio->GetNcells(); ++iBin) {
+        const Double_t b1 = ratio->getNum()->GetBinContent(iBin);
+        const Double_t b2 = ratio->getDen()->GetBinContent(iBin);
+        if (b2 == 0) {
+          ratio->SetBinError(iBin, 0);
+          continue;
+        }
+        const Double_t b1sq = b1 * b1;
+        const Double_t b2sq = b2 * b2;
+        const Double_t e1 = ratio->getNum()->GetBinError(iBin), e1sq = e1 * e1;
+        const Double_t e2 = ratio->getDen()->GetBinError(iBin), e2sq = e2 * e2;
+        if (b1 != b2) {
+          ratio->SetBinError(iBin, TMath::Sqrt(TMath::Abs(((1. - 2. * b1 / b2) * e1sq + b1sq * e2sq / b2sq) / b2sq)));
+        } else {
+          ratio->SetBinError(iBin, 0);
+        }
       }
-    }
 
-    { // Phi
-      auto hEffPhi = mMatchITSTPCQC.getFractionITSTPCmatchPhi(gloqc::MatchITSTPCQC::ITS);
-      mHEffPhi.reset();
-      mHEffPhi.reset(dynamic_cast<TH1*>(hEffPhi->GetPassedHistogram()->Clone("mFractionITSTPCmatchPhi_ITS_Hist")));
-      if (mHEffPhi) {
-        mHEffPhi->Divide(hEffPhi->GetPassedHistogram(), hEffPhi->GetTotalHistogram(), 1.0, 1.0, "B");
-        mHEffPhi->SetBit(TH1::EStatusBits::kNoStats);
-        getObjectsManager()->startPublishing(mHEffPhi.get(), PublicationPolicy::Once);
-      } else {
-        ILOG(Error) << "Failed cast for hEffPhiHist, will not publish!" << ENDM;
-      }
-    }
+      return ratio;
+    };
+
+    // Pt
+    mEffPt = makeRatio(mMatchITSTPCQC.getFractionITSTPCmatch(gloqc::MatchITSTPCQC::ITS));
+    getObjectsManager()->startPublishing(mEffPt.get(), PublicationPolicy::Once);
+    getObjectsManager()->setDefaultDrawOptions(mEffPt->GetName(), "logx");
+
+    // Eta
+    mEffEta = makeRatio(mMatchITSTPCQC.getFractionITSTPCmatchEta(gloqc::MatchITSTPCQC::ITS));
+    getObjectsManager()->startPublishing(mEffEta.get(), PublicationPolicy::Once);
+
+    // Phi
+    mEffPhi = makeRatio(mMatchITSTPCQC.getFractionITSTPCmatchPhi(gloqc::MatchITSTPCQC::ITS));
+    getObjectsManager()->startPublishing(mEffPhi.get(), PublicationPolicy::Once);
   }
 }
 
@@ -202,8 +214,11 @@ void ITSTPCMatchingTask::reset()
 {
   // clean all the monitor objects here
 
-  ILOG(Debug, Devel) << "Resetting the histogramss" << ENDM;
+  ILOG(Debug, Devel) << "Resetting the histograms" << ENDM;
   mMatchITSTPCQC.reset();
+  mEffPt.reset();
+  mEffPhi.reset();
+  mEffEta.reset();
 }
 
 } // namespace o2::quality_control_modules::glo


### PR DESCRIPTION
Changes from TH1 to TH1Ratio to get a correct efficiency after the mergers. One question I have if after each endOfCycle also reset is called?

Tested with:
```bash
#!/usr/bin/env sh

GLOSET=" -b --shm-segment-size 4000000000 --hbfutils-config o2_tfidinfo.root,upstream --timeframes-rate-limit 1 --timeframes-rate-limit-ipcid 0 "
CONFIG="$ALIBUILD_WORK_DIR/../QualityControl/Modules/GLO/glo-itstpc-mtch-qcmn-test.json"

export IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE=1
export ALICEO2_CCDB_LOCALCACHE=$PWD/ccdb

o2-reader-driver-workflow --max-tf 2 $GLOSET | \
    o2-global-track-cluster-reader $GLOSET --disable-mc --track-types "ITS,TPC,ITS-TPC,ITS-TPC-TOF,TPC-TOF,TPC-TRD,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC-TRD-TOF" --cluster-types "TPC,ITS" --primary-vertices --secondary-vertices | \
    o2-qc --full-chain --config json:///"$CONFIG" --timeframes-rate-limit 1 --timeframes-rate-limit-ipcid 0 -b --run | tee qc.log
```

Output on qcg-test:
![image](https://github.com/user-attachments/assets/8091dfce-d8cf-4b06-983c-41f9dc8e02d2)

Hopefully everything works now :)

Nota Bene: I added a manual calculation of binomial errors for the efficiency errors (which we might not care about) since TH1Ratio does not support it.