### PR TITLE
MUON: introduce station-dependent checker thresholds

### DIFF
--- a/Modules/MUON/MCH/include/MCH/DecodingCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingCheck.h
@@ -52,7 +52,9 @@ class DecodingCheck : public o2::quality_control::checker::CheckInterface
   int mMaxBadST12{ 2 };
   int mMaxBadST345{ 3 };
   double mMinGoodErrorFrac{ 0.9 };
+  std::array<std::optional<double>, 5> mMinGoodErrorFracPerStation;
   double mMinGoodSyncFrac{ 0.9 };
+  std::array<std::optional<double>, 5> mMinGoodSyncFracPerStation;
 
   QualityChecker mQualityChecker;
 

--- a/Modules/MUON/MCH/include/MCH/DigitsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsCheck.h
@@ -21,6 +21,7 @@
 #include "QualityControl/CheckInterface.h"
 #include "QualityControl/Quality.h"
 #include <string>
+#include <array>
 
 namespace o2::quality_control::core
 {
@@ -55,16 +56,15 @@ class DigitsCheck : public o2::quality_control::checker::CheckInterface
   std::array<Quality, getNumDE()> checkBadChannelsRatio(TH1F* h);
 
   std::string mMeanRateHistName{ "RatesSignal/LastCycle/MeanRate" };
-  std::string mMeanRateRatioHistName{ "RatesSignal/LastCycle/MeanRateRefRatio" };
   std::string mGoodChanFracHistName{ "RatesSignal/LastCycle/GoodChannelsFraction" };
-  std::string mGoodChanFracRatioHistName{ "RatesSignal/LastCycle/GoodChannelsFractionRefRatio" };
   int mMaxBadST12{ 2 };
   int mMaxBadST345{ 3 };
   double mMinRate{ 0.001 };
+  std::array<std::optional<double>, 5> mMinRatePerStation;
   double mMaxRate{ 10 };
-  double mMaxRateDelta{ 0.2 };
+  std::array<std::optional<double>, 5> mMaxRatePerStation;
   double mMinGoodFraction{ 0.9 };
-  double mMaxGoodFractionDelta{ 0.2 };
+  std::array<std::optional<double>, 5> mMinGoodFractionPerStation;
   double mRatePlotScaleMin{ 0 };
   double mRatePlotScaleMax{ 10 };
 

--- a/Modules/MUON/MCH/include/MCH/Helpers.h
+++ b/Modules/MUON/MCH/include/MCH/Helpers.h
@@ -19,6 +19,7 @@
 
 #include "QualityControl/DatabaseInterface.h"
 #include "QualityControl/Quality.h"
+#include "QualityControl/CustomParameters.h"
 #include "MCHConstants/DetectionElements.h"
 #include <TCanvas.h>
 #include <TH1F.h>
@@ -28,6 +29,7 @@
 #include <TText.h>
 #include <gsl/span>
 #include <utility>
+#include <array>
 #include <optional>
 
 namespace o2::quality_control::core
@@ -52,10 +54,18 @@ constexpr int getNumDE() { return (4 * 4 + 18 * 2 + 26 * 4); }
 int getNumDEinChamber(int chIndex);
 std::pair<int, int> getDEindexInChamber(int deId);
 
+void getThresholdsPerStation(o2::quality_control::core::CustomParameters customParameters,
+                             const o2::quality_control::core::Activity& activity,
+                             std::string parKey,
+                             std::array<std::optional<double>, 5>& thresholds,
+                             double& defaultThreshold);
+
 o2::quality_control::core::Quality checkDetectorQuality(gsl::span<o2::quality_control::core::Quality>& deQuality);
 
 void addChamberDelimiters(TH1F* h, float xmin = 0, float xmax = 0);
 void addChamberDelimiters(TH2F* h);
+void drawThresholdsPerStation(TH1* histogram, const std::array<std::optional<double>, 5>& thresholdsPerStation, double defaultThreshold);
+void addDEBinLabels(TH1* histogram);
 
 std::string getHistoPath(int deId);
 bool matchHistName(std::string hist, std::string name);

--- a/Modules/MUON/MCH/include/MCH/PreclustersCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersCheck.h
@@ -53,12 +53,10 @@ class PreclustersCheck : public o2::quality_control::checker::CheckInterface
 
   std::string mMeanEffHistNameB{ "Efficiency/LastCycle/MeanEfficiencyB" };
   std::string mMeanEffHistNameNB{ "Efficiency/LastCycle/MeanEfficiencyNB" };
-  std::string mMeanEffRatioHistNameB{ "Efficiency/LastCycle/MeanEfficiencyRefRatioB" };
-  std::string mMeanEffRatioHistNameNB{ "Efficiency/LastCycle/MeanEfficiencyRefRatioNB" };
   int mMaxBadST12{ 2 };
   int mMaxBadST345{ 3 };
   double mMinEfficiency{ 0.8 };
-  double mMaxEffDelta{ 0.2 };
+  std::array<std::optional<double>, 5> mMinEfficiencyPerStation;
   double mPseudoeffPlotScaleMin{ 0.0 };
   double mPseudoeffPlotScaleMax{ 1.0 };
 


### PR DESCRIPTION
Checker thresholds are extended to allow setting different values for specific stations, overriding the global default value.

The code is also simplified by removing checks of the ratio plots, that are now superseded by the common reference comparator output.