### PR TITLE
CTP: change in RawDataReaderCheck.cxx

### DIFF
--- a/Modules/CTP/src/RawDataReaderCheck.cxx
+++ b/Modules/CTP/src/RawDataReaderCheck.cxx
@@ -92,7 +92,7 @@ Quality RawDataReaderCheck::check(std::map<std::string, std::shared_ptr<MonitorO
       if (mLHCBCs.count() == 0) {
         continue;
       }
-      float average = h->GetEntries() / mLHCBCs.count();
+      float average = h->Integral() / mLHCBCs.count();
       mThreshold = average - mNSigBC * sqrt(average);
       if (mThreshold < std::sqrt(average)) {
         mThreshold = average / 2;


### PR DESCRIPTION
Fix for the check threshold value calculation for the scaled BC histograms. 