### PR TITLE
[EMCAL-792]: Add thresholds to EMCal Raw Errors for Medium Quality

### DIFF
--- a/Modules/EMCAL/include/EMCAL/RawErrorCheck.h
+++ b/Modules/EMCAL/include/EMCAL/RawErrorCheck.h
@@ -113,6 +113,8 @@ class RawErrorCheck : public o2::quality_control::checker::CheckInterface
   std::map<int, int> mErrorCountThresholdRFE;  ///< Thresholds for Raw Fit Error histogram
   std::map<int, int> mErrorCountThresholdGEE;  ///< Thresholds for Geometry Error histogram
   std::map<int, int> mErrorCountThresholdGTE;  ///< Thresholds for Gain Type Error histogram
+
+  std::map<int, std::array<int, 2>> mErrorCountThresholdRDESummary; ///< Thresholds for Raw Data Error Summary histograms. Values are for error and warning
 };
 
 } // namespace o2::quality_control_modules::emcal


### PR DESCRIPTION
- Minor Altro errors were fixed up until now as soon as they appeared. To increase the data taking time of EMCal, we now consider to only fix them at beam dump.
- New configurable values in the QC now allow to set specific values on how many minor altro errors can be presenent during data taking. The new flag "medium" is used to indicate minor altro errors that can be fixed at beam dump.