### PR TITLE
TPC QC: Fix cluster visualizer for raw digits

### DIFF
--- a/Modules/TPC/src/ClusterVisualizer.cxx
+++ b/Modules/TPC/src/ClusterVisualizer.cxx
@@ -158,13 +158,11 @@ void ClusterVisualizer::initialize(Trigger, framework::ServiceRegistryRef)
                   mStoreMaps.size() > 1 ? mStoreMaps.at(calDetIter) : mStoreMaps.at(0));
     calDetIter++;
   }
-  if (mIsClusters) {
-    mCalDetCanvasVec.emplace_back(std::vector<std::unique_ptr<TCanvas>>());
-    addAndPublish(getObjectsManager(),
-                  mCalDetCanvasVec.back(),
-                  { "c_radial_profile_Occupancy" },
-                  mStoreMaps.size() > 1 ? mStoreMaps.at(calDetIter) : mStoreMaps.at(0));
-  }
+  mCalDetCanvasVec.emplace_back(std::vector<std::unique_ptr<TCanvas>>());
+  addAndPublish(getObjectsManager(),
+                mCalDetCanvasVec.back(),
+                { "c_radial_profile_Occupancy" },
+                mStoreMaps.size() > 1 ? mStoreMaps.at(calDetIter) : mStoreMaps.at(0));
 }
 
 void ClusterVisualizer::update(Trigger t, framework::ServiceRegistryRef)


### PR DESCRIPTION
In a recent update to the visualizer task, QA histograms for occupancy have been added. The task was only test for running on Clusters, but not for raw digits. The mode for raw digits was broken.