### PR TITLE
MCH: make LastCycle and trending plots optional

### DIFF
--- a/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
@@ -74,6 +74,8 @@ class DecodingPostProcessing : public PostProcessingInterface
   static std::string syncStatusSourceName() { return "syncstatus"; }
 
   bool mFullHistos{ false };
+  bool mEnableLastCycleHistos{ false };
+  bool mEnableTrending{ false };
 
   PostProcessingConfigMCH mConfig;
 

--- a/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
@@ -62,8 +62,10 @@ class DigitsPostProcessing : public PostProcessingInterface
   static std::string orbitsSourceName() { return "orbits"; }
   static std::string orbitsSignalSourceName() { return "orbits_signal"; }
 
-  int64_t mRefTimeStamp{ 0 };
   bool mFullHistos{ false };
+  bool mEnableLastCycleHistos{ false };
+  bool mEnableTrending{ false };
+
   float mChannelRateMin{ 0 };
   float mChannelRateMax{ 100 };
 

--- a/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
@@ -74,6 +74,8 @@ class PreclustersPostProcessing : public PostProcessingInterface
   static std::string clusterSizeSourceName() { return "clsize"; }
 
   bool mFullHistos{ false };
+  bool mEnableLastCycleHistos{ false };
+  bool mEnableTrending{ false };
 
   PostProcessingConfigMCH mConfig;
 

--- a/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
@@ -34,22 +34,6 @@ void DigitsPostProcessing::configure(const boost::property_tree::ptree& config)
 
 void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInterface* qcdb)
 {
-  //------------------------------------------
-  // Helpers to extract plots from last cycle
-  //------------------------------------------
-
-  auto obj = mCcdbObjects.find(rateSourceName());
-  if (obj != mCcdbObjects.end()) {
-    mElecMapOnCycle.reset();
-    mElecMapOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
-  }
-
-  obj = mCcdbObjects.find(rateSignalSourceName());
-  if (obj != mCcdbObjects.end()) {
-    mElecMapSignalOnCycle.reset();
-    mElecMapSignalOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
-  }
-
   //----------------------------------
   // Rate plotters
   //----------------------------------
@@ -58,51 +42,56 @@ void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInte
   mRatesPlotter = std::make_unique<RatesPlotter>("Rates/", mChannelRateMin, mChannelRateMax, true, mFullHistos);
   mRatesPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
-  mRatesPlotterOnCycle.reset();
-  mRatesPlotterOnCycle = std::make_unique<RatesPlotter>("Rates/LastCycle/", mChannelRateMin, mChannelRateMax, false, mFullHistos);
-  mRatesPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
-
   mRatesPlotterSignal.reset();
   mRatesPlotterSignal = std::make_unique<RatesPlotter>("RatesSignal/", mChannelRateMin, mChannelRateMax, true, mFullHistos);
   mRatesPlotterSignal->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
-  mRatesPlotterSignalOnCycle.reset();
-  mRatesPlotterSignalOnCycle = std::make_unique<RatesPlotter>("RatesSignal/LastCycle/", mChannelRateMin, mChannelRateMax, false, mFullHistos);
-  mRatesPlotterSignalOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  //----------------------------------
+  // Rate plotters for last cycle
+  //----------------------------------
+
+  if (mEnableLastCycleHistos) {
+    // Helpers to extract plots from last cycle
+    auto obj = mCcdbObjects.find(rateSourceName());
+    if (obj != mCcdbObjects.end()) {
+      mElecMapOnCycle.reset();
+      mElecMapOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
+    }
+
+    obj = mCcdbObjects.find(rateSignalSourceName());
+    if (obj != mCcdbObjects.end()) {
+      mElecMapSignalOnCycle.reset();
+      mElecMapSignalOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
+    }
+
+    mRatesPlotterOnCycle.reset();
+    mRatesPlotterOnCycle = std::make_unique<RatesPlotter>("Rates/LastCycle/", mChannelRateMin, mChannelRateMax, false, mFullHistos);
+    mRatesPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+
+    mRatesPlotterSignalOnCycle.reset();
+    mRatesPlotterSignalOnCycle = std::make_unique<RatesPlotter>("RatesSignal/LastCycle/", mChannelRateMin, mChannelRateMax, false, mFullHistos);
+    mRatesPlotterSignalOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 
   //----------------------------------
   // Rate trends
   //----------------------------------
 
-  mRatesTrendsPlotter.reset();
-  mRatesTrendsPlotter = std::make_unique<RatesTrendsPlotter>("Trends/Rates/", mFullHistos);
-  mRatesTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  if (mEnableTrending) {
+    mRatesTrendsPlotter.reset();
+    mRatesTrendsPlotter = std::make_unique<RatesTrendsPlotter>("Trends/Rates/", mFullHistos);
+    mRatesTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
-  mRatesTrendsPlotterSignal.reset();
-  mRatesTrendsPlotterSignal = std::make_unique<RatesTrendsPlotter>("Trends/RatesSignal/", mFullHistos);
-  mRatesTrendsPlotterSignal->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+    mRatesTrendsPlotterSignal.reset();
+    mRatesTrendsPlotterSignal = std::make_unique<RatesTrendsPlotter>("Trends/RatesSignal/", mFullHistos);
+    mRatesTrendsPlotterSignal->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 }
 
 //_________________________________________________________________________________________
 
 void DigitsPostProcessing::createOrbitHistos(Trigger t, repository::DatabaseInterface* qcdb)
 {
-  //------------------------------------------
-  // Helpers to extract plots from last cycle
-  //------------------------------------------
-
-  auto obj = mCcdbObjects.find(orbitsSourceName());
-  if (obj != mCcdbObjects.end()) {
-    mDigitsOrbitsOnCycle.reset();
-    mDigitsOrbitsOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
-  }
-
-  obj = mCcdbObjects.find(orbitsSignalSourceName());
-  if (obj != mCcdbObjects.end()) {
-    mDigitsSignalOrbitsOnCycle.reset();
-    mDigitsSignalOrbitsOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
-  }
-
   //----------------------------------
   // Orbit plotters
   //----------------------------------
@@ -111,17 +100,36 @@ void DigitsPostProcessing::createOrbitHistos(Trigger t, repository::DatabaseInte
   mOrbitsPlotter = std::make_unique<OrbitsPlotter>("Orbits/");
   mOrbitsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
-  mOrbitsPlotterOnCycle.reset();
-  mOrbitsPlotterOnCycle = std::make_unique<OrbitsPlotter>("Orbits/LastCycle/");
-  mOrbitsPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
-
   mOrbitsPlotterSignal.reset();
   mOrbitsPlotterSignal = std::make_unique<OrbitsPlotter>("OrbitsSignal/");
   mOrbitsPlotterSignal->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
-  mOrbitsPlotterSignalOnCycle.reset();
-  mOrbitsPlotterSignalOnCycle = std::make_unique<OrbitsPlotter>("OrbitsSignal/LastCycle/");
-  mOrbitsPlotterSignalOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  //----------------------------------
+  // Orbit plotters for last cycle
+  //----------------------------------
+
+  if (mEnableLastCycleHistos) {
+    // Helpers to extract plots from last cycle
+    auto obj = mCcdbObjects.find(orbitsSourceName());
+    if (obj != mCcdbObjects.end()) {
+      mDigitsOrbitsOnCycle.reset();
+      mDigitsOrbitsOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
+    }
+
+    obj = mCcdbObjects.find(orbitsSignalSourceName());
+    if (obj != mCcdbObjects.end()) {
+      mDigitsSignalOrbitsOnCycle.reset();
+      mDigitsSignalOrbitsOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
+    }
+
+    mOrbitsPlotterOnCycle.reset();
+    mOrbitsPlotterOnCycle = std::make_unique<OrbitsPlotter>("Orbits/LastCycle/");
+    mOrbitsPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+
+    mOrbitsPlotterSignalOnCycle.reset();
+    mOrbitsPlotterSignalOnCycle = std::make_unique<OrbitsPlotter>("OrbitsSignal/LastCycle/");
+    mOrbitsPlotterSignalOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 }
 
 //_________________________________________________________________________________________
@@ -132,6 +140,8 @@ void DigitsPostProcessing::initialize(Trigger t, framework::ServiceRegistryRef s
   const auto& activity = t.activity;
 
   mFullHistos = getConfigurationParameter<bool>(mCustomParameters, "FullHistos", mFullHistos, activity);
+  mEnableLastCycleHistos = getConfigurationParameter<bool>(mCustomParameters, "EnableLastCycleHistos", mEnableLastCycleHistos, activity);
+  mEnableTrending = getConfigurationParameter<bool>(mCustomParameters, "EnableTrending", mEnableTrending, activity);
 
   mChannelRateMin = getConfigurationParameter<float>(mCustomParameters, "ChannelRateMin", mChannelRateMin, activity);
   mChannelRateMax = getConfigurationParameter<float>(mCustomParameters, "ChannelRateMax", mChannelRateMax, activity);
@@ -186,12 +196,20 @@ void DigitsPostProcessing::updateRateHistos(Trigger t, repository::DatabaseInter
     TH2FRatio* hr = obj->second.get<TH2FRatio>();
     if (hr) {
       mRatesPlotter->update(hr);
-      // extract the average occupancies on the last cycle
-      mElecMapOnCycle->update(hr);
-      mRatesPlotterOnCycle->update(mElecMapOnCycle.get());
+      if (mEnableLastCycleHistos) {
+        // extract the average occupancies on the last cycle
+        mElecMapOnCycle->update(hr);
+        mRatesPlotterOnCycle->update(mElecMapOnCycle.get());
+      }
 
-      auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
-      mRatesTrendsPlotter->update(time, mElecMapOnCycle.get());
+      if (mEnableTrending) {
+        auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
+        if (mEnableLastCycleHistos) {
+          mRatesTrendsPlotter->update(time, mElecMapOnCycle.get());
+        } else {
+          mRatesTrendsPlotter->update(time, hr);
+        }
+      }
     }
   }
 
@@ -200,12 +218,20 @@ void DigitsPostProcessing::updateRateHistos(Trigger t, repository::DatabaseInter
     TH2FRatio* hr = obj->second.get<TH2FRatio>();
     if (hr) {
       mRatesPlotterSignal->update(hr);
-      // extract the average occupancies on the last cycle
-      mElecMapSignalOnCycle->update(hr);
-      mRatesPlotterSignalOnCycle->update(mElecMapSignalOnCycle.get());
+      if (mEnableLastCycleHistos) {
+        // extract the average occupancies on the last cycle
+        mElecMapSignalOnCycle->update(hr);
+        mRatesPlotterSignalOnCycle->update(mElecMapSignalOnCycle.get());
+      }
 
-      auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
-      mRatesTrendsPlotterSignal->update(time, mElecMapSignalOnCycle.get());
+      if (mEnableTrending) {
+        auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
+        if (mEnableLastCycleHistos) {
+          mRatesTrendsPlotterSignal->update(time, mElecMapSignalOnCycle.get());
+        } else {
+          mRatesTrendsPlotterSignal->update(time, hr);
+        }
+      }
     }
   }
 }
@@ -219,9 +245,11 @@ void DigitsPostProcessing::updateOrbitHistos(Trigger t, repository::DatabaseInte
     TH2F* hr = obj->second.get<TH2F>();
     if (hr) {
       mOrbitsPlotter->update(hr);
-      // extract the average occupancies on the last cycle
-      mDigitsOrbitsOnCycle->update(hr);
-      mOrbitsPlotterOnCycle->update(mDigitsOrbitsOnCycle.get());
+      if (mEnableLastCycleHistos) {
+        // extract the average occupancies on the last cycle
+        mDigitsOrbitsOnCycle->update(hr);
+        mOrbitsPlotterOnCycle->update(mDigitsOrbitsOnCycle.get());
+      }
     }
   }
 
@@ -230,9 +258,11 @@ void DigitsPostProcessing::updateOrbitHistos(Trigger t, repository::DatabaseInte
     TH2F* hr = obj->second.get<TH2F>();
     if (hr) {
       mOrbitsPlotterSignal->update(hr);
-      // extract the average occupancies on the last cycle
-      mDigitsSignalOrbitsOnCycle->update(hr);
-      mOrbitsPlotterSignalOnCycle->update(mDigitsSignalOrbitsOnCycle.get());
+      if (mEnableLastCycleHistos) {
+        // extract the average occupancies on the last cycle
+        mDigitsSignalOrbitsOnCycle->update(hr);
+        mOrbitsPlotterSignalOnCycle->update(mDigitsSignalOrbitsOnCycle.get());
+      }
     }
   }
 }

--- a/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
@@ -32,15 +32,6 @@ void PreclustersPostProcessing::configure(const boost::property_tree::ptree& con
 
 void PreclustersPostProcessing::createEfficiencyHistos(Trigger t, repository::DatabaseInterface* qcdb)
 {
-  //------------------------------------------
-  // Helpers to extract plots from last cycle
-  //------------------------------------------
-
-  auto obj = mCcdbObjects.find(effSourceName());
-  if (obj != mCcdbObjects.end()) {
-    mElecMapOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
-  }
-
   //----------------------------------
   // Efficiency plotters
   //----------------------------------
@@ -49,33 +40,33 @@ void PreclustersPostProcessing::createEfficiencyHistos(Trigger t, repository::Da
   mEfficiencyPlotter = std::make_unique<EfficiencyPlotter>("Efficiency/", mFullHistos);
   mEfficiencyPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
-  mEfficiencyPlotterOnCycle.reset();
-  mEfficiencyPlotterOnCycle = std::make_unique<EfficiencyPlotter>("Efficiency/LastCycle/", mFullHistos);
-  mEfficiencyPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  if (mEnableLastCycleHistos) {
+    // Helpers to extract plots from last cycle
+    auto obj = mCcdbObjects.find(effSourceName());
+    if (obj != mCcdbObjects.end()) {
+      mElecMapOnCycle = std::make_unique<HistoOnCycle<TH2FRatio>>();
+    }
+
+    mEfficiencyPlotterOnCycle.reset();
+    mEfficiencyPlotterOnCycle = std::make_unique<EfficiencyPlotter>("Efficiency/LastCycle/", mFullHistos);
+    mEfficiencyPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 
   //----------------------------------
   // Efficiency trends
   //----------------------------------
 
-  mEfficiencyTrendsPlotter.reset();
-  mEfficiencyTrendsPlotter = std::make_unique<EfficiencyTrendsPlotter>("Trends/", mFullHistos);
-  mEfficiencyTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  if (mEnableTrending) {
+    mEfficiencyTrendsPlotter.reset();
+    mEfficiencyTrendsPlotter = std::make_unique<EfficiencyTrendsPlotter>("Trends/", mFullHistos);
+    mEfficiencyTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 }
 
 //_________________________________________________________________________________________
 
 void PreclustersPostProcessing::createClusterChargeHistos(Trigger t, repository::DatabaseInterface* qcdb)
 {
-  //------------------------------------------
-  // Helpers to extract plots from last cycle
-  //------------------------------------------
-
-  auto obj = mCcdbObjects.find(clusterChargeSourceName());
-  if (obj != mCcdbObjects.end()) {
-    mClusterChargeOnCycle.reset();
-    mClusterChargeOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
-  }
-
   //----------------------------------
   // Cluster charge plotters
   //----------------------------------
@@ -84,33 +75,34 @@ void PreclustersPostProcessing::createClusterChargeHistos(Trigger t, repository:
   mClusterChargePlotter = std::make_unique<ClusterChargePlotter>("ClusterCharge/", mFullHistos);
   mClusterChargePlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
-  mClusterChargePlotterOnCycle.reset();
-  mClusterChargePlotterOnCycle = std::make_unique<ClusterChargePlotter>("ClusterCharge/LastCycle/", mFullHistos);
-  mClusterChargePlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  if (mEnableLastCycleHistos) {
+    // Helpers to extract plots from last cycle
+    auto obj = mCcdbObjects.find(clusterChargeSourceName());
+    if (obj != mCcdbObjects.end()) {
+      mClusterChargeOnCycle.reset();
+      mClusterChargeOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
+    }
+
+    mClusterChargePlotterOnCycle.reset();
+    mClusterChargePlotterOnCycle = std::make_unique<ClusterChargePlotter>("ClusterCharge/LastCycle/", mFullHistos);
+    mClusterChargePlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 
   //----------------------------------
   // Cluster charge trends
   //----------------------------------
 
-  mClusterChargeTrendsPlotter.reset();
-  mClusterChargeTrendsPlotter = std::make_unique<ClusterChargeTrendsPlotter>("Trends/", mFullHistos);
-  mClusterChargeTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  if (mEnableTrending) {
+    mClusterChargeTrendsPlotter.reset();
+    mClusterChargeTrendsPlotter = std::make_unique<ClusterChargeTrendsPlotter>("Trends/", mFullHistos);
+    mClusterChargeTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 }
 
 //_________________________________________________________________________________________
 
 void PreclustersPostProcessing::createClusterSizeHistos(Trigger t, repository::DatabaseInterface* qcdb)
 {
-  //------------------------------------------
-  // Helpers to extract plots from last cycle
-  //------------------------------------------
-
-  auto obj = mCcdbObjects.find(clusterSizeSourceName());
-  if (obj != mCcdbObjects.end()) {
-    mClusterSizeOnCycle.reset();
-    mClusterSizeOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
-  }
-
   //----------------------------------
   // Cluster size plotters
   //----------------------------------
@@ -119,17 +111,28 @@ void PreclustersPostProcessing::createClusterSizeHistos(Trigger t, repository::D
   mClusterSizePlotter = std::make_unique<ClusterSizePlotter>("ClusterSize/", mFullHistos);
   mClusterSizePlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
-  mClusterSizePlotterOnCycle.reset();
-  mClusterSizePlotterOnCycle = std::make_unique<ClusterSizePlotter>("ClusterSize/LastCycle/", mFullHistos);
-  mClusterSizePlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  if (mEnableLastCycleHistos) {
+    // Helpers to extract plots from last cycle
+    auto obj = mCcdbObjects.find(clusterSizeSourceName());
+    if (obj != mCcdbObjects.end()) {
+      mClusterSizeOnCycle.reset();
+      mClusterSizeOnCycle = std::make_unique<HistoOnCycle<TH2F>>();
+    }
+
+    mClusterSizePlotterOnCycle.reset();
+    mClusterSizePlotterOnCycle = std::make_unique<ClusterSizePlotter>("ClusterSize/LastCycle/", mFullHistos);
+    mClusterSizePlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 
   //----------------------------------
   // Cluster size trends
   //----------------------------------
 
-  mClusterSizeTrendsPlotter.reset();
-  mClusterSizeTrendsPlotter = std::make_unique<ClusterSizeTrendsPlotter>("Trends/", mFullHistos);
-  mClusterSizeTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  if (mEnableTrending) {
+    mClusterSizeTrendsPlotter.reset();
+    mClusterSizeTrendsPlotter = std::make_unique<ClusterSizeTrendsPlotter>("Trends/", mFullHistos);
+    mClusterSizeTrendsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+  }
 }
 
 //_________________________________________________________________________________________
@@ -140,6 +143,8 @@ void PreclustersPostProcessing::initialize(Trigger t, framework::ServiceRegistry
   const auto& activity = t.activity;
 
   mFullHistos = getConfigurationParameter<bool>(mCustomParameters, "FullHistos", mFullHistos, activity);
+  mEnableLastCycleHistos = getConfigurationParameter<bool>(mCustomParameters, "EnableLastCycleHistos", mEnableLastCycleHistos, activity);
+  mEnableTrending = getConfigurationParameter<bool>(mCustomParameters, "EnableTrending", mEnableTrending, activity);
 
   mCcdbObjects.clear();
   mCcdbObjects.emplace(effSourceName(), CcdbObjectHelper());
@@ -191,12 +196,20 @@ void PreclustersPostProcessing::updateEfficiencyHistos(Trigger t, repository::Da
     TH2FRatio* hr = obj->second.get<TH2FRatio>();
     if (hr) {
       mEfficiencyPlotter->update(hr);
-      // extract the average occupancies on the last cycle
-      mElecMapOnCycle->update(hr);
-      mEfficiencyPlotterOnCycle->update(mElecMapOnCycle.get());
+      if (mEnableLastCycleHistos) {
+        // extract the average occupancies on the last cycle
+        mElecMapOnCycle->update(hr);
+        mEfficiencyPlotterOnCycle->update(mElecMapOnCycle.get());
+      }
 
-      auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
-      mEfficiencyTrendsPlotter->update(time, mElecMapOnCycle.get());
+      if (mEnableTrending) {
+        auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
+        if (mEnableLastCycleHistos) {
+          mEfficiencyTrendsPlotter->update(time, mElecMapOnCycle.get());
+        } else {
+          mEfficiencyTrendsPlotter->update(time, hr);
+        }
+      }
     }
   }
 }
@@ -210,12 +223,20 @@ void PreclustersPostProcessing::updateClusterChargeHistos(Trigger t, repository:
     TH2F* h = obj->second.get<TH2F>();
     if (h) {
       mClusterChargePlotter->update(h);
-      // extract the average occupancies on the last cycle
-      mClusterChargeOnCycle->update(h);
-      mClusterChargePlotterOnCycle->update(mClusterChargeOnCycle.get());
+      if (mEnableLastCycleHistos) {
+        // extract the average occupancies on the last cycle
+        mClusterChargeOnCycle->update(h);
+        mClusterChargePlotterOnCycle->update(mClusterChargeOnCycle.get());
+      }
 
-      auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
-      mClusterChargeTrendsPlotter->update(time, mClusterChargeOnCycle.get());
+      if (mEnableTrending) {
+        auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
+        if (mEnableLastCycleHistos) {
+          mClusterChargeTrendsPlotter->update(time, mClusterChargeOnCycle.get());
+        } else {
+          mClusterChargeTrendsPlotter->update(time, h);
+        }
+      }
     }
   }
 }
@@ -229,12 +250,20 @@ void PreclustersPostProcessing::updateClusterSizeHistos(Trigger t, repository::D
     TH2F* h = obj->second.get<TH2F>();
     if (h) {
       mClusterSizePlotter->update(h);
-      // extract the average occupancies on the last cycle
-      mClusterSizeOnCycle->update(h);
-      mClusterSizePlotterOnCycle->update(mClusterSizeOnCycle.get());
+      if (mEnableLastCycleHistos) {
+        // extract the average occupancies on the last cycle
+        mClusterSizeOnCycle->update(h);
+        mClusterSizePlotterOnCycle->update(mClusterSizeOnCycle.get());
+      }
 
-      auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
-      mClusterSizeTrendsPlotter->update(time, mClusterSizeOnCycle.get());
+      if (mEnableTrending) {
+        auto time = obj->second.getTimeStamp() / 1000; // ROOT expects seconds since epoch
+        if (mEnableLastCycleHistos) {
+          mClusterSizeTrendsPlotter->update(time, mClusterSizeOnCycle.get());
+        } else {
+          mClusterSizeTrendsPlotter->update(time, h);
+        }
+      }
     }
   }
 }

--- a/Modules/MUON/MCH/src/RatesTrendsPlotter.cxx
+++ b/Modules/MUON/MCH/src/RatesTrendsPlotter.cxx
@@ -31,7 +31,6 @@ RatesTrendsPlotter::RatesTrendsPlotter(std::string path, bool fullPlots) : mPath
 {
   mReductor = std::make_unique<TH2ElecMapReductor>();
 
-
   mOrbits = std::make_unique<TrendGraph>(fmt::format("{}Orbits", path), "Orbits", "orbits");
   addCanvas(mOrbits.get(), "");
 


### PR DESCRIPTION
The LastCycle plots have been introduced as a workaround to mimic the moving windows, before they were implemented in the framework.

Since the moving windows are now the proper way to produce plots for a single QC cycle, the processing of LastCycle plots is made optional and disabled by default.

The creation of trending plots is also made optional and disabled by default. It should be enabled for the tasks that process the moving window outputs.