### PR TITLE
ITS - plots of cluster and hit multiplicity distributions

### DIFF
--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -77,6 +77,9 @@ class ITSClusterTask : public TaskInterface
 
   std::vector<TObject*> mPublishedObjects;
 
+  // Task
+  TH1D* hTFCounter = nullptr;
+
   // Inner barrel
   TH1D* hClusterTopologySummaryIB[NLayer][48][9] = { { { nullptr } } };
   TH1D* hGroupedClusterSizeSummaryIB[NLayer][48][9] = { { { nullptr } } };

--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -96,7 +96,7 @@ class ITSClusterTask : public TaskInterface
   TH1L* hClusterSizeLayerSummary[NLayer] = { nullptr };
   TH1L* hClusterTopologyLayerSummary[NLayer] = { nullptr };
   TH1L* hGroupedClusterSizeLayerSummary[NLayer] = { nullptr };
-  TH1D* hClusterOccupancyDistribution[NLayer] = { nullptr }; // number of clusters with npix > 1, per chip, per ROF
+  TH2D* hClusterOccupancyDistribution[NLayer] = { nullptr }; // number of clusters and hits per chip, per ROF. From clusters with npix > 2
 
   // Anomalies plots
   TH2D* hLongClustersPerChip[3] = { nullptr };

--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -96,6 +96,7 @@ class ITSClusterTask : public TaskInterface
   TH1L* hClusterSizeLayerSummary[NLayer] = { nullptr };
   TH1L* hClusterTopologyLayerSummary[NLayer] = { nullptr };
   TH1L* hGroupedClusterSizeLayerSummary[NLayer] = { nullptr };
+  TH1D* hClusterOccupancyDistribution[NLayer] = { nullptr }; // number of clusters with npix > 1, per chip, per ROF
 
   // Anomalies plots
   TH2D* hLongClustersPerChip[3] = { nullptr };

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -40,6 +40,7 @@ ITSClusterTask::ITSClusterTask() : TaskInterface() {}
 
 ITSClusterTask::~ITSClusterTask()
 {
+  delete hTFCounter;
   delete hEmptyLaneFractionGlobal;
   delete hClusterVsBunchCrossing;
 
@@ -370,6 +371,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
     }
   }
 
+  hTFCounter->Fill(0);
+
   end = std::chrono::high_resolution_clock::now();
   difference = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
   ILOG(Debug, Devel) << "Time in QC Cluster Task:  " << difference << ENDM;
@@ -404,6 +407,7 @@ void ITSClusterTask::endOfActivity(const Activity& /*activity*/)
 void ITSClusterTask::reset()
 {
   ILOG(Debug, Devel) << "Resetting the histograms" << ENDM;
+  hTFCounter->Reset();
   hClusterVsBunchCrossing->Reset();
   hEmptyLaneFractionGlobal->Reset("ICES");
   mGeneralOccupancy->Reset();
@@ -451,6 +455,11 @@ void ITSClusterTask::reset()
 
 void ITSClusterTask::createAllHistos()
 {
+  hTFCounter = new TH1D("TFcounter", "TFcounter", 1, 0, 1);
+  hTFCounter->SetTitle("TF counter");
+  addObject(hTFCounter);
+  formatAxes(hTFCounter, "", "TF", 1, 1.10);
+
   hClusterVsBunchCrossing = new TH2D("BunchCrossingIDvsClusters", "BunchCrossingIDvsClusters", nBCbins, 0, 4095, 150, 0, 3000);
   hClusterVsBunchCrossing->SetTitle("#clusters vs BC id for clusters with npix > 2");
   addObject(hClusterVsBunchCrossing);

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -157,8 +157,8 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
 
     const auto& ROF = clusRofArr[iROF];
     const auto bcdata = ROF.getBCData();
-    int nClusters3pixLay[7] = { 0 };
     int nDigits3pixLay[7] = { 0 };
+    int nClusters3pixLay[7] = { 0 };
     int nClusters3pix = 0;
     int nLongClusters[ChipBoundary[NLayerIB]] = {};
     int nHitsFromClusters[ChipBoundary[NLayerIB]] = {}; // only IB is implemented at the moment


### PR DESCRIPTION
Adding one TH2D for each layer showing the distribution of the number of clusters vs sum of cluster size, event by event. Normalized to the number of chips of that layer. Computed only from clusters with size > 2.

(also, increasing y axis scale for plot of clusters vs bunch crossing). 

Tested locally.

@IsakovAD @iravasen   