### PR TITLE
Common: customize BigScreen colors

### DIFF
--- a/Modules/Common/include/Common/BigScreenCanvas.h
+++ b/Modules/Common/include/Common/BigScreenCanvas.h
@@ -31,7 +31,8 @@ struct BigScreenElement;
 class BigScreenCanvas : public TCanvas
 {
  public:
-  BigScreenCanvas(std::string name, std::string title, int nRows, int nCols, int borderWidth);
+  BigScreenCanvas(std::string name, std::string title, int nRows, int nCols, int borderWidth,
+                  int foregroundColor = kBlack, int backgroundColor = kWhite);
   ~BigScreenCanvas() = default;
 
   /// \brief add a box in the canvas at a given index, with "name" displayed above the box
@@ -60,6 +61,9 @@ class BigScreenCanvas : public TCanvas
   float mLabelOffset{ 0.05 };
   /// \brief colors associated to each quality state (Good/Medium/Bad/Null)
   std::unordered_map<std::string, int> mColors;
+  int mForegroundColor{ kBlack };      /// ROOT color index for the foreground text
+  int mBackgroundColor{ kWhite };      /// ROOT color index for the canvas backgound
+  std::shared_ptr<TPad> mBackgoundPad; /// TPad used to draw the background color
   /// \brief elements (colored boxes + labels) displayed in the canvas
   std::unordered_map<std::string, std::shared_ptr<BigScreenElement>> mBoxes;
 };

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -890,6 +890,8 @@ The system names are displayed above each box, while the quality flag is display
 
 In addition, the boxes are filled with a grey color is the corresponding QualityObjects cannot be retrieved or are too old.
 
+The color of the canvas background and of the detector labels can be customized with the `"foregroundColor"` and `"backgroundColor"` parameters. They accept interger values corresponding to the indexes of the [default ROOT colors](https://root.cern.ch/doc/master/classTColor.html#C01) or the indexes defined in the [color wheel](https://root.cern.ch/doc/master/classTColor.html#C02). The example below shows a color combination with white text over a dark gray background.
+
 The task is configured as follows:
 ```json
 {
@@ -909,6 +911,9 @@ The task is configured as follows:
               "nRows": "4",
               "nCols": "5",
               "borderWidth": "1",
+              "": "white text over dark gray background",
+              "foregroundColor": "0",
+              "backgroundColor": "923",
               "maxObjectTimeShift": "10000",
               "ignoreActivity": "0",
               "labels": "CPV,EMC,FDD,FT0,FV0,HMP,ITS,MCH,MFT,MID,PHS,TPC,TOF,TRD,,TRK,MTK,VTX,PID"


### PR DESCRIPTION
Add customization of the foreground and backgound colors for the BigScreen. The colors can be modified via two new custom parameters (`foregroundColor` and `backgroundColor`), both accepting only ROOT color indexes as values.

The code has also been updated to use the `getFromExtendedConfig()` function to extract the custom parameter values.

Here is an example of a dark color combination:
![image](https://github.com/user-attachments/assets/24f651c7-aa7e-45e2-84ee-8ed5dab37ea0)
