### PR TITLE
THRatio: fix again update of histograms with bin labels

### DIFF
--- a/Modules/Common/include/Common/TH1Ratio.inl
+++ b/Modules/Common/include/Common/TH1Ratio.inl
@@ -218,7 +218,11 @@ void TH1Ratio<T>::update()
   }
 
   T::Reset();
-  mHistoNum->GetXaxis()->Copy(*T::GetXaxis());
+  if (mHistoNum->GetXaxis()->IsVariableBinSize()) {
+    T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXbins()->GetArray());
+  } else {
+    T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
+  }
   T::SetBinsLength();
 
   // Copy bin labels between histograms.

--- a/Modules/Common/include/Common/TH2Ratio.inl
+++ b/Modules/Common/include/Common/TH2Ratio.inl
@@ -277,8 +277,16 @@ void TH2Ratio<T>::update()
   }
 
   T::Reset();
-  mHistoNum->GetXaxis()->Copy(*T::GetXaxis());
-  mHistoNum->GetYaxis()->Copy(*T::GetYaxis());
+  if (mHistoNum->GetXaxis()->IsVariableBinSize()) {
+    T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXbins()->GetArray());
+  } else {
+    T::GetXaxis()->Set(mHistoNum->GetXaxis()->GetNbins(), mHistoNum->GetXaxis()->GetXmin(), mHistoNum->GetXaxis()->GetXmax());
+  }
+  if (mHistoNum->GetYaxis()->IsVariableBinSize()) {
+    T::GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXbins()->GetArray());
+  } else {
+    T::GetYaxis()->Set(mHistoNum->GetYaxis()->GetNbins(), mHistoNum->GetYaxis()->GetXmin(), mHistoNum->GetYaxis()->GetXmax());
+  }
   T::SetBinsLength();
 
   // Copy bin labels between histograms.


### PR DESCRIPTION
A direct copy of the axis objects from the numerator to the ratio histograms, that was introduced in a [recent commit](https://github.com/AliceO2Group/QualityControl/pull/2438/commits/42a5a592b790c1fbe86c13cabdba151df57b096e), breaks the preservation of the bin labels that are eventually set in the ratio histogram.

The code in this commit replaces the copy with an explicit update of the number and limits of the bins, such that it works also if the numerator is filled with `TH1::kCanRebin` or `TH1::SetCanExtend()` set, and therefore the axis range can change after the histogram creation.