### PR TITLE
Fix assert

### DIFF
--- a/Modules/ITS/include/ITS/ITSTrackTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackTask.h
@@ -226,7 +226,7 @@ class ITSTrackTask : public TaskInterface
     // implementation of the function to be minimized
     double operator()(const double* par)
     { // const double -> double
-      assert(fHits != 0);
+      assert(fHits.size() != 0);
 
       int nhits = fHits.size();
       double sum = 0;


### PR DESCRIPTION
For me compilation fails, since `std::vector<TVector3>` cannot be compared to int. I assume the what was intended is this PR. But perhaps it should be fixed differently, since I think assert is only checked in debug builds. So the code might lead to division by 0.