### PR TITLE
Common: add support for variable bins in THxRatio

### DIFF
--- a/Modules/Common/include/Common/TH1Ratio.h
+++ b/Modules/Common/include/Common/TH1Ratio.h
@@ -32,6 +32,8 @@ class TH1Ratio : public T, public o2::mergers::MergeInterface
   TH1Ratio();
   TH1Ratio(TH1Ratio const& copymerge);
   TH1Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, bool uniformScaling = false);
+  TH1Ratio(const char* name, const char* title, int nbinsx, float* xbins, bool uniformScaling = false);
+  TH1Ratio(const char* name, const char* title, int nbinsx, double* xbins, bool uniformScaling = false);
   TH1Ratio(const char* name, const char* title, bool uniformScaling = false);
 
   ~TH1Ratio();

--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -106,6 +106,56 @@ TH1Ratio<T>::TH1Ratio(const char* name, const char* title, int nbinsx, double xm
 }
 
 template<class T>
+TH1Ratio<T>::TH1Ratio(const char* name, const char* title, int nbinsx, float* xbins, bool uniformScaling)
+  : T(name, title, nbinsx, xbins),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
+  {
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(nameNum, titleNum, nbinsx, xbins);
+    if (mUniformScaling) {
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1);
+    } else {
+      mHistoDen = new T(nameDen, titleDen, nbinsx, xbins);
+    }
+  }
+
+  init();
+}
+
+template<class T>
+TH1Ratio<T>::TH1Ratio(const char* name, const char* title, int nbinsx, double* xbins, bool uniformScaling)
+  : T(name, title, nbinsx, xbins),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
+  {
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(nameNum, titleNum, nbinsx, xbins);
+    if (mUniformScaling) {
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1);
+    } else {
+      mHistoDen = new T(nameDen, titleDen, nbinsx, xbins);
+    }
+  }
+
+  init();
+}
+
+template<class T>
 TH1Ratio<T>::TH1Ratio(const char* name, const char* title, bool uniformScaling)
   : T(name, title, 10, 0, 10),
     o2::mergers::MergeInterface(),
@@ -168,7 +218,7 @@ void TH1Ratio<T>::update()
   }
 
   T::Reset();
-  T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
+  mHistoNum->GetXaxis()->Copy(*T::GetXaxis());
   T::SetBinsLength();
 
   // Copy bin labels between histograms.

--- a/Modules/Common/include/Common/TH2Ratio.h
+++ b/Modules/Common/include/Common/TH2Ratio.h
@@ -32,6 +32,10 @@ class TH2Ratio : public T, public o2::mergers::MergeInterface
   TH2Ratio();
   TH2Ratio(TH2Ratio const& copymerge);
   TH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax, bool uniformScaling = false);
+  TH2Ratio(const char* name, const char* title, int nbinsx, const float* xbins, int nbinsy, const float* ybins, bool uniformScaling = false);
+  TH2Ratio(const char* name, const char* title, int nbinsx, const double* xbins, int nbinsy, const double* ybins, bool uniformScaling = false);
+  TH2Ratio(const char* name, const char* title, int nbinsx, const double* xbins, int nbinsy, double ymin, double ymax, bool uniformScaling = false);
+  TH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, const double* ybins, bool uniformScaling = false);
   TH2Ratio(const char* name, const char* title, bool uniformScaling = false);
 
   ~TH2Ratio();

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -115,6 +115,106 @@ TH2Ratio<T>::TH2Ratio(const char* name, const char* title, int nbinsx, double xm
 }
 
 template<class T>
+TH2Ratio<T>::TH2Ratio(const char* name, const char* title, int nbinsx, const float *xbins, int nbinsy, const float *ybins, bool uniformScaling)
+  : T(name, title, nbinsx, xbins, nbinsy, ybins),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
+  {
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(nameNum, titleNum, nbinsx, xbins, nbinsy, ybins);
+    if (mUniformScaling) {
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1, 1, -1, 1);
+    } else {
+      mHistoDen = new T(nameDen, titleDen, nbinsx, xbins, nbinsy, ybins);
+    }
+  }
+
+  init();
+}
+
+template<class T>
+TH2Ratio<T>::TH2Ratio(const char* name, const char* title, int nbinsx, const double *xbins, int nbinsy, const double *ybins, bool uniformScaling)
+  : T(name, title, nbinsx, xbins, nbinsy, ybins),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
+  {
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(nameNum, titleNum, nbinsx, xbins, nbinsy, ybins);
+    if (mUniformScaling) {
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1, 1, -1, 1);
+    } else {
+      mHistoDen = new T(nameDen, titleDen, nbinsx, xbins, nbinsy, ybins);
+    }
+  }
+
+  init();
+}
+
+template<class T>
+TH2Ratio<T>::TH2Ratio(const char* name, const char* title, int nbinsx, const double *xbins, int nbinsy, double ymin, double ymax, bool uniformScaling)
+  : T(name, title, nbinsx, xbins, nbinsy, ymin, ymax),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
+  {
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(nameNum, titleNum, nbinsx, xbins, nbinsy, ymin, ymax);
+    if (mUniformScaling) {
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1, 1, -1, 1);
+    } else {
+      mHistoDen = new T(nameDen, titleDen, nbinsx, xbins, nbinsy, ymin, ymax);
+    }
+  }
+
+  init();
+}
+
+template<class T>
+TH2Ratio<T>::TH2Ratio(const char* name, const char* title, int nbinsx, double xmin, double xmax, int nbinsy, const double *ybins, bool uniformScaling)
+  : T(name, title, nbinsx, xmin, xmax, nbinsy, ybins),
+    o2::mergers::MergeInterface(),
+    mUniformScaling(uniformScaling)
+{
+  // do not add created histograms to gDirectory
+  // see https://root.cern.ch/doc/master/TEfficiency_8cxx.html
+  {
+    TString nameNum = T::GetName() + TString("_num");
+    TString nameDen = T::GetName() + TString("_den");
+    TString titleNum = T::GetTitle() + TString(" num");
+    TString titleDen = T::GetTitle() + TString(" den");
+    TDirectory::TContext ctx(nullptr);
+    mHistoNum = new T(nameNum, titleNum, nbinsx, xmin, xmax, nbinsy, ybins);
+    if (mUniformScaling) {
+      mHistoDen = new T(nameDen, titleDen, 1, -1, 1, 1, -1, 1);
+    } else {
+      mHistoDen = new T(nameDen, titleDen, nbinsx, xmin, xmax, nbinsy, ybins);
+    }
+  }
+
+  init();
+}
+
+template<class T>
 TH2Ratio<T>::TH2Ratio(const char* name, const char* title, bool uniformScaling)
   : T(name, title, 10, 0, 10, 10, 0, 10),
     o2::mergers::MergeInterface(),
@@ -177,8 +277,8 @@ void TH2Ratio<T>::update()
   }
 
   T::Reset();
-  T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
-  T::GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXmin(), mHistoNum->GetYaxis()->GetXmax());
+  mHistoNum->GetXaxis()->Copy(*T::GetXaxis());
+  mHistoNum->GetYaxis()->Copy(*T::GetYaxis());
   T::SetBinsLength();
 
   // Copy bin labels between histograms.


### PR DESCRIPTION
The added support for variable bins requires two changes:
* implementation of the corresponding constructors
* the histogram axes need to be updated using the `TAxis::Copy()` function