### PR TITLE
ITS Clusters: cluster size distributions for IB chips

### DIFF
--- a/Modules/ITS/include/ITS/ITSClusterTask.h
+++ b/Modules/ITS/include/ITS/ITSClusterTask.h
@@ -80,6 +80,7 @@ class ITSClusterTask : public TaskInterface
   // Inner barrel
   TH1D* hClusterTopologySummaryIB[NLayer][48][9] = { { { nullptr } } };
   TH1D* hGroupedClusterSizeSummaryIB[NLayer][48][9] = { { { nullptr } } };
+  TH1D* hClusterSizeSummaryIB[NLayer][48][9] = { { { nullptr } } };
 
   std::shared_ptr<TH2DRatio> hAverageClusterOccupancySummaryIB[NLayer];
   std::shared_ptr<TH2DRatio> hAverageClusterSizeSummaryIB[NLayer];

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -62,6 +62,7 @@ ITSClusterTask::~ITSClusterTask()
 
             delete hClusterTopologySummaryIB[iLayer][iStave][iChip];
             delete hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip];
+            delete hClusterSizeSummaryIB[iLayer][iStave][iChip];
           }
         }
       } else {
@@ -235,6 +236,10 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
 
         hClusterSizeLayerSummary[lay]->Fill(npix);
         hClusterTopologyLayerSummary[lay]->Fill(ClusterID);
+
+        if (mDoPublish1DSummary) {
+          hClusterSizeSummaryIB[lay][sta][chip]->Fill(npix);
+        }
 
         if (isGrouped) {
           if (mDoPublish1DSummary == 1) {
@@ -413,6 +418,7 @@ void ITSClusterTask::reset()
           for (int iChip = 0; iChip < mNChipsPerHic[iLayer]; iChip++) {
             hClusterTopologySummaryIB[iLayer][iStave][iChip]->Reset();
             hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip]->Reset();
+            hClusterSizeSummaryIB[iLayer][iStave][iChip]->Reset();
           }
         }
       }
@@ -545,6 +551,11 @@ void ITSClusterTask::createAllHistos()
             hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip]->SetTitle(Form("Cluster Size for grouped topologies on Layer %d Stave %d Chip %d", iLayer, iStave, iChip));
             addObject(hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip]);
             formatAxes(hGroupedClusterSizeSummaryIB[iLayer][iStave][iChip], "Cluster size (Pixel)", "Counts", 1, 1.10);
+
+            hClusterSizeSummaryIB[iLayer][iStave][iChip] = new TH1D(Form("Layer%d/Stave%d/CHIP%d/ClusterSize", iLayer, iStave, iChip), Form("Layer%dStave%dCHIP%dClusterSize", iLayer, iStave, iChip), 100, 0, 100);
+            hClusterSizeSummaryIB[iLayer][iStave][iChip]->SetTitle(Form("Cluster Size for Layer %d Stave %d Chip %d", iLayer, iStave, iChip));
+            addObject(hClusterSizeSummaryIB[iLayer][iStave][iChip]);
+            formatAxes(hClusterSizeSummaryIB[iLayer][iStave][iChip], "Cluster size (Pixel)", "Counts", 1, 1.10);
 
             hClusterTopologySummaryIB[iLayer][iStave][iChip] = new TH1D(Form("Layer%d/Stave%d/CHIP%d/ClusterTopology", iLayer, iStave, iChip), Form("Layer%dStave%dCHIP%dClusterTopology", iLayer, iStave, iChip), 300, 0, 300);
             hClusterTopologySummaryIB[iLayer][iStave][iChip]->SetTitle(Form("Cluster Topology on Layer %d Stave %d Chip %d", iLayer, iStave, iChip));


### PR DESCRIPTION
Introduced cluster size distributions for every IB chip when enabled (`mDoPublish1DSummary` = 1). Only the distributions for grouped clusters were available. 