### PR TITLE
Fix CompletionPolicy for BookkeepingQualitySink

### DIFF
--- a/Framework/src/InfrastructureGenerator.cxx
+++ b/Framework/src/InfrastructureGenerator.cxx
@@ -810,7 +810,7 @@ void InfrastructureGenerator::generateBookkeepingQualitySink(WorkflowSpec& workf
     .algorithm = adaptFromTask<quality_control::core::BookkeepingQualitySink>(
       infrastructureSpec.common.bookkeepingUrl,
       core::toEnum(infrastructureSpec.common.activityProvenance)),
-    .labels = { { "resilient" } }
+    .labels = { { "resilient" }, BookkeepingQualitySink::getLabel() }
   };
   workflow.emplace_back(std::move(sinkDataProcessor));
 }


### PR DESCRIPTION
A label for matching the correct CompletionPolicy in BookkeepingQualitySink was missing. This was causing it to wait indefinitely for matching inputs for the same timeslice if QOs from different Data Processors were requested. The change allows BookkeepingQualitySink to consume the inputs immediatelly and pass them to any other process which may also need them.