### PR TITLE
 ITS/ChipStatus: fix in error message text

### DIFF
--- a/Modules/ITS/src/ITSChipStatusCheck.cxx
+++ b/Modules/ITS/src/ITSChipStatusCheck.cxx
@@ -67,7 +67,7 @@ Quality ITSChipStatusCheck::check(std::map<std::string, std::shared_ptr<MonitorO
           if (abs(h->GetBinContent(ibin) - 1) < 0.01) {
             result = Quality::Bad;
             TString text = Form("BAD: At least one stave is without data");
-            vBadStaves.push_back(Form("L%d_%d", ilayer, ibin - StaveBoundary[ilayer]));
+            vBadStaves.push_back(Form("L%d_%d", ilayer, ibin - StaveBoundary[ilayer] - 1));
             result.addFlag(o2::quality_control::FlagTypeFactory::Unknown(), text.Data());
           }
         }


### PR DESCRIPTION
Added shift in the error message about missing stave