### PR TITLE
[ITS] Anomalous clusters plots

### DIFF
--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -92,10 +92,14 @@ class ITSClusterTask : public TaskInterface
   std::shared_ptr<TH2DRatio> hAverageClusterOccupancySummaryOB[NLayer];
   std::shared_ptr<TH2DRatio> hAverageClusterSizeSummaryOB[NLayer];
 
-  // Layer synnary
+  // Layer summary
   TH1D* hClusterSizeLayerSummary[NLayer] = { nullptr };
   TH1D* hClusterTopologyLayerSummary[NLayer] = { nullptr };
   TH1D* hGroupedClusterSizeLayerSummary[NLayer] = { nullptr };
+
+  // Anomalies plots
+  TH2D* hLongClustersPerChip[3] = { nullptr };
+  TH2D* hMultPerChipWhenLongClusters[3] = { nullptr };
 
   // General
   TH2D* hClusterVsBunchCrossing = nullptr;

--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -140,13 +140,13 @@ class ITSClusterTask : public TaskInterface
   int minColSpanLongCluster = 128; // driven by o2::itsmft::ClusterPattern::MaxColSpan = 128
   int maxRowSpanLongCluster = 29;
 
-  const int mNStaves[NLayer] = { 12, 16, 20, 24, 30, 42, 48 };
-  const int mNHicPerStave[NLayer] = { 1, 1, 1, 8, 8, 14, 14 };
-  const int mNChipsPerHic[NLayer] = { 9, 9, 9, 14, 14, 14, 14 };
-  const int mNLanePerHic[NLayer] = { 3, 3, 3, 2, 2, 2, 2 };
-  const int ChipBoundary[NLayer + 1] = { 0, 108, 252, 432, 3120, 6480, 14712, 24120 };
-  const int StaveBoundary[NLayer + 1] = { 0, 12, 28, 48, 72, 102, 144, 192 };
-  const float mLength[NLayer] = { 14., 14., 14., 43., 43., 74., 74. };
+  static constexpr int mNStaves[NLayer] = { 12, 16, 20, 24, 30, 42, 48 };
+  static constexpr int mNHicPerStave[NLayer] = { 1, 1, 1, 8, 8, 14, 14 };
+  static constexpr int mNChipsPerHic[NLayer] = { 9, 9, 9, 14, 14, 14, 14 };
+  static constexpr int mNLanePerHic[NLayer] = { 3, 3, 3, 2, 2, 2, 2 };
+  static constexpr int ChipBoundary[NLayer + 1] = { 0, 108, 252, 432, 3120, 6480, 14712, 24120 };
+  static constexpr int StaveBoundary[NLayer + 1] = { 0, 12, 28, 48, 72, 102, 144, 192 };
+  static constexpr float mLength[NLayer] = { 14., 14., 14., 43., 43., 74., 74. };
   const std::string mYlabels[NLayer * 2] = { "L6B(S24#rightarrow47)", "L5B(S21#rightarrow41)", "L4B(S15#rightarrow29)", "L3B(S12#rightarrow23)", "L2B(S10#rightarrow19)", "L1B(S08#rightarrow15)", "L0B(S06#rightarrow11)", "L0T(S00#rightarrow05)", "L1T(S00#rightarrow07)", "L2T(S00#rightarrow09)", "L3T(S00#rightarrow11)", "L4T(S00#rightarrow14)", "L5T(S00#rightarrow20)", "L6T(S00#rightarrow23)" };
 
   int mEnableLayers[NLayer] = { 0 };

--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -137,6 +137,9 @@ class ITSClusterTask : public TaskInterface
   std::string mLaneStatusFlag[NFlags] = { "IB", "ML", "OL", "Total" };
   int mDoPublishDetailedSummary = 0;
 
+  int minColSpanLongCluster = 128; // driven by o2::itsmft::ClusterPattern::MaxColSpan = 128
+  int maxRowSpanLongCluster = 29;
+
   const int mNStaves[NLayer] = { 12, 16, 20, 24, 30, 42, 48 };
   const int mNHicPerStave[NLayer] = { 1, 1, 1, 8, 8, 14, 14 };
   const int mNChipsPerHic[NLayer] = { 9, 9, 9, 14, 14, 14, 14 };

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -155,8 +155,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     const auto& ROF = clusRofArr[iROF];
     const auto bcdata = ROF.getBCData();
     int nClustersForBunchCrossing = 0;
-    int nLongClusters[ChipBoundary[3]] = {};
-    int nHitsFromClusters[ChipBoundary[3]] = {}; // only IB is implemented at the moment
+    int nLongClusters[ChipBoundary[NLayerIB]] = {};
+    int nHitsFromClusters[ChipBoundary[NLayerIB]] = {}; // only IB is implemented at the moment
 
     for (int icl = ROF.getFirstEntry(); icl < ROF.getFirstEntry() + ROF.getNEntries(); icl++) {
 
@@ -181,9 +181,11 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (ClusterID != o2::itsmft::CompCluster::InvalidPatternID) { // Normal (frequent) cluster shapes
         if (!mDict->isGroup(ClusterID)) {
           npix = mDict->getNpixels(ClusterID);
+
           // TODO: is there way other than calling the pattern?
           colspan = mDict->getPattern(ClusterID).getColumnSpan();
           rowspan = mDict->getPattern(ClusterID).getRowSpan();
+
           if (mDoPublishDetailedSummary == 1) {
             locC = mDict->getClusterCoordinates(cluster);
           }
@@ -277,11 +279,9 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     for (int ichip = 0; ichip < ChipBoundary[NLayerIB]; ichip++) {
 
       int nLong = TMath::Min(nLongClusters[ichip], 21);
-
       if (nLong < 1) {
         continue;
       }
-
       int ilayer = -1;
       while (ichip >= ChipBoundary[ilayer + 1]) {
         ilayer++;

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -137,8 +137,6 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
   auto clusPatternArr = ctx.inputs().get<gsl::span<unsigned char>>("patterns");
   auto pattIt = clusPatternArr.begin();
 
-  int ChipIDprev = -1;
-
   // Reset this histo to have the latest picture
   hEmptyLaneFractionGlobal->Reset("ICES");
 
@@ -153,6 +151,9 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     const auto& ROF = clusRofArr[iROF];
     const auto bcdata = ROF.getBCData();
     int nClustersForBunchCrossing = 0;
+    int nLongClusters[ChipBoundary[NLayerIB]] = { 0 };
+    int nHitsFromClusters[ChipBoundary[NLayerIB]] = { 0 }; // only IB is implemented at the moment
+
     for (int icl = ROF.getFirstEntry(); icl < ROF.getFirstEntry() + ROF.getNEntries(); icl++) {
 
       auto& cluster = clusArr[icl];
@@ -160,13 +161,15 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       int ClusterID = cluster.getPatternID(); // used for normal (frequent) cluster shapes
       int lay, sta, ssta, mod, chip, lane;
 
-      if (ChipID != ChipIDprev) {
+      if (ChipID != -1) { // TODO: is this needed?
         mGeom->getChipId(ChipID, lay, sta, ssta, mod, chip);
         mod = mod + (ssta * (mNHicPerStave[lay] / 2));
         int chipIdLocal = (ChipID - ChipBoundary[lay]) % (14 * mNHicPerStave[lay]);
         lane = (chipIdLocal % (14 * mNHicPerStave[lay])) / (14 / 2);
       }
       int npix = -1;
+      int colspan = -1;
+      int rowspan = -1;
       int isGrouped = -1;
 
       o2::math_utils::Point3D<float> locC; // local coordinates
@@ -174,6 +177,9 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (ClusterID != o2::itsmft::CompCluster::InvalidPatternID) { // Normal (frequent) cluster shapes
         if (!mDict->isGroup(ClusterID)) {
           npix = mDict->getNpixels(ClusterID);
+          // to do: is there way other than calling the pattern?
+          colspan = mDict->getPattern(ClusterID).getColumnSpan();
+          rowspan = mDict->getPattern(ClusterID).getRowSpan();
           if (mDoPublishDetailedSummary == 1) {
             locC = mDict->getClusterCoordinates(cluster);
           }
@@ -181,6 +187,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
         } else {
           o2::itsmft::ClusterPattern patt(pattIt);
           npix = patt.getNPixels();
+          colspan = patt.getColumnSpan();
+          rowspan = patt.getRowSpan();
           if (mDoPublishDetailedSummary == 1) {
             locC = mDict->getClusterCoordinates(cluster, patt, true);
           }
@@ -190,6 +198,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       } else { // invalid pattern
         o2::itsmft::ClusterPattern patt(pattIt);
         npix = patt.getNPixels();
+        colspan = patt.getColumnSpan();
+        rowspan = patt.getRowSpan();
         isGrouped = 0;
         if (mDoPublishDetailedSummary == 1) {
           locC = mDict->getClusterCoordinates(cluster, patt, false);
@@ -198,6 +208,15 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
 
       if (npix > 2) {
         nClustersForBunchCrossing++;
+      }
+
+      if (lay < NLayerIB) {
+        nHitsFromClusters[ChipID] += npix;
+      }
+
+      if (lay < NLayerIB && colspan > 127 && rowspan < 30) {
+        // definition of long cluster. 127 is driven by o2::itsmft::ClusterPattern::MaxColSpan = 128
+        nLongClusters[ChipID]++;
       }
 
       if (lay < NLayerIB) {
@@ -249,6 +268,23 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       }
     }
     hClusterVsBunchCrossing->Fill(bcdata.bc, nClustersForBunchCrossing); // we count only the number of clusters, not their sizes
+
+    // filling these anomaly plots once per ROF, ignoring chips w/o long clusters
+    for (int ichip = 0; ichip < ChipBoundary[NLayerIB]; ichip++) {
+
+      int nLong = nLongClusters[ichip] <= 20 ? nLongClusters[ichip] : 21;
+
+      if (nLong < 1) {
+        continue;
+      }
+
+      int ilayer = -1;
+      while (ichip >= ChipBoundary[ilayer + 1]) {
+        ilayer++;
+      }
+      hLongClustersPerChip[ilayer]->Fill(ichip, nLong);
+      hMultPerChipWhenLongClusters[ilayer]->Fill(ichip, nHitsFromClusters[ichip]);
+    }
   }
 
   if ((int)clusRofArr.size() > 0) {
@@ -396,7 +432,7 @@ void ITSClusterTask::reset()
 
 void ITSClusterTask::createAllHistos()
 {
-  hClusterVsBunchCrossing = new TH2D("BunchCrossingIDvsClusters", "BunchCrossingIDvsClusters", nBCbins, 0, 4095, 100, 0, 1000);
+  hClusterVsBunchCrossing = new TH2D("BunchCrossingIDvsClusters", "BunchCrossingIDvsClusters", nBCbins, 0, 4095, 100, 0, 2000);
   hClusterVsBunchCrossing->SetTitle("#clusters vs BC id for clusters with npix > 2");
   addObject(hClusterVsBunchCrossing);
   formatAxes(hClusterVsBunchCrossing, "Bunch Crossing ID", "Number of clusters with npix > 2 in ROF", 1, 1.10);
@@ -418,6 +454,17 @@ void ITSClusterTask::createAllHistos()
   for (int iLayer = 0; iLayer < NLayer; iLayer++) {
     if (!mEnableLayers[iLayer])
       continue;
+
+    if (iLayer < NLayerIB) {
+      hLongClustersPerChip[iLayer] = new TH2D(Form("Anomalies/Layer%d/LongClusters", iLayer), Form("Layer%d/LongClusters", iLayer), ChipBoundary[iLayer + 1] - ChipBoundary[iLayer], ChipBoundary[iLayer], ChipBoundary[iLayer + 1], 21, 0, 21);
+      hMultPerChipWhenLongClusters[iLayer] = new TH2D(Form("Anomalies/Layer%d/HitsWhenLongClusters", iLayer), Form("Layer%d/HitsWhenLongClusters", iLayer), ChipBoundary[iLayer + 1] - ChipBoundary[iLayer], ChipBoundary[iLayer], ChipBoundary[iLayer + 1], 150, 0, 15000);
+      addObject(hLongClustersPerChip[iLayer]);
+      formatAxes(hLongClustersPerChip[iLayer], "Chip ID", "events with long clusters", 1, 1.10);
+      hLongClustersPerChip[iLayer]->SetStats(0);
+      addObject(hMultPerChipWhenLongClusters[iLayer]);
+      formatAxes(hMultPerChipWhenLongClusters[iLayer], "Chip ID", "Sum of clusters size (events w/ long clus)", 1, 1.10);
+      hMultPerChipWhenLongClusters[iLayer]->SetStats(0);
+    }
 
     hClusterSizeLayerSummary[iLayer] = new TH1D(Form("Layer%d/AverageClusterSizeSummary", iLayer), Form("Layer%dAverageClusterSizeSummary", iLayer), 100, 0, 100);
     hClusterSizeLayerSummary[iLayer]->SetTitle(Form("Cluster size summary for Layer %d", iLayer));

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -465,7 +465,7 @@ void ITSClusterTask::createAllHistos()
       hLongClustersPerChip[iLayer] = new TH2D(Form("Anomalies/Layer%d/LongClusters", iLayer), Form("Layer%d/LongClusters", iLayer), ChipBoundary[iLayer + 1] - ChipBoundary[iLayer], ChipBoundary[iLayer], ChipBoundary[iLayer + 1], 21, 0, 21);
       hMultPerChipWhenLongClusters[iLayer] = new TH2D(Form("Anomalies/Layer%d/HitsWhenLongClusters", iLayer), Form("Layer%d/HitsWhenLongClusters", iLayer), ChipBoundary[iLayer + 1] - ChipBoundary[iLayer], ChipBoundary[iLayer], ChipBoundary[iLayer + 1], 150, 0, 15000);
       addObject(hLongClustersPerChip[iLayer]);
-      formatAxes(hLongClustersPerChip[iLayer], "Chip ID", "events with long clusters", 1, 1.10);
+      formatAxes(hLongClustersPerChip[iLayer], "Chip ID", "number of long clusters", 1, 1.10);
       hLongClustersPerChip[iLayer]->SetStats(0);
       addObject(hMultPerChipWhenLongClusters[iLayer]);
       formatAxes(hMultPerChipWhenLongClusters[iLayer], "Chip ID", "Sum of clusters size (events w/ long clus)", 1, 1.10);

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -47,6 +47,10 @@ ITSClusterTask::~ITSClusterTask()
     if (!mEnableLayers[iLayer])
       continue;
 
+    if (iLayer < NLayerIB) {
+      delete hLongClustersPerChip[iLayer];
+      delete hMultPerChipWhenLongClusters[iLayer];
+    }
     delete hClusterSizeLayerSummary[iLayer];
     delete hClusterTopologyLayerSummary[iLayer];
     delete hGroupedClusterSizeLayerSummary[iLayer];
@@ -400,6 +404,8 @@ void ITSClusterTask::reset()
     hClusterTopologyLayerSummary[iLayer]->Reset();
 
     if (iLayer < NLayerIB) {
+      hLongClustersPerChip[iLayer]->Reset();
+      hMultPerChipWhenLongClusters[iLayer]->Reset();
       hAverageClusterOccupancySummaryIB[iLayer]->Reset();
       hAverageClusterSizeSummaryIB[iLayer]->Reset();
       if (mDoPublish1DSummary == 1) {

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -155,8 +155,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     const auto& ROF = clusRofArr[iROF];
     const auto bcdata = ROF.getBCData();
     int nClustersForBunchCrossing = 0;
-    int nLongClusters[ChipBoundary[NLayerIB]] = { 0 };
-    int nHitsFromClusters[ChipBoundary[NLayerIB]] = { 0 }; // only IB is implemented at the moment
+    int nLongClusters[ChipBoundary[3]] = {};
+    int nHitsFromClusters[ChipBoundary[3]] = {}; // only IB is implemented at the moment
 
     for (int icl = ROF.getFirstEntry(); icl < ROF.getFirstEntry() + ROF.getNEntries(); icl++) {
 
@@ -165,12 +165,12 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       int ClusterID = cluster.getPatternID(); // used for normal (frequent) cluster shapes
       int lay, sta, ssta, mod, chip, lane;
 
-      if (ChipID != -1) { // TODO: is this needed?
-        mGeom->getChipId(ChipID, lay, sta, ssta, mod, chip);
-        mod = mod + (ssta * (mNHicPerStave[lay] / 2));
-        int chipIdLocal = (ChipID - ChipBoundary[lay]) % (14 * mNHicPerStave[lay]);
-        lane = (chipIdLocal % (14 * mNHicPerStave[lay])) / (14 / 2);
-      }
+      // TODO: avoid call Geom if ChipID is the same as previous cluster
+      mGeom->getChipId(ChipID, lay, sta, ssta, mod, chip);
+      mod = mod + (ssta * (mNHicPerStave[lay] / 2));
+      int chipIdLocal = (ChipID - ChipBoundary[lay]) % (14 * mNHicPerStave[lay]);
+      lane = (chipIdLocal % (14 * mNHicPerStave[lay])) / (14 / 2);
+
       int npix = -1;
       int colspan = -1;
       int rowspan = -1;
@@ -181,7 +181,7 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (ClusterID != o2::itsmft::CompCluster::InvalidPatternID) { // Normal (frequent) cluster shapes
         if (!mDict->isGroup(ClusterID)) {
           npix = mDict->getNpixels(ClusterID);
-          // to do: is there way other than calling the pattern?
+          // TODO: is there way other than calling the pattern?
           colspan = mDict->getPattern(ClusterID).getColumnSpan();
           rowspan = mDict->getPattern(ClusterID).getRowSpan();
           if (mDoPublishDetailedSummary == 1) {

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -218,8 +218,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
         nHitsFromClusters[ChipID] += npix;
       }
 
-      if (lay < NLayerIB && colspan > 127 && rowspan < 30) {
-        // definition of long cluster. 127 is driven by o2::itsmft::ClusterPattern::MaxColSpan = 128
+      if (lay < NLayerIB && colspan >= minColSpanLongCluster && rowspan <= maxRowSpanLongCluster) {
+        // definition of long cluster
         nLongClusters[ChipID]++;
       }
 
@@ -276,7 +276,7 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     // filling these anomaly plots once per ROF, ignoring chips w/o long clusters
     for (int ichip = 0; ichip < ChipBoundary[NLayerIB]; ichip++) {
 
-      int nLong = nLongClusters[ichip] <= 20 ? nLongClusters[ichip] : 21;
+      int nLong = TMath::Min(nLongClusters[ichip], 21);
 
       if (nLong < 1) {
         continue;
@@ -463,7 +463,7 @@ void ITSClusterTask::createAllHistos()
 
     if (iLayer < NLayerIB) {
       hLongClustersPerChip[iLayer] = new TH2D(Form("Anomalies/Layer%d/LongClusters", iLayer), Form("Layer%d/LongClusters", iLayer), ChipBoundary[iLayer + 1] - ChipBoundary[iLayer], ChipBoundary[iLayer], ChipBoundary[iLayer + 1], 21, 0, 21);
-      hMultPerChipWhenLongClusters[iLayer] = new TH2D(Form("Anomalies/Layer%d/HitsWhenLongClusters", iLayer), Form("Layer%d/HitsWhenLongClusters", iLayer), ChipBoundary[iLayer + 1] - ChipBoundary[iLayer], ChipBoundary[iLayer], ChipBoundary[iLayer + 1], 150, 0, 15000);
+      hMultPerChipWhenLongClusters[iLayer] = new TH2D(Form("Anomalies/Layer%d/HitsWhenLongClusters", iLayer), Form("Layer%d/HitsWhenLongClusters", iLayer), ChipBoundary[iLayer + 1] - ChipBoundary[iLayer], ChipBoundary[iLayer], ChipBoundary[iLayer + 1], 200, 0, 20000);
       addObject(hLongClustersPerChip[iLayer]);
       formatAxes(hLongClustersPerChip[iLayer], "Chip ID", "number of long clusters", 1, 1.10);
       hLongClustersPerChip[iLayer]->SetStats(0);


### PR DESCRIPTION
This PR adds two sets of 2D plots published by the cluster task:

- Number of long clusters vs chip ID (3 plots, for the IB layers)
- Number of hits as sum of the clusters size for those events with at least one long cluster, vs chip ID (3 plots, for the IB layers)

Tested locally