### PR TITLE
ITS - rearrangement of plots and checks for shifters

### DIFF
--- a/Modules/ITS/include/ITS/ITSChipStatusCheck.h
+++ b/Modules/ITS/include/ITS/ITSChipStatusCheck.h
@@ -52,6 +52,7 @@ class ITSChipStatusCheck : public o2::quality_control::checker::CheckInterface
   static const int NLayer = 7;
   const int StaveBoundary[NLayer + 1] = { 0, 12, 28, 48, 72, 102, 144, 192 };
   std::shared_ptr<TLatex> tInfo;
+  const int FeeIDBoundaryVsBarrel[4] = { 0, 144, 252, 432 };
 };
 
 } // namespace o2::quality_control_modules::its

--- a/Modules/ITS/include/ITS/ITSChipStatusTask.h
+++ b/Modules/ITS/include/ITS/ITSChipStatusTask.h
@@ -85,10 +85,13 @@ class ITSChipStatusTask final : public TaskInterface
   void setAxisTitle(TH1* object, const char* xTitle, const char* yTitle);
   void Beautify();
   void getStavePoint(int layer, int stave, double* px, double* py);
+  int getFEEID(int barrel, int chipinbarrel);
+
   static constexpr int NLayer = 7;
   static constexpr int NLayerIB = 3;
   const int nHicPerStave[NLayer] = { 1, 1, 1, 8, 8, 14, 14 };
   const int nChipsPerHic[NLayer] = { 9, 9, 9, 14, 14, 14, 14 };
+  const int nChipsPerFeeID[3] = { 3, 56, 98 }; // index is the barrel
   const int nChipsPerLayer[NLayer] = { 108, 144, 180, 2688, 3360, 8232, 9408 };
   const int StaveBoundary[NLayer + 1] = { 0, 12, 28, 48, 72, 102, 144, 192 };
   const int ChipBoundary[NLayer + 1] = { 0, 108, 252, 432, 3120, 6480, 14712, 24120 };
@@ -105,6 +108,7 @@ class ITSChipStatusTask final : public TaskInterface
   int nQCCycleToMonitor = 10;
   TString BarrelNames[3] = { "IB", "ML", "OB" };
   TH2Poly* StaveOverview;
+  TH1D* FeeIDOverview;
   int NCycleForOverview = 3;
   int nRotationType = 1;
   std::vector<int> CurrentDeadChips[3]; // Vectors of Dead Chips in current QC cycle

--- a/Modules/ITS/include/ITS/ITSDecodingErrorCheck.h
+++ b/Modules/ITS/include/ITS/ITSDecodingErrorCheck.h
@@ -44,6 +44,7 @@ class ITSDecodingErrorCheck : public o2::quality_control::checker::CheckInterfac
   void beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult = Quality::Null) override;
   std::vector<int> vListErrorIdBad, vListErrorIdMedium;
   bool doFlatCheck = false;
+  std::map<int, std::vector<int>> vAlreadyCheckedFeeIDs{}; // alreadychecked[fee] = <vector of error flags to skip>
   o2::itsmft::GBTLinkDecodingStat statistics;
 
  private:

--- a/Modules/ITS/itsChipStatus.json
+++ b/Modules/ITS/itsChipStatus.json
@@ -48,6 +48,12 @@
                 "moduleName": "QcITS",
                 "policy": "OnEachSeparately",
                 "detectorName": "ITS",
+		"checkParameters": {
+		    "feelimitsIB": "1,1",
+		    "feelimitsML": "1,0.87",
+		    "feelimitsOL": "1,0.92",
+		    "excludedfeeid": "",
+		},
                 "dataSource": [{
                     "type": "Task",
                     "name": "ITSChipStatus",

--- a/Modules/ITS/itsChipStatus.json
+++ b/Modules/ITS/itsChipStatus.json
@@ -49,10 +49,10 @@
                 "policy": "OnEachSeparately",
                 "detectorName": "ITS",
 		"checkParameters": {
-		    "feelimitsIB": "1,1",
-		    "feelimitsML": "1,0.87",
-		    "feelimitsOL": "1,0.92",
-		    "excludedfeeid": "",
+		    "feeidlimitsIB": "1,1",
+		    "feeidlimitsML": "1,0.87",
+		    "feeidlimitsOL": "1,0.92",
+		    "excludedfeeid": ""
 		},
                 "dataSource": [{
                     "type": "Task",

--- a/Modules/ITS/itsDecoding.json
+++ b/Modules/ITS/itsDecoding.json
@@ -48,6 +48,7 @@
                 "policy": "OnEachSeparately",
                 "detectorName": "ITS",
                 "checkParameters": {
+		      "checkfeeIDonce": "true",
                       "DecLinkErrorLimits": "5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, -1",
                       "DecLinkErrorLimitsRatio": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1",
                       "DecLinkErrorType": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",

--- a/Modules/ITS/itsDecoding.json
+++ b/Modules/ITS/itsDecoding.json
@@ -48,7 +48,7 @@
                 "policy": "OnEachSeparately",
                 "detectorName": "ITS",
                 "checkParameters": {
-		      "checkfeeIDonce": "true",
+		      "checkfeeIDonlyonce": "true",
                       "DecLinkErrorLimits": "5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, -1",
                       "DecLinkErrorLimitsRatio": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1",
                       "DecLinkErrorType": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",

--- a/Modules/ITS/src/ITSChipStatusCheck.cxx
+++ b/Modules/ITS/src/ITSChipStatusCheck.cxx
@@ -117,7 +117,7 @@ void ITSChipStatusCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality che
   TString status;
   int textColor;
 
-  if (mo->GetName() == "FEEIDOverview") {
+  if ((string)mo->GetName() == "FEEIDOverview") {
     auto* h = dynamic_cast<TH1D*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast FEEIDOverview to TH1D*" << ENDM;
@@ -129,14 +129,9 @@ void ITSChipStatusCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality che
       textColor = kGreen;
     } else if (checkResult == Quality::Bad) {
       status = "Quality::BAD (call expert)";
-      tInfo = std::make_shared<TLatex>(0.12, 0.831, "BAD: at least one FEEid with large number of missing chips");
-      tInfo->SetTextColor(kRed + 2);
-      tInfo->SetTextSize(0.04);
-      tInfo->SetTextFont(43);
-      tInfo->SetNDC();
-      h->GetListOfFunctions()->Add(tInfo->Clone());
       textColor = kRed + 2;
     }
+
     tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
     tInfo->SetTextColor(textColor);
     tInfo->SetTextSize(0.06);
@@ -145,7 +140,7 @@ void ITSChipStatusCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality che
     h->GetListOfFunctions()->Add(tInfo->Clone());
   }
 
-  if (mo->getName() == "StaveStatusOverview") {
+  if ((string)mo->getName() == "StaveStatusOverview") {
     auto* h = dynamic_cast<TH2Poly*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast StaveStatusOverview to TH2Poly*" << ENDM;

--- a/Modules/ITS/src/ITSChipStatusTask.cxx
+++ b/Modules/ITS/src/ITSChipStatusTask.cxx
@@ -200,15 +200,18 @@ void ITSChipStatusTask::endOfCycle()
 
   FeeIDOverview->Reset();
   for (int iBarrel = 0; iBarrel < 3; iBarrel++) {
-    TH1D* hBarProj = DeadChips[iBarrel]->getNum()->ProjectionY("temp", TMath::Max(1, nQCCycleToMonitor - NCycleForOverview), nQCCycleToMonitor);
-    for (int ic = 0; ic < hBarProj->GetNbinsX(); ic++) {
+    TH1D* hBarProj = DeadChips[iBarrel]->getNum()->ProjectionY("temp", TMath::Max(1, nQCCycleToMonitor - NCycleForOverview + 1), nQCCycleToMonitor);
 
+    for (int ic = 0; ic < hBarProj->GetNbinsX(); ic++) {
       if (hBarProj->GetBinContent(ic + 1) < NCycleForOverview) { // report only chips dead for N consecutive cycles
         continue;
       }
       FeeIDOverview->Fill(getFEEID(iBarrel, ic), 1. / nChipsPerFeeID[iBarrel]);
     }
   }
+  FeeIDOverview->Sumw2(kFALSE);
+  FeeIDOverview->SetMinimum(0);
+  FeeIDOverview->SetMaximum(1);
 
   int iLayer = 0;
   int iStave = 0;

--- a/Modules/ITS/src/ITSChipStatusTask.cxx
+++ b/Modules/ITS/src/ITSChipStatusTask.cxx
@@ -77,6 +77,9 @@ void ITSChipStatusTask::initialize(o2::framework::InitContext& /*ctx*/)
     }
   }
   getObjectsManager()->startPublishing(StaveOverview);
+
+  FeeIDOverview = new TH1D("FEEIDOverview", Form("Fraction of missing chips in the last %d cycles;QC FEEid;fraction of missing chips", NCycleForOverview), NFees, 0, NFees);
+  getObjectsManager()->startPublishing(FeeIDOverview);
 }
 
 void ITSChipStatusTask::setAxisTitle(TH1* object, const char* xTitle, const char* yTitle)
@@ -131,6 +134,22 @@ void ITSChipStatusTask::getStavePoint(int layer, int stave, double* px, double* 
   }
 }
 
+int ITSChipStatusTask::getFEEID(int barrel, int chipinbarrel)
+{
+  if (barrel == 0) {
+    return chipinbarrel / nChipsPerFeeID[0];
+  }
+  if (barrel == 1) {
+    return ChipsBoundaryBarrels[1] / nChipsPerFeeID[0] + chipinbarrel / nChipsPerFeeID[1];
+  }
+  if (barrel == 2) {
+    return (ChipsBoundaryBarrels[1] / nChipsPerFeeID[0]) +
+           ((ChipsBoundaryBarrels[2] - ChipsBoundaryBarrels[1]) / nChipsPerFeeID[1]) +
+           chipinbarrel / nChipsPerFeeID[2];
+  }
+  return -1;
+}
+
 void ITSChipStatusTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
   auto aliveChips = ctx.inputs().get<gsl::span<char>>("chipstatus");
@@ -179,6 +198,18 @@ void ITSChipStatusTask::endOfCycle()
   Beautify();
   //---------- Shifter plot
 
+  FeeIDOverview->Reset();
+  for (int iBarrel = 0; iBarrel < 3; iBarrel++) {
+    TH1D* hBarProj = DeadChips[iBarrel]->getNum()->ProjectionY("temp", TMath::Max(1, nQCCycleToMonitor - NCycleForOverview), nQCCycleToMonitor);
+    for (int ic = 0; ic < hBarProj->GetNbinsX(); ic++) {
+
+      if (hBarProj->GetBinContent(ic + 1) < NCycleForOverview) { // report only chips dead for N consecutive cycles
+        continue;
+      }
+      FeeIDOverview->Fill(getFEEID(iBarrel, ic), 1. / nChipsPerFeeID[iBarrel]);
+    }
+  }
+
   int iLayer = 0;
   int iStave = 0;
   StaveOverview->Reset("content");
@@ -190,11 +221,16 @@ void ITSChipStatusTask::endOfCycle()
       TH1D* hBarrelProj = DeadChips[iBarrel]->getNum()->ProjectionY("dummy", nQCCycleToMonitor - iSlice, nQCCycleToMonitor - iSlice);
       iStave = 0;
       int nEmptyChips = 0;
+
       for (int iChip = 1; iChip <= hBarrelProj->GetNbinsX(); iChip++) {
+
         if (hBarrelProj->GetBinContent(iChip) > 0)
           nEmptyChips++;
-        if (((iChip) % (nChipsPerHic[iLayer] * nHicPerStave[iLayer]) == 0)) {
-          if (nEmptyChips == nChipsPerHic[iLayer] * nHicPerStave[iLayer]) {
+
+        if ((iChip) % (nChipsPerHic[iLayer] * nHicPerStave[iLayer]) == 0) {
+
+          if (nEmptyChips == nChipsPerHic[iLayer] * nHicPerStave[iLayer]) { // all the chips of the stave are dead
+
             int binContent = StaveOverview->GetBinContent(iStave + StaveBoundary[iLayer]) * NCycleForOverview + 1;
             StaveOverview->SetBinContent(iStave + StaveBoundary[iLayer], 1. * binContent / NCycleForOverview);
           }
@@ -204,7 +240,8 @@ void ITSChipStatusTask::endOfCycle()
             iLayer++;
             iStave = 0;
           }
-        }
+
+        } // end of ((iChip) % (nChipsPerHic[iLayer] * nHicPerStave[iLayer]) == 0)
       }
     }
   }

--- a/Modules/ITS/src/ITSDecodingErrorCheck.cxx
+++ b/Modules/ITS/src/ITSDecodingErrorCheck.cxx
@@ -53,13 +53,13 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
     doFlatCheck = true;
   }
 
-  bool checkFeeIDOnce = o2::quality_control_modules::common::getFromConfig<bool>(mCustomParameters, "checkfeeoIDonce", "");
+  bool checkFeeIDOnce = o2::quality_control_modules::common::getFromConfig<bool>(mCustomParameters, "checkfeeIDonlyonce", "");
 
   Quality result = Quality::Null;
   for (auto& [moName, mo] : *moMap) {
     (void)moName;
 
-    if (mo->getName() == "General/ChipErrorPlots") {
+    if ((string)mo->getName() == "General/ChipErrorPlots") {
       result = Quality::Good;
       auto* h = dynamic_cast<TH1D*>(mo->getObject());
       if (h == nullptr) {
@@ -70,7 +70,8 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
         result.set(Quality::Bad);
     }
 
-    if (mo->GetName() == "General/LinkErrorVsFeeid") {
+    if ((string)mo->GetName() == "General/LinkErrorVsFeeid") {
+
       result = Quality::Good;
       auto* h = dynamic_cast<TH2D*>(mo->getObject());
       if (h == nullptr) {
@@ -78,7 +79,7 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
         continue;
       }
       for (int ifee = 0; ifee < h->GetNbinsX(); ifee++) {
-        for (int ierr = 0; ierr < h->GetNbinsY() - 1; ierr++) { // last y bin is recovery flag: do not check
+        for (int ierr = 0; ierr < h->GetNbinsY(); ierr++) { // last y bin is recovery flag: do not check
 
           if ((doFlatCheck && h->GetBinContent(ifee, ierr + 1) == 0) || (!doFlatCheck && h->GetBinContent(ifee + 1, ierr + 1) < vDecErrorLimits[ierr])) { // ok if below threshold
             continue;


### PR DESCRIPTION
In this PR:

- The Deconding Errors vs FeeID can be checked, and it is possible to ignore multiple occurrences of the same error on the same FeeID
- The ChipStatus task publishes an object with the fraction chips that are missing in the last N cycles, versus FeeID
   - This is passed through a checker. Different thresholds can be set for IB, ML and OL  