### PR TITLE
MCH: add rate and efficiency plots per DualSAMPA

### DIFF
--- a/Modules/MUON/MCH/include/MCH/DigitsTask.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsTask.h
@@ -24,6 +24,7 @@
 #include "MCHBase/Digit.h"
 #endif
 #include "MCHDigitFiltering/DigitFilter.h"
+#include "Common/TH1Ratio.h"
 #include "Common/TH2Ratio.h"
 
 class TH1F;
@@ -67,6 +68,9 @@ class DigitsTask /*final*/ : public TaskInterface // todo add back the "final" w
   template <typename T>
   void publishObject(T* histo, std::string drawOption, bool statBox, bool isExpert);
 
+  bool mEnable1DRateMaps{ true };  // whether to publish 1D maps of channel rates
+  bool mEnable2DRateMaps{ false }; // whether to publish 2D maps of channel rates
+
   bool mFullHistos{ false }; // publish extra diagnostics plots
 
   o2::mch::DigitFilter mIsSignalDigit;
@@ -76,6 +80,10 @@ class DigitsTask /*final*/ : public TaskInterface // todo add back the "final" w
   // 2D Histograms, using Elec view (where x and y uniquely identify each pad based on its Elec info (fee, link, de)
   std::unique_ptr<TH2FRatio> mHistogramOccupancyElec;       // Occupancy histogram (Elec view)
   std::unique_ptr<TH2FRatio> mHistogramSignalOccupancyElec; // Occupancy histogram (Elec view) for signal-like digits
+
+  // 1D rate histograms using Elec view, where each x bin corresponds to the unique ID of a DualSAMPA board
+  std::unique_ptr<TH1DRatio> mHistogramRatePerDualSampa;
+  std::unique_ptr<TH1DRatio> mHistogramRateSignalPerDualSampa;
 
   std::unique_ptr<TH2F> mHistogramDigitsOrbitElec;
   std::unique_ptr<TH2F> mHistogramDigitsSignalOrbitElec;

--- a/Modules/MUON/MCH/include/MCH/PreclustersTask.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersTask.h
@@ -64,9 +64,15 @@ class PreclustersTask /*final*/ : public o2::quality_control::core::TaskInterfac
 
   void plotPrecluster(const o2::mch::PreCluster& preCluster, gsl::span<const o2::mch::Digit> digits);
 
+  bool mEnable1DPseudoeffMaps{ true };  // whether to publish 1D maps of channel pseudo-efficiencies
+  bool mEnable2DPseudoeffMaps{ false }; // whether to publish 2D maps of channel pseudo-efficiencies
+
   o2::mch::DigitFilter mIsSignalDigit;
 
   std::unique_ptr<TH2FRatio> mHistogramPseudoeffElec; // Mergeable object, Occupancy histogram (Elec view)
+
+  // 1D pseudo-efficiency histogram using Elec view, where each x bin corresponds to the unique ID of a DualSAMPA board
+  std::unique_ptr<TH1DRatio> mHistogramPseudoeffPerDualSampa;
 
   std::unique_ptr<TH1DRatio> mHistogramPreclustersPerDE;       // number of pre-clusters per DE and per TF
   std::unique_ptr<TH1DRatio> mHistogramPreclustersSignalPerDE; // number of pre-clusters with signal per DE and per TF


### PR DESCRIPTION
The new histograms are 1D lightweight versions of the 2D maps in electronics coordinates, that are more suitable for saving moving windows plots in async productions. The 1D versions provide the quantities averaged over each DualSAMPA board, while the 2D versions contain values on a channel-by-channel basis.

By default the 1D histograms are enabled and the 2D are disabled.