### PR TITLE
ITS Track Check returns Null Quality by default

### DIFF
--- a/Modules/ITS/src/ITSTrackCheck.cxx
+++ b/Modules/ITS/src/ITSTrackCheck.cxx
@@ -33,7 +33,7 @@ Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
   mEtaRatio = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "EtaRatio", mEtaRatio);
   mPhiRatio = o2::quality_control_modules::common::getFromConfig<float>(mCustomParameters, "PhiRatio", mPhiRatio);
 
-  Quality result = 0;
+  Quality result;
   Int_t id = 0;
   std::map<std::string, std::shared_ptr<MonitorObject>>::iterator iter;
   for (iter = moMap->begin(); iter != moMap->end(); ++iter) {


### PR DESCRIPTION
Initializing Quality result with 0 had an effect of producing a Quality without a name and with level 0, which is treated as "not worse than Good". This does not seem like an intentional behaviour, so I am proposing to use the default Null Quality instead. Precautions will be taken in the framework, so that it cannot be done anymore.