### PR TITLE
[QC-1292] Missing run number in logs from BookkeepingSink

### DIFF
--- a/Framework/include/QualityControl/BookkeepingQualitySink.h
+++ b/Framework/include/QualityControl/BookkeepingQualitySink.h
@@ -39,7 +39,6 @@ class BookkeepingQualitySink : public framework::Task
   // sendCallback is mainly used for testing without the necessity to do grpc calls
   BookkeepingQualitySink(const std::string& grpcUri, Provenance, SendCallback sendCallback = send);
 
-  void init(framework::InitContext&) override;
   void run(framework::ProcessingContext&) override;
   void init(framework::InitContext& iCtx) override;
 

--- a/Framework/src/BookkeepingQualitySink.cxx
+++ b/Framework/src/BookkeepingQualitySink.cxx
@@ -26,10 +26,10 @@
 #include "QualityControl/runnerUtils.h"
 
 #include <BookkeepingApi/QcFlagServiceClient.h>
-#include <BookkeepingApi/BkpClientFactory.h>
 #include <CCDB/BasicCCDBManager.h>
 #include <stdexcept>
 #include <utility>
+#include <QualityControl/Bookkeeping.h>
 
 namespace o2::quality_control::core
 {
@@ -45,6 +45,7 @@ void BookkeepingQualitySink::customizeInfrastructure(std::vector<framework::Comp
 
 void BookkeepingQualitySink::init(framework::InitContext& iCtx)
 {
+  Bookkeeping::getInstance().init(mGrpcUri);
   initInfologger(iCtx, {}, "bkqsink/", "");
 
   try { // registering state machine callbacks
@@ -147,11 +148,6 @@ auto collectionForQualityObject(const QualityObject& qualityObject) -> std::uniq
     qualityObject.getActivity().mPeriodName,
     qualityObject.getActivity().mPassName,
     qualityObject.getActivity().mProvenance);
-}
-
-void BookkeepingQualitySink::init(framework::InitContext& context)
-{
-  o2::quality_control::core::Bookkeeping::getInstance().init(mGrpcUri);
 }
 
 void BookkeepingQualitySink::run(framework::ProcessingContext& context)


### PR DESCRIPTION
- added initialization of IL
- set the run number whenever we get one