### PR TITLE
QC-1086 Replaying postprocessing with foreachobject trigger does not produce valid results

### DIFF
--- a/Framework/include/QualityControl/CcdbDatabase.h
+++ b/Framework/include/QualityControl/CcdbDatabase.h
@@ -76,9 +76,14 @@ class CcdbDatabase : public DatabaseInterface
                     const std::string& createdNotAfter = "", const std::string& createdNotBefore = "") override;
 
   // retrieval - MO - deprecated
-  std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string objectPath, std::string objectName, long timestamp = Timestamp::Current, const core::Activity& activity = {}) override;
+  std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string objectPath, std::string objectName,
+                                                                       long timestamp = Timestamp::Current,
+                                                                       const core::Activity& activity = {},
+                                                                       const std::map<std::string, std::string>& metadata = {}) override;
   // retrieval - QO - deprecated
-  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = Timestamp::Current, const core::Activity& activity = {}) override;
+  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = Timestamp::Current,
+                                                                       const core::Activity& activity = {},
+                                                                       const std::map<std::string, std::string>& metadata = {}) override;
 
   // retrieval - general
   std::string retrieveJson(std::string path, long timestamp, const std::map<std::string, std::string>& metadata) override;
@@ -91,10 +96,10 @@ class CcdbDatabase : public DatabaseInterface
   static long getCurrentTimestamp();
   static long getFutureTimestamp(int secondsInFuture);
   /**
-  * Return the listing of folder and/or objects in the subpath.
-  * @param subpath The folder we want to list the children of.
-  * @return The listing of folder and/or objects at the subpath.
-  */
+   * Return the listing of folder and/or objects in the subpath.
+   * @param subpath The folder we want to list the children of.
+   * @return The listing of folder and/or objects at the subpath.
+   */
   std::vector<std::string> getListing(const std::string& subpath = "");
 
   /**

--- a/Framework/include/QualityControl/DatabaseInterface.h
+++ b/Framework/include/QualityControl/DatabaseInterface.h
@@ -135,7 +135,9 @@ class DatabaseInterface
    * @param activity Activity of the object
    * @deprecated
    */
-  virtual std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string objectPath, std::string objectName, long timestamp = Timestamp::Current, const core::Activity& activity = {}) = 0;
+  virtual std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string objectPath, std::string objectName,
+                                                                               long timestamp = Timestamp::Current, const core::Activity& activity = {},
+                                                                               const std::map<std::string, std::string>& metadata = {}) = 0;
   /**
    * \brief Look up a quality object and return it.
    * Look up a quality object and return it if found or nullptr if not.
@@ -144,7 +146,9 @@ class DatabaseInterface
    * @param activity Activity of the object
    * @deprecated
    */
-  virtual std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = Timestamp::Current, const core::Activity& activity = {}) = 0;
+  virtual std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string qoPath, long timestamp = Timestamp::Current,
+                                                                               const core::Activity& activity = {},
+                                                                               const std::map<std::string, std::string>& metadata = {}) = 0;
 
   /**
    * \brief Look up an object and return it.

--- a/Framework/include/QualityControl/DummyDatabase.h
+++ b/Framework/include/QualityControl/DummyDatabase.h
@@ -35,10 +35,10 @@ class DummyDatabase : public DatabaseInterface
                 std::string const& detectorName, std::string const& taskName, long from = -1, long to = -1) override;
   // MonitorObject
   void storeMO(std::shared_ptr<const o2::quality_control::core::MonitorObject> q) override;
-  std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = -1, const core::Activity& activity = {}) override;
+  std::shared_ptr<o2::quality_control::core::MonitorObject> retrieveMO(std::string taskName, std::string objectName, long timestamp = -1, const core::Activity& activity = {}, const std::map<std::string, std::string>& metadata = {}) override;
   // QualityObject
   void storeQO(std::shared_ptr<const o2::quality_control::core::QualityObject> q) override;
-  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string checkerName, long timestamp = -1, const core::Activity& activity = {}) override;
+  std::shared_ptr<o2::quality_control::core::QualityObject> retrieveQO(std::string checkerName, long timestamp = -1, const core::Activity& activity = {}, const std::map<std::string, std::string>& metadata = {}) override;
 
   // General
   void* retrieveAny(std::type_info const& tinfo, std::string const& path,

--- a/Framework/include/QualityControl/MonitorObject.h
+++ b/Framework/include/QualityControl/MonitorObject.h
@@ -18,6 +18,7 @@
 #define QC_CORE_MONITOROBJECT_H
 
 // std
+#include <optional>
 #include <string>
 #include <map>
 // ROOT
@@ -113,6 +114,8 @@ class MonitorObject : public TObject
   const std::map<std::string, std::string>& getMetadataMap() const;
   /// \brief Update the value of metadata or add it if it does not exist yet.
   void addOrUpdateMetadata(std::string key, std::string value);
+  /// \brief Get metadata value of given key, returns std::nullopt if none exists;
+  std::optional<std::string> getMetadata(const std::string& key);
 
   void Draw(Option_t* option) override;
   TObject* DrawClone(Option_t* option) const override;
@@ -146,7 +149,7 @@ class MonitorObject : public TObject
   void releaseObject();
   void cloneAndSetObject(const MonitorObject&);
 
-  ClassDefOverride(MonitorObject, 13);
+  ClassDefOverride(MonitorObject, 14);
 };
 
 } // namespace o2::quality_control::core

--- a/Framework/include/QualityControl/MonitorObjectCollection.h
+++ b/Framework/include/QualityControl/MonitorObjectCollection.h
@@ -40,15 +40,17 @@ class MonitorObjectCollection : public TObjArray, public mergers::MergeInterface
   void setTaskName(const std::string&);
   const std::string& getTaskName() const;
 
+  void addOrUpdateMetadata(std::string key, std::string value);
+
   MergeInterface* cloneMovingWindow() const override;
 
  private:
   std::string mDetector = "TST";
   std::string mTaskName = "Test";
 
-  ClassDefOverride(MonitorObjectCollection, 2);
+  ClassDefOverride(MonitorObjectCollection, 3);
 };
 
 } // namespace o2::quality_control::core
 
-#endif //QUALITYCONTROL_MONITOROBJECTCOLLECTION_H
+#endif // QUALITYCONTROL_MONITOROBJECTCOLLECTION_H

--- a/Framework/include/QualityControl/ObjectMetadataKeys.h
+++ b/Framework/include/QualityControl/ObjectMetadataKeys.h
@@ -28,6 +28,8 @@ constexpr auto created = "Created";
 constexpr auto md5sum = "Content-MD5";
 constexpr auto objectType = "ObjectType";
 constexpr auto lastModified = "lastModified";
+constexpr auto cycle = "Cycle";
+
 // General QC framework
 constexpr auto qcVersion = "qc_version";
 constexpr auto qcDetectorCode = "qc_detector_name";
@@ -36,6 +38,7 @@ constexpr auto qcTaskClass = "qc_task_class";
 constexpr auto qcQuality = "qc_quality";
 constexpr auto qcCheckName = "qc_check_name";
 constexpr auto qcAdjustableEOV = "adjustableEOV"; // this is a keyword for the CCDB
+
 // QC Activity
 constexpr auto runType = "RunType";
 constexpr auto runNumber = "RunNumber";

--- a/Framework/include/QualityControl/Triggers.h
+++ b/Framework/include/QualityControl/Triggers.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <iosfwd>
 #include <utility>
+#include <map>
 #include "QualityControl/Activity.h"
 
 namespace o2::quality_control::postprocessing
@@ -48,12 +49,12 @@ struct Trigger {
 
   /// \brief Constructor. Timestamp is generated from the time of construction.
   Trigger(TriggerType triggerType, bool last = false, core::Activity activity = {})
-    : triggerType(triggerType), last(last), activity(std::move(activity)), timestamp(msSinceEpoch()){};
+    : triggerType(triggerType), last(last), activity(std::move(activity)), timestamp(msSinceEpoch()) {};
   /// \brief Constructor.
   Trigger(TriggerType triggerType, bool last, core::Activity activity, uint64_t timestamp, std::string config = {})
-    : triggerType(triggerType), last(last), activity(std::move(activity)), timestamp(timestamp), config(std::move(config)){};
+    : triggerType(triggerType), last(last), activity(std::move(activity)), timestamp(timestamp), config(std::move(config)) {};
   /// \brief Constructor.
-  Trigger(TriggerType triggerType, bool last, uint64_t timestamp) : triggerType(triggerType), last(last), activity(), timestamp(timestamp){};
+  Trigger(TriggerType triggerType, bool last, uint64_t timestamp) : triggerType(triggerType), last(last), activity(), timestamp(timestamp) {};
 
   operator bool() const { return triggerType != TriggerType::No && triggerType != TriggerType::INVALID; }
   friend std::ostream& operator<<(std::ostream& out, const Trigger& t);
@@ -69,6 +70,7 @@ struct Trigger {
   core::Activity activity; // if tracking an object, it contains also its validity start and end
   uint64_t timestamp;      // if tracking an object, it is the validity start (validFrom)
   std::string config{};
+  std::map<std::string, std::string> metadata{}; // metadata to search in database
 };
 
 using TriggerFcn = std::function<Trigger()>;

--- a/Framework/src/CcdbDatabase.cxx
+++ b/Framework/src/CcdbDatabase.cxx
@@ -283,6 +283,9 @@ TObject* CcdbDatabase::retrieveTObject(std::string path, std::map<std::string, s
   auto* object = ccdbApi->retrieveFromTFileAny<TObject>(path, metadata, timestamp, headers);
   if (object == nullptr) {
     ILOG(Warning, Support) << "We could NOT retrieve the object " << path << " with timestamp " << timestamp << "." << ENDM;
+    for (auto [metaKey, metaVal] : metadata) {
+      ILOG(Debug, Support) << "and with metadata: [" << metaKey << ", " << metaVal << "]" << ENDM;
+    }
     return nullptr;
   }
   ILOG(Debug, Support) << "Retrieved object " << path << " with timestamp " << timestamp << ENDM;
@@ -307,11 +310,14 @@ void* CcdbDatabase::retrieveAny(const type_info& tinfo, const string& path, cons
   return object;
 }
 
-std::shared_ptr<o2::quality_control::core::MonitorObject> CcdbDatabase::retrieveMO(std::string objectPath, std::string objectName, long timestamp, const core::Activity& activity)
+std::shared_ptr<o2::quality_control::core::MonitorObject> CcdbDatabase::retrieveMO(std::string objectPath, std::string objectName,
+                                                                                   long timestamp, const core::Activity& activity,
+                                                                                   const std::map<std::string, std::string>& metadataToRetrieve)
 {
   string fullPath = activity.mProvenance + "/" + objectPath + "/" + objectName;
   map<string, string> headers;
   map<string, string> metadata = activity_helpers::asDatabaseMetadata(activity, false);
+  metadata.insert(metadataToRetrieve.begin(), metadataToRetrieve.end());
   TObject* obj = retrieveTObject(fullPath, metadata, timestamp, &headers);
 
   // no object found
@@ -348,10 +354,13 @@ std::shared_ptr<o2::quality_control::core::MonitorObject> CcdbDatabase::retrieve
   return mo;
 }
 
-std::shared_ptr<o2::quality_control::core::QualityObject> CcdbDatabase::retrieveQO(std::string qoPath, long timestamp, const core::Activity& activity)
+std::shared_ptr<o2::quality_control::core::QualityObject> CcdbDatabase::retrieveQO(std::string qoPath, long timestamp,
+                                                                                   const core::Activity& activity,
+                                                                                   const std::map<std::string, std::string>& metadataToRetrieve)
 {
   map<string, string> headers;
   map<string, string> metadata = activity_helpers::asDatabaseMetadata(activity, false);
+  metadata.insert(metadataToRetrieve.begin(), metadataToRetrieve.end());
   auto fullPath = activity.mProvenance + "/" + qoPath;
   TObject* obj = retrieveTObject(fullPath, metadata, timestamp, &headers);
   if (obj == nullptr) {

--- a/Framework/src/Check.cxx
+++ b/Framework/src/Check.cxx
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <algorithm>
+#include <string>
 #include <utility>
 #include <ranges>
 // O2
@@ -24,6 +25,7 @@
 #include "QualityControl/CommonSpec.h"
 #include "QualityControl/InputUtils.h"
 #include "QualityControl/MonitorObject.h"
+#include "QualityControl/ObjectMetadataKeys.h"
 #include "QualityControl/RootClassFactory.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/Quality.h"
@@ -163,7 +165,14 @@ QualityObjectsType Check::check(std::map<std::string, std::shared_ptr<MonitorObj
       }));
     ILOG(Debug, Devel) << "Check '" << mCheckConfig.name << "', quality '" << quality << "'" << ENDM;
     std::vector<std::string> monitorObjectsNames;
-    std::ranges::copy(moMapToCheck | std::views::keys, std::back_inserter(monitorObjectsNames));
+    // std::ranges::copy(moMapToCheck | std::views::keys, std::back_inserter(monitorObjectsNames));
+    unsigned long maxCycle{};
+    for (const auto& [moName, mo] : moMapToCheck) {
+      monitorObjectsNames.emplace_back(moName);
+      if (const auto cycle = mo->getMetadata(repository::metadata_keys::cycle)) {
+        maxCycle = std::max(std::stoul(cycle.value()), maxCycle);
+      }
+    }
     // todo: take metadata from somewhere
     qualityObjects.emplace_back(std::make_shared<QualityObject>(
       quality,
@@ -172,7 +181,11 @@ QualityObjectsType Check::check(std::map<std::string, std::shared_ptr<MonitorObj
       UpdatePolicyTypeUtils::ToString(mCheckConfig.policyType),
       stringifyInput(mCheckConfig.inputSpecs),
       monitorObjectsNames));
+
     qualityObjects.back()->setActivity(commonActivity);
+    if (maxCycle > 0) {
+      qualityObjects.back()->addMetadata(repository::metadata_keys::cycle, std::to_string(maxCycle));
+    }
     beautify(moMapToCheck, quality);
   }
 

--- a/Framework/src/DummyDatabase.cxx
+++ b/Framework/src/DummyDatabase.cxx
@@ -38,7 +38,7 @@ void DummyDatabase::storeMO(std::shared_ptr<const o2::quality_control::core::Mon
 {
 }
 
-std::shared_ptr<o2::quality_control::core::MonitorObject> DummyDatabase::retrieveMO(std::string, std::string, long, const core::Activity& activity)
+std::shared_ptr<o2::quality_control::core::MonitorObject> DummyDatabase::retrieveMO(std::string, std::string, long, const core::Activity& activity, const std::map<std::string, std::string>&)
 {
   return {};
 }
@@ -47,7 +47,7 @@ void DummyDatabase::storeQO(std::shared_ptr<const o2::quality_control::core::Qua
 {
 }
 
-std::shared_ptr<o2::quality_control::core::QualityObject> DummyDatabase::retrieveQO(std::string, long, const core::Activity& activity)
+std::shared_ptr<o2::quality_control::core::QualityObject> DummyDatabase::retrieveQO(std::string, long, const core::Activity& activity, const std::map<std::string, std::string>& metadata)
 {
   return {};
 }

--- a/Framework/src/MonitorObject.cxx
+++ b/Framework/src/MonitorObject.cxx
@@ -20,6 +20,8 @@
 #include "QualityControl/QcInfoLogger.h"
 
 #include <iostream>
+#include <iterator>
+#include <optional>
 
 using namespace std;
 
@@ -151,6 +153,14 @@ void MonitorObject::addOrUpdateMetadata(std::string key, std::string value)
   } else {
     mUserMetadata.insert({ key, value });
   }
+}
+
+std::optional<std::string> MonitorObject::getMetadata(const std::string& key)
+{
+  if (const auto foundIt = mUserMetadata.find(key); foundIt != std::end(mUserMetadata)) {
+    return foundIt->second;
+  }
+  return std::nullopt;
 }
 
 std::string MonitorObject::getPath() const

--- a/Framework/src/MonitorObjectCollection.cxx
+++ b/Framework/src/MonitorObjectCollection.cxx
@@ -16,15 +16,27 @@
 
 #include "QualityControl/MonitorObjectCollection.h"
 #include "QualityControl/MonitorObject.h"
+#include "QualityControl/ObjectMetadataKeys.h"
 #include "QualityControl/QcInfoLogger.h"
 
 #include <Mergers/MergerAlgorithm.h>
 #include <TNamed.h>
+#include <string>
 
 using namespace o2::mergers;
 
 namespace o2::quality_control::core
 {
+
+void mergeCycles(MonitorObject*& otherMO, MonitorObject*& targetMO)
+{
+  const auto otherCycle = otherMO->getMetadata(repository::metadata_keys::cycle);
+  const auto targetCycle = targetMO->getMetadata(repository::metadata_keys::cycle);
+  if (otherCycle.has_value() && targetCycle.has_value()) {
+    // TODO: would it be worth it for metadata to store other types than std::string?
+    targetMO->addOrUpdateMetadata(repository::metadata_keys::cycle, std::to_string(std::max(std::stoul(otherCycle.value()), std::stoul(targetCycle.value()))));
+  }
+}
 
 void MonitorObjectCollection::merge(mergers::MergeInterface* const other)
 {
@@ -59,6 +71,8 @@ void MonitorObjectCollection::merge(mergers::MergeInterface* const other)
         otherMO->Copy(*targetMO);
         continue;
       }
+
+      mergeCycles(otherMO, targetMO);
 
       if (!reportedMismatchingRunNumbers && otherMO->getActivity().mId < targetMO->getActivity().mId) {
         ILOG(Error, Ops) << "The run number of the input object '" << otherMO->GetName() << "' ("
@@ -135,6 +149,15 @@ void MonitorObjectCollection::setTaskName(const std::string& taskName)
 const std::string& MonitorObjectCollection::getTaskName() const
 {
   return mTaskName;
+}
+
+void MonitorObjectCollection::addOrUpdateMetadata(std::string key, std::string value)
+{
+  for (auto obj : *this) {
+    if (auto mo = dynamic_cast<MonitorObject*>(obj)) {
+      mo->addOrUpdateMetadata(key, value);
+    }
+  }
 }
 
 std::string formatDuration(uint64_t durationMs)

--- a/Framework/src/ReductorHelpers.cxx
+++ b/Framework/src/ReductorHelpers.cxx
@@ -34,7 +34,7 @@ bool updateReductorImpl(Reductor* r, const Trigger& t, const std::string& path, 
   }
 
   if (type == "repository") {
-    auto mo = qcdb.retrieveMO(path, name, t.timestamp, t.activity);
+    auto mo = qcdb.retrieveMO(path, name, t.timestamp, t.activity, t.metadata);
     TObject* obj = mo ? mo->getObject() : nullptr;
     auto reductorTObject = dynamic_cast<ReductorTObject*>(r);
     if (obj && reductorTObject) {
@@ -42,7 +42,7 @@ bool updateReductorImpl(Reductor* r, const Trigger& t, const std::string& path, 
       return true;
     }
   } else if (type == "repository-quality") {
-    auto qo = qcdb.retrieveQO(path + "/" + name, t.timestamp, t.activity);
+    auto qo = qcdb.retrieveQO(path + "/" + name, t.timestamp, t.activity, t.metadata);
     auto reductorTObject = dynamic_cast<ReductorTObject*>(r);
     if (qo && reductorTObject) {
       reductorTObject->update(qo.get());

--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -45,7 +45,7 @@ void SliceTrendingTask::configure(const boost::property_tree::ptree& config)
   mConfig = SliceTrendingTaskConfig(getID(), config);
 }
 
-void SliceTrendingTask::initialize(Trigger, framework::ServiceRegistryRef services)
+void SliceTrendingTask::initialize(Trigger t, framework::ServiceRegistryRef services)
 {
   // removing leftovers from any previous runs
   mTrend.reset();
@@ -63,7 +63,7 @@ void SliceTrendingTask::initialize(Trigger, framework::ServiceRegistryRef servic
     ILOG(Info, Support) << "Trying to retrieve an existing TTree for this task to continue the trend." << ENDM;
     auto& qcdb = services.get<repository::DatabaseInterface>();
     auto path = RepoPathUtils::getMoPath(mConfig.detectorName, PostProcessingInterface::getName(), "", "", false);
-    auto mo = qcdb.retrieveMO(path, PostProcessingInterface::getName(), repository::DatabaseInterface::Timestamp::Latest);
+    auto mo = qcdb.retrieveMO(path, PostProcessingInterface::getName(), repository::DatabaseInterface::Timestamp::Latest, {}, t.metadata);
     if (mo && mo->getObject()) {
       auto tree = dynamic_cast<TTree*>(mo->getObject());
       if (tree) {
@@ -151,7 +151,7 @@ void SliceTrendingTask::trendValues(const Trigger& t,
     mNumberPads[dataSource.name] = 0;
     mSources[dataSource.name]->clear();
     if (dataSource.type == "repository") {
-      auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name, t.timestamp, t.activity);
+      auto mo = qcdb.retrieveMO(dataSource.path, dataSource.name, t.timestamp, t.activity, t.metadata);
       TObject* obj = mo ? mo->getObject() : nullptr;
 
       mAxisDivision[dataSource.name] = dataSource.axisDivision;

--- a/Framework/src/TaskRunner.cxx
+++ b/Framework/src/TaskRunner.cxx
@@ -37,6 +37,7 @@
 #include <CommonUtils/ConfigurableParam.h>
 #include <DetectorsBase/GRPGeomHelper.h>
 
+#include "QualityControl/ObjectMetadataKeys.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/TaskFactory.h"
 #include "QualityControl/runnerUtils.h"
@@ -523,6 +524,8 @@ int TaskRunner::publish(DataAllocator& outputs)
   // getNonOwningArray creates a TObjArray containing the monitoring objects, but not
   // owning them. The array is created by new and must be cleaned up by the caller
   std::unique_ptr<MonitorObjectCollection> array(mObjectsManager->getNonOwningArray());
+  // TODO: this will send object with cycle == 0. should I send here cycle + 1? (same for QOs)
+  array->addOrUpdateMetadata(repository::metadata_keys::cycle, std::to_string(mCycleNumber));
   int objectsPublished = array->GetEntries();
 
   outputs.snapshot(

--- a/Framework/src/Triggers.cxx
+++ b/Framework/src/Triggers.cxx
@@ -293,7 +293,11 @@ TriggerFcn ForEachObject(const std::string& databaseUrl, const std::string& data
       auto currentActivity = activity_helpers::asActivity(*currentObject, activity.mProvenance);
       bool last = currentObject + 1 == filteredObjects->end();
       Trigger trigger(TriggerType::ForEachObject, last, currentActivity, currentObject->get<int64_t>(timestampSortKey));
+      if (auto cycle = currentObject->get_optional<std::string>(metadata_keys::cycle); cycle.has_value()) {
+        trigger.metadata.emplace(metadata_keys::cycle, cycle.value());
+      }
       ++currentObject;
+
       return trigger;
     } else {
       return { TriggerType::No, true, activity, Trigger::msSinceEpoch(), config };

--- a/Framework/test/testCcdbDatabase.cxx
+++ b/Framework/test/testCcdbDatabase.cxx
@@ -15,6 +15,7 @@
 /// \author Barthelemy von Haller
 ///
 
+#include "QualityControl/Activity.h"
 #include "QualityControl/CcdbDatabase.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/Version.h"
@@ -24,6 +25,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include <TH1F.h>
 #include "QualityControl/RepoPathUtils.h"
 #include "QualityControl/ObjectMetadataKeys.h"
@@ -129,6 +131,18 @@ BOOST_AUTO_TEST_CASE(ccdb_store)
   shared_ptr<MonitorObject> mo4 = make_shared<MonitorObject>(h4, f.taskName, "TestClass", "TST");
   mo4->updateActivity(1234, "LHC66", "passName1", "qc_hello");
 
+  TH1F* h5 = new TH1F("cycle", "asdf", 100, 0, 99);
+  shared_ptr<MonitorObject> mo5 = make_shared<MonitorObject>(h5, f.taskName, "TestClass", "TST");
+  mo5->addMetadata(metadata_keys::cycle, "1");
+  mo5->setValidity({ 10000, 20000 });
+  mo5->updateActivity(1234, "LHC66", "passName1", "qc");
+
+  TH1F* h6 = new TH1F("cycle", "asdf", 100, 0, 99);
+  shared_ptr<MonitorObject> mo6 = make_shared<MonitorObject>(h6, f.taskName, "TestClass", "TST");
+  mo6->addMetadata(metadata_keys::cycle, "2");
+  mo6->setValidity({ 10000, 20000 });
+  mo6->updateActivity(1234, "LHC66", "passName1", "qc");
+
   shared_ptr<QualityObject> qo1 = make_shared<QualityObject>(Quality::Bad, f.taskName + "/test-ccdb-check", "TST", "OnAll", vector{ string("input1"), string("input2") });
   qo1->updateActivity(1234, "LHC66", "passName1", "qc");
   shared_ptr<QualityObject> qo2 = make_shared<QualityObject>(Quality::Null, f.taskName + "/metadata", "TST", "OnAll", vector{ string("input1") });
@@ -141,6 +155,9 @@ BOOST_AUTO_TEST_CASE(ccdb_store)
   f.backend->storeMO(mo1);
   f.backend->storeMO(mo2);
   f.backend->storeMO(mo4);
+  f.backend->storeMO(mo5);
+  f.backend->storeMO(mo6);
+
   f.backend->storeQO(qo1);
   f.backend->storeQO(qo2);
   f.backend->storeQO(qo4);
@@ -210,6 +227,23 @@ BOOST_AUTO_TEST_CASE(ccdb_retrieve_inexisting_mo)
   BOOST_CHECK(mo == nullptr);
 }
 
+BOOST_AUTO_TEST_CASE(ccdb_retrieve_mo_with_cycle, *utf::depends_on("ccdb_store"))
+{
+  test_fixture f;
+  std::shared_ptr<MonitorObject> mo{};
+  mo = f.backend->retrieveMO(f.getMoFolder("cycle"), "cycle",
+                             15000, Activity{}, { { metadata_keys::cycle, "1" } });
+  BOOST_REQUIRE(mo.get() != nullptr);
+  BOOST_REQUIRE_NO_THROW(mo->getMetadata(metadata_keys::cycle));
+  BOOST_REQUIRE(mo->getMetadata(metadata_keys::cycle) == "1");
+
+  mo = f.backend->retrieveMO(f.getMoFolder("cycle"), "cycle",
+                             15000, Activity{}, { { metadata_keys::cycle, "2" } });
+  BOOST_REQUIRE(mo.get() != nullptr);
+  BOOST_REQUIRE_NO_THROW(mo->getMetadata(metadata_keys::cycle));
+  BOOST_REQUIRE(mo->getMetadata(metadata_keys::cycle) == "2");
+}
+
 BOOST_AUTO_TEST_CASE(ccdb_retrieve_qo, *utf::depends_on("ccdb_store"))
 {
   test_fixture f;
@@ -221,6 +255,14 @@ BOOST_AUTO_TEST_CASE(ccdb_retrieve_qo, *utf::depends_on("ccdb_store"))
   BOOST_CHECK_EQUAL(qo->getActivity().mPeriodName, "LHC66");
   BOOST_CHECK_EQUAL(qo->getActivity().mPassName, "passName1");
   BOOST_CHECK_EQUAL(qo->getActivity().mProvenance, "qc");
+
+  qo = f.backend->retrieveQO(RepoPathUtils::getQoPath("TST", f.taskName + "/metadata", "", {}, "", false), repository::CcdbDatabase::Timestamp::Current, {}, { { "my_meta", "is_good" } });
+  BOOST_REQUIRE_NE(qo, nullptr);
+  BOOST_REQUIRE_NO_THROW(qo->getMetadata("my_meta"));
+  BOOST_CHECK_EQUAL(qo->getMetadata("my_meta"), "is_good");
+
+  qo = f.backend->retrieveQO(RepoPathUtils::getQoPath("TST", f.taskName + "/metadata", "", {}, "", false), repository::CcdbDatabase::Timestamp::Current, {}, { { "my_meta", "nonexistent" } });
+  BOOST_REQUIRE_EQUAL(qo, nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(ccdb_provenance, *utf::depends_on("ccdb_store"))


### PR DESCRIPTION
Adding Cycle value to the metadata of the MonitorObject and QualityObject. These are stored in ccdb and used to pull correct version of object when using ForEachObject trigger. 

During merging we use the maximum value of all encountered cycles. The same strategy is used when converting MOs to QOs.