### PR TITLE
[TPC-QC]: Fix memory leak in ClusterVisualizer

### DIFF
--- a/Modules/TPC/src/ClusterVisualizer.cxx
+++ b/Modules/TPC/src/ClusterVisualizer.cxx
@@ -161,9 +161,9 @@ void ClusterVisualizer::update(Trigger t, framework::ServiceRegistryRef)
 
   auto calDetIter = 0;
 
-  auto clusterData = mCdbApi.retrieveFromTFileAny<ClustersData>(mPath,
-                                                                mLookupMaps.size() > 1 ? mLookupMaps.at(calDetIter) : mLookupMaps.at(0),
-                                                                mTimestamps.size() > 0 ? mTimestamps.at(calDetIter) : t.timestamp);
+  std::unique_ptr<ClustersData> clusterData(mCdbApi.retrieveFromTFileAny<ClustersData>(mPath,
+                                                                                       mLookupMaps.size() > 1 ? mLookupMaps.at(calDetIter) : mLookupMaps.at(0),
+                                                                                       mTimestamps.size() > 0 ? mTimestamps.at(calDetIter) : t.timestamp));
 
   auto& clusters = clusterData->getClusters();
 


### PR DESCRIPTION
Special care has to be taken when handling ClustersData objects. They contain an o2::mergers::MergeInterface object, which needs to be deleted explicitly. Wrapping the ClustersData object, which is pulled from CCDB in the ClusterVisualizer, ensures the memory is appropriately freed at the end of the update method.