### PR TITLE
 ITS/general: added extendedTaskParameters for ITS

### DIFF
--- a/Modules/ITS/itsCluster.json
+++ b/Modules/ITS/itsCluster.json
@@ -10,7 +10,8 @@
       },
       "Activity": {
         "number": "42",
-        "type": "NONE"
+        "type": "PHYSICS",
+        "beamType" : "PbPb",     "": "Beam type: `PROTON-PROTON`, `Pb-Pb`, `Pb-PROTON` "
       },
       "monitoring": {
         "url": "infologger:///debug?qc"
@@ -67,6 +68,57 @@
           "plotWithTextMessage": "",
           "textMessage": "" 
 
+        },
+	"extendedCheckParameters": {
+                "default": {
+                        "default": {
+                                          "maxcluoccL0": "5",
+          				  "maxcluoccL1": "3",
+          				  "maxcluoccL2": "3",
+          				  "maxcluoccL3": "0.3",
+          				  "maxcluoccL4": "0.3",
+          				  "maxcluoccL5": "0.2",
+          				  "maxcluoccL6": "0.2"
+                        }
+                },
+                "PHYSICS": {
+                        "default": {
+					  "maxcluoccL0": "5",
+                                          "maxcluoccL1": "3",
+                                          "maxcluoccL2": "3",
+                                          "maxcluoccL3": "0.3",
+                                          "maxcluoccL4": "0.3",
+                                          "maxcluoccL5": "0.2",
+                                          "maxcluoccL6": "0.2"
+                        },
+                        "PROTON-PROTON": {
+				          "maxcluoccL0": "5",
+                                          "maxcluoccL1": "3",
+                                          "maxcluoccL2": "3",
+                                          "maxcluoccL3": "0.3",
+                                          "maxcluoccL4": "0.3",
+                                          "maxcluoccL5": "0.2",
+                                          "maxcluoccL6": "0.2"
+                        },
+                        "Pb-Pb": {
+				          "maxcluoccL0": "65",
+                                          "maxcluoccL1": "35",
+                                          "maxcluoccL2": "25",
+                                          "maxcluoccL3": "1",
+                                          "maxcluoccL4": "1",
+                                          "maxcluoccL5": "1",
+                                          "maxcluoccL6": "1"
+                        }
+                },
+                "COSMICS": {
+			                  "maxcluoccL0": "5",
+                                          "maxcluoccL1": "3",
+                                          "maxcluoccL2": "3",
+                                          "maxcluoccL3": "0.3",
+                                          "maxcluoccL4": "0.3",
+                                          "maxcluoccL5": "0.2",
+                                          "maxcluoccL6": "0.2"
+                        }
         },
         "dataSource": [
           {

--- a/Modules/ITS/itsFee.json
+++ b/Modules/ITS/itsFee.json
@@ -9,8 +9,9 @@
                 "name": "not_applicable"
             },
             "Activity": {
-                "number": "42",
-                "type": "NONE"
+		        "number": "42",        
+		        "type": "PHYSICS",     
+        		"beamType" : "PbPb",     "": "Beam type: `PROTON-PROTON`, `Pb-Pb`, `Pb-PROTON` "
             },
             "monitoring": {
                 "url": "infologger:///debug?qc"
@@ -66,6 +67,27 @@
                   "plotWithTextMessage": "",
                   "textMessage": "" 
                 },
+		"extendedCheckParameters": {
+          	"default": {
+            		"default": {
+              			"expectedROFperOrbit": "18"
+            		}
+          	},
+          	"PHYSICS": {
+            		"default": {
+              			"expectedROFperOrbit": "18"
+            		},
+            		"PROTON-PROTON": {
+              			"expectedROFperOrbit": "18"
+            		},
+            		"Pb-Pb": {
+              			"expectedROFperOrbit": "6"
+            		}
+          	},
+          		"COSMICS": {
+            			"expectedROFperOrbit": "18"
+          		}
+        	},
                 "dataSource": [
                     {
                         "type": "Task",

--- a/Modules/ITS/src/ITSClusterCheck.cxx
+++ b/Modules/ITS/src/ITSClusterCheck.cxx
@@ -69,6 +69,7 @@ Quality ITSClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
 
     if (iter->second->getName().find("General_Occupancy") != std::string::npos) {
       auto* hp = dynamic_cast<TH2D*>(iter->second->getObject());
+      auto activity = iter->second->getActivity();
       if (hp == nullptr) {
         ILOG(Error, Support) << "could not cast general occupancy to TH2D*" << ENDM;
         continue;
@@ -90,7 +91,9 @@ Quality ITSClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
             continue;
           }
 
-          maxcluocc[ilayer] = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, Form("maxcluoccL%d", ilayer), maxcluocc[ilayer]);
+          // maxcluocc[ilayer] = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, Form("maxcluoccL%d", ilayer), maxcluocc[ilayer]);
+
+          maxcluocc[ilayer] = stof(mCustomParameters.at(Form("maxcluoccL%d", ilayer), activity));
           if (hp->GetBinContent(ix, iy) > maxcluocc[ilayer]) {
             result.set(Quality::Medium);
             result.updateMetadata(Form("Layer%d%s", ilayer, tb.c_str()), "medium");

--- a/Modules/ITS/src/ITSFeeCheck.cxx
+++ b/Modules/ITS/src/ITSFeeCheck.cxx
@@ -381,7 +381,7 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
             tInfoLayers[ilayer]->SetNDC();
             hp->GetListOfFunctions()->Add(tInfoLayers[ilayer]->Clone());
           } // end check result over layer
-        } // end of loop over layers
+        }// end of loop over layers
       }
       tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
       tInfo->SetTextColor(textColor);

--- a/Modules/ITS/src/ITSFeeCheck.cxx
+++ b/Modules/ITS/src/ITSFeeCheck.cxx
@@ -381,7 +381,7 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
             tInfoLayers[ilayer]->SetNDC();
             hp->GetListOfFunctions()->Add(tInfoLayers[ilayer]->Clone());
           } // end check result over layer
-        }// end of loop over layers
+        }   // end of loop over layers
       }
       tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
       tInfo->SetTextColor(textColor);

--- a/Modules/ITS/src/ITSFeeCheck.cxx
+++ b/Modules/ITS/src/ITSFeeCheck.cxx
@@ -32,6 +32,7 @@ namespace o2::quality_control_modules::its
 Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
 
+
   Quality result = Quality::Null;
   bool badStaveCount, badStaveIB, badStaveML, badStaveOL;
 
@@ -252,6 +253,8 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
     }
 
     if (((string)mo->getName()).find("TrailerCount") != std::string::npos) {
+
+      auto activity = mo->getActivity();
       auto* h = dynamic_cast<TH2I*>(mo->getObject());
       if (h == nullptr) {
         ILOG(Error, Support) << "could not cast TrailerCount to TH2I*" << ENDM;
@@ -259,7 +262,7 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
       }
       result.set(Quality::Good);
       result.addMetadata("CheckROFRate", "good");
-      expectedROFperOrbit = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "expectedROFperOrbit", expectedROFperOrbit);
+      expectedROFperOrbit = stoi(mCustomParameters.at("expectedROFperOrbit", activity));
       if (h->Integral(1, 432, 1, h->GetYaxis()->FindBin(expectedROFperOrbit) - 1) > 0 || h->Integral(1, 432, h->GetYaxis()->FindBin(expectedROFperOrbit) + 1, h->GetYaxis()->GetLast()) > 0) {
         result.set(Quality::Bad);
         result.updateMetadata("expectedROFperOrbit", "bad");
@@ -379,7 +382,7 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
             tInfoLayers[ilayer]->SetNDC();
             hp->GetListOfFunctions()->Add(tInfoLayers[ilayer]->Clone());
           } // end check result over layer
-        }   // end of loop over layers
+        } // end of loop over layers
       }
       tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
       tInfo->SetTextColor(textColor);

--- a/Modules/ITS/src/ITSFeeCheck.cxx
+++ b/Modules/ITS/src/ITSFeeCheck.cxx
@@ -32,7 +32,6 @@ namespace o2::quality_control_modules::its
 Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
 
-
   Quality result = Quality::Null;
   bool badStaveCount, badStaveIB, badStaveML, badStaveOL;
 


### PR DESCRIPTION
extendedTaskParameters were added for `Cluster/general occupancy` and `FEE/Number of Internal Triggers per Orbit plots`; 

Slightly tuned numbers for Cluster occupancy plot based on 560402 (Pb-Pb, 23 Nov) and 554524 (p-p, 21 July)