### PR TITLE
TH1Ratio: Add weighted opt. binomial error calculation

### DIFF
--- a/Modules/Common/include/Common/TH1Ratio.h
+++ b/Modules/Common/include/Common/TH1Ratio.h
@@ -60,6 +60,10 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
     return mUniformScaling;
   }
 
+  // Use Binominal errors; only works if Sumw2 was called
+  void setHasBinominalErrors(bool flag = true) { mBinominalErrors = flag; }
+  bool hasBinominalErrors() const { return mBinominalErrors; }
+
   void update();
 
   // functions inherited from TH1x
@@ -76,10 +80,11 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
   T* mHistoNum{ nullptr };
   T* mHistoDen{ nullptr };
   bool mUniformScaling{ true };
+  bool mBinominalErrors{ false };
   Bool_t mSumw2Enabled{ kTRUE };
   std::string mTreatMeAs{ T::Class_Name() };
 
-  ClassDefOverride(TH1Ratio, 2);
+  ClassDefOverride(TH1Ratio, 3);
 };
 
 typedef TH1Ratio<TH1F> TH1FRatio;

--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -149,9 +149,8 @@ void TH1Ratio<T>::update()
   T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
   T::SetBinsLength();
 
-  T::Add(mHistoNum);
-
   if (mUniformScaling) {
+    T::Add(mHistoNum);
     double entries = mHistoDen->GetBinContent(1);
     double norm = (entries > 0) ? 1.0 / entries : 0;
     // make sure the sum-of-weights structure is not initialized if not required
@@ -167,7 +166,7 @@ void TH1Ratio<T>::update()
         mHistoDen->GetXaxis()->SetBinLabel(bin, T::GetXaxis()->GetBinLabel(bin));
       }
     }
-    T::Divide(mHistoDen);
+    T::Divide(mHistoNum, mHistoDen, 1.0, 1.0, mBinominalErrors ? "B" : "");
   }
 }
 

--- a/Modules/Common/include/Common/TH2Ratio.h
+++ b/Modules/Common/include/Common/TH2Ratio.h
@@ -60,6 +60,10 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
     return mUniformScaling;
   }
 
+  // Use Binominal errors; only works if Sumw2 was called
+  void setHasBinominalErrors(bool flag = true) { mBinominalErrors = flag; }
+  bool hasBinominalErrors() const { return mBinominalErrors; }
+
   void update();
 
   // functions inherited from TH2x
@@ -76,10 +80,11 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
   T* mHistoNum{ nullptr };
   T* mHistoDen{ nullptr };
   bool mUniformScaling{ true };
+  bool mBinominalErrors{ false };
   Bool_t mSumw2Enabled{ kTRUE };
   std::string mTreatMeAs{ T::Class_Name() };
 
-  ClassDefOverride(TH2Ratio, 2);
+  ClassDefOverride(TH2Ratio, 3);
 };
 
 typedef TH2Ratio<TH2F> TH2FRatio;

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -150,9 +150,8 @@ void TH2Ratio<T>::update()
   T::GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXmin(), mHistoNum->GetYaxis()->GetXmax());
   T::SetBinsLength();
 
-  T::Add(mHistoNum);
-
   if (mUniformScaling) {
+    T::Add(mHistoNum);
     double entries = mHistoDen->GetBinContent(1, 1);
     double norm = (entries > 0) ? 1.0 / entries : 0;
     // make sure the sum-of-weights structure is not initialized if not required
@@ -173,7 +172,7 @@ void TH2Ratio<T>::update()
         mHistoDen->GetYaxis()->SetBinLabel(bin, T::GetYaxis()->GetBinLabel(bin));
       }
     }
-    T::Divide(mHistoDen);
+    T::Divide(mHistoNum, mHistoDen, 1.0, 1.0, mBinominalErrors ? "B" : "");
   }
 }
 

--- a/Modules/GLO/src/ITSTPCMatchingTask.cxx
+++ b/Modules/GLO/src/ITSTPCMatchingTask.cxx
@@ -166,6 +166,7 @@ void ITSTPCMatchingTask::endOfCycle()
         ILOG(Error) << "Add operation for denominator histogram of " << name << " failed; efficiency will be skewed" << ENDM;
       }
       ratio->Sumw2();
+      ratio->setHasBinominalErrors();
       ratio->update();
       return ratio;
     };

--- a/Modules/GLO/src/ITSTPCMatchingTask.cxx
+++ b/Modules/GLO/src/ITSTPCMatchingTask.cxx
@@ -165,6 +165,8 @@ void ITSTPCMatchingTask::endOfCycle()
       if (!ratio->getDen()->Add(eff->GetTotalHistogram())) {
         ILOG(Error) << "Add operation for denominator histogram of " << name << " failed; efficiency will be skewed" << ENDM;
       }
+      ratio->GetXaxis()->SetTitle(eff->GetPassedHistogram()->GetXaxis()->GetTitle());
+      ratio->GetYaxis()->SetTitle(eff->GetPassedHistogram()->GetYaxis()->GetTitle());
       ratio->Sumw2();
       ratio->setHasBinominalErrors();
       ratio->update();


### PR DESCRIPTION
This adds the correct weighted error (iff Sumw2) calculation with an optionally binomial treatment modelled what is done in ROOT to the TH1Ratio class. The errors are re-calculated in the update step thus also correctly treated during merging. 
Nota Bene: I do not know if we care about the error bars at all? I did not test the TH2Ratio but the code is the same.

With only the weighted errors:
![image](https://github.com/user-attachments/assets/3c44a7db-c3ba-4ce2-a8e5-f09168d06576)

plus the binomial treatment:
![image](https://github.com/user-attachments/assets/3482aa03-3014-4fca-b401-82b8b89c9237)

One benefit is that for efficiencies besides correct calculation of error-bars, is that the errors do not go beyond 1 anymore, which might spare some confusion.
I also added the use case to the GLO matching check.