### PR TITLE
Common: reference comparator check improvements

### DIFF
--- a/Modules/Common/CMakeLists.txt
+++ b/Modules/Common/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(O2QcCommon
                        src/CcdbInspectorCheck.cxx
                        src/ObjectComparatorInterface.cxx
                        src/ObjectComparatorDeviation.cxx
+                       src/ObjectComparatorBinByBinDeviation.cxx
                        src/ObjectComparatorChi2.cxx
                        src/ObjectComparatorKolmogorov.cxx
                        src/ReferenceComparatorPlot.cxx
@@ -64,6 +65,7 @@ add_root_dictionary(O2QcCommon
                             include/Common/CcdbInspectorCheck.h
                             include/Common/ObjectComparatorInterface.h
                             include/Common/ObjectComparatorDeviation.h
+                            include/Common/ObjectComparatorBinByBinDeviation.h
                             include/Common/ObjectComparatorChi2.h
                             include/Common/ObjectComparatorKolmogorov.h
                             include/Common/ReferenceComparatorTask.h

--- a/Modules/Common/include/Common/LinkDef.h
+++ b/Modules/Common/include/Common/LinkDef.h
@@ -20,6 +20,7 @@
 #pragma link C++ class o2::quality_control_modules::common::CcdbInspectorTask + ;
 #pragma link C++ class o2::quality_control_modules::common::CcdbInspectorCheck + ;
 #pragma link C++ class o2::quality_control_modules::common::ObjectComparatorDeviation + ;
+#pragma link C++ class o2::quality_control_modules::common::ObjectComparatorBinByBinDeviation + ;
 #pragma link C++ class o2::quality_control_modules::common::ObjectComparatorChi2 + ;
 #pragma link C++ class o2::quality_control_modules::common::ObjectComparatorKolmogorov + ;
 #pragma link C++ class o2::quality_control_modules::common::ReferenceComparatorTask + ;

--- a/Modules/Common/include/Common/ObjectComparatorBinByBinDeviation.h
+++ b/Modules/Common/include/Common/ObjectComparatorBinByBinDeviation.h
@@ -1,0 +1,48 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ObjectComparatorBinByBinDeviation.h
+/// \author Andrea Ferrero
+/// \brief  A class for comparing two histogram objects based on the average of the relative deviation between the bins
+///
+
+#ifndef QUALITYCONTROL_ObjectComparatorBinByBinDeviation_H
+#define QUALITYCONTROL_ObjectComparatorBinByBinDeviation_H
+
+#include "Common/ObjectComparatorInterface.h"
+
+namespace o2::quality_control_modules::common
+{
+
+/// \brief A class for comparing two histogram objects based on the average of the relative deviation between the bins
+class ObjectComparatorBinByBinDeviation : public ObjectComparatorInterface
+{
+ public:
+  /// \brief Constructor
+  ObjectComparatorBinByBinDeviation() = default;
+  /// \brief Destructor
+  virtual ~ObjectComparatorBinByBinDeviation() = default;
+
+  /// \brief comparator configuration via CustomParameters
+  void configure(const o2::quality_control::core::CustomParameters& customParameters, const std::string& plotName, const o2::quality_control::core::Activity activity = {}) override;
+
+  /// \brief objects comparison function
+  /// \return the quality resulting from the object comparison
+  o2::quality_control::core::Quality compare(TObject* object, TObject* referenceObject, std::string& message) override;
+
+ private:
+  int mMaxAllowedBadBins{ 0 };
+};
+
+} // namespace o2::quality_control_modules::common
+
+#endif // QUALITYCONTROL_ObjectComparatorBinByBinDeviation_H

--- a/Modules/Common/include/Common/ObjectComparatorInterface.h
+++ b/Modules/Common/include/Common/ObjectComparatorInterface.h
@@ -40,11 +40,16 @@ class ObjectComparatorInterface
   virtual ~ObjectComparatorInterface() = default;
 
   /// \brief comparator configuration via CustomParameters
-  // virtual void configure(const o2::quality_control::core::CustomParameters& customParameters, const o2::quality_control::core::Activity activity = {}){};
+  virtual void configure(const o2::quality_control::core::CustomParameters& customParameters, const std::string& plotName, const o2::quality_control::core::Activity activity = {});
 
   /// setter/getter methods for the threshold to define the goodness of the comparison
   void setThreshold(double threshold) { mThreshold = threshold; }
   double getThreshold() { return mThreshold; }
+
+  void setXRange(const std::pair<double, double>& range) { mRanges[0] = range; }
+  void setYRange(const std::pair<double, double>& range) { mRanges[1] = range; }
+  std::optional<std::pair<double, double>> getXRange() { return mRanges[0]; }
+  std::optional<std::pair<double, double>> getYRange() { return mRanges[1]; }
 
   /// perform a number of sanity checks on the input objects
   /// \return a tuple containing pointers to the histogram, the reference histogram, and a boolean indicating the success of the checks
@@ -54,9 +59,15 @@ class ObjectComparatorInterface
   /// \return the quality resulting from the object comparison
   virtual o2::quality_control::core::Quality compare(TObject* object, TObject* referenceObject, std::string& message) = 0;
 
+ protected:
+  /// \brief helper function to retrieve plot-specific configuration parameters
+  std::string getParameterForPlot(const o2::quality_control::core::CustomParameters& customParameters, const std::string& parKey, const std::string& plotName, const o2::quality_control::core::Activity& activity);
+
  private:
   /// the threshold to define the goodness of the comparison
   double mThreshold{ 0 };
+  // optional ranges to restrict the histogram area on which the comparison is performed
+  std::array<std::optional<std::pair<double, double>>, 2> mRanges;
 };
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/ReferenceComparatorCheck.h
+++ b/Modules/Common/include/Common/ReferenceComparatorCheck.h
@@ -25,6 +25,7 @@
 #include <unordered_map>
 
 class TPaveText;
+class TCanvas;
 
 namespace o2::quality_control_modules::common
 {
@@ -50,16 +51,22 @@ class ReferenceComparatorCheck : public o2::quality_control::checker::CheckInter
   void endOfActivity(const Activity& activity) override;
 
  private:
-  Quality getSinglePlotQuality(std::shared_ptr<MonitorObject> mo, std::string& message);
+  Quality getSinglePlotQuality(std::shared_ptr<MonitorObject> mo, ObjectComparatorInterface* comparator, std::string& message);
+  void drawHorizontalRange(const std::string& moName, TCanvas* canvas, const Quality& quality);
 
-  std::unique_ptr<ObjectComparatorInterface> mComparator;
   std::map<std::string, Quality> mQualityFlags;
   std::map<std::string, std::shared_ptr<TPaveText>> mQualityLabels;
+  quality_control::core::Activity mActivity;
   quality_control::core::Activity mReferenceActivity;
+  std::string mComparatorModuleName;      /// dynamic module providing the object comparator
+  std::string mComparatorClassName;       /// name of the object comparator class
   bool mIgnorePeriodForReference{ true }; /// whether to specify the period name in the reference run query
   bool mIgnorePassForReference{ true };   /// whether to specify the pass name in the reference run query
   size_t mReferenceRun;
+  /// cached reference MOs
   std::unordered_map<std::string, std::shared_ptr<MonitorObject>> mReferencePlots;
+  /// collection of object comparators with plot-specific settings
+  std::unordered_map<std::string, std::unique_ptr<ObjectComparatorInterface>> mComparators;
 };
 
 } // namespace o2::quality_control_modules::common

--- a/Modules/Common/include/Common/ReferenceComparatorCheck.h
+++ b/Modules/Common/include/Common/ReferenceComparatorCheck.h
@@ -52,7 +52,7 @@ class ReferenceComparatorCheck : public o2::quality_control::checker::CheckInter
 
  private:
   Quality getSinglePlotQuality(std::shared_ptr<MonitorObject> mo, ObjectComparatorInterface* comparator, std::string& message);
-  void drawHorizontalRange(const std::string& moName, TCanvas* canvas, const Quality& quality);
+  void beautifyRatioPlot(const std::string& moName, TH1* ratioPlot, const Quality& quality);
 
   std::map<std::string, Quality> mQualityFlags;
   std::map<std::string, std::shared_ptr<TPaveText>> mQualityLabels;
@@ -63,6 +63,7 @@ class ReferenceComparatorCheck : public o2::quality_control::checker::CheckInter
   bool mIgnorePeriodForReference{ true }; /// whether to specify the period name in the reference run query
   bool mIgnorePassForReference{ true };   /// whether to specify the pass name in the reference run query
   size_t mReferenceRun;
+  double mRatioPlotRange{ 0 };
   /// cached reference MOs
   std::unordered_map<std::string, std::shared_ptr<MonitorObject>> mReferencePlots;
   /// collection of object comparators with plot-specific settings

--- a/Modules/Common/include/Common/Utils.h
+++ b/Modules/Common/include/Common/Utils.h
@@ -89,7 +89,11 @@ T getFromExtendedConfig(const quality_control::core::Activity& activity, const q
   if (auto param = params.atOptional(name, activity)) {
     parameter = param.value();
   } else {
-    parameter = params.atOrDefaultValue(name, std::to_string(retVal));
+    if constexpr (std::is_same<std::string, T>::value) {
+      parameter = params.atOrDefaultValue(name, retVal);
+    } else {
+      parameter = params.atOrDefaultValue(name, std::to_string(retVal));
+    }
   }
   return internal::stringToType<T>(parameter);
 }

--- a/Modules/Common/src/ObjectComparatorBinByBinDeviation.cxx
+++ b/Modules/Common/src/ObjectComparatorBinByBinDeviation.cxx
@@ -1,0 +1,100 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   ObjectComparatorBinByBinDeviation.cxx
+/// \author Andrea Ferrero
+/// \brief  A class for comparing two histogram objects based on the average of the relative deviation between the bins
+///
+
+#include "Common/ObjectComparatorBinByBinDeviation.h"
+#include "Common/Utils.h"
+#include "QualityControl/QcInfoLogger.h"
+//  ROOT
+#include <TH1.h>
+
+#include <fmt/core.h>
+
+using namespace o2::quality_control;
+using namespace o2::quality_control::core;
+
+namespace o2::quality_control_modules::common
+{
+
+void ObjectComparatorBinByBinDeviation::configure(const CustomParameters& customParameters, const std::string& plotName, const Activity activity)
+{
+  ObjectComparatorInterface::configure(customParameters, plotName, activity);
+
+  // get configuration parameter associated to the key
+  std::string parValue = getParameterForPlot(customParameters, std::string("maxAllowedBadBins"), plotName, activity);
+  if (parValue.empty()) {
+    return;
+  }
+
+  try {
+    mMaxAllowedBadBins = std::stoi(parValue);
+  } catch (std::exception& exception) {
+    ILOG(Error, Support) << "Cannot convert maxAllowedBadBins for plot \"" << plotName << "\", string is " << parValue << ENDM;
+    return;
+  }
+}
+
+Quality ObjectComparatorBinByBinDeviation::compare(TObject* object, TObject* referenceObject, std::string& message)
+{
+  auto checkResult = checkInputObjects(object, referenceObject, message);
+  if (!std::get<2>(checkResult)) {
+    return Quality::Null;
+  }
+
+  auto* histogram = std::get<0>(checkResult);
+  auto* referenceHistogram = std::get<1>(checkResult);
+
+  int binRangeX[2] = { 1, histogram->GetXaxis()->GetNbins()};
+  if( getXRange().has_value()) {
+    binRangeX[0] = histogram->GetXaxis()->FindBin(getXRange()->first);
+    binRangeX[1] = histogram->GetXaxis()->FindBin(getXRange()->second);
+  }
+
+  int binRangeY[2] = { 1, histogram->GetYaxis()->GetNbins()};
+  if( getYRange().has_value()) {
+    binRangeY[0] = histogram->GetYaxis()->FindBin(getYRange()->first);
+    binRangeY[1] = histogram->GetYaxis()->FindBin(getYRange()->second);
+  }
+
+  int binRangeZ[2] = { 1, histogram->GetZaxis()->GetNbins()};
+
+  // compute the average relative deviation between the bins
+  double averageDeviation = 0;
+  int numberOfBadBins = 0;
+  for (int binX = binRangeX[0]; binX <= binRangeX[1]; binX++) {
+    for (int binY = binRangeY[0]; binY <= binRangeY[1]; binY++) {
+      for (int binZ = binRangeZ[0]; binZ <= binRangeZ[1]; binZ++) {
+        int bin = histogram->GetBin(binX, binY, binZ);
+        double val = histogram->GetBinContent(bin);
+        double refVal = referenceHistogram->GetBinContent(bin);
+        double deviation = (refVal == 0) ? 0 : std::abs((val - refVal) / refVal);
+        if (deviation > getThreshold()) {
+          numberOfBadBins += 1;
+        }
+      }
+    }
+  }
+
+  // compare the average deviation with the maximum allowed value
+  if (numberOfBadBins > mMaxAllowedBadBins) {
+    message = fmt::format("bins above {:.2f}: {} > {}", getThreshold(), numberOfBadBins, mMaxAllowedBadBins);
+    return Quality::Bad;
+  }
+
+  return Quality::Good;
+}
+
+} // namespace o2::quality_control_modules::common

--- a/Modules/Common/src/ObjectComparatorBinByBinDeviation.cxx
+++ b/Modules/Common/src/ObjectComparatorBinByBinDeviation.cxx
@@ -57,19 +57,19 @@ Quality ObjectComparatorBinByBinDeviation::compare(TObject* object, TObject* ref
   auto* histogram = std::get<0>(checkResult);
   auto* referenceHistogram = std::get<1>(checkResult);
 
-  int binRangeX[2] = { 1, histogram->GetXaxis()->GetNbins()};
-  if( getXRange().has_value()) {
+  int binRangeX[2] = { 1, histogram->GetXaxis()->GetNbins() };
+  if (getXRange().has_value()) {
     binRangeX[0] = histogram->GetXaxis()->FindBin(getXRange()->first);
     binRangeX[1] = histogram->GetXaxis()->FindBin(getXRange()->second);
   }
 
-  int binRangeY[2] = { 1, histogram->GetYaxis()->GetNbins()};
-  if( getYRange().has_value()) {
+  int binRangeY[2] = { 1, histogram->GetYaxis()->GetNbins() };
+  if (getYRange().has_value()) {
     binRangeY[0] = histogram->GetYaxis()->FindBin(getYRange()->first);
     binRangeY[1] = histogram->GetYaxis()->FindBin(getYRange()->second);
   }
 
-  int binRangeZ[2] = { 1, histogram->GetZaxis()->GetNbins()};
+  int binRangeZ[2] = { 1, histogram->GetZaxis()->GetNbins() };
 
   // compute the average relative deviation between the bins
   double averageDeviation = 0;

--- a/Modules/Common/src/ObjectComparatorChi2.cxx
+++ b/Modules/Common/src/ObjectComparatorChi2.cxx
@@ -40,7 +40,7 @@ Quality ObjectComparatorChi2::compare(TObject* object, TObject* referenceObject,
   // if X and/or Y ranges are specified, set the appropriate bin range in the corresponding axis
   // to restrict the histogram area where the test is applied
   const double epsilon = 1.0e-6;
-  if( getXRange().has_value()) {
+  if (getXRange().has_value()) {
     int binMin = histogram->GetXaxis()->FindBin(getXRange()->first);
     // subtract a small amount to the upper edge to avoid getting the next bin
     int binMax = histogram->GetXaxis()->FindBin(getXRange()->second - epsilon);
@@ -49,7 +49,7 @@ Quality ObjectComparatorChi2::compare(TObject* object, TObject* referenceObject,
     referenceHistogram->GetXaxis()->SetRange(binMin, binMax);
   }
 
-  if( getYRange().has_value()) {
+  if (getYRange().has_value()) {
     int binMin = histogram->GetYaxis()->FindBin(getYRange()->first);
     // subtract a small amount to the upper edge to avoid getting the next bin
     int binMax = histogram->GetYaxis()->FindBin(getYRange()->second - epsilon);

--- a/Modules/Common/src/ObjectComparatorChi2.cxx
+++ b/Modules/Common/src/ObjectComparatorChi2.cxx
@@ -37,10 +37,37 @@ Quality ObjectComparatorChi2::compare(TObject* object, TObject* referenceObject,
   auto* histogram = std::get<0>(checkResult);
   auto* referenceHistogram = std::get<1>(checkResult);
 
+  // if X and/or Y ranges are specified, set the appropriate bin range in the corresponding axis
+  // to restrict the histogram area where the test is applied
+  const double epsilon = 1.0e-6;
+  if( getXRange().has_value()) {
+    int binMin = histogram->GetXaxis()->FindBin(getXRange()->first);
+    // subtract a small amount to the upper edge to avoid getting the next bin
+    int binMax = histogram->GetXaxis()->FindBin(getXRange()->second - epsilon);
+
+    histogram->GetXaxis()->SetRange(binMin, binMax);
+    referenceHistogram->GetXaxis()->SetRange(binMin, binMax);
+  }
+
+  if( getYRange().has_value()) {
+    int binMin = histogram->GetYaxis()->FindBin(getYRange()->first);
+    // subtract a small amount to the upper edge to avoid getting the next bin
+    int binMax = histogram->GetYaxis()->FindBin(getYRange()->second - epsilon);
+
+    histogram->GetYaxis()->SetRange(binMin, binMax);
+    referenceHistogram->GetYaxis()->SetRange(binMin, binMax);
+  }
+
   // perform a chi2 compatibility test between the two histograms
   // it assumes that both histigrams represent counts, but the reference might
   // have been rescaled to match the integral of the current histogram
   double testProbability = histogram->Chi2Test(referenceHistogram, "UU NORM");
+
+  // reset the axis ranges
+  histogram->GetXaxis()->SetRange(0, 0);
+  histogram->GetYaxis()->SetRange(0, 0);
+  referenceHistogram->GetXaxis()->SetRange(0, 0);
+  referenceHistogram->GetYaxis()->SetRange(0, 0);
 
   // compare the chi2 probability with the minimum allowed value
   if (testProbability < getThreshold()) {

--- a/Modules/Common/src/ObjectComparatorDeviation.cxx
+++ b/Modules/Common/src/ObjectComparatorDeviation.cxx
@@ -37,15 +37,41 @@ Quality ObjectComparatorDeviation::compare(TObject* object, TObject* referenceOb
   auto* histogram = std::get<0>(checkResult);
   auto* referenceHistogram = std::get<1>(checkResult);
 
+  const double epsilon = 1.0e-6;
+  int binRangeX[2] = { 1, histogram->GetXaxis()->GetNbins()};
+  int binRangeY[2] = { 1, histogram->GetYaxis()->GetNbins()};
+  int binRangeZ[2] = { 1, histogram->GetZaxis()->GetNbins()};
+
+  if( getXRange().has_value()) {
+    binRangeX[0] = histogram->GetXaxis()->FindBin(getXRange()->first);
+    // subtract a small amount to the upper edge to avoid getting the next bin
+    binRangeX[1] = histogram->GetXaxis()->FindBin(getXRange()->second - epsilon);
+  }
+
+  if( getYRange().has_value()) {
+    binRangeY[0] = histogram->GetYaxis()->FindBin(getYRange()->first);
+    // subtract a small amount to the upper edge to avoid getting the next bin
+    binRangeY[1] = histogram->GetYaxis()->FindBin(getYRange()->second - epsilon);
+  }
+
   // compute the average relative deviation between the bins
   double averageDeviation = 0;
-  int numberOfBins = histogram->GetNcells() - 2;
-  for (int bin = 1; bin <= numberOfBins; bin++) {
-    double val = histogram->GetBinContent(bin);
-    double refVal = referenceHistogram->GetBinContent(bin);
-    averageDeviation += (refVal == 0) ? 0 : std::abs((val - refVal) / refVal);
+  int numberOfBins = 0;
+  for (int binX = binRangeX[0]; binX <= binRangeX[1]; binX++) {
+    for (int binY = binRangeY[0]; binY <= binRangeY[1]; binY++) {
+      for (int binZ = binRangeZ[0]; binZ <= binRangeZ[1]; binZ++) {
+        int bin = histogram->GetBin(binX, binY, binZ);
+        double val = histogram->GetBinContent(bin);
+        double refVal = referenceHistogram->GetBinContent(bin);
+        double deviation = (refVal == 0) ? 0 : std::abs((val - refVal) / refVal);
+        averageDeviation += deviation;
+        numberOfBins += 1;
+      }
+    }
   }
-  averageDeviation /= numberOfBins;
+  if (numberOfBins > 0) {
+    averageDeviation /= numberOfBins;
+  }
 
   // compare the average deviation with the maximum allowed value
   if (averageDeviation > getThreshold()) {

--- a/Modules/Common/src/ObjectComparatorDeviation.cxx
+++ b/Modules/Common/src/ObjectComparatorDeviation.cxx
@@ -38,17 +38,17 @@ Quality ObjectComparatorDeviation::compare(TObject* object, TObject* referenceOb
   auto* referenceHistogram = std::get<1>(checkResult);
 
   const double epsilon = 1.0e-6;
-  int binRangeX[2] = { 1, histogram->GetXaxis()->GetNbins()};
-  int binRangeY[2] = { 1, histogram->GetYaxis()->GetNbins()};
-  int binRangeZ[2] = { 1, histogram->GetZaxis()->GetNbins()};
+  int binRangeX[2] = { 1, histogram->GetXaxis()->GetNbins() };
+  int binRangeY[2] = { 1, histogram->GetYaxis()->GetNbins() };
+  int binRangeZ[2] = { 1, histogram->GetZaxis()->GetNbins() };
 
-  if( getXRange().has_value()) {
+  if (getXRange().has_value()) {
     binRangeX[0] = histogram->GetXaxis()->FindBin(getXRange()->first);
     // subtract a small amount to the upper edge to avoid getting the next bin
     binRangeX[1] = histogram->GetXaxis()->FindBin(getXRange()->second - epsilon);
   }
 
-  if( getYRange().has_value()) {
+  if (getYRange().has_value()) {
     binRangeY[0] = histogram->GetYaxis()->FindBin(getYRange()->first);
     // subtract a small amount to the upper edge to avoid getting the next bin
     binRangeY[1] = histogram->GetYaxis()->FindBin(getYRange()->second - epsilon);

--- a/Modules/Common/src/ObjectComparatorInterface.cxx
+++ b/Modules/Common/src/ObjectComparatorInterface.cxx
@@ -16,6 +16,9 @@
 ///
 
 #include "Common/ObjectComparatorInterface.h"
+#include "Common/Utils.h"
+#include "QualityControl/QcInfoLogger.h"
+#include <CommonUtils/StringUtils.h>
 //  ROOT
 #include <TH1.h>
 
@@ -26,6 +29,66 @@ using namespace o2::quality_control::core;
 
 namespace o2::quality_control_modules::common
 {
+
+std::string ObjectComparatorInterface::getParameterForPlot(const CustomParameters& customParameters, const std::string& parKey, const std::string& plotName, const Activity& activity)
+{
+  // get configuration parameter associated to the key
+  std::string parValue;
+  if (!plotName.empty()) {
+    // first try to retrieve the plot-specific value, if existing
+    auto parKeyForPlot = parKey + ":" + plotName;
+    parValue = getFromExtendedConfig<std::string>(activity, customParameters, parKeyForPlot);
+  }
+
+  if (parValue.empty()) {
+    // get the default value if the plot-specific one is not found
+    parValue = getFromExtendedConfig<std::string>(activity, customParameters, parKey);
+  }
+
+  return parValue;
+}
+
+void ObjectComparatorInterface::configure(const CustomParameters& customParameters, const std::string& plotName, const Activity activity)
+{
+  // get configuration parameter associated to the key
+  std::string parValue = getParameterForPlot(customParameters, std::string("threshold"), plotName, activity);
+
+  if (parValue.empty()) {
+    ILOG(Error, Support) << "Reference comparator threshold not found for plot \"" << plotName << "\"" << ENDM;
+    return;
+  }
+
+  try {
+    mThreshold = std::stod(parValue);
+  } catch (std::exception& exception) {
+    ILOG(Error, Support) << "Cannot convert reference comparator threshold for plot \"" << plotName << "\", string is " << parValue << ENDM;
+    return;
+  }
+
+  // get optional axis ranges
+  std::array<std::string, 2> axisNames{ "X", "Y" };
+  for (int index = 0; index < 2; index++) {
+    // get configuration parameter associated to the key
+    std::string parValue = getParameterForPlot(customParameters, std::string("range") + axisNames[index], plotName, activity);
+
+    if (parValue.empty()) {
+      continue;
+    }
+
+    // extract min and max values of the range
+    auto rangeMinMax = o2::utils::Str::tokenize(parValue, ',', false, true);
+    if (rangeMinMax.size() != 2) {
+      ILOG(Error, Support) << "Cannot parse values for " << axisNames[index] << " axis range of plot \"" << plotName << "\", string is " << parValue << ENDM;
+      return;
+    }
+
+    try {
+      mRanges[index] = std::make_pair<double, double>(std::stod(rangeMinMax[0]), std::stod(rangeMinMax[1]));
+    } catch (std::exception& exception) {
+      ILOG(Error, Support) << "Cannot convert values from string to double for " << axisNames[index] << " axis range of plot \"" << plotName << "\", string is " << parValue << ENDM;
+    }
+  }
+}
 
 std::tuple<TH1*, TH1*, bool> ObjectComparatorInterface::checkInputObjects(TObject* object, TObject* referenceObject, std::string& message)
 {

--- a/Modules/Common/src/ReferenceComparatorCheck.cxx
+++ b/Modules/Common/src/ReferenceComparatorCheck.cxx
@@ -360,7 +360,7 @@ void ReferenceComparatorCheck::drawHorizontalRange(const std::string& moName, TC
   // draw an horizontal double arrow marking the X-axis range
   double xMin = ratioPlot->GetXaxis()->GetBinLowEdge(ratioPlot->GetXaxis()->FindBin(rangeX->first));
   double xMax = ratioPlot->GetXaxis()->GetBinUpEdge(ratioPlot->GetXaxis()->FindBin(rangeX->second - 1.0e-6));
-  auto arrow = new TArrow(xMin,1.8,xMax,1.8,0.015,"<|>");
+  auto arrow = new TArrow(xMin, 1.8, xMax, 1.8, 0.015, "<|>");
   arrow->SetLineColor(getQualityColor(quality));
   arrow->SetFillColor(getQualityColor(quality));
   ratioPlot->GetListOfFunctions()->Add(arrow);

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -505,10 +505,38 @@ The `normalizeReference` boolean parameter controls wether the reference histogr
 
 The checker extracts the current and reference plots from the stored MO, and compares them using external modules, specified via the `moduleName` and `comparatorName` parameters. The `threshold` parameter specifies the value used to discriminate between good and bad matches between the histograms.
 
-Three comparison modules are provided in the framework:
-1. `o2::quality_control_modules::common::ObjectComparatorDeviation`: comparison based on the average relative deviation between the bins of the current and reference histograms; the `threshold` parameter represent in this case the maximum allowed deviation
-2. `o2::quality_control_modules::common::ObjectComparatorChi2`: comparison based on a standard chi2 test between the current and reference histograms; the `threshold` parameter represent in this case the minimum allowed chi2 probability
-3. `o2::quality_control_modules::common::ObjectComparatorKolmogorov`: comparison based on a standard Kolmogorov test between the current and reference histograms; the `threshold` parameter represent in this case the minimum allowed Kolmogorov probability
+Four comparison modules are provided in the framework:
+1. `o2::quality_control_modules::common::ObjectComparatorDeviation`: comparison based on the average relative deviation between the bins of the current and reference histograms; the module accepts the following configuration parameters:
+    * `threshold`: the maximum allowed average relative deviation between current and reference histograms
+    * `rangeX`, `rangeY`: if set, the comparison is restricted to the bins in the specified X and Y ranges; bins outside the ranges are ignored
+2. `o2::quality_control_modules::common::ObjectComparatorBinByBinDeviation`: comparison based on the relative deviation between each bin of the current and reference histograms; the module accepts the following configuration parameters:
+    * `threshold`: the maximum allowed relative deviation for each bin between current and reference histograms
+    * `rangeX`, `rangeY`: if set, the comparison is restricted to the bins in the specified X and Y ranges; bins outside the ranges are ignored
+    * `maxAllowedBadBins`: the maximum number of bins above threshold for which the quality is still considered Good
+3. `o2::quality_control_modules::common::ObjectComparatorChi2`: comparison based on a standard chi2 test between the current and reference histograms; the module accepts the following configuration parameters:
+    * `threshold`: the minimum allowed chi2 probability
+    * `rangeX`, `rangeY`: if set, the Chi2 test is restricted to the bins in the specified X and Y ranges; bins outside the ranges are ignored
+4. `o2::quality_control_modules::common::ObjectComparatorKolmogorov`: comparison based on a standard Kolmogorov test between the current and reference histograms; the module accepts the following configuration parameters:
+    * `threshold`: the minimum allowed Kolmogorov probability
+
+All the configuration parameters of the comparison modules optionally allow to restrict their validity to specific plots.
+The following example specifies a threshold value common to all the plots, and then overrides the threshold and X range for all plots named `TrackEta`:
+
+```json
+        "extendedCheckParameters": {
+          "default": {      
+            "default": {      
+              "moduleName" : "QualityControl",
+              "comparatorName" : "o2::quality_control_modules::common::ObjectComparatorChi2",
+              "threshold" : "0.5",
+              "threshold:TrackEta" : "0.2",
+              "rangeX:TrackEta" : "-3.5,-2.5"
+            }
+          }
+        }
+```
+
+#### Full configuration example
 
 In the example configuration below, the relationship between the input and output histograms is the following:
 * `MCH/MO/Tracks/WithCuts/TrackEta` (1-D histogram)
@@ -586,7 +614,9 @@ In the example configuration below, the relationship between the input and outpu
             "default": {      
               "moduleName" : "QualityControl",
               "comparatorName" : "o2::quality_control_modules::common::ObjectComparatorChi2",
-              "threshold" : "0.5"
+              "threshold" : "0.5",
+              "threshold:TrackEta" : "0.2",
+              "rangeX:TrackEta" : "-3.5,-2.5"
             }
           }
         },


### PR DESCRIPTION
Several improvements to the reference comparator check:
* optional X and Y ranges can be specified in the configuration to restrict the comparison to a given histogram area
* the comparators now access directly the custom parameters, allowing to have parameters specific to each comparator
* added a `ObjectComparatorBinByBinDeviation` class that checks the relative deviation between each bin of the current and reference histograms
    * A `maxAllowedBadBins` parameter allows to specify the maximum number of bins above threshold for which the quality is still considered Good. 
    * If X and/or Y ranges are specified, only the bins inside the ranges are considered for the comparison.
* The "average deviation" and "Chi2 test"  comparison methods are improved to take into account the X and/or Y ranges in the comparison.
* For 1-D histograms, the checker shows the X range (if specified) on the ratio plot as a double-arrow horizontal line