### PR TITLE
DAQ: properly reset and un-publish mSumRDHSizesInTF

### DIFF
--- a/Modules/Daq/src/DaqTask.cxx
+++ b/Modules/Daq/src/DaqTask.cxx
@@ -117,7 +117,7 @@ void DaqTask::endOfActivity(const Activity& /*activity*/)
   getObjectsManager()->stopPublishing(mInputSize.get());
   getObjectsManager()->stopPublishing(mNumberRDHs.get());
   getObjectsManager()->stopPublishing(mSumRDHSizesInRDH.get());
-  getObjectsManager()->stopPublishing(mSumRDHSizesInRDH.get());
+  getObjectsManager()->stopPublishing(mSumRDHSizesInTF.get());
   getObjectsManager()->stopPublishing(mRDHSizesPerCRUIds.get());
 }
 
@@ -132,7 +132,7 @@ void DaqTask::reset()
   mInputSize->Reset();
   mNumberRDHs->Reset();
   mSumRDHSizesInRDH->Reset();
-  mSumRDHSizesInRDH->Reset();
+  mSumRDHSizesInTF->Reset();
   mRDHSizesPerCRUIds->Reset();
 }
 


### PR DESCRIPTION
The `mSumRDHSizesInRDH` plot was reset and un-published twice. In the second of each calls `mSumRDHSizesInTF` should appear instead.