### PR TITLE
Remove any mentions of dataSamplingPoliciesFile

### DIFF
--- a/Framework/example-default.json
+++ b/Framework/example-default.json
@@ -184,9 +184,6 @@
       }
     }
   },
-  "dataSamplingPoliciesFile_comment": "In case that policies are stored in different file, specify its path below. When both dataSamplingPolicies and dataSamplingPoliciesFile are specified, the latter has higher priority",
-  "dataSamplingPoliciesFile": "json:///home/genghiskhan/alice/QualityControl/dataSamplingConfig.json",
-  "dataSamplingPolicies_comment": "this is ignored when dataSamplingPoliciesFile is specified",
   "dataSamplingPolicies": [
     {
       "id": "ex1",

--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1594,7 +1594,6 @@ This is the global structure of the configuration in QC.
       
     }
   },
-  "dataSamplingPoliciesFile": "json:///path/to/data/sampling/config.json",
   "dataSamplingPolicies": [
 
   ]
@@ -1613,8 +1612,8 @@ There are six QC-related components:
 * "postprocessing" - contains declarations of PostProcessing Tasks. It is only needed only when Post-Processing is
   run.
 
-The configuration file can also include a path to Data Sampling configuration ("dataSamplingPoliciesFile") or the
-list of Data Sampling Policies. Please refer to the [Data Sampling documentation](https://github.com/AliceO2Group/AliceO2/tree/dev/Utilities/DataSampling) to find more information.
+The configuration file can also include a list of Data Sampling Policies.
+Please refer to the [Data Sampling documentation](https://github.com/AliceO2Group/AliceO2/tree/dev/Utilities/DataSampling) to find more information.
 
 ### Common configuration
 


### PR DESCRIPTION
~~The feature is not used by anyone and will be removed from the Data Sampling library. In consul/apricot we have templating to perform file inclusion, in O2DPG we use `jq` for this. No need to keep something we do not use, but can be easily added back if needed.~~

It seems the feature is already gone, but some mentions in the documentation remained.

Closes QC-1247.