### PR TITLE
MCH: removed custom code for reference plots

### DIFF
--- a/Modules/MUON/MCH/include/MCH/ClusterChargePlotter.h
+++ b/Modules/MUON/MCH/include/MCH/ClusterChargePlotter.h
@@ -36,7 +36,7 @@ namespace muonchambers
 class ClusterChargePlotter : public HistPlotter
 {
  public:
-  ClusterChargePlotter(std::string path, TH2F* hRef, bool fullPlots = false);
+  ClusterChargePlotter(std::string path, bool fullPlots = false);
 
   void update(TH2F* hCharge);
 
@@ -62,9 +62,6 @@ class ClusterChargePlotter : public HistPlotter
   std::unique_ptr<ClusterChargeReductor> mChargeReductor;
 
   std::unique_ptr<TH1F> mHistogramChargePerDE;
-  std::unique_ptr<TH1F> mHistogramChargePerDERef;
-  std::unique_ptr<TH1F> mHistogramChargeRefRatio;
-  std::unique_ptr<TCanvas> mCanvasChargePerDE;
   std::array<std::unique_ptr<TH1F>, getNumDE()> mHistogramCharge;
 };
 

--- a/Modules/MUON/MCH/include/MCH/ClusterChargeTrendsPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/ClusterChargeTrendsPlotter.h
@@ -35,7 +35,7 @@ namespace muonchambers
 class ClusterChargeTrendsPlotter : public HistPlotter
 {
  public:
-  ClusterChargeTrendsPlotter(std::string path, TH2F* hRef, bool fullPlots = false);
+  ClusterChargeTrendsPlotter(std::string path, bool fullPlots = false);
 
   void update(long time, TH2F* hEfficiency);
 

--- a/Modules/MUON/MCH/include/MCH/ClusterSizePlotter.h
+++ b/Modules/MUON/MCH/include/MCH/ClusterSizePlotter.h
@@ -37,7 +37,7 @@ namespace muonchambers
 class ClusterSizePlotter : public HistPlotter
 {
  public:
-  ClusterSizePlotter(std::string path, TH2F* hRef, bool fullPlots = false);
+  ClusterSizePlotter(std::string path, bool fullPlots = false);
 
   void update(TH2F* hCharge);
 
@@ -52,9 +52,6 @@ class ClusterSizePlotter : public HistPlotter
   std::unique_ptr<ClusterSizeReductor> mClusterSizeReductor;
 
   std::array<std::unique_ptr<TH1F>, 3> mHistogramClusterSizePerDE;
-  std::array<std::unique_ptr<TH1F>, 3> mHistogramClusterSizePerDERef;
-  std::array<std::unique_ptr<TH1F>, 3> mHistogramClusterSizePerDERefRatio;
-  std::array<std::unique_ptr<TCanvas>, 3> mCanvasClusterSizePerDE;
   std::array<std::unique_ptr<TH1F>, getNumDE() * 3> mHistogramClusterSize;
   std::array<std::unique_ptr<TLegend>, getNumDE()> mLegendClusterSize;
   std::array<std::unique_ptr<TCanvas>, getNumDE()> mCanvasClusterSize;

--- a/Modules/MUON/MCH/include/MCH/ClusterSizeTrendsPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/ClusterSizeTrendsPlotter.h
@@ -36,7 +36,7 @@ namespace muonchambers
 class ClusterSizeTrendsPlotter : public HistPlotter
 {
  public:
-  ClusterSizeTrendsPlotter(std::string path, TH2F* hRef, bool fullPlots = false);
+  ClusterSizeTrendsPlotter(std::string path, bool fullPlots = false);
 
   void update(long time, TH2F* hEfficiency);
 

--- a/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
@@ -71,7 +71,6 @@ class DigitsPostProcessing : public PostProcessingInterface
 
   // CCDB object accessors
   std::map<std::string, CcdbObjectHelper> mCcdbObjects;
-  std::map<std::string, CcdbObjectHelper> mCcdbObjectsRef;
 
   // Hit rate histograms ===============================================
 

--- a/Modules/MUON/MCH/include/MCH/EfficiencyPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/EfficiencyPlotter.h
@@ -35,7 +35,7 @@ namespace muonchambers
 class EfficiencyPlotter : public HistPlotter
 {
  public:
-  EfficiencyPlotter(std::string path, TH2F* hRef, bool fullPlots = false);
+  EfficiencyPlotter(std::string path, bool fullPlots = false);
 
   void update(TH2F* hEfficiency);
 
@@ -69,9 +69,6 @@ class EfficiencyPlotter : public HistPlotter
   std::unique_ptr<TH2ElecMapReductor> mElecMapReductor;
 
   std::array<std::unique_ptr<TH1F>, 2> mHistogramMeanEfficiencyPerDE;
-  std::array<std::unique_ptr<TH1F>, 2> mHistogramMeanEfficiencyPerDERef;
-  std::array<std::unique_ptr<TH1F>, 2> mHistogramMeanEfficiencyRefRatio;
-  std::array<std::unique_ptr<TCanvas>, 2> mCanvasMeanEfficiencyPerDE;
 
   std::array<std::map<int, std::shared_ptr<DetectorHistogram>>, 2> mHistogramEfficiencyDE; // 2D hit rate map for each DE
   std::array<std::unique_ptr<GlobalHistogram>, 2> mHistogramEfficiencyGlobal;              // Efficiency histogram (global XY view)

--- a/Modules/MUON/MCH/include/MCH/EfficiencyTrendsPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/EfficiencyTrendsPlotter.h
@@ -35,7 +35,7 @@ namespace muonchambers
 class EfficiencyTrendsPlotter : public HistPlotter
 {
  public:
-  EfficiencyTrendsPlotter(std::string path, TH2F* hRef, bool fullPlots = false);
+  EfficiencyTrendsPlotter(std::string path, bool fullPlots = false);
 
   void update(long time, TH2F* hEfficiency);
 

--- a/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
@@ -73,15 +73,12 @@ class PreclustersPostProcessing : public PostProcessingInterface
   static std::string clusterChargeSourceName() { return "clcharge"; }
   static std::string clusterSizeSourceName() { return "clsize"; }
 
-  // PreclustersConfig mConfig;
-  int64_t mRefTimeStamp{ 0 };
   bool mFullHistos{ false };
 
   PostProcessingConfigMCH mConfig;
 
   // CCDB object accessors
   std::map<std::string, CcdbObjectHelper> mCcdbObjects;
-  std::map<std::string, CcdbObjectHelper> mCcdbObjectsRef;
 
   // Hit rate histograms ===============================================
 

--- a/Modules/MUON/MCH/include/MCH/RatesPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/RatesPlotter.h
@@ -35,7 +35,7 @@ namespace muonchambers
 class RatesPlotter : public HistPlotter
 {
  public:
-  RatesPlotter(std::string path, TH2F* hRef, float rateMin, float rateMax, bool perStationPlots = false, bool fullPlots = false);
+  RatesPlotter(std::string path, float rateMin, float rateMax, bool perStationPlots = false, bool fullPlots = false);
 
   void update(TH2F* hRates);
 
@@ -69,14 +69,8 @@ class RatesPlotter : public HistPlotter
   std::unique_ptr<TH2F> mHistogramRatePerStation;
 
   std::unique_ptr<TH1F> mHistogramMeanRatePerDE;
-  std::unique_ptr<TH1F> mHistogramMeanRatePerDERef;
-  std::unique_ptr<TH1F> mHistogramMeanRateRefRatio;
-  std::unique_ptr<TCanvas> mCanvasMeanRatePerDE;
 
   std::unique_ptr<TH1F> mHistogramGoodChannelsFractionPerDE;
-  std::unique_ptr<TH1F> mHistogramGoodChannelsFractionPerDERef;
-  std::unique_ptr<TH1F> mHistogramGoodChannelsFractionRefRatio;
-  std::unique_ptr<TCanvas> mCanvasGoodChannelsFractionPerDE;
 
   std::map<int, std::shared_ptr<DetectorHistogram>> mHistogramRateDE[2]; // 2D hit rate map for each DE
   std::shared_ptr<GlobalHistogram> mHistogramRateGlobal[2];              // Rate histogram (global XY view)

--- a/Modules/MUON/MCH/include/MCH/RatesTrendsPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/RatesTrendsPlotter.h
@@ -36,7 +36,7 @@ namespace muonchambers
 class RatesTrendsPlotter : public HistPlotter
 {
  public:
-  RatesTrendsPlotter(std::string path, TH2F* hRef, bool fullPlots = false);
+  RatesTrendsPlotter(std::string path, bool fullPlots = false);
 
   void update(long time, TH2F* hEfficiency);
 
@@ -51,11 +51,9 @@ class RatesTrendsPlotter : public HistPlotter
 
   // Data reductor
   std::unique_ptr<TH2ElecMapReductor> mReductor;
-  std::array<std::optional<float>, getNumDE()> mRefValues;
   // Trend plots
   std::unique_ptr<TrendGraph> mOrbits;
   std::array<std::unique_ptr<TrendGraph>, getNumDE()> mTrendsDE;
-  std::array<std::unique_ptr<TrendGraph>, getNumDE()> mTrendsRefRatioDE;
   std::array<std::unique_ptr<TrendGraph>, 10> mTrendsChamber;
   std::unique_ptr<TrendMultiGraph> mTrends;
 };

--- a/Modules/MUON/MCH/src/ClusterChargePlotter.cxx
+++ b/Modules/MUON/MCH/src/ClusterChargePlotter.cxx
@@ -23,29 +23,9 @@ namespace quality_control_modules
 namespace muonchambers
 {
 
-ClusterChargePlotter::ClusterChargePlotter(std::string path, TH2F* hRef, bool fullPlots)
+ClusterChargePlotter::ClusterChargePlotter(std::string path, bool fullPlots)
 {
   mChargeReductor = std::make_unique<ClusterChargeReductor>();
-
-  //----------------------------------
-  // Reference charge MPV histogram
-  //----------------------------------
-  mHistogramChargePerDERef =
-    std::make_unique<TH1F>(TString::Format("%sChargeRef", path.c_str()),
-                           TString::Format("Charge vs DE, reference"), getNumDE(), 0, getNumDE());
-  mHistogramChargePerDERef->SetLineColor(kRed);
-  mHistogramChargePerDERef->SetLineStyle(kDashed);
-  mHistogramChargePerDERef->SetLineWidth(2);
-
-  if (hRef) {
-    ClusterChargeReductor reductorRef;
-    reductorRef.update(hRef);
-
-    for (size_t de = 0; de < mHistogramChargePerDERef->GetXaxis()->GetNbins(); de++) {
-      mHistogramChargePerDERef->SetBinContent(de + 1, reductorRef.getDeValue(de));
-      mHistogramChargePerDERef->SetBinError(de + 1, 0);
-    }
-  }
 
   //----------------------------------
   // Charge MPV histograms
@@ -53,15 +33,7 @@ ClusterChargePlotter::ClusterChargePlotter(std::string path, TH2F* hRef, bool fu
 
   mHistogramChargePerDE = std::make_unique<TH1F>(TString::Format("%sClusterChargeMPVHist", path.c_str()),
                                                  TString::Format("Charge vs DE"), getNumDE(), 0, getNumDE());
-
-  mHistogramChargeRefRatio = std::make_unique<TH1F>(TString::Format("%sClusterChargeMPVRefRatio", path.c_str()),
-                                                    TString::Format("Charge vs DE, ratio wrt reference"), getNumDE(), 0, getNumDE());
-  addHisto(mHistogramChargeRefRatio.get(), false, "histo", "");
-
-  mCanvasChargePerDE = std::make_unique<TCanvas>(TString::Format("%sClusterChargeMPV", path.c_str()),
-                                                 TString::Format("Charge MPV vs DE"), 800, 600);
-  // mCanvasChargePerDE->SetLogy(kTRUE);
-  addCanvas(mCanvasChargePerDE.get(), mHistogramChargePerDE.get(), false, "", "");
+  addHisto(mHistogramChargePerDE.get(), false, "histo", "");
 
   for (auto de : o2::mch::constants::deIdsForAllMCH) {
     int deID = getDEindex(de);
@@ -86,27 +58,6 @@ void ClusterChargePlotter::update(TH2F* hCharge)
   for (size_t de = 0; de < mHistogramChargePerDE->GetXaxis()->GetNbins(); de++) {
     mHistogramChargePerDE->SetBinContent(de + 1, mChargeReductor->getDeValue(de));
     mHistogramChargePerDE->SetBinError(de + 1, 0.1);
-  }
-
-  mCanvasChargePerDE->Clear();
-  mCanvasChargePerDE->cd();
-  mHistogramChargePerDE->Draw();
-
-  if (mHistogramChargePerDERef) {
-    mHistogramChargePerDERef->Draw("histsame");
-
-    mHistogramChargeRefRatio->Reset();
-    mHistogramChargeRefRatio->Add(mHistogramChargePerDE.get());
-    mHistogramChargeRefRatio->Divide(mHistogramChargePerDERef.get());
-
-    // special handling of bins with zero rate in reference
-    int nbinsx = mHistogramChargePerDERef->GetXaxis()->GetNbins();
-    for (int b = 1; b <= nbinsx; b++) {
-      if (mHistogramChargePerDERef->GetBinContent(b) == 0) {
-        mHistogramChargeRefRatio->SetBinContent(b, 1);
-        mHistogramChargeRefRatio->SetBinError(b, 0);
-      }
-    }
   }
 
   for (int xbin = 1; xbin <= hCharge->GetXaxis()->GetNbins(); xbin++) {

--- a/Modules/MUON/MCH/src/ClusterChargeTrendsPlotter.cxx
+++ b/Modules/MUON/MCH/src/ClusterChargeTrendsPlotter.cxx
@@ -25,19 +25,9 @@ namespace quality_control_modules
 namespace muonchambers
 {
 
-ClusterChargeTrendsPlotter::ClusterChargeTrendsPlotter(std::string path, TH2F* hRef, bool fullPlots)
+ClusterChargeTrendsPlotter::ClusterChargeTrendsPlotter(std::string path, bool fullPlots)
 {
   mReductor = std::make_unique<ClusterChargeReductor>();
-
-  //--------------------------------------------------
-  // Cluster charge reference values
-  //--------------------------------------------------
-
-  std::unique_ptr<ClusterChargeReductor> reductorRef;
-  if (hRef) {
-    reductorRef = std::make_unique<ClusterChargeReductor>();
-    reductorRef->update(hRef);
-  }
 
   //--------------------------------------------------
   // Cluster charge trends
@@ -49,13 +39,8 @@ ClusterChargeTrendsPlotter::ClusterChargeTrendsPlotter(std::string path, TH2F* h
       continue;
     }
 
-    std::optional<float> refVal;
-    if (reductorRef) {
-      refVal = reductorRef->getDeValue(deID);
-    }
-
     mTrends[deID] = std::make_unique<TrendGraph>(fmt::format("{}{}/ClusterCharge_DE{}", path, getHistoPath(de), de),
-                                                 fmt::format("DE{} Cluster Charge MPV", de), "charge (ADC)", refVal);
+                                                 fmt::format("DE{} Cluster Charge MPV", de), "charge (ADC)");
     // mTrends[deID]->setRange(0, 1.2);
     if (fullPlots) {
       addCanvas(mTrends[deID].get(), "");

--- a/Modules/MUON/MCH/src/ClusterSizeTrendsPlotter.cxx
+++ b/Modules/MUON/MCH/src/ClusterSizeTrendsPlotter.cxx
@@ -27,15 +27,9 @@ namespace quality_control_modules
 namespace muonchambers
 {
 
-ClusterSizeTrendsPlotter::ClusterSizeTrendsPlotter(std::string path, TH2F* hRef, bool fullPlots)
+ClusterSizeTrendsPlotter::ClusterSizeTrendsPlotter(std::string path, bool fullPlots)
 {
   mReductor = std::make_unique<ClusterSizeReductor>();
-
-  std::unique_ptr<ClusterSizeReductor> reductorRef;
-  if (hRef) {
-    reductorRef = std::make_unique<ClusterSizeReductor>();
-    reductorRef->update(hRef);
-  }
 
   //--------------------------------------------------
   // Efficiency trends
@@ -47,18 +41,11 @@ ClusterSizeTrendsPlotter::ClusterSizeTrendsPlotter(std::string path, TH2F* hRef,
       continue;
     }
 
-    std::optional<float> refB, refNB, refBNB;
-    if (reductorRef) {
-      refB = reductorRef->getDeValue(deID, 0);
-      refNB = reductorRef->getDeValue(deID, 1);
-      refBNB = reductorRef->getDeValue(deID, 2);
-    }
-
     mTrends[deID] = std::make_unique<TrendMultiGraph>(fmt::format("{}{}/ClusterSize_DE{}", path, getHistoPath(de), de),
                                                       fmt::format("DE{} Cluster Size", de), "cluster size");
-    mTrends[deID]->addGraph("B", "bending    ", refB);
-    mTrends[deID]->addGraph("NB", "non-bending", refNB);
-    mTrends[deID]->addGraph("BNB", "full       ", refBNB);
+    mTrends[deID]->addGraph("B", "bending    ");
+    mTrends[deID]->addGraph("NB", "non-bending");
+    mTrends[deID]->addGraph("BNB", "full       ");
     mTrends[deID]->addLegends();
 
     if (fullPlots) {

--- a/Modules/MUON/MCH/src/EfficiencyTrendsPlotter.cxx
+++ b/Modules/MUON/MCH/src/EfficiencyTrendsPlotter.cxx
@@ -29,15 +29,9 @@ namespace quality_control_modules
 namespace muonchambers
 {
 
-EfficiencyTrendsPlotter::EfficiencyTrendsPlotter(std::string path, TH2F* hRef, bool fullPlots)
+EfficiencyTrendsPlotter::EfficiencyTrendsPlotter(std::string path, bool fullPlots)
 {
   mElecMapReductor = std::make_unique<TH2ElecMapReductor>();
-
-  std::unique_ptr<TH2ElecMapReductor> reductorRef;
-  if (hRef) {
-    reductorRef = std::make_unique<TH2ElecMapReductor>();
-    reductorRef->update(hRef);
-  }
 
   //--------------------------------------------------
   // Efficiency trends
@@ -49,16 +43,10 @@ EfficiencyTrendsPlotter::EfficiencyTrendsPlotter(std::string path, TH2F* hRef, b
       continue;
     }
 
-    std::optional<float> refB, refNB;
-    if (reductorRef) {
-      refB = reductorRef->getDeValue(deID, 0);
-      refNB = reductorRef->getDeValue(deID, 1);
-    }
-
     mTrendsEfficiency[deID] = std::make_unique<TrendMultiGraph>(fmt::format("{}{}/Efficiency_DE{}", path, getHistoPath(de), de),
                                                                 fmt::format("DE{} Efficiency", de), "efficiency");
-    mTrendsEfficiency[deID]->addGraph("B", "bending    ", refB);
-    mTrendsEfficiency[deID]->addGraph("NB", "non-bending", refNB);
+    mTrendsEfficiency[deID]->addGraph("B", "bending    ");
+    mTrendsEfficiency[deID]->addGraph("NB", "non-bending");
     mTrendsEfficiency[deID]->addLegends();
     // mTrendsEfficiency[deID]->setRange(0, 1.2);
 

--- a/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
@@ -42,27 +42,15 @@ void PreclustersPostProcessing::createEfficiencyHistos(Trigger t, repository::Da
   }
 
   //----------------------------------
-  // Reference mean efficiency histogram
-  //----------------------------------
-
-  TH2F* hElecHistoRef{ nullptr };
-  obj = mCcdbObjectsRef.find(effSourceName());
-  if (obj != mCcdbObjectsRef.end() && obj->second.update(qcdb, mRefTimeStamp)) {
-    ILOG(Info, Devel) << "Loaded reference plot \"" << obj->second.mObject->getName()
-                      << "\", time stamp " << mRefTimeStamp << ENDM;
-    hElecHistoRef = obj->second.get<TH2F>();
-  }
-
-  //----------------------------------
   // Efficiency plotters
   //----------------------------------
 
   mEfficiencyPlotter.reset();
-  mEfficiencyPlotter = std::make_unique<EfficiencyPlotter>("Efficiency/", hElecHistoRef, mFullHistos);
+  mEfficiencyPlotter = std::make_unique<EfficiencyPlotter>("Efficiency/", mFullHistos);
   mEfficiencyPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
   mEfficiencyPlotterOnCycle.reset();
-  mEfficiencyPlotterOnCycle = std::make_unique<EfficiencyPlotter>("Efficiency/LastCycle/", hElecHistoRef, mFullHistos);
+  mEfficiencyPlotterOnCycle = std::make_unique<EfficiencyPlotter>("Efficiency/LastCycle/", mFullHistos);
   mEfficiencyPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
   //----------------------------------
@@ -70,7 +58,7 @@ void PreclustersPostProcessing::createEfficiencyHistos(Trigger t, repository::Da
   //----------------------------------
 
   mEfficiencyTrendsPlotter.reset();
-  mEfficiencyTrendsPlotter = std::make_unique<EfficiencyTrendsPlotter>("Trends/", hElecHistoRef, mFullHistos);
+  mEfficiencyTrendsPlotter = std::make_unique<EfficiencyTrendsPlotter>("Trends/", mFullHistos);
   mEfficiencyTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 }
 
@@ -89,25 +77,15 @@ void PreclustersPostProcessing::createClusterChargeHistos(Trigger t, repository:
   }
 
   //----------------------------------
-  // Reference mean cluster charge histogram
-  //----------------------------------
-
-  TH2F* histoRef{ nullptr };
-  obj = mCcdbObjectsRef.find(clusterChargeSourceName());
-  if (obj != mCcdbObjectsRef.end() && obj->second.update(qcdb, mRefTimeStamp)) {
-    histoRef = obj->second.get<TH2F>();
-  }
-
-  //----------------------------------
   // Cluster charge plotters
   //----------------------------------
 
   mClusterChargePlotter.reset();
-  mClusterChargePlotter = std::make_unique<ClusterChargePlotter>("ClusterCharge/", histoRef, mFullHistos);
+  mClusterChargePlotter = std::make_unique<ClusterChargePlotter>("ClusterCharge/", mFullHistos);
   mClusterChargePlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
   mClusterChargePlotterOnCycle.reset();
-  mClusterChargePlotterOnCycle = std::make_unique<ClusterChargePlotter>("ClusterCharge/LastCycle/", histoRef, mFullHistos);
+  mClusterChargePlotterOnCycle = std::make_unique<ClusterChargePlotter>("ClusterCharge/LastCycle/", mFullHistos);
   mClusterChargePlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
   //----------------------------------
@@ -115,7 +93,7 @@ void PreclustersPostProcessing::createClusterChargeHistos(Trigger t, repository:
   //----------------------------------
 
   mClusterChargeTrendsPlotter.reset();
-  mClusterChargeTrendsPlotter = std::make_unique<ClusterChargeTrendsPlotter>("Trends/", histoRef, mFullHistos);
+  mClusterChargeTrendsPlotter = std::make_unique<ClusterChargeTrendsPlotter>("Trends/", mFullHistos);
   mClusterChargeTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 }
 
@@ -134,25 +112,15 @@ void PreclustersPostProcessing::createClusterSizeHistos(Trigger t, repository::D
   }
 
   //----------------------------------
-  // Reference mean cluster size histogram
-  //----------------------------------
-
-  TH2F* histoRef{ nullptr };
-  obj = mCcdbObjectsRef.find(clusterSizeSourceName());
-  if (obj != mCcdbObjectsRef.end() && obj->second.update(qcdb, mRefTimeStamp)) {
-    histoRef = obj->second.get<TH2F>();
-  }
-
-  //----------------------------------
   // Cluster size plotters
   //----------------------------------
 
   mClusterSizePlotter.reset();
-  mClusterSizePlotter = std::make_unique<ClusterSizePlotter>("ClusterSize/", histoRef, mFullHistos);
+  mClusterSizePlotter = std::make_unique<ClusterSizePlotter>("ClusterSize/", mFullHistos);
   mClusterSizePlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
   mClusterSizePlotterOnCycle.reset();
-  mClusterSizePlotterOnCycle = std::make_unique<ClusterSizePlotter>("ClusterSize/LastCycle/", histoRef, mFullHistos);
+  mClusterSizePlotterOnCycle = std::make_unique<ClusterSizePlotter>("ClusterSize/LastCycle/", mFullHistos);
   mClusterSizePlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
   //----------------------------------
@@ -160,7 +128,7 @@ void PreclustersPostProcessing::createClusterSizeHistos(Trigger t, repository::D
   //----------------------------------
 
   mClusterSizeTrendsPlotter.reset();
-  mClusterSizeTrendsPlotter = std::make_unique<ClusterSizeTrendsPlotter>("Trends/", histoRef, mFullHistos);
+  mClusterSizeTrendsPlotter = std::make_unique<ClusterSizeTrendsPlotter>("Trends/", mFullHistos);
   mClusterSizeTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 }
 
@@ -173,20 +141,10 @@ void PreclustersPostProcessing::initialize(Trigger t, framework::ServiceRegistry
 
   mFullHistos = getConfigurationParameter<bool>(mCustomParameters, "FullHistos", mFullHistos, activity);
 
-  mRefTimeStamp = getConfigurationParameter<int64_t>(mCustomParameters, "ReferenceTimeStamp", mRefTimeStamp, activity);
-  ILOG(Info, Devel) << "Reference time stamp: " << mRefTimeStamp << ENDM;
-
   mCcdbObjects.clear();
   mCcdbObjects.emplace(effSourceName(), CcdbObjectHelper());
   mCcdbObjects.emplace(clusterChargeSourceName(), CcdbObjectHelper());
   mCcdbObjects.emplace(clusterSizeSourceName(), CcdbObjectHelper());
-
-  mCcdbObjectsRef.clear();
-  if (mRefTimeStamp > 0) {
-    mCcdbObjectsRef.emplace(effSourceName(), CcdbObjectHelper());
-    mCcdbObjectsRef.emplace(clusterChargeSourceName(), CcdbObjectHelper());
-    mCcdbObjectsRef.emplace(clusterSizeSourceName(), CcdbObjectHelper());
-  }
 
   // set objects path from configuration
   for (const auto& source : mConfig.dataSources) {
@@ -200,12 +158,6 @@ void PreclustersPostProcessing::initialize(Trigger t, framework::ServiceRegistry
     if (obj != mCcdbObjects.end()) {
       obj->second.mPath = source.path;
       obj->second.mName = sourceName;
-    }
-
-    auto objRef = mCcdbObjectsRef.find(sourceType);
-    if (objRef != mCcdbObjectsRef.end()) {
-      objRef->second.mPath = source.path;
-      objRef->second.mName = sourceName;
     }
   }
 


### PR DESCRIPTION
* remove the custom MCH code for loading reference plots and comparing with actual data

* store directly histograms instead of TCanvas objects for several plots