### PR TITLE
[QC-1229] Repocleaner policy for the moving windows

### DIFF
--- a/Framework/script/RepoCleaner/qcrepocleaner/config.yaml
+++ b/Framework/script/RepoCleaner/qcrepocleaner/config.yaml
@@ -12,6 +12,10 @@ Rules:
     delay: 1
     policy: multiple_per_run
     mw_deletion_delay: 15
+  - object_path: qc/TST/MO/QcTask
+    delay: 1440
+    policy: multiple_per_run
+    mw_deletion_delay: 15
 #  - object_path: qc/TST/MO/QcTask-barth/example3[/.*]{0,1}
 #    delay: 0
 #    policy: none_kept

--- a/Framework/script/RepoCleaner/qcrepocleaner/config.yaml
+++ b/Framework/script/RepoCleaner/qcrepocleaner/config.yaml
@@ -8,6 +8,10 @@ Rules:
     delay: 0
     policy: 1_per_run
     to_timestamp: 1674700609718
+  - object_path: qc/.*/mw/.*
+    delay: 1
+    policy: multiple_per_run
+    mw_deletion_delay: 15
 #  - object_path: qc/TST/MO/QcTask-barth/example3[/.*]{0,1}
 #    delay: 0
 #    policy: none_kept

--- a/Framework/script/RepoCleaner/qcrepocleaner/rules/multiple_per_run.py
+++ b/Framework/script/RepoCleaner/qcrepocleaner/rules/multiple_per_run.py
@@ -109,7 +109,7 @@ def process(ccdb: Ccdb, object_path: str, delay: int,  from_timestamp: int, to_t
         elif first_object.createdAtDt < datetime.now() - timedelta(minutes=mw_deletion_delay):
             logger.debug(f"     after mw_deletion_delay period, delete this bucket")
             for v in run_versions:
-                if "mw" in v.path: # this is because we really don't want to take the risk of batch deleting non moving windows
+                if "/mw/" in v.path: # this is because we really don't want to take the risk of batch deleting non moving windows
                     logger.debug(f"          deleting {v}")
                     deletion_list.append(v)
                     ccdb.deleteVersion(v)

--- a/Framework/script/RepoCleaner/qcrepocleaner/rules/multiple_per_run.py
+++ b/Framework/script/RepoCleaner/qcrepocleaner/rules/multiple_per_run.py
@@ -109,10 +109,13 @@ def process(ccdb: Ccdb, object_path: str, delay: int,  from_timestamp: int, to_t
         elif first_object.createdAtDt < datetime.now() - timedelta(minutes=mw_deletion_delay):
             logger.debug(f"     after mw_deletion_delay period, delete this bucket")
             for v in run_versions:
-                logger.debug(f"process {v}")
                 if "mw" in v.path: # this is because we really don't want to take the risk of batch deleting non moving windows
+                    logger.debug(f"          deleting {v}")
                     deletion_list.append(v)
                     ccdb.deleteVersion(v)
+                else:
+                    logger.debug(f"          deletion is aborted as path does not contain `mw` ({v})")
+                    preservation_list.append(v)
         else:
             logger.debug(f"    not in the grace period")
 

--- a/Framework/script/RepoCleaner/qcrepocleaner/rules/multiple_per_run.py
+++ b/Framework/script/RepoCleaner/qcrepocleaner/rules/multiple_per_run.py
@@ -82,7 +82,7 @@ def process(ccdb: Ccdb, object_path: str, delay: int,  from_timestamp: int, to_t
     delete_first_last = (extra_params.get("delete_first_last", False) is True)
     logger.debug(f"delete_first_last : {delete_first_last}")
     mw_deletion_delay = int(extra_params.get("mw_deletion_delay", -1))
-    logger.info(f"mw_deletion_delay : {mw_deletion_delay}")
+    logger.debug(f"mw_deletion_delay : {mw_deletion_delay}")
 
     # Find all the runs and group the versions (by run or by a combination of multiple attributes)
     policies_utils.group_versions(ccdb, object_path, period_pass, versions_buckets_dict)


### PR DESCRIPTION
modify `multiple_per_run` to have an option for the moving windows. 
I did not want to duplicate the policy thus I added an option that will trigger the deletion after a certain amount of time. 
As I was afraid that it would for some reason delete "normal" data, I added a check and it only deletes if it is in a path containing `mw`. 