### PR TITLE
sor/eor triggers use numeric bounds for the unknown fields in validity

### DIFF
--- a/Framework/src/KafkaPoller.cxx
+++ b/Framework/src/KafkaPoller.cxx
@@ -62,7 +62,7 @@ void fillActivityWithoutTimestamp(const events::Event& event, Activity& activity
 void start_of_run::fillActivity(const events::Event& event, Activity& activity)
 {
   fillActivityWithoutTimestamp(event, activity);
-  activity.mValidity.setMin(event.timestamp());
+  activity.mValidity = ValidityInterval{ uint64_t(event.timestamp()), std::numeric_limits<validity_time_t>::max() };
 }
 
 bool start_of_run::isValid(const events::Event& event, const std::string& environmentID, int runNumber)
@@ -87,7 +87,7 @@ bool start_of_run::isValid(const events::Event& event, const std::string& enviro
 void end_of_run::fillActivity(const events::Event& event, Activity& activity)
 {
   fillActivityWithoutTimestamp(event, activity);
-  activity.mValidity.setMax(event.timestamp());
+  activity.mValidity = ValidityInterval{ std::numeric_limits<validity_time_t>::min(), uint64_t(event.timestamp()) };
 }
 
 bool end_of_run::isValid(const events::Event& event, const std::string& environmentID, int runNumber)


### PR DESCRIPTION
this ensures that:
- SOR trigger uses validity end which is understood by the framework as unknown
- EOR trigger uses validity start which is understood by the framework as unknown

For better or worse, we use numerical limits of validity_time_t as unknown/invalid validity timestamps. We could consider using optionals instead, but before we do, this is the easiest fix.