### PR TITLE
RecoQC FT0: changed amp-time hist

### DIFF
--- a/Modules/FIT/FT0/CMakeLists.txt
+++ b/Modules/FIT/FT0/CMakeLists.txt
@@ -11,7 +11,8 @@ target_sources(O2QcFT0 PRIVATE src/AgingLaserTask.cxx
                                src/OutOfBunchCollCheck.cxx
                                src/MergedTreeCheck.cxx
                                src/RecPointsQcTask.cxx
-                               src/ChannelGeometry.cxx)
+                               src/ChannelGeometry.cxx
+                               src/AmpTimeDistribution.cxx)
 
 target_include_directories(
   O2QcFT0
@@ -43,6 +44,7 @@ add_root_dictionary(O2QcFT0
           include/FT0/MergedTreeCheck.h
           include/FT0/RecPointsQcTask.h
           include/FT0/ChannelGeometry.h
+          include/FT0/AmpTimeDistribution.h
   LINKDEF include/FT0/LinkDef.h)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/FT0

--- a/Modules/FIT/FT0/include/FT0/AmpTimeDistribution.h
+++ b/Modules/FIT/FT0/include/FT0/AmpTimeDistribution.h
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FITAMPTIMEDISTRIBUTION_H
+#define O2_FITAMPTIMEDISTRIBUTION_H
+
+#include "TH2F.h"
+
+#include <string>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <span>
+
+namespace o2::fit
+{
+
+struct AmpTimeDistribution {
+  AmpTimeDistribution() = default;
+  AmpTimeDistribution(const std::string& name, const std::string& title, int nBins, double minRange, double maxRange, int binsInStep = 50, int binMax = 4095, int axis = 0);
+  AmpTimeDistribution(const AmpTimeDistribution&);
+  AmpTimeDistribution(AmpTimeDistribution&&) noexcept;
+  AmpTimeDistribution& operator=(const AmpTimeDistribution&);
+  AmpTimeDistribution& operator=(AmpTimeDistribution&&) noexcept;
+  typedef float Content_t; // to template?
+  typedef TH2F Hist2F_t;
+  std::unique_ptr<Hist2F_t> mHist = nullptr;
+
+  void initHists(const std::string& name, const std::string& title, int nBins, double minRange, double maxRange, int binsInStep = 50, int binMax = 4095, int axis = 0);
+  static std::vector<double> makeVaribleBins(const std::vector<std::pair<int, int>>& vecParams, int binMax = 4095);
+  static std::vector<double> makeVaribleBins(int binsInStep = 50, int binMax = 4095);
+};
+
+template <std::size_t NCHANNELS, std::size_t NADC>
+using AmpTimeDistributionDetector = std::array<std::array<AmpTimeDistribution, NCHANNELS>, NADC>;
+
+} // namespace o2::fit
+#endif

--- a/Modules/FIT/FT0/include/FT0/RecPointsQcTask.h
+++ b/Modules/FIT/FT0/include/FT0/RecPointsQcTask.h
@@ -19,7 +19,7 @@
 #define QC_MODULE_FT0_FT0RECOQCTASK_H
 
 #include <Framework/InputRecord.h>
-
+#include <FT0/AmpTimeDistribution.h>
 #include "QualityControl/QcInfoLogger.h"
 #include <FT0Base/Geometry.h>
 #include <DataFormatsFT0/RecPoints.h>
@@ -46,7 +46,7 @@ namespace o2::quality_control_modules::ft0
 
 class RecPointsQcTask final : public TaskInterface
 {
-  static constexpr int NCHANNELS = o2::ft0::Geometry::Nchannels;
+  static constexpr int sNCHANNELS = o2::ft0::Geometry::Nchannels;
 
  public:
   /// \brief Constructor
@@ -62,8 +62,10 @@ class RecPointsQcTask final : public TaskInterface
   void endOfActivity(const Activity& activity) override;
   void reset() override;
   using Detector_t = o2::quality_control_modules::fit::detectorFIT::DetectorFT0;
+  void initHists();
 
  private:
+  std::array<o2::fit::AmpTimeDistribution, sNCHANNELS> mArrAmpTimeDistribution;
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
   unsigned int mTrgPos_minBias;

--- a/Modules/FIT/FT0/src/AmpTimeDistribution.cxx
+++ b/Modules/FIT/FT0/src/AmpTimeDistribution.cxx
@@ -1,0 +1,99 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <FT0/AmpTimeDistribution.h>
+#include <cstring>
+
+using namespace o2::fit;
+
+AmpTimeDistribution::AmpTimeDistribution(const std::string& name, const std::string& title, int nBins, double minRange, double maxRange, int binsInStep, int binMax, int axis)
+{
+  initHists(name, title, nBins, minRange, maxRange, binsInStep, binMax, axis);
+}
+
+AmpTimeDistribution::AmpTimeDistribution(const AmpTimeDistribution& other)
+{
+  if (other.mHist) {
+    const std::string newName = std::string(other.mHist->GetName()) + "_Cloned";
+    mHist = std::unique_ptr<AmpTimeDistribution::Hist2F_t>(dynamic_cast<AmpTimeDistribution::Hist2F_t*>(other.mHist->Clone(newName.c_str())));
+  }
+}
+
+AmpTimeDistribution::AmpTimeDistribution(AmpTimeDistribution&& other) noexcept : mHist(std::move(other.mHist))
+{
+}
+
+AmpTimeDistribution& AmpTimeDistribution::operator=(const AmpTimeDistribution& other)
+{
+  if (this != &other) {
+    if (other.mHist) {
+      const std::string newName = std::string(other.mHist->GetName()) + "_Cloned";
+      mHist = std::unique_ptr<AmpTimeDistribution::Hist2F_t>(dynamic_cast<AmpTimeDistribution::Hist2F_t*>(other.mHist->Clone(newName.c_str())));
+    } else {
+      mHist.reset();
+    }
+  }
+  return *this;
+}
+AmpTimeDistribution& AmpTimeDistribution::operator=(AmpTimeDistribution&& other) noexcept
+{
+  if (this != &other) {
+    mHist = std::move(other.mHist);
+  }
+  return *this;
+}
+
+void AmpTimeDistribution::initHists(const std::string& name, const std::string& title, int nBins, double minRange, double maxRange, int binsInStep, int binMax, int axis)
+{
+  const auto& varBins = makeVaribleBins(binsInStep, binMax);
+  const int varNbins = varBins.size() - 1;
+  if (axis == 0) {
+    mHist = std::make_unique<AmpTimeDistribution::Hist2F_t>(name.c_str(), title.c_str(), varNbins, varBins.data(), nBins, minRange, maxRange);
+  } else if (axis == 1) {
+    mHist = std::make_unique<AmpTimeDistribution::Hist2F_t>(name.c_str(), title.c_str(), nBins, minRange, maxRange, varNbins, varBins.data());
+  }
+}
+
+std::vector<double> AmpTimeDistribution::makeVaribleBins(const std::vector<std::pair<int, int>>& vecParams, int binMax)
+{
+  std::vector<double> vecLowEdgeBins{};
+  int startBin{ 0 };
+  auto makeBinRange = [&vec = vecLowEdgeBins, binMax](int startBin, int binWidth, int nBins) {
+    const int endBin = startBin + binWidth * nBins;
+    for (int iBin = startBin; iBin < endBin; iBin += binWidth) {
+      vec.emplace_back(static_cast<double>(iBin));
+      if (iBin > binMax) {
+        break;
+      }
+    }
+    return endBin;
+  };
+  for (const auto& entry : vecParams) {
+    startBin = makeBinRange(startBin, entry.first, entry.second);
+  }
+  return vecLowEdgeBins;
+}
+
+std::vector<double> AmpTimeDistribution::makeVaribleBins(int binsInStep, int binMax)
+{
+  auto generateParams = [](int binsInStep, int binMax) {
+    std::vector<std::pair<int, int>> vecParams{};
+    int endBin{ 0 };
+    int binWidth = 1;
+    while (endBin < binMax) {
+      vecParams.push_back({ binWidth, binsInStep });
+      endBin += (binWidth * binsInStep);
+      binWidth *= 2;
+    }
+    return vecParams;
+  };
+  return makeVaribleBins(generateParams(binsInStep, binMax), binMax);
+}


### PR DESCRIPTION
1. Temporary entity `AmpTimeDistribution` is added into QC until it is not implemented into O2 DataFormatsFIT with FT0 calibration patch.
2. Binning along x-axis is changed in amp-time hist 1000->315 and 100->200 for y-axis. Total size decrease is 1.5
3. Coll BC selection is added for amp-time, askGRPLHCIF option is needed for cfg. Also added min bias trigger parametrization based on system type.