### PR TITLE
QC-1214 Updates and improvements to QO -> Flag conversion

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -119,7 +119,8 @@ add_library(O2QualityControl
   src/TimekeeperFactory.cxx
   src/RootFileStorage.cxx
   src/ReductorHelpers.cxx
-  src/KafkaPoller.cxx)
+  src/KafkaPoller.cxx
+  src/FlagHelpers.cxx)
 
 target_include_directories(
   O2QualityControl
@@ -276,7 +277,9 @@ add_executable(o2-qc-test-core
                test/testMonitorObjectCollection.cxx
                test/testTrendingTask.cxx
                test/testKafkaTests.cxx
-               )
+               test/testFlagHelpers.cxx
+               test/testQualitiesToFlagCollectionConverter.cxx
+)
 set_property(TARGET o2-qc-test-core
              PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 target_link_libraries(o2-qc-test-core PRIVATE O2QualityControl O2::Catch2)
@@ -305,7 +308,6 @@ set(TEST_SRCS
     test/testCheckWorkflow.cxx
     test/testWorkflow.cxx
     test/testRepoPathUtils.cxx
-    test/testQualitiesToFlagCollectionConverter.cxx
     test/testUserCodeInterface.cxx
     test/testStringUtils.cxx
     test/testRunnerUtils.cxx

--- a/Framework/include/QualityControl/BookkeepingQualitySink.h
+++ b/Framework/include/QualityControl/BookkeepingQualitySink.h
@@ -17,11 +17,11 @@
 #ifndef QUALITYCONTROL_BOOKKEEPINGQUALITYSINK_H
 #define QUALITYCONTROL_BOOKKEEPINGQUALITYSINK_H
 
-#include <DataFormatsQualityControl/QualityControlFlagCollection.h>
 #include <Framework/CompletionPolicy.h>
 #include <Framework/DataProcessorSpec.h>
 #include <Framework/Task.h>
-#include "Provenance.h"
+#include "QualityControl/QualitiesToFlagCollectionConverter.h"
+#include "QualityControl/Provenance.h"
 
 namespace o2::quality_control::core
 {
@@ -31,7 +31,9 @@ class BookkeepingQualitySink : public framework::Task
 {
  public:
   // we are using map here instead of the set, because items in the map are changeable, however items of the set are not.
-  using FlagsMap = std::unordered_map<std::string /*detector*/, std::unique_ptr<QualityControlFlagCollection>>;
+  using FlagsMap = std::unordered_map<std::string /*detector*/,
+                                      std::unordered_map<std::string /* QO name */,
+                                                         std::unique_ptr<QualitiesToFlagCollectionConverter>>>;
   using SendCallback = std::function<void(const std::string& grpcUri, const FlagsMap&, Provenance)>;
 
   // sendCallback is mainly used for testing without the necessity to do grpc calls
@@ -50,7 +52,7 @@ class BookkeepingQualitySink : public framework::Task
   std::string mGrpcUri;
   Provenance mProvenance;
   SendCallback mSendCallback;
-  FlagsMap mQualityObjectsMap;
+  FlagsMap mFlagsMap;
 
   void sendAndClear();
 };

--- a/Framework/include/QualityControl/FlagHelpers.h
+++ b/Framework/include/QualityControl/FlagHelpers.h
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   FlagHelpers.h
+/// \author Piotr Konopka
+///
+
+#ifndef QUALITYCONTROL_FLAGHELPERS_H
+#define QUALITYCONTROL_FLAGHELPERS_H
+
+#include "DataFormatsQualityControl/QualityControlFlag.h"
+#include "QualityControl/ValidityInterval.h"
+#include <vector>
+#include <optional>
+
+namespace o2::quality_control::core::flag_helpers
+{
+
+/// \brief returns true if the provided intervals are valid and are overlapping or adjacent
+bool intervalsConnect(const ValidityInterval& one, const ValidityInterval& other);
+
+/// \brief returns true if the provided intervals are valid and are overlapping (there is at least one 1ms common)
+bool intervalsOverlap(const ValidityInterval& one, const ValidityInterval& other);
+
+/// \brief Removes the provided interval from the flag.
+///
+/// Removes the provided interval from the flag. A result can be:
+/// - an empty vector if the interval fully covers the flag's interval
+/// - a vector with one flag if the interval covers the flag's interval on one side
+/// - a vector with two flags if the interval is fully contained by the flag's interval
+std::vector<QualityControlFlag> excludeInterval(const QualityControlFlag& flag, ValidityInterval interval);
+
+/// Trims the provided flag to the intersection with the provided interval.
+/// If the intersection does not exist, it returns nullopt
+std::optional<QualityControlFlag> intersection(const QualityControlFlag& flag, ValidityInterval interval);
+
+} // namespace o2::quality_control::core::flag_helpers
+#endif // QUALITYCONTROL_FLAGHELPERS_H

--- a/Framework/src/FlagHelpers.cxx
+++ b/Framework/src/FlagHelpers.cxx
@@ -1,0 +1,73 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   FlagHelpers.cxx
+/// \author Piotr Konopka
+///
+
+#include "QualityControl/FlagHelpers.h"
+
+namespace o2::quality_control::core::flag_helpers
+{
+
+bool intervalsConnect(const ValidityInterval& one, const ValidityInterval& other)
+{
+  // Object validity in CCDB is a right-open range, which means it includes the beginning and excludes the ending.
+  // In other words, for the validity [1, 10), 9 is the last integer to be included.
+  // Thus, ranges [1, 10) and [10, 20) are considered adjacent, while [1, 10) and [11, 20) are already separate
+  // and should not be merged.
+  return one.isValid() && other.isValid() && one.getMax() >= other.getMin() && one.getMin() <= other.getMax();
+}
+
+bool intervalsOverlap(const ValidityInterval& one, const ValidityInterval& other)
+{
+  return one.isValid() && other.isValid() && one.getMax() > other.getMin() && one.getMin() < other.getMax();
+}
+
+std::vector<QualityControlFlag> excludeInterval(const QualityControlFlag& flag, ValidityInterval interval)
+{
+  std::vector<QualityControlFlag> result;
+
+  if (flag.getInterval().isInvalid()) {
+    return result;
+  }
+
+  if (auto overlap = flag.getInterval().getOverlap(interval); overlap.isInvalid() || overlap.isZeroLength()) {
+    result.push_back(flag);
+    return result;
+  }
+
+  if (interval.getMin() > flag.getStart()) {
+    result.emplace_back(flag.getStart(), interval.getMin(), flag.getFlag(), flag.getComment(), flag.getSource());
+  }
+  if (interval.getMax() < flag.getEnd()) {
+    result.emplace_back(interval.getMax(), flag.getEnd(), flag.getFlag(), flag.getComment(), flag.getSource());
+  }
+  return result;
+}
+
+std::optional<QualityControlFlag> intersection(const QualityControlFlag& flag, ValidityInterval interval)
+{
+  if (flag.getInterval().isInvalid()) {
+    return std::nullopt;
+  }
+  if (interval.isInvalid()) {
+    return flag;
+  }
+  auto intersection = flag.getInterval().getOverlap(interval);
+  if (intersection.isInvalid()) {
+    return std::nullopt;
+  }
+  return QualityControlFlag{ intersection.getMin(), intersection.getMax(), flag.getFlag(), flag.getComment(), flag.getSource() };
+}
+
+} // namespace o2::quality_control::core::flag_helpers

--- a/Framework/src/Quality.cxx
+++ b/Framework/src/Quality.cxx
@@ -95,7 +95,12 @@ std::string Quality::getMetadata(const std::string& key, const std::string& defa
 
 Quality& Quality::addFlag(const FlagType& flag, std::string comment)
 {
-  mFlags.emplace_back(std::move(flag), std::move(comment));
+  if (isWorseThan(Quality::Medium) && !flag.getBad()) {
+    std::cerr << "Warning: assigning good flag to " << mName << " quality" << std::endl;
+  } else if (isBetterThan(Quality::Medium) && flag.getBad()) {
+    std::cerr << "Warning: assigning bad flag to " << mName << " quality" << std::endl;
+  }
+  mFlags.emplace_back(flag, std::move(comment));
   return *this;
 }
 const CommentedFlagTypes& Quality::getFlags() const

--- a/Framework/test/testFlagHelpers.cxx
+++ b/Framework/test/testFlagHelpers.cxx
@@ -1,0 +1,298 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    testFlagHelpers.cxx
+/// \author  Piotr Konopka
+///
+
+#include "QualityControl/FlagHelpers.h"
+#include "QualityControl/ValidityInterval.h"
+
+#include <catch_amalgamated.hpp>
+
+using namespace o2::quality_control;
+using namespace o2::quality_control::core;
+using namespace o2::quality_control::core::flag_helpers;
+
+TEST_CASE("intervalsConnect")
+{
+  SECTION("Valid intervals that are adjacent")
+  {
+    ValidityInterval interval1{ 1, 10 };
+    ValidityInterval interval2{ 10, 20 };
+    REQUIRE(intervalsConnect(interval1, interval2));
+    REQUIRE(intervalsConnect(interval2, interval1));
+  }
+
+  SECTION("Valid intervals that are not adjacent")
+  {
+    ValidityInterval interval1{ 1, 10 };
+    ValidityInterval interval2{ 11, 20 };
+    REQUIRE_FALSE(intervalsConnect(interval1, interval2));
+    REQUIRE_FALSE(intervalsConnect(interval2, interval1));
+  }
+
+  SECTION("Overlapping intervals")
+  {
+    ValidityInterval interval1{ 1, 15 };
+    ValidityInterval interval2{ 10, 20 };
+    REQUIRE(intervalsConnect(interval1, interval2));
+    REQUIRE(intervalsConnect(interval2, interval1));
+  }
+
+  SECTION("Invalid intervals")
+  {
+    ValidityInterval invalidInterval{ 10, 5 }; // max < min
+    ValidityInterval validInterval{ 1, 10 };
+    REQUIRE_FALSE(intervalsConnect(invalidInterval, validInterval));
+    REQUIRE_FALSE(intervalsConnect(validInterval, invalidInterval));
+  }
+
+  SECTION("Intervals with same start and end")
+  {
+    ValidityInterval interval{ 10, 10 };
+    REQUIRE(intervalsConnect(interval, interval));
+  }
+}
+
+TEST_CASE("intervalsOverlap")
+{
+  SECTION("Valid intervals that are adjacent")
+  {
+    ValidityInterval interval1{ 1, 10 };
+    ValidityInterval interval2{ 10, 20 };
+    REQUIRE_FALSE(intervalsOverlap(interval1, interval2));
+    REQUIRE_FALSE(intervalsOverlap(interval2, interval1));
+  }
+
+  SECTION("Overlapping intervals")
+  {
+    ValidityInterval interval1{ 1, 15 };
+    ValidityInterval interval2{ 10, 20 };
+    REQUIRE(intervalsOverlap(interval1, interval2));
+    REQUIRE(intervalsOverlap(interval2, interval1));
+  }
+
+  SECTION("Invalid intervals")
+  {
+    ValidityInterval invalidInterval{ 10, 5 }; // max < min
+    ValidityInterval validInterval{ 1, 10 };
+    REQUIRE_FALSE(intervalsOverlap(invalidInterval, validInterval));
+    REQUIRE_FALSE(intervalsOverlap(validInterval, invalidInterval));
+  }
+
+  // fixme: This now returns false due to < and > comparators being used.
+  //  However, the true reason for returning false should be the invalidity of the two intervals,
+  //  which are now considered valid, since we use o2::math_utils::detail::Bracket::isValid().
+  //  This could be refactored, so an interval [x, x) is consistently treated as invalid.
+  SECTION("Intervals with same start and end")
+  {
+    ValidityInterval interval{ 10, 10 };
+    REQUIRE_FALSE(intervalsOverlap(interval, interval));
+  }
+}
+
+TEST_CASE("excludeInterval")
+{
+  SECTION("Empty vector when interval fully covers the flag's interval")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 5, 25 };
+
+    auto result = excludeInterval(qcFlag, interval);
+
+    REQUIRE(result.empty());
+  }
+
+  SECTION("One flag when interval covers the start of the flag's interval")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 5, 15 };
+
+    auto result = excludeInterval(qcFlag, interval);
+
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].getStart() == 15);
+    REQUIRE(result[0].getEnd() == 20);
+    REQUIRE(result[0].getFlag() == qcFlag.getFlag());
+    REQUIRE(result[0].getComment() == qcFlag.getComment());
+    REQUIRE(result[0].getSource() == qcFlag.getSource());
+  }
+
+  SECTION("One flag when interval covers the end of the flag's interval")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 15, 25 };
+
+    auto result = excludeInterval(qcFlag, interval);
+
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].getStart() == 10);
+    REQUIRE(result[0].getEnd() == 15);
+    REQUIRE(result[0].getFlag() == qcFlag.getFlag());
+    REQUIRE(result[0].getComment() == qcFlag.getComment());
+    REQUIRE(result[0].getSource() == qcFlag.getSource());
+  }
+
+  SECTION("Two flags when interval is fully contained within the flag's interval")
+  {
+    QualityControlFlag qcFlag{ 10, 30, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 15, 25 };
+
+    auto result = excludeInterval(qcFlag, interval);
+
+    REQUIRE(result.size() == 2);
+    REQUIRE(result[0].getStart() == 10);
+    REQUIRE(result[0].getEnd() == 15);
+    REQUIRE(result[0].getFlag() == qcFlag.getFlag());
+    REQUIRE(result[0].getComment() == qcFlag.getComment());
+    REQUIRE(result[0].getSource() == qcFlag.getSource());
+    REQUIRE(result[1].getStart() == 25);
+    REQUIRE(result[1].getEnd() == 30);
+    REQUIRE(result[1].getFlag() == qcFlag.getFlag());
+    REQUIRE(result[1].getComment() == qcFlag.getComment());
+    REQUIRE(result[1].getSource() == qcFlag.getSource());
+  }
+
+  SECTION("No exclusion when interval is before the flag's interval")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 0, 5 };
+
+    auto result = excludeInterval(qcFlag, interval);
+
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].getStart() == 10);
+    REQUIRE(result[0].getEnd() == 20);
+    REQUIRE(result[0].getFlag() == qcFlag.getFlag());
+    REQUIRE(result[0].getComment() == qcFlag.getComment());
+    REQUIRE(result[0].getSource() == qcFlag.getSource());
+  }
+
+  SECTION("No exclusion when interval is after the flag's interval")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 25, 30 };
+
+    auto result = excludeInterval(qcFlag, interval);
+
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].getStart() == 10);
+    REQUIRE(result[0].getEnd() == 20);
+    REQUIRE(result[0].getFlag() == qcFlag.getFlag());
+    REQUIRE(result[0].getComment() == qcFlag.getComment());
+    REQUIRE(result[0].getSource() == qcFlag.getSource());
+  }
+
+  SECTION("Invalid flag interval returns the same flag")
+  {
+    QualityControlFlag qcFlag{ 10, 10, FlagTypeFactory::BadTracking() }; // Zero-length interval
+    ValidityInterval interval{ 5, 15 };
+
+    auto result = excludeInterval(qcFlag, interval);
+
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].getStart() == 10);
+    REQUIRE(result[0].getEnd() == 10);
+    REQUIRE(result[0].getFlag() == qcFlag.getFlag());
+    REQUIRE(result[0].getComment() == qcFlag.getComment());
+    REQUIRE(result[0].getSource() == qcFlag.getSource());
+  }
+
+  SECTION("Zero-length overlap returns original flag")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 15, 15 }; // Zero-length interval
+
+    auto result = excludeInterval(qcFlag, interval);
+
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0].getStart() == 10);
+    REQUIRE(result[0].getEnd() == 20);
+    REQUIRE(result[0].getFlag() == qcFlag.getFlag());
+    REQUIRE(result[0].getComment() == qcFlag.getComment());
+    REQUIRE(result[0].getSource() == qcFlag.getSource());
+  }
+}
+
+TEST_CASE("intersection")
+{
+  SECTION("Returns original flag when interval is invalid")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 10, 5 };
+
+    auto result = intersection(qcFlag, interval);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->getStart() == 10);
+    REQUIRE(result->getEnd() == 20);
+    REQUIRE(result->getFlag() == qcFlag.getFlag());
+    REQUIRE(result->getComment() == qcFlag.getComment());
+    REQUIRE(result->getSource() == qcFlag.getSource());
+  }
+
+  SECTION("Returns nullopt when there is no overlap")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking() };
+    ValidityInterval interval{ 25, 30 };
+
+    auto result = intersection(qcFlag, interval);
+
+    REQUIRE(!result.has_value());
+  }
+
+  SECTION("Returns intersected flag when intervals partially overlap")
+  {
+    QualityControlFlag qcFlag{ 10, 20, FlagTypeFactory::BadTracking(), "comment", "source" };
+    ValidityInterval interval{ 15, 25 };
+
+    auto result = intersection(qcFlag, interval);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->getStart() == 15);
+    REQUIRE(result->getEnd() == 20);
+    REQUIRE(result->getFlag() == qcFlag.getFlag());
+    REQUIRE(result->getComment() == qcFlag.getComment());
+    REQUIRE(result->getSource() == qcFlag.getSource());
+  }
+
+  SECTION("Returns intersected flag when intervals fully overlap")
+  {
+    QualityControlFlag qcFlag{ 10, 30, FlagTypeFactory::BadTracking(), "comment", "source" };
+    ValidityInterval interval{ 15, 25 };
+
+    auto result = intersection(qcFlag, interval);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->getStart() == 15);
+    REQUIRE(result->getEnd() == 25);
+    REQUIRE(result->getFlag() == qcFlag.getFlag());
+    REQUIRE(result->getComment() == qcFlag.getComment());
+    REQUIRE(result->getSource() == qcFlag.getSource());
+  }
+
+  SECTION("Returns intersected flag when flag's interval is fully within the given interval")
+  {
+    QualityControlFlag qcFlag{ 15, 25, FlagTypeFactory::BadTracking(), "comment", "source" };
+    ValidityInterval interval{ 10, 30 };
+
+    auto result = intersection(qcFlag, interval);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->getStart() == 15);
+    REQUIRE(result->getEnd() == 25);
+    REQUIRE(result->getFlag() == qcFlag.getFlag());
+    REQUIRE(result->getComment() == qcFlag.getComment());
+    REQUIRE(result->getSource() == qcFlag.getSource());
+  }
+}

--- a/Framework/test/testQualitiesToFlagCollectionConverter.cxx
+++ b/Framework/test/testQualitiesToFlagCollectionConverter.cxx
@@ -16,136 +16,279 @@
 
 #include "QualityControl/QualitiesToFlagCollectionConverter.h"
 #include "QualityControl/QualityObject.h"
-#include "QualityControl/ObjectMetadataKeys.h"
 #include <DataFormatsQualityControl/QualityControlFlagCollection.h>
 #include <DataFormatsQualityControl/FlagTypeFactory.h>
-
-#define BOOST_TEST_MODULE QO2QCFCConversion test
-#define BOOST_TEST_MAIN
-#define BOOST_TEST_DYN_LINK
-
-#include <boost/test/unit_test.hpp>
+#include <ranges>
+#include <catch_amalgamated.hpp>
 
 using namespace o2::quality_control;
 using namespace o2::quality_control::core;
-using namespace o2::quality_control::repository;
 
-BOOST_AUTO_TEST_CASE(test_NoQOs)
+TEST_CASE("Default QO conversions", "[QualitiesToFlagCollectionConverter]")
 {
-  std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-  QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-  qcfc = converter.getResult();
+  SECTION("Good QO with no Flags is not converted to any Flag")
+  {
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
 
-  BOOST_REQUIRE_EQUAL(qcfc->size(), 1);
-  auto& flag = *qcfc->begin();
-  BOOST_CHECK_EQUAL(flag.getStart(), 5);
-  BOOST_CHECK_EQUAL(flag.getEnd(), 100);
-  BOOST_CHECK_EQUAL(flag.getFlag(), FlagTypeFactory::UnknownQuality());
-  BOOST_CHECK_EQUAL(flag.getSource(), "qc/DET/QO/xyzCheck");
+    QualityObject qo{ Quality::Good, "xyzCheck", "DET" };
+    qo.setValidity({ 5, 100 });
+    converter(qo);
+
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 0);
+  }
+  SECTION("Bad and Medium QOs with no Flags are converted to Unknown Flag")
+  {
+    std::vector<QualityObject> qos{
+      { Quality::Medium, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" }
+    };
+
+    qos[0].setValidity({ 5, 150 });
+    qos[1].setValidity({ 10, 100 });
+
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+    for (const auto& qo : qos) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 2);
+
+    auto& flag1 = *qcfc->begin();
+    CHECK(flag1.getStart() == 5);
+    CHECK(flag1.getEnd() == 100);
+    CHECK(flag1.getFlag() == FlagTypeFactory::Unknown());
+    CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
+
+    auto& flag2 = *(++qcfc->begin());
+    CHECK(flag2.getStart() == 10);
+    CHECK(flag2.getEnd() == 100);
+    CHECK(flag2.getFlag() == FlagTypeFactory::Unknown());
+    CHECK(flag2.getSource() == "qc/DET/QO/xyzCheck");
+  }
+
+  SECTION("Null QO with no Flags is converted to UnknownQuality Flag")
+  {
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+
+    QualityObject qo{ Quality::Null, "xyzCheck", "DET" };
+    qo.setValidity({ 5, 100 });
+    converter(qo);
+
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 1);
+    auto& flag = *qcfc->begin();
+    CHECK(flag.getStart() == 5);
+    CHECK(flag.getEnd() == 100);
+    CHECK(flag.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag.getSource() == "qc/DET/QO/xyzCheck");
+  }
 }
 
-BOOST_AUTO_TEST_CASE(test_NoBeginning)
+TEST_CASE("Filling empty intervals with UnknownQuality", "[QualitiesToFlagCollectionConverter]")
 {
+  SECTION("test_NoQOs")
+  {
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 1);
+    auto& flag = *qcfc->begin();
+    CHECK(flag.getStart() == 5);
+    CHECK(flag.getEnd() == 100);
+    CHECK(flag.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag.getSource() == "qc/DET/QO/xyzCheck");
+  }
+
+  SECTION("test_NoBeginning")
+  {
+    std::vector<QualityObject> qos{
+      { Quality::Bad, "xyzCheck", "DET" },
+      { Quality::Good, "xyzCheck", "DET" }
+    };
+
+    qos[0].setValidity({ 10, 50 });
+    qos[1].setValidity({ 50, 120 });
+
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+    for (const auto& qo : qos) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 2);
+
+    auto& flag1 = *qcfc->begin();
+    CHECK(flag1.getStart() == 5);
+    CHECK(flag1.getEnd() == 10);
+    CHECK(flag1.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
+
+    auto& flag2 = *(++qcfc->begin());
+    CHECK(flag2.getStart() == 10);
+    CHECK(flag2.getEnd() == 50);
+    CHECK(flag2.getFlag() == FlagTypeFactory::Unknown());
+    CHECK(flag2.getSource() == "qc/DET/QO/xyzCheck");
+  }
+
+  SECTION("test_NoEnd")
+  {
+    std::vector<QualityObject> qos{
+      { Quality::Good, "xyzCheck", "DET" }
+    };
+
+    qos[0].setValidity({ 5, 80 });
+
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+    for (const auto& qo : qos) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 1);
+    auto& flag = *qcfc->begin();
+    CHECK(flag.getStart() == 80);
+    CHECK(flag.getEnd() == 100);
+    CHECK(flag.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag.getSource() == "qc/DET/QO/xyzCheck");
+  }
+}
+
+TEST_CASE("UnknownQuality is overwritten by other Flags", "[QualitiesToFlagCollectionConverter]")
+{
+  // Automatically generated UnknownQuality is overwritten by anything
+  // User-provided UnknownQuality and default Flag for Null are overwritten by other user-provided flags which are not UnknownQuality
+
   std::vector<QualityObject> qos{
-    { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Good, "xyzCheck", "DET" }
+    { Quality::Null, "xyzCheck", "DET" }, // Null with default UnknownQuality Flag, to be trimmed
+    { Quality::Null, "xyzCheck", "DET" }, // Null with default UnknownQuality Flag, to be removed
+    { Quality::Null, "xyzCheck", "DET" }, // Null with a user-provided UnknownQuality Flag, to be trimmed
+    { Quality::Null, "xyzCheck", "DET" }, // Null with a user-provided UnknownQuality Flag, to be removed
+    { Quality::Good, "xyzCheck", "DET" }  // "known" Flag which should trim/remove all of the above
   };
 
-  qos[0].setValidity({ 10, 50 });
-  qos[1].setValidity({ 50, 120 });
+  qos[0].setValidity({ 5, 30 });
+  qos[1].setValidity({ 40, 50 });
+  qos[2].setValidity({ 50, 100 });
+  qos[2].addFlag(FlagTypeFactory::UnknownQuality(), "custom comment 1");
+  qos[3].setValidity({ 50, 60 });
+  qos[3].addFlag(FlagTypeFactory::UnknownQuality(), "custom comment 2");
+  qos[4].setValidity({ 20, 60 });
 
-  std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+  auto check = [](const QualityControlFlagCollection& qcfc) {
+    REQUIRE(qcfc.size() == 2);
+
+    auto it = qcfc.begin();
+    auto& flag1 = *it;
+    CHECK(flag1.getStart() == 5);
+    CHECK(flag1.getEnd() == 20);
+    CHECK(flag1.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
+
+    auto& flag2 = *(++it);
+    CHECK(flag2.getStart() == 60);
+    CHECK(flag2.getEnd() == 100);
+    CHECK(flag2.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag2.getComment() == "custom comment 1");
+    CHECK(flag2.getSource() == "qc/DET/QO/xyzCheck");
+  };
+
+  // we perform the same test twice by feeding the converter in the normal and reverse order
+  // to make sure it does not affect the result
+  SECTION("flags provided from the first to last in the vector")
+  {
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+    for (const auto& qo : qos) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+    check(*qcfc);
+  }
+  SECTION("flags provided in the reverse order")
+  {
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+    for (const auto& qo : qos | std::views::reverse) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+    check(*qcfc);
+  }
+}
+
+TEST_CASE("All QOs with Flags are converted to Flags, while Quality is ignored", "[QualitiesToFlagCollectionConverter]")
+{
+  std::vector<QualityObject> qos{
+    { Quality::Null, "xyzCheck", "DET" },
+    { Quality::Bad, "xyzCheck", "DET" },
+    { Quality::Medium, "xyzCheck", "DET" },
+    { Quality::Good, "xyzCheck", "DET" },
+  };
+
+  qos[0].setValidity({ 5, 20 });
+  qos[0].addFlag(FlagTypeFactory::Good(), "null");
+
+  qos[1].setValidity({ 20, 40 });
+  qos[1].addFlag(FlagTypeFactory::Good(), "bad");
+
+  qos[2].setValidity({ 40, 60 });
+  qos[2].addFlag(FlagTypeFactory::Good(), "medium");
+
+  qos[3].setValidity({ 60, 100 });
+  qos[3].addFlag(FlagTypeFactory::Unknown(), "good");
+
+  std::unique_ptr<QualityControlFlagCollection> qcfc{
+    new QualityControlFlagCollection("test1", "DET", { 5, 100 })
+  };
   QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
   for (const auto& qo : qos) {
     converter(qo);
   }
   qcfc = converter.getResult();
 
-  BOOST_REQUIRE_EQUAL(qcfc->size(), 2);
+  REQUIRE(qcfc->size() == 4);
 
-  auto& flag1 = *qcfc->begin();
-  BOOST_CHECK_EQUAL(flag1.getStart(), 5);
-  BOOST_CHECK_EQUAL(flag1.getEnd(), 9);
-  BOOST_CHECK_EQUAL(flag1.getFlag(), FlagTypeFactory::UnknownQuality());
-  BOOST_CHECK_EQUAL(flag1.getSource(), "qc/DET/QO/xyzCheck");
+  auto it = qcfc->begin();
+  auto& flag1 = *it;
+  CHECK(flag1.getStart() == 5);
+  CHECK(flag1.getEnd() == 20);
+  CHECK(flag1.getFlag() == FlagTypeFactory::Good());
+  CHECK(flag1.getComment() == "null");
+  CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
 
-  auto& flag2 = *(++qcfc->begin());
-  BOOST_CHECK_EQUAL(flag2.getStart(), 10);
-  BOOST_CHECK_EQUAL(flag2.getEnd(), 50);
-  BOOST_CHECK_EQUAL(flag2.getFlag(), FlagTypeFactory::Unknown());
-  BOOST_CHECK_EQUAL(flag2.getSource(), "qc/DET/QO/xyzCheck");
+  auto& flag2 = *(++it);
+  CHECK(flag2.getStart() == 20);
+  CHECK(flag2.getEnd() == 40);
+  CHECK(flag2.getFlag() == FlagTypeFactory::Good());
+  CHECK(flag2.getComment() == "bad");
+  CHECK(flag2.getSource() == "qc/DET/QO/xyzCheck");
+
+  auto& flag3 = *(++it);
+  CHECK(flag3.getStart() == 40);
+  CHECK(flag3.getEnd() == 60);
+  CHECK(flag3.getFlag() == FlagTypeFactory::Good());
+  CHECK(flag3.getComment() == "medium");
+  CHECK(flag3.getSource() == "qc/DET/QO/xyzCheck");
+
+  auto& flag4 = *(++it);
+  CHECK(flag4.getStart() == 60);
+  CHECK(flag4.getEnd() == 100);
+  CHECK(flag4.getFlag() == FlagTypeFactory::Unknown());
+  CHECK(flag4.getComment() == "good");
+  CHECK(flag4.getSource() == "qc/DET/QO/xyzCheck");
 }
 
-BOOST_AUTO_TEST_CASE(test_NoEnd)
-{
-  std::vector<QualityObject> qos{
-    { Quality::Good, "xyzCheck", "DET" }
-  };
-
-  qos[0].setValidity({ 5, 80 });
-
-  std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-  QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-  for (const auto& qo : qos) {
-    converter(qo);
-  }
-  qcfc = converter.getResult();
-
-  BOOST_REQUIRE_EQUAL(qcfc->size(), 1);
-  auto& flag = *qcfc->begin();
-  BOOST_CHECK_EQUAL(flag.getStart(), 80);
-  BOOST_CHECK_EQUAL(flag.getEnd(), 100);
-  BOOST_CHECK_EQUAL(flag.getFlag(), FlagTypeFactory::UnknownQuality());
-  BOOST_CHECK_EQUAL(flag.getSource(), "qc/DET/QO/xyzCheck");
-}
-
-BOOST_AUTO_TEST_CASE(test_WrongOrder)
-{
-  std::vector<QualityObject> qos{
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Good, "xyzCheck", "DET" }
-  };
-
-  qos[0].setValidity({ 70, 90 });
-  qos[1].setValidity({ 60, 90 });
-  qos[2].setValidity({ 50, 120 });
-  qos[3].setValidity({ 40, 120 });
-  qos[4].setValidity({ 30, 120 });
-
-  {
-    // good to good
-    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-    converter(qos[0]);
-    BOOST_CHECK_THROW(converter(qos[1]), std::runtime_error);
-  }
-  {
-    // good to bad
-    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-    converter(qos[1]);
-    BOOST_CHECK_THROW(converter(qos[2]), std::runtime_error);
-  }
-  {
-    // bad to bad
-    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-    converter(qos[2]);
-    BOOST_CHECK_THROW(converter(qos[3]), std::runtime_error);
-  }
-  {
-    // bad to good
-    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-    converter(qos[3]);
-    BOOST_CHECK_THROW(converter(qos[4]), std::runtime_error);
-  }
-}
-
-BOOST_AUTO_TEST_CASE(test_MismatchingParameters)
+TEST_CASE("Input parameter validation", "[QualitiesToFlagCollectionConverter]")
 {
   std::vector<QualityObject> qos{
     { Quality::Bad, "xyzCheck", "TPC" },
@@ -157,211 +300,298 @@ BOOST_AUTO_TEST_CASE(test_MismatchingParameters)
   qos[1].setValidity({ 1000, 10000 });
   qos[2].setValidity({ 40, 30 });
 
+  SECTION("Different detector")
   {
     // different detector
-    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    std::unique_ptr<QualityControlFlagCollection> qcfc{
+      new QualityControlFlagCollection("test1", "DET", { 5, 100 })
+    };
     QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-    BOOST_CHECK_THROW(converter(qos[0]), std::runtime_error);
+    CHECK_THROWS_AS(converter(qos[0]), std::runtime_error);
   }
+  SECTION("QO start after the QCFC end limit")
   {
-    // QO start after the QCFC end limit
-    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    std::unique_ptr<QualityControlFlagCollection> qcfc{
+      new QualityControlFlagCollection("test1", "DET", { 5, 100 })
+    };
     QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-    BOOST_CHECK_THROW(converter(qos[1]), std::runtime_error);
+    converter(qos[1]);
+
+    qcfc = converter.getResult();
+    REQUIRE(qcfc->size() == 1);
+    auto& flag = *qcfc->begin();
+    CHECK(flag.getStart() == 5);
+    CHECK(flag.getEnd() == 100);
+    CHECK(flag.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag.getSource() == "qc/DET/QO/xyzCheck");
   }
+  SECTION("QO validity starts after it finishes")
   {
-    // QO validity starts after it finishes
+    std::unique_ptr<QualityControlFlagCollection> qcfc{
+      new QualityControlFlagCollection("test1", "DET", { 5, 100 })
+    };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+
+    qcfc = converter.getResult();
+    REQUIRE(qcfc->size() == 1);
+    auto& flag = *qcfc->begin();
+    CHECK(flag.getStart() == 5);
+    CHECK(flag.getEnd() == 100);
+    CHECK(flag.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag.getSource() == "qc/DET/QO/xyzCheck");
+  }
+}
+
+TEST_CASE("Merging Flags", "[QualitiesToFlagCollectionConverter]")
+{
+  SECTION("test_OverlappingQOs")
+  {
+    std::vector<QualityObject> qos{
+      { Quality::Good, "xyzCheck", "DET" },
+      { Quality::Good, "xyzCheck", "DET" },
+      { Quality::Good, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" }
+    };
+
+    qos[0].setValidity({ 5, 50 });
+    qos[1].setValidity({ 10, 50 });
+    qos[2].setValidity({ 15, 60 });
+    qos[3].setValidity({ 55, 120 });
+    qos[4].setValidity({ 60, 120 });
+    qos[5].setValidity({ 70, 120 });
+
     std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
     QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-    BOOST_CHECK_THROW(converter(qos[2]), std::runtime_error);
+    for (const auto& qo : qos) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 1);
+
+    auto& flag1 = *qcfc->begin();
+    CHECK(flag1.getStart() == 55);
+    CHECK(flag1.getEnd() == 100);
+    CHECK(flag1.getFlag() == FlagTypeFactory::Unknown());
+    CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
+  }
+
+  SECTION("test_AdjacentQOs")
+  {
+    std::vector<QualityObject> qos{
+      { Quality::Good, "xyzCheck", "DET" },
+      { Quality::Good, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" }
+    };
+
+    qos[0].setValidity({ 5, 10 });
+    qos[1].setValidity({ 10, 50 });
+    qos[2].setValidity({ 50, 80 });
+    qos[3].setValidity({ 80, 120 });
+
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+
+    for (const auto& qo : qos) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 1);
+
+    auto& flag1 = *qcfc->begin();
+    CHECK(flag1.getStart() == 50);
+    CHECK(flag1.getEnd() == 100);
+    CHECK(flag1.getFlag() == FlagTypeFactory::Unknown());
+    CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
+  }
+
+  SECTION("test_NonDefaultFlags")
+  {
+    std::vector<QualityObject> qos{
+      { Quality::Good, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" }
+    };
+
+    qos[0].setValidity({ 5, 10 });
+    qos[1].setValidity({ 10, 40 });
+    qos[2].setValidity({ 30, 80 });
+    qos[3].setValidity({ 50, 100 });
+
+    qos[1].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
+    qos[2].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
+    qos[2].addFlag(FlagTypeFactory::BadHadronPID(), "evil CERN scientists changed the proton mass");
+    qos[3].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
+
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+    for (const auto& qo : qos) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 2);
+
+    auto& flag1 = *qcfc->begin();
+    CHECK(flag1.getStart() == 10);
+    CHECK(flag1.getEnd() == 100);
+    CHECK(flag1.getFlag() == FlagTypeFactory::BadTracking());
+    CHECK(flag1.getComment() == "Bug in reco");
+    CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
+
+    auto& flag2 = *(++qcfc->begin());
+    CHECK(flag2.getStart() == 30);
+    CHECK(flag2.getEnd() == 80);
+    CHECK(flag2.getFlag() == FlagTypeFactory::BadHadronPID());
+    CHECK(flag2.getComment() == "evil CERN scientists changed the proton mass");
+    CHECK(flag2.getSource() == "qc/DET/QO/xyzCheck");
+  }
+
+  SECTION("test_TheSameFlagsButSeparated")
+  {
+    std::vector<QualityObject> qos{
+      { Quality::Bad, "xyzCheck", "DET" },
+      { Quality::Good, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" },
+      { Quality::Bad, "xyzCheck", "DET" }
+    };
+
+    qos[0].setValidity({ 5, 25 });
+    qos[1].setValidity({ 10, 40 });
+    qos[2].setValidity({ 30, 50 });
+    qos[3].setValidity({ 80, 100 });
+
+    qos[0].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
+
+    qos[2].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
+    qos[3].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
+
+    std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
+    QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
+
+    for (const auto& qo : qos) {
+      converter(qo);
+    }
+    qcfc = converter.getResult();
+
+    REQUIRE(qcfc->size() == 4);
+
+    auto it = qcfc->begin();
+    auto& flag1 = *it;
+    CHECK(flag1.getStart() == 5);
+    CHECK(flag1.getEnd() == 25);
+    CHECK(flag1.getFlag() == FlagTypeFactory::BadTracking());
+    CHECK(flag1.getComment() == "Bug in reco");
+    CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
+
+    auto& flag2 = *(++it);
+    CHECK(flag2.getStart() == 30);
+    CHECK(flag2.getEnd() == 50);
+    CHECK(flag2.getFlag() == FlagTypeFactory::BadTracking());
+    CHECK(flag2.getComment() == "Bug in reco");
+    CHECK(flag2.getSource() == "qc/DET/QO/xyzCheck");
+
+    auto& flag3 = *(++it);
+    CHECK(flag3.getStart() == 50);
+    CHECK(flag3.getEnd() == 80);
+    CHECK(flag3.getFlag() == FlagTypeFactory::UnknownQuality());
+    CHECK(flag3.getSource() == "qc/DET/QO/xyzCheck");
+
+    auto& flag4 = *(++it);
+    CHECK(flag4.getStart() == 80);
+    CHECK(flag4.getEnd() == 100);
+    CHECK(flag4.getFlag() == FlagTypeFactory::BadTracking());
+    CHECK(flag4.getComment() == "Bug in reco");
+    CHECK(flag4.getSource() == "qc/DET/QO/xyzCheck");
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_OverlappingQOs)
+TEST_CASE("Trimming the validity interval", "[QualitiesToFlagCollectionConverter]")
 {
   std::vector<QualityObject> qos{
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Good, "xyzCheck", "DET" },
     { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" },
+    { Quality::Good, "xyzCheck", "DET" },
     { Quality::Bad, "xyzCheck", "DET" }
   };
 
-  qos[0].setValidity({ 5, 50 });
-  qos[1].setValidity({ 10, 50 });
-  qos[2].setValidity({ 15, 60 });
-  qos[3].setValidity({ 55, 120 });
-  qos[4].setValidity({ 60, 120 });
-  qos[5].setValidity({ 70, 120 });
+  qos[0].setValidity({ 5, 100 });
+  qos[1].setValidity({ 50, 100 });
+  qos[1].addFlag(FlagTypeFactory::Good(), "hello");
+  qos[2].setValidity({ 30, 70 });
+  qos[2].addFlag(FlagTypeFactory::BadTracking(), "comment");
 
   std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
   QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-  for (const auto& qo : qos) {
-    converter(qo);
-  }
+  converter(qos[0]);
+  converter(qos[1]);
+  converter.updateValidityInterval({ 10, 40 });
+  converter(qos[2]);
   qcfc = converter.getResult();
 
-  BOOST_REQUIRE_EQUAL(qcfc->size(), 1);
+  REQUIRE(qcfc->size() == 2);
 
   auto& flag1 = *qcfc->begin();
-  BOOST_CHECK_EQUAL(flag1.getStart(), 55);
-  BOOST_CHECK_EQUAL(flag1.getEnd(), 100);
-  BOOST_CHECK_EQUAL(flag1.getFlag(), FlagTypeFactory::Unknown());
-  BOOST_CHECK_EQUAL(flag1.getSource(), "qc/DET/QO/xyzCheck");
-}
-
-BOOST_AUTO_TEST_CASE(test_AdjacentQOs)
-{
-  std::vector<QualityObject> qos{
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" }
-  };
-
-  qos[0].setValidity({ 5, 10 });
-  qos[1].setValidity({ 10, 14 });
-  qos[2].setValidity({ 15, 49 });
-  qos[3].setValidity({ 50, 80 });
-  qos[4].setValidity({ 80, 95 });
-  qos[5].setValidity({ 96, 120 });
-
-  std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-  QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-
-  for (const auto& qo : qos) {
-    converter(qo);
-  }
-  qcfc = converter.getResult();
-
-  BOOST_REQUIRE_EQUAL(qcfc->size(), 1);
-
-  auto& flag1 = *qcfc->begin();
-  BOOST_CHECK_EQUAL(flag1.getStart(), 50);
-  BOOST_CHECK_EQUAL(flag1.getEnd(), 100);
-  BOOST_CHECK_EQUAL(flag1.getFlag(), FlagTypeFactory::Unknown());
-  BOOST_CHECK_EQUAL(flag1.getSource(), "qc/DET/QO/xyzCheck");
-}
-
-BOOST_AUTO_TEST_CASE(test_UnexplainedMediumIsBad)
-{
-  std::vector<QualityObject> qos{
-    { Quality::Medium, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" }
-  };
-
-  qos[0].setValidity({ 5, 150 });
-  qos[1].setValidity({ 10, 100 });
-
-  std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-  QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-  for (const auto& qo : qos) {
-    converter(qo);
-  }
-  qcfc = converter.getResult();
-
-  BOOST_REQUIRE_EQUAL(qcfc->size(), 1);
-
-  auto& flag1 = *qcfc->begin();
-  BOOST_CHECK_EQUAL(flag1.getStart(), 5);
-  BOOST_CHECK_EQUAL(flag1.getEnd(), 100);
-  BOOST_CHECK_EQUAL(flag1.getFlag(), FlagTypeFactory::Unknown());
-  BOOST_CHECK_EQUAL(flag1.getSource(), "qc/DET/QO/xyzCheck");
-}
-
-BOOST_AUTO_TEST_CASE(test_KnownFlags)
-{
-  std::vector<QualityObject> qos{
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" }
-  };
-
-  qos[0].setValidity({ 5, 10 });
-  qos[1].setValidity({ 10, 40 });
-  qos[2].setValidity({ 30, 80 });
-  qos[3].setValidity({ 50, 100 });
-
-  qos[1].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
-  qos[2].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
-  qos[2].addFlag(FlagTypeFactory::BadHadronPID(), "evil CERN scientists changed the proton mass");
-  qos[3].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
-
-  std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
-  QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-  for (const auto& qo : qos) {
-    converter(qo);
-  }
-  qcfc = converter.getResult();
-
-  BOOST_REQUIRE_EQUAL(qcfc->size(), 2);
-
-  auto& flag1 = *qcfc->begin();
-  BOOST_CHECK_EQUAL(flag1.getStart(), 10);
-  BOOST_CHECK_EQUAL(flag1.getEnd(), 100);
-  BOOST_CHECK_EQUAL(flag1.getFlag(), FlagTypeFactory::BadTracking());
-  BOOST_CHECK_EQUAL(flag1.getComment(), "Bug in reco");
-  BOOST_CHECK_EQUAL(flag1.getSource(), "qc/DET/QO/xyzCheck");
+  CHECK(flag1.getStart() == 10);
+  CHECK(flag1.getEnd() == 40);
+  CHECK(flag1.getFlag() == FlagTypeFactory::Unknown());
+  CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
 
   auto& flag2 = *(++qcfc->begin());
-  BOOST_CHECK_EQUAL(flag2.getStart(), 30);
-  BOOST_CHECK_EQUAL(flag2.getEnd(), 50);
-  BOOST_CHECK_EQUAL(flag2.getFlag(), FlagTypeFactory::BadHadronPID());
-  BOOST_CHECK_EQUAL(flag2.getComment(), "evil CERN scientists changed the proton mass");
-  BOOST_CHECK_EQUAL(flag2.getSource(), "qc/DET/QO/xyzCheck");
+  CHECK(flag2.getStart() == 30);
+  CHECK(flag2.getEnd() == 40);
+  CHECK(flag2.getFlag() == FlagTypeFactory::BadTracking());
+  CHECK(flag2.getComment() == "comment");
 }
 
-BOOST_AUTO_TEST_CASE(test_TheSameFlagsButSeparated)
+TEST_CASE("Extending the validity interval", "[QualitiesToFlagCollectionConverter]")
 {
   std::vector<QualityObject> qos{
     { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Good, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" },
-    { Quality::Bad, "xyzCheck", "DET" }
+    { Quality::Good, "xyzCheck", "DET" }
   };
 
-  qos[0].setValidity({ 5, 25 });
-  qos[1].setValidity({ 10, 40 });
-  qos[2].setValidity({ 30, 50 });
-  qos[3].setValidity({ 80, 100 });
-
-  qos[0].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
-  qos[2].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
-  qos[3].addFlag(FlagTypeFactory::BadTracking(), "Bug in reco");
+  qos[0].setValidity({ 5, 100 });
+  qos[1].setValidity({ 50, 100 });
+  qos[1].addFlag(FlagTypeFactory::Good(), "hello");
 
   std::unique_ptr<QualityControlFlagCollection> qcfc{ new QualityControlFlagCollection("test1", "DET", { 5, 100 }) };
   QualitiesToFlagCollectionConverter converter(std::move(qcfc), "qc/DET/QO/xyzCheck");
-
   for (const auto& qo : qos) {
     converter(qo);
   }
+  converter.updateValidityInterval({ 1, 120 });
   qcfc = converter.getResult();
 
-  BOOST_REQUIRE_EQUAL(qcfc->size(), 3);
+  CHECK(qcfc->size() == 4);
 
   auto it = qcfc->begin();
   auto& flag1 = *it;
-  BOOST_CHECK_EQUAL(flag1.getStart(), 5);
-  BOOST_CHECK_EQUAL(flag1.getEnd(), 10);
-  BOOST_CHECK_EQUAL(flag1.getFlag(), FlagTypeFactory::BadTracking());
-  BOOST_CHECK_EQUAL(flag1.getComment(), "Bug in reco");
-  BOOST_CHECK_EQUAL(flag1.getSource(), "qc/DET/QO/xyzCheck");
+  CHECK(flag1.getStart() == 1);
+  CHECK(flag1.getEnd() == 5);
+  CHECK(flag1.getFlag() == FlagTypeFactory::UnknownQuality());
+  CHECK(flag1.getSource() == "qc/DET/QO/xyzCheck");
 
   auto& flag2 = *(++it);
-  BOOST_CHECK_EQUAL(flag2.getStart(), 30);
-  BOOST_CHECK_EQUAL(flag2.getEnd(), 50);
-  BOOST_CHECK_EQUAL(flag2.getFlag(), FlagTypeFactory::BadTracking());
-  BOOST_CHECK_EQUAL(flag2.getComment(), "Bug in reco");
-  BOOST_CHECK_EQUAL(flag2.getSource(), "qc/DET/QO/xyzCheck");
+  CHECK(flag2.getStart() == 5);
+  CHECK(flag2.getEnd() == 100);
+  CHECK(flag2.getFlag() == FlagTypeFactory::Unknown());
+  CHECK(flag2.getSource() == "qc/DET/QO/xyzCheck");
 
   auto& flag3 = *(++it);
-  BOOST_CHECK_EQUAL(flag3.getStart(), 80);
-  BOOST_CHECK_EQUAL(flag3.getEnd(), 100);
-  BOOST_CHECK_EQUAL(flag3.getFlag(), FlagTypeFactory::BadTracking());
-  BOOST_CHECK_EQUAL(flag3.getComment(), "Bug in reco");
-  BOOST_CHECK_EQUAL(flag3.getSource(), "qc/DET/QO/xyzCheck");
+  CHECK(flag3.getStart() == 50);
+  CHECK(flag3.getEnd() == 100);
+  CHECK(flag3.getFlag() == FlagTypeFactory::Good());
+  CHECK(flag3.getComment() == "hello");
+  CHECK(flag3.getSource() == "qc/DET/QO/xyzCheck");
+
+  auto& flag4 = *(++it);
+  CHECK(flag4.getStart() == 100);
+  CHECK(flag4.getEnd() == 120);
+  CHECK(flag4.getFlag() == FlagTypeFactory::UnknownQuality());
+  CHECK(flag4.getSource() == "qc/DET/QO/xyzCheck");
 }


### PR DESCRIPTION
The converter has been adapted to the rules below:
- **Good QOs with no Flags are not onverted to any Flags**
- **Bad and Medium QOs with no Flags are converted to Flag 14 (Unknown)**
- **Null QOs with no Flags are converted to Flag 1**
- **All QOs with Flags are converted to Flags, while Quality is ignored**. A warning should be printed if a Check associates a GOOD flag to BAD quality, or a BAD flag to GOOD quality.
- **Timespans not covered by a given QO are filled with Flag 1 (Unknown Quality)**
- **Overlapping or adjacent Flags with the same ID, comment and source (QO) are merged, even if they were associated to different Qualities.**
- **Flag 1 (UnknownQuality) gets overwritten by any other Flag**.
- **Good and Bad flags do not affect each other, they may coexist**.
- **Flags for different QOs do not affect each other, Flag 1 is added separately for each.**
- **The order of QO arrival should not matter**. Today, `QualitiesToFlagCollectionConverter` assumes it should receive quality flags in chronological order. However, this may not always be the case in sync QC, where validity start might slightly move to the past due unaligned validities of objects coming from EPNs, being merged in the merger nodes.

Additionally the tests were extended and updated.