### PR TITLE
Common: allow retrieving latest QOs in QualityTask

### DIFF
--- a/Modules/Common/include/Common/QualityTask.h
+++ b/Modules/Common/include/Common/QualityTask.h
@@ -83,12 +83,14 @@ class QualityTask : public quality_control::postprocessing::PostProcessingInterf
   void finalize(quality_control::postprocessing::Trigger, framework::ServiceRegistryRef) override;
 
  private:
-  std::pair<std::shared_ptr<quality_control::core::QualityObject>, bool> getQO(
-    quality_control::repository::DatabaseInterface& qcdb, const quality_control::postprocessing::Trigger& t, const std::string& fullPath, const std::string& group);
+  std::pair<std::shared_ptr<quality_control::core::QualityObject>, bool> getLatestQO(
+    quality_control::repository::DatabaseInterface& qcdb, const o2::quality_control::core::Activity& activity, const std::string& fullPath, const std::string& group);
 
  private:
   /// \brief configuration parameters
   QualityTaskConfig mConfig;
+  /// \brief QOs are discarded if their creation time stamp is more than mMaxObjectAgeMs milliseconds in the past (set to zero to accept all objects)
+  int64_t mMaxObjectAgeMs{ 600000 };
   /// \brief latest creation timestamp of each tracked QO
   std::unordered_map<std::string /* full path */, uint64_t> mLatestTimestamps;
   /// \brief colors associated to each quality state (Good/Medium/Bad/Null)


### PR DESCRIPTION
Instead of retrieving the QOs based on the time stamp of the update trigger, the latest version of the QOs is retrieved, even if their validities are ending before the update time stamp.

A `maxObjectAgeSeconds` configuration parameter allows to consider only QOs that were created not more than a given number of seconds before the time at which the `update()` function was called.

This logic only works for the online QualityControl, where the QOs creation time follows is aligned with the time of the QC cycles and of the post-processing updates. 