### PR TITLE
[QC-1206] Make database available to user code + refactor *Config to extract common part

### DIFF
--- a/Framework/include/QualityControl/AggregatorConfig.h
+++ b/Framework/include/QualityControl/AggregatorConfig.h
@@ -24,25 +24,20 @@
 #include <Framework/DataProcessorSpec.h>
 #include "QualityControl/UpdatePolicyType.h"
 #include "QualityControl/AggregatorSource.h"
-#include "QualityControl/CustomParameters.h"
+#include "QualityControl/UserCodeConfig.h"
 
 namespace o2::quality_control::checker
 {
 
 /// \brief  Container for the configuration of an Aggregator.
-struct AggregatorConfig {
+struct AggregatorConfig : public o2::quality_control::core::UserCodeConfig {
   std::string name;
-  std::string moduleName;
-  std::string className;
-  std::string detectorName = "MISC"; // intended to be the 3 letters code;
-  core::CustomParameters customParameters;
   UpdatePolicyType policyType = UpdatePolicyType::OnAny;
   std::vector<std::string> objectNames{}; // fixme: if object names are empty, allObjects are true, consider reducing to one var // fixme: duplicates "sources"
   bool allObjects = false;
   framework::Inputs inputSpecs{};
   framework::OutputSpec qoSpec{ "XXX", "INVALID" };
   std::vector<AggregatorSource> sources;
-  std::string conditionUrl{};
 };
 
 } // namespace o2::quality_control::checker

--- a/Framework/include/QualityControl/Check.h
+++ b/Framework/include/QualityControl/Check.h
@@ -94,11 +94,6 @@ class Check
   static CheckConfig extractConfig(const core::CommonSpec&, const CheckSpec&);
   static framework::OutputSpec createOutputSpec(const std::string& detector, const std::string& checkName);
 
-  void setDatabase(std::shared_ptr<o2::quality_control::repository::DatabaseInterface> database)
-  {
-    mCheckInterface->setDatabase(database);
-  }
-
  private:
   void beautify(std::map<std::string, std::shared_ptr<core::MonitorObject>>& moMap, const core::Quality& quality);
 

--- a/Framework/include/QualityControl/CheckConfig.h
+++ b/Framework/include/QualityControl/CheckConfig.h
@@ -22,25 +22,20 @@
 
 #include <Framework/DataProcessorSpec.h>
 #include "QualityControl/UpdatePolicyType.h"
-#include "QualityControl/CustomParameters.h"
+#include "QualityControl/UserCodeConfig.h"
 
 namespace o2::quality_control::checker
 {
 
 /// \brief  Container for the configuration of a Check.
-struct CheckConfig {
+struct CheckConfig : public o2::quality_control::core::UserCodeConfig {
   std::string name;
-  std::string moduleName;
-  std::string className;
-  std::string detectorName = "MISC"; // intended to be the 3 letters code;
-  core::CustomParameters customParameters;
   UpdatePolicyType policyType = UpdatePolicyType::OnAny;
   std::vector<std::string> objectNames{}; // fixme: if object names are empty, allObjects are true, consider reducing to one var
   bool allObjects = false;
   bool allowBeautify = false;
   framework::Inputs inputSpecs{};
   framework::OutputSpec qoSpec{ "XXX", "INVALID" };
-  std::string conditionUrl{};
 };
 
 } // namespace o2::quality_control::checker

--- a/Framework/include/QualityControl/CheckInterface.h
+++ b/Framework/include/QualityControl/CheckInterface.h
@@ -83,11 +83,6 @@ class CheckInterface : public core::UserCodeInterface
   virtual void startOfActivity(const core::Activity& activity); // not fully abstract because we don't want to change all the existing subclasses
   virtual void endOfActivity(const core::Activity& activity);   // not fully abstract because we don't want to change all the existing subclasses
 
-  void setDatabase(std::shared_ptr<o2::quality_control::repository::DatabaseInterface> database)
-  {
-    mDatabase = database;
-  }
-
  protected:
   /// \brief Called each time mCustomParameters is updated.
   virtual void configure() override;
@@ -99,9 +94,6 @@ class CheckInterface : public core::UserCodeInterface
   /// \param referenceActivity Reference activity (usually a copy of the current activity with a different run number)
   /// \return
   std::shared_ptr<MonitorObject> retrieveReference(std::string path, Activity referenceActivity);
-
- private:
-  std::shared_ptr<o2::quality_control::repository::DatabaseInterface> mDatabase;
 
   ClassDef(CheckInterface, 6)
 };

--- a/Framework/include/QualityControl/PostProcessingConfig.h
+++ b/Framework/include/QualityControl/PostProcessingConfig.h
@@ -17,12 +17,11 @@
 #ifndef QUALITYCONTROL_POSTPROCESSINGCONFIG_H
 #define QUALITYCONTROL_POSTPROCESSINGCONFIG_H
 
-#include "QualityControl/CustomParameters.h"
-
 #include <vector>
 #include <string>
 #include <boost/property_tree/ptree_fwd.hpp>
 #include "QualityControl/Activity.h"
+#include "QualityControl/UserCodeConfig.h"
 
 namespace o2::quality_control::postprocessing
 {
@@ -30,27 +29,20 @@ namespace o2::quality_control::postprocessing
 // todo pretty print
 
 /// \brief  Post-processing configuration structure
-struct PostProcessingConfig {
+struct PostProcessingConfig : public o2::quality_control::core::UserCodeConfig {
   PostProcessingConfig() = default;
   PostProcessingConfig(const std::string& id, const boost::property_tree::ptree& config);
   ~PostProcessingConfig() = default;
   std::string id;
   std::string taskName;
-  std::string moduleName;
-  std::string className;
-  std::string detectorName = "MISC";
   std::vector<std::string> initTriggers = {};
   std::vector<std::string> updateTriggers = {};
   std::vector<std::string> stopTriggers = {};
-  std::string qcdbUrl;
-  std::string ccdbUrl;
-  std::string consulUrl;
   std::string kafkaBrokersUrl;
   std::string kafkaTopic;
   core::Activity activity;
   bool matchAnyRunNumber = false;
   bool critical;
-  core::CustomParameters customParameters;
 };
 
 } // namespace o2::quality_control::postprocessing

--- a/Framework/include/QualityControl/TaskRunnerConfig.h
+++ b/Framework/include/QualityControl/TaskRunnerConfig.h
@@ -24,7 +24,7 @@
 #include <Framework/DataProcessorSpec.h>
 #include "QualityControl/Activity.h"
 #include "QualityControl/LogDiscardParameters.h"
-#include "QualityControl/CustomParameters.h"
+#include "QualityControl/UserCodeConfig.h"
 
 namespace o2::base
 {
@@ -40,23 +40,17 @@ namespace o2::quality_control::core
 {
 
 /// \brief  Container for the configuration of a Task
-struct TaskRunnerConfig {
+struct TaskRunnerConfig : public UserCodeConfig {
   std::string deviceName;
   std::string taskName;
-  std::string moduleName;
-  std::string className;
   std::vector<std::pair<size_t, size_t>> cycleDurations = {};
   int maxNumberCycles;
   bool critical;
-  std::string consulUrl{};
-  std::string conditionUrl{};
   std::string monitoringUrl{};
   std::string bookkeepingUrl{};
   framework::Inputs inputSpecs{};
   framework::OutputSpec moSpec{ "XXX", "INVALID" };
   framework::Options options{};
-  CustomParameters customParameters;
-  std::string detectorName = "MISC"; // intended to be the 3 letters code
   int parallelTaskID = 0;            // ID to differentiate parallel local Tasks from one another. 0 means this is the only one.
   std::string saveToFile{};
   int resetAfterCycles = 0;

--- a/Framework/include/QualityControl/UserCodeConfig.h
+++ b/Framework/include/QualityControl/UserCodeConfig.h
@@ -30,8 +30,8 @@ struct UserCodeConfig {
   std::string detectorName = "MISC"; // intended to be the 3 letters code;
   std::string consulUrl;
   CustomParameters customParameters;
-  std::string conditionUrl{};
-  std::unordered_map<std::string, std::string> database;
+  std::string ccdbUrl;
+  std::unordered_map<std::string, std::string> repository; // we need the full config of the database to build the database in the subclasses
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/UserCodeConfig.h
+++ b/Framework/include/QualityControl/UserCodeConfig.h
@@ -1,0 +1,39 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   UserCodeConfig.h
+/// \author Barthelemy von Haller
+///
+
+#ifndef QUALITYCONTROL_USERCODECONFIG_H
+#define QUALITYCONTROL_USERCODECONFIG_H
+
+#include "QualityControl/CustomParameters.h"
+#include "QualityControl/stringUtils.h"
+
+namespace o2::quality_control::core
+{
+
+/// \brief  Container for the configuration of a Task
+struct UserCodeConfig {
+  std::string moduleName;
+  std::string className;
+  std::string detectorName = "MISC"; // intended to be the 3 letters code;
+  std::string consulUrl;
+  CustomParameters customParameters;
+  std::string conditionUrl{};
+  std::unordered_map<std::string, std::string> database;
+};
+
+} // namespace o2::quality_control::core
+
+#endif // QUALITYCONTROL_USERCODECONFIG_H

--- a/Framework/include/QualityControl/UserCodeInterface.h
+++ b/Framework/include/QualityControl/UserCodeInterface.h
@@ -23,6 +23,7 @@
 
 #include "QualityControl/ConditionAccess.h"
 #include "QualityControl/CustomParameters.h"
+#include "QualityControl/DatabaseInterface.h"
 
 namespace o2::quality_control::core
 {
@@ -48,12 +49,14 @@ class UserCodeInterface : public ConditionAccess
 
   const std::string& getName() const;
   void setName(const std::string& name);
+  void setDatabase(std::unordered_map<std::string, std::string> dbConfig);
 
  protected:
   CustomParameters mCustomParameters;
   std::string mName;
+  std::shared_ptr<o2::quality_control::repository::DatabaseInterface> mDatabase;
 
-  ClassDef(UserCodeInterface, 3)
+  ClassDef(UserCodeInterface, 4)
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/src/Aggregator.cxx
+++ b/Framework/src/Aggregator.cxx
@@ -51,8 +51,8 @@ void Aggregator::init()
       root_class_factory::create<AggregatorInterface>(mAggregatorConfig.moduleName, mAggregatorConfig.className);
     mAggregatorInterface->setName(mAggregatorConfig.name);
     mAggregatorInterface->setCustomParameters(mAggregatorConfig.customParameters);
-    mAggregatorInterface->setCcdbUrl(mAggregatorConfig.conditionUrl);
-    mAggregatorInterface->setDatabase(mAggregatorConfig.database);
+    mAggregatorInterface->setCcdbUrl(mAggregatorConfig.ccdbUrl);
+    mAggregatorInterface->setDatabase(mAggregatorConfig.repository);
     mAggregatorInterface->configure();
   } catch (...) {
     std::string diagnostic = boost::current_exception_diagnostic_information();

--- a/Framework/src/Aggregator.cxx
+++ b/Framework/src/Aggregator.cxx
@@ -52,6 +52,7 @@ void Aggregator::init()
     mAggregatorInterface->setName(mAggregatorConfig.name);
     mAggregatorInterface->setCustomParameters(mAggregatorConfig.customParameters);
     mAggregatorInterface->setCcdbUrl(mAggregatorConfig.conditionUrl);
+    mAggregatorInterface->setDatabase(mAggregatorConfig.database);
     mAggregatorInterface->configure();
   } catch (...) {
     std::string diagnostic = boost::current_exception_diagnostic_information();
@@ -217,18 +218,20 @@ AggregatorConfig Aggregator::extractConfig(const core::CommonSpec& commonSpec, c
   }
 
   return {
-    aggregatorSpec.aggregatorName,
     aggregatorSpec.moduleName,
     aggregatorSpec.className,
     aggregatorSpec.detectorName,
+    commonSpec.consulUrl,
     aggregatorSpec.customParameters,
+    commonSpec.conditionDBUrl,
+    commonSpec.database,
+    aggregatorSpec.aggregatorName,
     updatePolicy,
     std::move(objectNames),
     checkAllObjects,
     std::move(inputs),
     createOutputSpec(aggregatorSpec.detectorName, aggregatorSpec.aggregatorName),
-    sources,
-    commonSpec.conditionDBUrl
+    sources
   };
 }
 

--- a/Framework/src/Check.cxx
+++ b/Framework/src/Check.cxx
@@ -71,9 +71,9 @@ void Check::init()
   try {
     mCheckInterface = root_class_factory::create<CheckInterface>(mCheckConfig.moduleName, mCheckConfig.className);
     mCheckInterface->setName(mCheckConfig.name);
-    mCheckInterface->setDatabase(mCheckConfig.database);
+    mCheckInterface->setDatabase(mCheckConfig.repository);
     mCheckInterface->setCustomParameters(mCheckConfig.customParameters);
-    mCheckInterface->setCcdbUrl(mCheckConfig.conditionUrl);
+    mCheckInterface->setCcdbUrl(mCheckConfig.ccdbUrl);
   } catch (...) {
     std::string diagnostic = boost::current_exception_diagnostic_information();
     ILOG(Fatal, Ops) << "Unexpected exception, diagnostic information follows: "

--- a/Framework/src/Check.cxx
+++ b/Framework/src/Check.cxx
@@ -28,6 +28,7 @@
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/Quality.h"
 #include "QualityControl/HashDataDescription.h"
+#include "QualityControl/runnerUtils.h"
 
 #include <QualityControl/AggregatorRunner.h>
 
@@ -70,6 +71,7 @@ void Check::init()
   try {
     mCheckInterface = root_class_factory::create<CheckInterface>(mCheckConfig.moduleName, mCheckConfig.className);
     mCheckInterface->setName(mCheckConfig.name);
+    mCheckInterface->setDatabase(mCheckConfig.database);
     mCheckInterface->setCustomParameters(mCheckConfig.customParameters);
     mCheckInterface->setCcdbUrl(mCheckConfig.conditionUrl);
   } catch (...) {
@@ -250,18 +252,20 @@ CheckConfig Check::extractConfig(const CommonSpec& commonSpec, const CheckSpec& 
   }
 
   return {
-    checkSpec.checkName,
     checkSpec.moduleName,
     checkSpec.className,
     checkSpec.detectorName,
+    commonSpec.consulUrl,
     checkSpec.customParameters,
+    commonSpec.conditionDBUrl,
+    commonSpec.database,
+    checkSpec.checkName,
     updatePolicy,
     std::move(objectNames),
     checkAllObjects,
     allowBeautify,
     std::move(inputs),
     createOutputSpec(checkSpec.detectorName, checkSpec.checkName),
-    commonSpec.conditionDBUrl
   };
 }
 

--- a/Framework/src/CheckRunner.cxx
+++ b/Framework/src/CheckRunner.cxx
@@ -190,7 +190,6 @@ void CheckRunner::init(framework::InitContext& iCtx)
     updatePolicyManager.reset();
     for (auto& [checkName, check] : mChecks) {
       check.init();
-      check.setDatabase(mDatabase);
       updatePolicyManager.addPolicy(check.getName(), check.getUpdatePolicyType(), check.getObjectsNames(), check.getAllObjectsOption(), false);
     }
   } catch (...) {

--- a/Framework/src/PostProcessingConfig.cxx
+++ b/Framework/src/PostProcessingConfig.cxx
@@ -44,8 +44,8 @@ PostProcessingConfig::PostProcessingConfig(const std::string& id, const boost::p
   auto qcdbUrl = config.get<std::string>(databasePath + ".implementation") == "CCDB" ? config.get<std::string>(databasePath + ".host") : "";
   // build the config of the qcdb
   std::unordered_map<std::string, std::string> dbConfig{
-      { "implementation", config.get<std::string>("qc.config.database.implementation") },
-      { "host", qcdbUrl }
+    { "implementation", config.get<std::string>("qc.config.database.implementation") },
+    { "host", qcdbUrl }
   };
   repository = dbConfig;
 

--- a/Framework/src/PostProcessingConfig.cxx
+++ b/Framework/src/PostProcessingConfig.cxx
@@ -39,9 +39,9 @@ PostProcessingConfig::PostProcessingConfig(const std::string& id, const boost::p
   detectorName = config.get<std::string>("qc.postprocessing." + id + ".detectorName", "MISC");
   consulUrl = config.get<std::string>("qc.config.consul.url", "");
   conditionUrl = config.get<std::string>("qc.config.conditionDB.url", "");
-  std::unordered_map<std::string, std::string> dbConfig {
-      {"implementation", config.get<std::string>("qc.config.database.implementation")},
-      {"host", config.get<std::string>("qc.config.database.host")}
+  std::unordered_map<std::string, std::string> dbConfig{
+      { "implementation", config.get<std::string>("qc.config.database.implementation") },
+      { "host", config.get<std::string>("qc.config.database.host") }
   };
   database = dbConfig;
 

--- a/Framework/src/PostProcessingConfig.cxx
+++ b/Framework/src/PostProcessingConfig.cxx
@@ -38,17 +38,16 @@ PostProcessingConfig::PostProcessingConfig(const std::string& id, const boost::p
   className = config.get<std::string>("qc.postprocessing." + id + ".className");
   detectorName = config.get<std::string>("qc.postprocessing." + id + ".detectorName", "MISC");
   consulUrl = config.get<std::string>("qc.config.consul.url", "");
-  conditionUrl = config.get<std::string>("qc.config.conditionDB.url", "");
-  std::unordered_map<std::string, std::string> dbConfig{
-      { "implementation", config.get<std::string>("qc.config.database.implementation") },
-      { "host", config.get<std::string>("qc.config.database.host") }
-  };
-  database = dbConfig;
-
   // if available, use the source repo as defined in the postprocessing task, otherwise the general QCDB
   auto sourceRepo = config.get_child_optional("qc.postprocessing." + id + ".sourceRepo");
   auto databasePath = sourceRepo ? "qc.postprocessing." + id + ".sourceRepo" : "qc.config.database";
-  qcdbUrl = config.get<std::string>(databasePath + ".implementation") == "CCDB" ? config.get<std::string>(databasePath + ".host") : "";
+  auto qcdbUrl = config.get<std::string>(databasePath + ".implementation") == "CCDB" ? config.get<std::string>(databasePath + ".host") : "";
+  // build the config of the qcdb
+  std::unordered_map<std::string, std::string> dbConfig{
+      { "implementation", config.get<std::string>("qc.config.database.implementation") },
+      { "host", qcdbUrl }
+  };
+  repository = dbConfig;
 
   for (const auto& initTrigger : config.get_child("qc.postprocessing." + id + ".initTrigger")) {
     initTriggers.push_back(initTrigger.second.get_value<std::string>());

--- a/Framework/src/PostProcessingConfig.cxx
+++ b/Framework/src/PostProcessingConfig.cxx
@@ -24,11 +24,6 @@ namespace o2::quality_control::postprocessing
 PostProcessingConfig::PostProcessingConfig(const std::string& id, const boost::property_tree::ptree& config) //
   : id(id),
     taskName(config.get<std::string>("qc.postprocessing." + id + ".taskName", id)),
-    moduleName(config.get<std::string>("qc.postprocessing." + id + ".moduleName")),
-    className(config.get<std::string>("qc.postprocessing." + id + ".className")),
-    detectorName(config.get<std::string>("qc.postprocessing." + id + ".detectorName", "MISC")),
-    ccdbUrl(config.get<std::string>("qc.config.conditionDB.url", "")),
-    consulUrl(config.get<std::string>("qc.config.consul.url", "")),
     activity(config.get<int>("qc.config.Activity.number", 0),
              config.get<std::string>("qc.config.Activity.type", "NONE"),
              config.get<std::string>("qc.config.Activity.periodName", ""),
@@ -39,6 +34,17 @@ PostProcessingConfig::PostProcessingConfig(const std::string& id, const boost::p
     matchAnyRunNumber(config.get<bool>("qc.config.postprocessing.matchAnyRunNumber", false)),
     critical(true)
 {
+  moduleName = config.get<std::string>("qc.postprocessing." + id + ".moduleName");
+  className = config.get<std::string>("qc.postprocessing." + id + ".className");
+  detectorName = config.get<std::string>("qc.postprocessing." + id + ".detectorName", "MISC");
+  consulUrl = config.get<std::string>("qc.config.consul.url", "");
+  conditionUrl = config.get<std::string>("qc.config.conditionDB.url", "");
+  std::unordered_map<std::string, std::string> dbConfig {
+      {"implementation", config.get<std::string>("qc.config.database.implementation")},
+      {"host", config.get<std::string>("qc.config.database.host")}
+  };
+  database = dbConfig;
+
   // if available, use the source repo as defined in the postprocessing task, otherwise the general QCDB
   auto sourceRepo = config.get_child_optional("qc.postprocessing." + id + ".sourceRepo");
   auto databasePath = sourceRepo ? "qc.postprocessing." + id + ".sourceRepo" : "qc.config.database";

--- a/Framework/src/PostProcessingFactory.cxx
+++ b/Framework/src/PostProcessingFactory.cxx
@@ -29,7 +29,7 @@ PostProcessingInterface* PostProcessingFactory::create(const PostProcessingConfi
 {
   auto* result = root_class_factory::create<PostProcessingInterface>(config.moduleName, config.className);
   result->setCustomParameters(config.customParameters);
-  result->setDatabase(config.database);
+  result->setDatabase(config.repository);
   return result;
 }
 

--- a/Framework/src/PostProcessingFactory.cxx
+++ b/Framework/src/PostProcessingFactory.cxx
@@ -29,6 +29,7 @@ PostProcessingInterface* PostProcessingFactory::create(const PostProcessingConfi
 {
   auto* result = root_class_factory::create<PostProcessingInterface>(config.moduleName, config.className);
   result->setCustomParameters(config.customParameters);
+  result->setDatabase(config.database);
   return result;
 }
 

--- a/Framework/src/PostProcessingRunner.cxx
+++ b/Framework/src/PostProcessingRunner.cxx
@@ -114,7 +114,7 @@ void PostProcessingRunner::init(const PostProcessingRunnerConfig& runnerConfig, 
     mTask->setID(mTaskConfig.id);
     mTask->setName(mTaskConfig.taskName);
     mTask->setCustomParameters(mTaskConfig.customParameters);
-    mTask->setCcdbUrl(mTaskConfig.ccdbUrl);
+    mTask->setCcdbUrl(mTaskConfig.conditionUrl);
     mTask->configure(mRunnerConfig.configTree);
   } else {
     throw std::runtime_error("Failed to create the task '" + mTaskConfig.taskName + "' (det " + mTaskConfig.detectorName + ")");

--- a/Framework/src/PostProcessingRunner.cxx
+++ b/Framework/src/PostProcessingRunner.cxx
@@ -114,7 +114,7 @@ void PostProcessingRunner::init(const PostProcessingRunnerConfig& runnerConfig, 
     mTask->setID(mTaskConfig.id);
     mTask->setName(mTaskConfig.taskName);
     mTask->setCustomParameters(mTaskConfig.customParameters);
-    mTask->setCcdbUrl(mTaskConfig.conditionUrl);
+    mTask->setCcdbUrl(mTaskConfig.ccdbUrl);
     mTask->configure(mRunnerConfig.configTree);
   } else {
     throw std::runtime_error("Failed to create the task '" + mTaskConfig.taskName + "' (det " + mTaskConfig.detectorName + ")");

--- a/Framework/src/TaskFactory.cxx
+++ b/Framework/src/TaskFactory.cxx
@@ -27,7 +27,7 @@ TaskInterface* TaskFactory::create(const TaskRunnerConfig& taskConfig, std::shar
   result->setName(taskConfig.taskName);
   result->setObjectsManager(objectsManager);
   result->setCustomParameters(taskConfig.customParameters);
-  result->setCcdbUrl(taskConfig.conditionUrl);
+  result->setCcdbUrl(taskConfig.ccdbUrl);
 
   return result;
 }

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -49,6 +49,7 @@
 #include "QualityControl/ActivityHelpers.h"
 #include "QualityControl/WorkflowType.h"
 #include "QualityControl/HashDataDescription.h"
+#include "QualityControl/runnerUtils.h"
 
 #include <string>
 #include <TFile.h>
@@ -122,6 +123,7 @@ void TaskRunner::init(InitContext& iCtx)
   mTask.reset(TaskFactory::create(mTaskConfig, mObjectsManager));
   mTask->setMonitoring(mCollector);
   mTask->setGlobalTrackingDataRequest(mTaskConfig.globalTrackingDataRequest);
+  mTask->setDatabase(mTaskConfig.database);
 
   // load config params
   if (!ConfigParamGlo::keyValues.empty()) {

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -123,7 +123,7 @@ void TaskRunner::init(InitContext& iCtx)
   mTask.reset(TaskFactory::create(mTaskConfig, mObjectsManager));
   mTask->setMonitoring(mCollector);
   mTask->setGlobalTrackingDataRequest(mTaskConfig.globalTrackingDataRequest);
-  mTask->setDatabase(mTaskConfig.database);
+  mTask->setDatabase(mTaskConfig.repository);
 
   // load config params
   if (!ConfigParamGlo::keyValues.empty()) {

--- a/Framework/src/TaskRunnerFactory.cxx
+++ b/Framework/src/TaskRunnerFactory.cxx
@@ -168,22 +168,23 @@ TaskRunnerConfig TaskRunnerFactory::extractConfig(const CommonSpec& globalConfig
   o2::globaltracking::RecoContainer rd;
 
   return {
-    deviceName,
-    taskSpec.taskName,
     taskSpec.moduleName,
     taskSpec.className,
+    InfrastructureSpecReader::validateDetectorName(taskSpec.detectorName),
+    globalConfig.consulUrl,
+    taskSpec.customParameters,
+    globalConfig.conditionDBUrl,
+    globalConfig.database,
+    deviceName,
+    taskSpec.taskName,
     multipleCycleDurations,
     taskSpec.maxNumberCycles,
     taskSpec.critical,
-    globalConfig.consulUrl,
-    globalConfig.conditionDBUrl,
     globalConfig.monitoringUrl,
     globalConfig.bookkeepingUrl,
     inputs,
     monitorObjectsSpec,
     options,
-    taskSpec.customParameters,
-    InfrastructureSpecReader::validateDetectorName(taskSpec.detectorName),
     parallelTaskID,
     taskSpec.saveObjectsToFile,
     resetAfterCycles.value_or(taskSpec.resetAfterCycles),
@@ -192,7 +193,7 @@ TaskRunnerConfig TaskRunnerFactory::extractConfig(const CommonSpec& globalConfig
     grpGeomRequest,
     globalTrackingDataRequest,
     taskSpec.movingWindows,
-    taskSpec.disableLastCycle
+    taskSpec.disableLastCycle,
   };
 }
 

--- a/Framework/src/TriggerHelpers.cxx
+++ b/Framework/src/TriggerHelpers.cxx
@@ -104,15 +104,15 @@ TriggerFcn triggerFactory(const std::string& trigger, const PostProcessingConfig
     return triggers::EndOfFill(activity);
   } else if (triggerLowerCase.find("newobject") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "newobject");
-    const std::string& dbUrl = db == "qcdb" ? config.qcdbUrl : config.ccdbUrl;
+    const std::string& dbUrl = db == "qcdb" ? config.database.at("host") : config.conditionUrl;
     return triggers::NewObject(dbUrl, db, objectPath, activity, trigger);
   } else if (triggerLowerCase.find("foreachobject") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "foreachobject");
-    const std::string& dbUrl = db == "qcdb" ? config.qcdbUrl : config.ccdbUrl;
+    const std::string& dbUrl = db == "qcdb" ? config.database.at("host") : config.conditionUrl;
     return triggers::ForEachObject(dbUrl, db, objectPath, activity, trigger);
   } else if (triggerLowerCase.find("foreachlatest") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "foreachlatest");
-    const std::string& dbUrl = db == "qcdb" ? config.qcdbUrl : config.ccdbUrl;
+    const std::string& dbUrl = db == "qcdb" ? config.database.at("host") : config.conditionUrl;
     return triggers::ForEachLatest(dbUrl, db, objectPath, activity, trigger);
   } else if (auto seconds = string2Seconds(triggerLowerCase); seconds.has_value()) {
     if (seconds.value() < 0) {

--- a/Framework/src/TriggerHelpers.cxx
+++ b/Framework/src/TriggerHelpers.cxx
@@ -104,15 +104,15 @@ TriggerFcn triggerFactory(const std::string& trigger, const PostProcessingConfig
     return triggers::EndOfFill(activity);
   } else if (triggerLowerCase.find("newobject") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "newobject");
-    const std::string& dbUrl = db == "qcdb" ? config.database.at("host") : config.conditionUrl;
+    const std::string& dbUrl = db == "qcdb" ? config.repository.at("host") : config.ccdbUrl;
     return triggers::NewObject(dbUrl, db, objectPath, activity, trigger);
   } else if (triggerLowerCase.find("foreachobject") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "foreachobject");
-    const std::string& dbUrl = db == "qcdb" ? config.database.at("host") : config.conditionUrl;
+    const std::string& dbUrl = db == "qcdb" ? config.repository.at("host") : config.ccdbUrl;
     return triggers::ForEachObject(dbUrl, db, objectPath, activity, trigger);
   } else if (triggerLowerCase.find("foreachlatest") != std::string::npos) {
     const auto [db, objectPath] = parseDbTriggers(trigger, "foreachlatest");
-    const std::string& dbUrl = db == "qcdb" ? config.database.at("host") : config.conditionUrl;
+    const std::string& dbUrl = db == "qcdb" ? config.repository.at("host") : config.ccdbUrl;
     return triggers::ForEachLatest(dbUrl, db, objectPath, activity, trigger);
   } else if (auto seconds = string2Seconds(triggerLowerCase); seconds.has_value()) {
     if (seconds.value() < 0) {

--- a/Framework/src/UserCodeInterface.cxx
+++ b/Framework/src/UserCodeInterface.cxx
@@ -31,17 +31,19 @@ void UserCodeInterface::setCustomParameters(const CustomParameters& parameters)
   configure();
 }
 
-const std::string& UserCodeInterface::getName() const {
+const std::string& UserCodeInterface::getName() const
+{
   return mName;
 }
 
-void UserCodeInterface::setName(const std::string& name) {
+void UserCodeInterface::setName(const std::string& name)
+{
   mName = name;
 }
 
 void UserCodeInterface::setDatabase(std::unordered_map<std::string, std::string> dbConfig)
 {
-  if(dbConfig.count("implementation") == 0 || dbConfig.count("host") == 0) {
+  if (dbConfig.count("implementation") == 0 || dbConfig.count("host") == 0) {
     ILOG(Error, Devel) << "dbConfig is incomplete, we don't build the user code database instance" << ENDM;
     throw std::invalid_argument("Cannot set database in UserCodeInterface");
   }

--- a/Framework/src/UserCodeInterface.cxx
+++ b/Framework/src/UserCodeInterface.cxx
@@ -15,8 +15,12 @@
 ///
 
 #include "QualityControl/UserCodeInterface.h"
+#include <thread>
+#include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/DatabaseFactory.h"
 
 using namespace o2::ccdb;
+using namespace std;
 
 namespace o2::quality_control::core
 {
@@ -27,8 +31,24 @@ void UserCodeInterface::setCustomParameters(const CustomParameters& parameters)
   configure();
 }
 
-const std::string& UserCodeInterface::getName() const { return mName; }
+const std::string& UserCodeInterface::getName() const {
+  return mName;
+}
 
-void UserCodeInterface::setName(const std::string& name) { mName = name; }
+void UserCodeInterface::setName(const std::string& name) {
+  mName = name;
+}
+
+void UserCodeInterface::setDatabase(std::unordered_map<std::string, std::string> dbConfig)
+{
+  if(dbConfig.count("implementation") == 0 || dbConfig.count("host") == 0) {
+    ILOG(Error, Devel) << "dbConfig is incomplete, we don't build the user code database instance" << ENDM;
+    throw std::invalid_argument("Cannot set database in UserCodeInterface");
+  }
+
+  mDatabase = repository::DatabaseFactory::create(dbConfig.at("implementation"));
+  mDatabase->connect(dbConfig);
+  ILOG(Debug, Devel) << "Database that is going to be used > Implementation : " << dbConfig.at("implementation") << " / Host : " << dbConfig.at("host") << ENDM;
+}
 
 } // namespace o2::quality_control::core

--- a/Framework/test/testCheck.cxx
+++ b/Framework/test/testCheck.cxx
@@ -150,7 +150,7 @@ TEST_CASE("test_check_activity")
                 "",
                 {},
                 "",
-                {},
+      {{ "implementation", "CCDB" },{ "host", "" }},
                 "test",
                 UpdatePolicyType::OnAny,
                 {},

--- a/Framework/test/testCheck.cxx
+++ b/Framework/test/testCheck.cxx
@@ -144,14 +144,18 @@ TEST_CASE("test_check_postprocessing")
 
 TEST_CASE("test_check_activity")
 {
-  Check check({ "test",
-                "QcSkeleton",
+  Check check({      "QcSkeleton",
                 "o2::quality_control_modules::skeleton::SkeletonCheck",
                 "TST",
+                "",
                 {},
+                "",
+                {},
+                "test",
                 UpdatePolicyType::OnAny,
                 {},
-                true });
+                true }
+ );
 
   std::map<std::string, std::shared_ptr<MonitorObject>> moMap{
     { "abcTask/test1", dummyMO("test1") },

--- a/Framework/test/testCheck.cxx
+++ b/Framework/test/testCheck.cxx
@@ -144,7 +144,7 @@ TEST_CASE("test_check_postprocessing")
 
 TEST_CASE("test_check_activity")
 {
-  Check check({      "QcSkeleton",
+  Check check({ "QcSkeleton",
                 "o2::quality_control_modules::skeleton::SkeletonCheck",
                 "TST",
                 "",
@@ -154,8 +154,7 @@ TEST_CASE("test_check_activity")
                 "test",
                 UpdatePolicyType::OnAny,
                 {},
-                true }
- );
+                true });
 
   std::map<std::string, std::shared_ptr<MonitorObject>> moMap{
     { "abcTask/test1", dummyMO("test1") },

--- a/Framework/test/testCheck.cxx
+++ b/Framework/test/testCheck.cxx
@@ -150,7 +150,7 @@ TEST_CASE("test_check_activity")
                 "",
                 {},
                 "",
-      {{ "implementation", "CCDB" },{ "host", "" }},
+                { { "implementation", "CCDB" }, { "host", "" } },
                 "test",
                 UpdatePolicyType::OnAny,
                 {},

--- a/Framework/test/testCheckWorkflow.cxx
+++ b/Framework/test/testCheckWorkflow.cxx
@@ -62,7 +62,7 @@ using namespace o2::configuration;
  * It is expected to terminate as soon as all task publish for the first time.
  */
 
-class Receiver : public framework::Task
+class Receiver : public o2::framework::Task
 {
  public:
   Receiver(std::string configurationSource)
@@ -78,7 +78,7 @@ class Receiver : public framework::Task
   ~Receiver() override{};
 
   /// \brief Receiver process callback
-  void run(framework::ProcessingContext& pctx) override
+  void run(o2::framework::ProcessingContext& pctx) override
   {
     std::vector<std::string> namesToErase;
 

--- a/Framework/test/testTaskInterface.cxx
+++ b/Framework/test/testTaskInterface.cxx
@@ -167,10 +167,15 @@ TEST_CASE("test_invoke_all_TaskRunnerConfig_methods")
 TEST_CASE("test_task_factory")
 {
   TaskRunnerConfig config{
-    "SkeletonTaskRunner",
-    "skeletonTask",
     "QcSkeleton",
     "o2::quality_control_modules::skeleton::SkeletonTask",
+    "TST",
+    "",
+    {},
+    "",
+    {},
+    "SkeletonTaskRunner",
+    "skeletonTask",
     { { 10, 1 } },
     -1,
     true,

--- a/Framework/test/testTriggerHelpers.cxx
+++ b/Framework/test/testTriggerHelpers.cxx
@@ -63,8 +63,8 @@ TEST_CASE("test_factory")
 
   // generating new object trigger
   PostProcessingConfig configWithDBs;
-  configWithDBs.database["host"] = CCDB_ENDPOINT;
-  configWithDBs.conditionUrl = CCDB_ENDPOINT;
+  configWithDBs.repository["host"] = CCDB_ENDPOINT;
+  configWithDBs.ccdbUrl = CCDB_ENDPOINT;
   CHECK_NOTHROW(trigger_helpers::triggerFactory("newobject:qcdb:qc/asdf/vcxz", configWithDBs));
   CHECK_NOTHROW(trigger_helpers::triggerFactory("newobject:ccdb:qc/asdf/vcxz", configWithDBs));
   CHECK_NOTHROW(trigger_helpers::triggerFactory("newobject:QCDB:qc/asdf/vcxz", configWithDBs));

--- a/Framework/test/testTriggerHelpers.cxx
+++ b/Framework/test/testTriggerHelpers.cxx
@@ -63,8 +63,8 @@ TEST_CASE("test_factory")
 
   // generating new object trigger
   PostProcessingConfig configWithDBs;
-  configWithDBs.qcdbUrl = CCDB_ENDPOINT;
-  configWithDBs.ccdbUrl = CCDB_ENDPOINT;
+  configWithDBs.database["host"] = CCDB_ENDPOINT;
+  configWithDBs.conditionUrl = CCDB_ENDPOINT;
   CHECK_NOTHROW(trigger_helpers::triggerFactory("newobject:qcdb:qc/asdf/vcxz", configWithDBs));
   CHECK_NOTHROW(trigger_helpers::triggerFactory("newobject:ccdb:qc/asdf/vcxz", configWithDBs));
   CHECK_NOTHROW(trigger_helpers::triggerFactory("newobject:QCDB:qc/asdf/vcxz", configWithDBs));


### PR DESCRIPTION
- needed for the CTP Scalers
- it required adding the database param to all the *Config.h I decided to extract the common part to a new interface `UserCodeConfig`.

DO NOT MERGE BEFORE HI