### PR TITLE
Fix TrendCheck creating Quality without a name

### DIFF
--- a/Modules/Common/src/TrendCheck.cxx
+++ b/Modules/Common/src/TrendCheck.cxx
@@ -436,6 +436,9 @@ void TrendCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult
 
     auto graphName = moName + "_" + std::to_string(graphIndex);
 
+    if (!mQualities.contains(graphName)) {
+      continue;
+    }
     Quality quality = mQualities[graphName];
 
     if (mThresholdsTrendMedium.count(graphName) > 0) {


### PR DESCRIPTION
A default Quality would be created when TrendCheck::beautify was trying to access a non-existent entry in mQualities map. When using operator[] with a missing key, the object is added using the default constructor, so Quality(10, "") was being created. This was causing crashes in QualityTask, which was relying on a non-empty Quality name to be there.