### PR TITLE
ITS/Calibration: better handling of wrong run types and Pixel scans

### DIFF
--- a/Modules/ITS/include/ITS/ITSThresholdCalibrationTask.h
+++ b/Modules/ITS/include/ITS/ITSThresholdCalibrationTask.h
@@ -32,10 +32,8 @@ enum {
   VCASN,
   ITHR,
   THR,
-  TOT,
-  pixel_noise,
-  pixel_dead,
-  pixel_ineff
+  pixel,
+  TOT
 };
 
 namespace o2::quality_control_modules::its
@@ -128,7 +126,9 @@ class ITSThresholdCalibrationTask : public TaskInterface
   TH2F *hCalibrationThrNoiseRMSChipAverage[3], *hCalibrationThrNoiseChipAverage[3];
   // TH2F *hCalibrationDeadColumns[3], *hCalibrationDeadPixels[3];
   TH2D* hCalibrationDColChipAverage[3];
-  TH2D* hCalibrationPixelpAverage[3][3];
+  TH2D* hCalibrationPixel_dead[3];
+  TH2D* hCalibrationPixel_noise[3];
+  TH2D* hCalibrationPixel_inEff[3];
 
   TH2F* hUnsuccess[3];
   TH1F *hCalibrationLayer[NLayer][3], *hCalibrationRMSLayer[NLayer][3];

--- a/Modules/ITS/src/ITSThresholdCalibrationTask.cxx
+++ b/Modules/ITS/src/ITSThresholdCalibrationTask.cxx
@@ -155,6 +155,10 @@ void ITSThresholdCalibrationTask::monitorData(o2::framework::ProcessingContext& 
   else if (scanType == 'P') {
     iScan = 4;
   }
+
+  if (iScan!=CalibType)
+	  ILOG(FATAL) << "Scan Type from Data: "<< scanType << " is different from scan type from .json "<< CalibType << ENDM;
+
   auto splitRes = splitString(inString, "O2");
 
   if (scanType == 'A' || scanType == 'D')


### PR DESCRIPTION
- Added new error messages with QC Task is not properly set up in terms of run type: expected values: THR, ITHR, VCASN, Pixel, TOT
- Pixel scan plots now correctly filled when selected Pixel scan type