### PR TITLE
rejecting bad events in TOF mismatch template

### DIFF
--- a/Modules/PID/src/TaskFT0TOF.cxx
+++ b/Modules/PID/src/TaskFT0TOF.cxx
@@ -560,6 +560,9 @@ void TaskFT0TOF::monitorData(o2::framework::ProcessingContext& ctx)
     if (ft0firstOrbit > ft0.getInteractionRecord().orbit) {
       continue; // skip FT0 objects from previous orbits
     }
+    if (abs(ft0.getCollisionTime(0)) > 1000) {
+      continue; // skip bad FT0 time (not from collisions)
+    }
 
     double ft0time = ((ft0.getInteractionRecord().orbit - ft0firstOrbit) * o2::constants::lhc::LHCMaxBunches + ft0.getInteractionRecord().bc) * o2::tof::Geo::BC_TIME_INPS + ft0.getCollisionTime(0);
     double timemax = ft0time + 100E3;


### PR DESCRIPTION
This is to fix an imperfection in the TOF mismatch template due to bad FT0 times used in the procedure (now rejected)

@njacazio , @ercolessi 

Spurious peak now removed.

![image](https://github.com/user-attachments/assets/f94cc87f-3de7-4c0f-ba76-b7f051ebc901)
