### PR TITLE
QC-1289 Possibility to use a token with BKP client

### DIFF
--- a/Framework/src/Bookkeeping.cxx
+++ b/Framework/src/Bookkeeping.cxx
@@ -43,7 +43,11 @@ void Bookkeeping::init(const std::string& url)
   }
 
   try {
-    mClient = BkpClientFactory::create(url);
+    if (auto tokenEnv = std::getenv("QC_BKP_CLIENT_TOKEN"); tokenEnv != NULL) {
+      mClient = BkpClientFactory::create(url, tokenEnv);
+    } else {
+      mClient = BkpClientFactory::create(url);
+    }
   } catch (std::runtime_error& error) {
     ILOG(Warning, Support) << "Error connecting to Bookkeeping: " << error.what() << ENDM;
     return;

--- a/doc/Framework.md
+++ b/doc/Framework.md
@@ -595,7 +595,7 @@ Propagation can be enabled by adding the following key-value pair to Check/Aggre
 
 Using it for Aggregators is discouraged, as the information on which exact Check failed is lost or at least obfuscated.
 
-Also, make sure that the configuration file includes the Bookkeeping URL.
+Also, make sure that the configuration file includes the Bookkeeping URL and there is an env var `QC_BKP_CLIENT_TOKEN` with authentication token for setups external to P2.
 
 Check results are converted into Flags, which are documented in [O2/DataFormats/QualityControl](https://github.com/AliceO2Group/AliceO2/tree/dev/DataFormats/QualityControl).
 Information about the object validity is preserved, which allows for time-based flagging of good/bad data.


### PR DESCRIPTION
Token is expected as an env var to avoid exposing it in QC configuration files. Still, it's not ideal, but I don't think we have a better option at the moment.