### PR TITLE
Add fully qualified names for std::string and std::map

### DIFF
--- a/Modules/CTP/src/CTPTrendingTask.cxx
+++ b/Modules/CTP/src/CTPTrendingTask.cxx
@@ -60,7 +60,7 @@ void CTPTrendingTask::initCTP(Trigger& t)
   // o2::ctp::CTPConfiguration CTPconfig = o2::ctp::CTPRunManager::getConfigFromCCDB(t.timestamp, run, ok);
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
   mgr.setURL(CCDBHost);
-  map<string, string> metadata; // can be empty
+  std::map<std::string, std::string> metadata; // can be empty
   metadata["runNumber"] = run;
   mgr.setFatalWhenNull(false);
   auto ctpconfigdb = mgr.getSpecific<o2::ctp::CTPConfiguration>(o2::ctp::CCDBPathCTPConfig, t.timestamp, metadata);
@@ -80,11 +80,11 @@ void CTPTrendingTask::initCTP(Trigger& t)
   }
 
   for (int i = 0; i < 5; i++) {
-    mClassNames[i] = getFromExtendedConfig<string>(t.activity, mCustomParameters, mClassParameters[i], mClassNamesDefault[i]);
+    mClassNames[i] = getFromExtendedConfig<std::string>(t.activity, mCustomParameters, mClassParameters[i], mClassNamesDefault[i]);
     if (mClassNames[i] == "") {
       mClassNames[i] = mClassNamesDefault[i];
     }
-    mInputNames[i] = getFromExtendedConfig<string>(t.activity, mCustomParameters, mInputParameters[i], mInputNamesDefault[i]);
+    mInputNames[i] = getFromExtendedConfig<std::string>(t.activity, mCustomParameters, mInputParameters[i], mInputNamesDefault[i]);
     if (mInputNames[i] == "") {
       mInputNames[i] = mInputNamesDefault[i];
     }

--- a/Modules/CTP/src/RawDataQcTask.cxx
+++ b/Modules/CTP/src/RawDataQcTask.cxx
@@ -80,12 +80,12 @@ void CTPRawDataReaderTask::startOfActivity(const Activity& activity)
   mRunNumber = activity.mId;
   mTimestamp = activity.mValidity.getMin();
 
-  std::string readCTPConfig = getFromExtendedConfig<string>(activity, mCustomParameters, "readCTPconfigInMonitorData", "false");
+  std::string readCTPConfig = getFromExtendedConfig<std::string>(activity, mCustomParameters, "readCTPconfigInMonitorData", "false");
   if (readCTPConfig == "true") {
     mReadCTPconfigInMonitorData = true;
   }
 
-  mMBclassName = getFromExtendedConfig<string>(activity, mCustomParameters, "MBclassName", "CMTVX-B-NOPF");
+  mMBclassName = getFromExtendedConfig<std::string>(activity, mCustomParameters, "MBclassName", "CMTVX-B-NOPF");
 
   std::string run = std::to_string(mRunNumber);
   std::string ccdbName = mCustomParameters["ccdbName"];
@@ -98,7 +98,7 @@ void CTPRawDataReaderTask::startOfActivity(const Activity& activity)
     bool ok;
     auto& mgr = o2::ccdb::BasicCCDBManager::instance();
     mgr.setURL(ccdbName);
-    map<string, string> metadata; // can be empty
+    std::map<std::string, std::string> metadata; // can be empty
     metadata["runNumber"] = run;
     auto ctpconfigdb = mgr.getSpecific<o2::ctp::CTPConfiguration>(o2::ctp::CCDBPathCTPConfig, mTimestamp, metadata);
     if (ctpconfigdb == nullptr) {
@@ -130,8 +130,8 @@ void CTPRawDataReaderTask::startOfActivity(const Activity& activity)
     mHistoClassRatios->SetTitle(Form("Class Ratio to %s", mMBclassName.c_str()));
   }
 
-  std::string nameInput1 = getFromExtendedConfig<string>(activity, mCustomParameters, "MB1inputName", "MTVX");
-  std::string nameInput2 = getFromExtendedConfig<string>(activity, mCustomParameters, "MB2inputName", "MT0A");
+  std::string nameInput1 = getFromExtendedConfig<std::string>(activity, mCustomParameters, "MB1inputName", "MTVX");
+  std::string nameInput2 = getFromExtendedConfig<std::string>(activity, mCustomParameters, "MB2inputName", "MT0A");
 
   auto input1Tokens = o2::utils::Str::tokenize(nameInput1, ':', false, true);
   if (input1Tokens.size() > 0) {
@@ -206,7 +206,7 @@ void CTPRawDataReaderTask::startOfActivity(const Activity& activity)
   mHistoBCMinBias2->SetTitle(Form("%s; %s; %s", title2.Data(), titleX2.Data(), titley2.Data()));
   mHistoInputRatios->SetTitle(Form("Input Ratio to %s", nameInput1.c_str()));
 
-  std::string performConsistencyCheck = getFromExtendedConfig<string>(activity, mCustomParameters, "consistencyCheck", "true");
+  std::string performConsistencyCheck = getFromExtendedConfig<std::string>(activity, mCustomParameters, "consistencyCheck", "true");
   if (performConsistencyCheck == "true") {
     mDecoder.setCheckConsistency(1);
     mDecoder.setDecodeInps(1);

--- a/Modules/Common/src/CcdbInspectorTask.cxx
+++ b/Modules/Common/src/CcdbInspectorTask.cxx
@@ -154,7 +154,7 @@ std::tuple<uint64_t, uint64_t, uint64_t, int> CcdbInspectorTask::getObjectInfo(c
 
 void* CcdbInspectorTask::getObject(const std::string& path, std::type_info const& tinfo, uint64_t timestamp, const std::map<std::string, std::string>& metadata)
 {
-  map<string, string> headers;
+  std::map<std::string, std::string> headers;
   void* obj = mDatabase->retrieveAny(tinfo, path, metadata, timestamp, &headers);
   ILOG(Debug, Devel) << "Retrieved '" << path << "' from db '" << mDatabaseUrl << "' for timestamp " << timestamp << ENDM;
 

--- a/Modules/FIT/FDD/src/DigitQcTask.cxx
+++ b/Modules/FIT/FDD/src/DigitQcTask.cxx
@@ -411,7 +411,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   for (int i = 0; i < getObjectsManager()->getNumberPublishedObjects(); i++) {
     TH1* obj = dynamic_cast<TH1*>(getObjectsManager()->getMonitorObject(i)->getObject());
-    obj->SetTitle((string("FDD ") + obj->GetTitle()).c_str());
+    obj->SetTitle((std::string("FDD ") + obj->GetTitle()).c_str());
   }
   // Timestamp
   mMetaAnchorOutput = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "metaAnchorOutput", "CycleDurationNTF");

--- a/Modules/FIT/FDD/src/DigitQcTaskLaser.cxx
+++ b/Modules/FIT/FDD/src/DigitQcTaskLaser.cxx
@@ -208,7 +208,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
 
   for (int i = 0; i < getObjectsManager()->getNumberPublishedObjects(); i++) {
     TH1* obj = dynamic_cast<TH1*>(getObjectsManager()->getMonitorObject(i)->getObject());
-    obj->SetTitle((string("FDD Laser ") + obj->GetTitle()).c_str());
+    obj->SetTitle((std::string("FDD Laser ") + obj->GetTitle()).c_str());
   }
 }
 

--- a/Modules/FIT/FDD/src/PostProcTask.cxx
+++ b/Modules/FIT/FDD/src/PostProcTask.cxx
@@ -276,7 +276,7 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistryRef services)
   for (int i = 0; i < getObjectsManager()->getNumberPublishedObjects(); i++) {
     TH1* obj = dynamic_cast<TH1*>(getObjectsManager()->getMonitorObject(i)->getObject());
     if (obj != nullptr) {
-      obj->SetTitle((string("FDD ") + obj->GetTitle()).c_str());
+      obj->SetTitle((std::string("FDD ") + obj->GetTitle()).c_str());
     }
   }
 

--- a/Modules/FIT/FT0/src/DigitQcTask.cxx
+++ b/Modules/FIT/FT0/src/DigitQcTask.cxx
@@ -228,7 +228,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   for (int i = 0; i < getObjectsManager()->getNumberPublishedObjects(); i++) {
     TH1* obj = dynamic_cast<TH1*>(getObjectsManager()->getMonitorObject(i)->getObject());
-    obj->SetTitle((string("FT0 ") + obj->GetTitle()).c_str());
+    obj->SetTitle((std::string("FT0 ") + obj->GetTitle()).c_str());
   }
   //
   mGoodPMbits_ChID = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "goodPMbits_ChID", 1 << o2::ft0::ChannelData::kIsCFDinADCgate);

--- a/Modules/FIT/FV0/src/DigitQcTask.cxx
+++ b/Modules/FIT/FV0/src/DigitQcTask.cxx
@@ -372,7 +372,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   for (int i = 0; i < getObjectsManager()->getNumberPublishedObjects(); i++) {
     TH1* obj = dynamic_cast<TH1*>(getObjectsManager()->getMonitorObject(i)->getObject());
-    obj->SetTitle((string("FV0 ") + obj->GetTitle()).c_str());
+    obj->SetTitle((std::string("FV0 ") + obj->GetTitle()).c_str());
   }
   // Timestamp
   mMetaAnchorOutput = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "metaAnchorOutput", "CycleDurationNTF");

--- a/Modules/FIT/FV0/src/DigitQcTaskLaser.cxx
+++ b/Modules/FIT/FV0/src/DigitQcTaskLaser.cxx
@@ -304,7 +304,7 @@ void DigitQcTaskLaser::initialize(o2::framework::InitContext& /*ctx*/)
 
   for (int i = 0; i < getObjectsManager()->getNumberPublishedObjects(); i++) {
     TH1* obj = dynamic_cast<TH1*>(getObjectsManager()->getMonitorObject(i)->getObject());
-    obj->SetTitle((string("FV0 Laser ") + obj->GetTitle()).c_str());
+    obj->SetTitle((std::string("FV0 Laser ") + obj->GetTitle()).c_str());
   }
 }
 

--- a/Modules/FIT/FV0/src/PostProcTask.cxx
+++ b/Modules/FIT/FV0/src/PostProcTask.cxx
@@ -303,7 +303,7 @@ void PostProcTask::initialize(Trigger, framework::ServiceRegistryRef services)
   for (int i = 0; i < getObjectsManager()->getNumberPublishedObjects(); i++) {
     TH1* obj = dynamic_cast<TH1*>(getObjectsManager()->getMonitorObject(i)->getObject());
     if (obj != nullptr) {
-      obj->SetTitle((string("FV0 ") + obj->GetTitle()).c_str());
+      obj->SetTitle((std::string("FV0 ") + obj->GetTitle()).c_str());
     }
   }
 

--- a/Modules/GLO/src/CTFSizeTask.cxx
+++ b/Modules/GLO/src/CTFSizeTask.cxx
@@ -66,7 +66,7 @@ void CTFSize::initialize(o2::framework::InitContext& /*ctx*/)
   mDefaultBinning[DetID::CTP] = "100, 1, 100";
   mDefaultBinning[DetID::TST] = "1, 0, 1";
 
-  std::string detList = getFromConfig<string>(mCustomParameters, "detectors", "all");
+  std::string detList = getFromConfig<std::string>(mCustomParameters, "detectors", "all");
   auto detMask = DetID::getMask(detList);
 
   constexpr int nLogBins = 100;

--- a/Modules/ITS/include/ITS/ITSNoisyPixelTask.h
+++ b/Modules/ITS/include/ITS/ITSNoisyPixelTask.h
@@ -103,7 +103,7 @@ class ITSNoisyPixelTask : public TaskInterface
   long int mTimestamp;
 
   int mLocalGeometryFile = 0;
-  string mGeoTimestamp = "1640991600000";
+  std::string mGeoTimestamp = "1640991600000";
 };
 } //  namespace o2::quality_control_modules::its
 

--- a/Modules/ITS/include/ITS/ITSThresholdCalibrationTask.h
+++ b/Modules/ITS/include/ITS/ITSThresholdCalibrationTask.h
@@ -93,11 +93,11 @@ class ITSThresholdCalibrationTask : public TaskInterface
   Int_t getBarrel(Int_t iLayer);
   int getCurrentChip(int barrel, int chipid, int hic, int hs);
 
-  void doAnalysisTHR(string inString, int iScan);
-  void doAnalysisPixel(string inString);
+  void doAnalysisTHR(std::string inString, int iScan);
+  void doAnalysisPixel(std::string inString);
 
-  CalibrationResStructTHR CalibrationParserTHR(string input);
-  CalibrationResStructPixel CalibrationParserPixel(string input);
+  CalibrationResStructTHR CalibrationParserTHR(std::string input);
+  CalibrationResStructPixel CalibrationParserPixel(std::string input);
 
   std::vector<TObject*> mPublishedObjects;
 

--- a/Modules/ITS/src/ITSChipStatusCheck.cxx
+++ b/Modules/ITS/src/ITSChipStatusCheck.cxx
@@ -31,10 +31,10 @@ Quality ITSChipStatusCheck::check(std::map<std::string, std::shared_ptr<MonitorO
 {
 
   // limits to be used as "X,Y" --> BAD if at least X FFEIDs have at least Y chips each into error
-  std::vector<float> feeidlimitsIB = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "feeidlimitsIB", ""));
-  std::vector<float> feeidlimitsML = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "feeidlimitsML", ""));
-  std::vector<float> feeidlimitsOL = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "feeidlimitsOL", ""));
-  std::vector<int> excludedfeeid = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "excludedfeeid", ""));
+  std::vector<float> feeidlimitsIB = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "feeidlimitsIB", ""));
+  std::vector<float> feeidlimitsML = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "feeidlimitsML", ""));
+  std::vector<float> feeidlimitsOL = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "feeidlimitsOL", ""));
+  std::vector<int> excludedfeeid = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "excludedfeeid", ""));
 
   if (feeidlimitsIB.size() != 2) {
     ILOG(Error, Support) << "Incorrect setting for feeidlimitsIB, check .json. Using default 1,1" << ENDM;
@@ -117,7 +117,7 @@ void ITSChipStatusCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality che
   TString status;
   int textColor;
 
-  if ((string)mo->GetName() == "FEEIDOverview") {
+  if ((std::string)mo->GetName() == "FEEIDOverview") {
     auto* h = dynamic_cast<TH1D*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast FEEIDOverview to TH1D*" << ENDM;
@@ -140,7 +140,7 @@ void ITSChipStatusCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality che
     h->GetListOfFunctions()->Add(tInfo->Clone());
   }
 
-  if ((string)mo->getName() == "StaveStatusOverview") {
+  if ((std::string)mo->getName() == "StaveStatusOverview") {
     auto* h = dynamic_cast<TH2Poly*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast StaveStatusOverview to TH2Poly*" << ENDM;

--- a/Modules/ITS/src/ITSClusterCheck.cxx
+++ b/Modules/ITS/src/ITSClusterCheck.cxx
@@ -74,8 +74,8 @@ Quality ITSClusterCheck::check(std::map<std::string, std::shared_ptr<MonitorObje
         ILOG(Error, Support) << "could not cast general occupancy to TH2D*" << ENDM;
         continue;
       }
-      std::vector<int> skipxbins = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "skipxbinsoccupancy", ""));
-      std::vector<int> skipybins = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "skipybinsoccupancy", ""));
+      std::vector<int> skipxbins = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "skipxbinsoccupancy", ""));
+      std::vector<int> skipybins = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "skipybinsoccupancy", ""));
       std::vector<std::pair<int, int>> xypairs;
       for (int i = 0; i < (int)skipxbins.size(); i++) {
         xypairs.push_back(std::make_pair(skipxbins[i], skipybins[i]));
@@ -140,9 +140,9 @@ std::string ITSClusterCheck::getAcceptedType() { return "TH2D"; }
 
 void ITSClusterCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  std::vector<string> vPlotWithTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "plotWithTextMessage", ""));
-  std::vector<string> vTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "textMessage", ""));
-  std::map<string, string> ShifterInfoText;
+  std::vector<std::string> vPlotWithTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "plotWithTextMessage", ""));
+  std::vector<std::string> vTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "textMessage", ""));
+  std::map<std::string, std::string> ShifterInfoText;
 
   if ((int)vTextMessage.size() == (int)vPlotWithTextMessage.size()) {
     for (int i = 0; i < (int)vTextMessage.size(); i++) {

--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -123,7 +123,7 @@ void ITSClusterTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
   if (mTimestamp == -1) { // get dict from ccdb
-    mTimestamp = std::stol(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "dicttimestamp", "0"));
+    mTimestamp = std::stol(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "dicttimestamp", "0"));
     long int ts = mTimestamp ? mTimestamp : ctx.services().get<o2::framework::TimingInfo>().creation;
     ILOG(Debug, Devel) << "Getting dictionary from ccdb - timestamp: " << ts << ENDM;
     std::map<std::string, std::string> metadata;

--- a/Modules/ITS/src/ITSDecodingErrorCheck.cxx
+++ b/Modules/ITS/src/ITSDecodingErrorCheck.cxx
@@ -109,8 +109,8 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
           result.addFlag(o2::quality_control::FlagTypeFactory::Unknown(), Form("BAD: ID = %d, %s", ierr, std::string(statistics.ErrNames[ierr]).c_str()));
 
         } // end of y axis loop
-      }   // end of x axis loop
-    }     // end of check on General/LinkErrorVsFeeid
+      } // end of x axis loop
+    } // end of check on General/LinkErrorVsFeeid
 
     if (((std::string)mo->getName()).find("General/LinkErrorPlots") != std::string::npos) {
       result = Quality::Good;

--- a/Modules/ITS/src/ITSDecodingErrorCheck.cxx
+++ b/Modules/ITS/src/ITSDecodingErrorCheck.cxx
@@ -37,17 +37,17 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
     end = std::chrono::high_resolution_clock::now();
     TIME = std::chrono::duration_cast<std::chrono::seconds>(end - start).count();
   }
-  std::vector<int> vDecErrorLimits = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "DecLinkErrorLimits", ""));
+  std::vector<int> vDecErrorLimits = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "DecLinkErrorLimits", ""));
   if (vDecErrorLimits.size() != o2::itsmft::GBTLinkDecodingStat::NErrorsDefined) {
     ILOG(Error, Support) << "Incorrect vector with DecodingError limits, check .json" << ENDM;
     doFlatCheck = true;
   }
-  std::vector<float> vDecErrorLimitsRatio = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "DecLinkErrorLimitsRatio", ""));
+  std::vector<float> vDecErrorLimitsRatio = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "DecLinkErrorLimitsRatio", ""));
   if (vDecErrorLimitsRatio.size() != o2::itsmft::GBTLinkDecodingStat::NErrorsDefined) {
     ILOG(Error, Support) << "Incorrect vector with DecodingError limits Ratio, check .json" << ENDM;
     doFlatCheck = true;
   }
-  std::vector<int> vDecErrorType = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "DecLinkErrorType", ""));
+  std::vector<int> vDecErrorType = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "DecLinkErrorType", ""));
   if (vDecErrorType.size() != o2::itsmft::GBTLinkDecodingStat::NErrorsDefined) {
     ILOG(Error, Support) << "Incorrect vector with DecodingError Type, check .json" << ENDM;
     doFlatCheck = true;
@@ -59,7 +59,7 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
   for (auto& [moName, mo] : *moMap) {
     (void)moName;
 
-    if ((string)mo->getName() == "General/ChipErrorPlots") {
+    if ((std::string)mo->getName() == "General/ChipErrorPlots") {
       result = Quality::Good;
       auto* h = dynamic_cast<TH1D*>(mo->getObject());
       if (h == nullptr) {
@@ -70,7 +70,7 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
         result.set(Quality::Bad);
     }
 
-    if ((string)mo->GetName() == "General/LinkErrorVsFeeid") {
+    if ((std::string)mo->GetName() == "General/LinkErrorVsFeeid") {
 
       result = Quality::Good;
       auto* h = dynamic_cast<TH2D*>(mo->getObject());
@@ -112,7 +112,7 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
       }   // end of x axis loop
     }     // end of check on General/LinkErrorVsFeeid
 
-    if (((string)mo->getName()).find("General/LinkErrorPlots") != std::string::npos) {
+    if (((std::string)mo->getName()).find("General/LinkErrorPlots") != std::string::npos) {
       result = Quality::Good;
       auto* h = dynamic_cast<TH1D*>(mo->getObject());
       if (h == nullptr) {
@@ -164,9 +164,9 @@ Quality ITSDecodingErrorCheck::check(std::map<std::string, std::shared_ptr<Monit
 
 void ITSDecodingErrorCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  std::vector<string> vPlotWithTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "plotWithTextMessage", ""));
-  std::vector<string> vTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "textMessage", ""));
-  std::map<string, string> ShifterInfoText;
+  std::vector<std::string> vPlotWithTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "plotWithTextMessage", ""));
+  std::vector<std::string> vTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "textMessage", ""));
+  std::map<std::string, std::string> ShifterInfoText;
 
   if ((int)vTextMessage.size() == (int)vPlotWithTextMessage.size()) {
     for (int i = 0; i < (int)vTextMessage.size(); i++) {
@@ -183,7 +183,7 @@ void ITSDecodingErrorCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality 
   TString status;
   int textColor;
 
-  if (((string)mo->GetName()).find("General/LinkErrorVsFeeid") != std::string::npos) {
+  if (((std::string)mo->GetName()).find("General/LinkErrorVsFeeid") != std::string::npos) {
 
     auto* h = dynamic_cast<TH2D*>(mo->getObject());
     if (h == nullptr) {
@@ -207,7 +207,7 @@ void ITSDecodingErrorCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality 
 
   } // end of beautify LinkErrorVsFeeid
 
-  if ((((string)mo->getName()).find("General/LinkErrorPlots") != std::string::npos) || (mo->getName() == "General/ChipErrorPlots")) {
+  if ((((std::string)mo->getName()).find("General/LinkErrorPlots") != std::string::npos) || (mo->getName() == "General/ChipErrorPlots")) {
     auto* h = dynamic_cast<TH1D*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast LinkErrorPlots to TH1D*" << ENDM;

--- a/Modules/ITS/src/ITSFeeCheck.cxx
+++ b/Modules/ITS/src/ITSFeeCheck.cxx
@@ -143,7 +143,7 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
       }
     }
 
-    if (((string)mo->getName()).find("TriggerVsFeeid") != std::string::npos) {
+    if (((std::string)mo->getName()).find("TriggerVsFeeid") != std::string::npos) {
       result.set(Quality::Good);
       auto* h = dynamic_cast<TH2I*>(mo->getObject());
       if (h == nullptr) {
@@ -151,8 +151,8 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
         continue;
       }
 
-      std::vector<int> skipbins = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "skipbinstrg", skipbinstrg));
-      std::vector<int> skipfeeid = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "skipfeeids", skipfeeids));
+      std::vector<int> skipbins = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "skipbinstrg", skipbinstrg));
+      std::vector<int> skipfeeid = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "skipfeeids", skipfeeids));
       maxtfdifference = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "maxTFdifferenceAllowed", maxtfdifference);
 
       for (int itrg = 1; itrg <= h->GetNbinsY(); itrg++) {
@@ -230,7 +230,7 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
       result.set(Quality::Good);
       result.addMetadata("CheckTechnicals", "good");
       result.addMetadata("CheckTechnicalsFeeid", "good");
-      std::vector<int> skipfeeid = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "skipfeeids", skipfeeids));
+      std::vector<int> skipfeeid = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "skipfeeids", skipfeeids));
       minPayloadSize = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "minPayloadSize", minPayloadSize);
       if (h->Integral(1, 432, h->GetYaxis()->FindBin(minPayloadSize), h->GetYaxis()->GetLast()) > 0) {
         result.set(Quality::Bad);
@@ -251,7 +251,7 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
       }
     }
 
-    if (((string)mo->getName()).find("TrailerCount") != std::string::npos) {
+    if (((std::string)mo->getName()).find("TrailerCount") != std::string::npos) {
 
       auto activity = mo->getActivity();
       auto* h = dynamic_cast<TH2I*>(mo->getObject());
@@ -276,9 +276,9 @@ std::string ITSFeeCheck::getAcceptedType() { return "TH2I, TH2Poly"; }
 
 void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  std::vector<string> vPlotWithTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "plotWithTextMessage", ""));
-  std::vector<string> vTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "textMessage", ""));
-  std::map<string, string> ShifterInfoText;
+  std::vector<std::string> vPlotWithTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "plotWithTextMessage", ""));
+  std::vector<std::string> vTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "textMessage", ""));
+  std::map<std::string, std::string> ShifterInfoText;
 
   if ((int)vTextMessage.size() == (int)vPlotWithTextMessage.size()) {
     for (int i = 0; i < (int)vTextMessage.size(); i++) {
@@ -448,7 +448,7 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
   }
 
   // trigger plot
-  if (((string)mo->getName()).find("TriggerVsFeeid") != std::string::npos) {
+  if (((std::string)mo->getName()).find("TriggerVsFeeid") != std::string::npos) {
     auto* h = dynamic_cast<TH2I*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast TriggerVsFeeId to TH2I*" << ENDM;
@@ -523,7 +523,7 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
       h->GetListOfFunctions()->Add(tShifterInfo->Clone());
   }
 
-  if (((string)mo->getName()).find("TrailerCount") != std::string::npos) {
+  if (((std::string)mo->getName()).find("TrailerCount") != std::string::npos) {
     auto* h = dynamic_cast<TH2I*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast TrailerCount to TH2F*" << ENDM;

--- a/Modules/ITS/src/ITSFhrCheck.cxx
+++ b/Modules/ITS/src/ITSFhrCheck.cxx
@@ -60,7 +60,7 @@ Quality ITSFhrCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
       result.addMetadata("Gen_Occu_OB", "good");
       result.addMetadata("Gen_Occu_empty", "good");
       result.set(Quality::Good);
-      std::vector<int> skipbins = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "skipbins", ""));
+      std::vector<int> skipbins = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "skipbins", ""));
 
       TIter next(h->GetBins());
       int ibin = 1;
@@ -173,9 +173,9 @@ std::string ITSFhrCheck::getAcceptedType() { return "TH1"; }
 
 void ITSFhrCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  std::vector<string> vPlotWithTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "plotWithTextMessage", ""));
-  std::vector<string> vTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "textMessage", ""));
-  std::map<string, string> ShifterInfoText;
+  std::vector<std::string> vPlotWithTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "plotWithTextMessage", ""));
+  std::vector<std::string> vTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "textMessage", ""));
+  std::map<std::string, std::string> ShifterInfoText;
 
   if ((int)vTextMessage.size() == (int)vPlotWithTextMessage.size()) {
     for (int i = 0; i < (int)vTextMessage.size(); i++) {

--- a/Modules/ITS/src/ITSNoisyPixelTask.cxx
+++ b/Modules/ITS/src/ITSNoisyPixelTask.cxx
@@ -97,7 +97,7 @@ void ITSNoisyPixelTask::initialize(o2::framework::InitContext& /*ctx*/)
   publishHistos();
 
   // get dict from ccdb
-  mTimestamp = std::stol(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "dicttimestamp", "0"));
+  mTimestamp = std::stol(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "dicttimestamp", "0"));
   long int ts = mTimestamp ? mTimestamp : o2::ccdb::getCurrentTimestamp();
   ILOG(Debug, Devel) << "Getting dictionary from ccdb - timestamp: " << ts << ENDM;
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
@@ -447,8 +447,8 @@ void ITSNoisyPixelTask::createAllHistos()
 void ITSNoisyPixelTask::getJsonParameters()
 {
   mLocalGeometryFile = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "isLocalGeometry", mLocalGeometryFile);
-  mGeoTimestamp = o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "geomstamp", mGeoTimestamp);
-  mGeomPath = o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "geomPath", mGeomPath);
+  mGeoTimestamp = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "geomstamp", mGeoTimestamp);
+  mGeomPath = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "geomPath", mGeomPath);
 
   std::string LayerConfig = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "layer", "0000000");
 
@@ -461,7 +461,7 @@ void ITSNoisyPixelTask::getJsonParameters()
     }
   }
 
-  std::string queryOption = o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "queryOption", "from-digit");
+  std::string queryOption = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "queryOption", "from-digit");
   if (queryOption.find("digit") != std::string::npos)
     mQueryOption = kDigit;
   else if (queryOption.find("cluster") != std::string::npos)

--- a/Modules/ITS/src/ITSThresholdCalibrationTask.cxx
+++ b/Modules/ITS/src/ITSThresholdCalibrationTask.cxx
@@ -85,7 +85,7 @@ void ITSThresholdCalibrationTask::initialize(o2::framework::InitContext& /*ctx*/
 
   ILOG(Debug, Devel) << "initialize ITSThresholdCalibrationTask" << ENDM;
 
-  string mCalibrationType = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "CalibrationType", "THR"); // THR, ITHR, VCASN, TOT, pixel_noise, pixel_dead, pixel_ineff
+  std::string mCalibrationType = o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "CalibrationType", "THR"); // THR, ITHR, VCASN, TOT, pixel_noise, pixel_dead, pixel_ineff
 
   if (mCalibrationType == "THR")
     CalibType = THR;
@@ -118,7 +118,7 @@ void ITSThresholdCalibrationTask::startOfCycle()
 
 void ITSThresholdCalibrationTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
-  string inStringChipDone, inString, inPixel;
+  std::string inStringChipDone, inString, inPixel;
   char scanType;
   for (auto&& input : o2::framework::InputRecordWalker(ctx.inputs())) {
     if (input.header != nullptr && input.payload != nullptr) {
@@ -179,7 +179,7 @@ void ITSThresholdCalibrationTask::monitorData(o2::framework::ProcessingContext& 
   }
 }
 
-void ITSThresholdCalibrationTask::doAnalysisTHR(string inString, int iScan)
+void ITSThresholdCalibrationTask::doAnalysisTHR(std::string inString, int iScan)
 {
 
   auto splitRes = splitString(inString, "O2");
@@ -223,7 +223,7 @@ void ITSThresholdCalibrationTask::doAnalysisTHR(string inString, int iScan)
   }
 }
 
-void ITSThresholdCalibrationTask::doAnalysisPixel(string inString)
+void ITSThresholdCalibrationTask::doAnalysisPixel(std::string inString)
 {
 
   auto splitRes = splitString(inString, "O2");
@@ -264,17 +264,17 @@ int ITSThresholdCalibrationTask::getCurrentChip(int barrel, int chipid, int hic,
   return currentChip;
 }
 
-ITSThresholdCalibrationTask::CalibrationResStructPixel ITSThresholdCalibrationTask::CalibrationParserPixel(string input)
+ITSThresholdCalibrationTask::CalibrationResStructPixel ITSThresholdCalibrationTask::CalibrationParserPixel(std::string input)
 {
   CalibrationResStructPixel result;
   auto StaveINFO = splitString(input, ",");
 
-  for (string info : StaveINFO) {
+  for (std::string info : StaveINFO) {
     if (info.size() == 0)
       continue;
 
     std::string name = splitString(info, ":")[0];
-    string data = splitString(info, ":")[1];
+    std::string data = splitString(info, ":")[1];
 
     if (name == "ChipID") {
       int o2chipid = std::stod(data);
@@ -301,11 +301,11 @@ ITSThresholdCalibrationTask::CalibrationResStructPixel ITSThresholdCalibrationTa
   return result;
 }
 
-ITSThresholdCalibrationTask::CalibrationResStructTHR ITSThresholdCalibrationTask::CalibrationParserTHR(string input)
+ITSThresholdCalibrationTask::CalibrationResStructTHR ITSThresholdCalibrationTask::CalibrationParserTHR(std::string input)
 {
   CalibrationResStructTHR result;
   auto StaveINFO = splitString(input, ",");
-  for (string info : StaveINFO) {
+  for (std::string info : StaveINFO) {
     if (info.size() == 0)
       continue;
 
@@ -315,7 +315,7 @@ ITSThresholdCalibrationTask::CalibrationResStructTHR ITSThresholdCalibrationTask
     } else {
 
       std::string name = splitString(info, ":")[0];
-      string data = splitString(info, ":")[1];
+      std::string data = splitString(info, ":")[1];
       if (name == "ChipID") {
         int o2chipid = std::stod(data);
         int Hs, HIC, ChipID, Layer, Stave;
@@ -682,7 +682,7 @@ std::vector<std::string> ITSThresholdCalibrationTask::splitString(std::string s,
   std::string token;
   std::vector<std::string> res;
 
-  while ((pos_end = s.find(delimiter, pos_start)) != string::npos) {
+  while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos) {
     token = s.substr(pos_start, pos_end - pos_start);
     pos_start = pos_end + delim_len;
     res.push_back(token);

--- a/Modules/ITS/src/ITSTrackCheck.cxx
+++ b/Modules/ITS/src/ITSTrackCheck.cxx
@@ -38,7 +38,7 @@ Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
   std::map<std::string, std::shared_ptr<MonitorObject>>::iterator iter;
   for (iter = moMap->begin(); iter != moMap->end(); ++iter) {
 
-    if (((string)iter->second->getName()).find("NClusters") != std::string::npos) {
+    if (((std::string)iter->second->getName()).find("NClusters") != std::string::npos) {
       auto* h = dynamic_cast<TH1D*>(iter->second->getObject());
       if (h == nullptr) {
         ILOG(Error, Support) << "could not cast NClusters to TH1D*" << ENDM;
@@ -84,7 +84,7 @@ Quality ITSTrackCheck::check(std::map<std::string, std::shared_ptr<MonitorObject
       }
     }
 
-    if (((string)iter->second->getName()).find("AngularDistribution") != std::string::npos) {
+    if (((std::string)iter->second->getName()).find("AngularDistribution") != std::string::npos) {
       auto* hAngular = dynamic_cast<TH2D*>(iter->second->getObject());
       if (hAngular == nullptr) {
         ILOG(Error, Support) << "could not cast AngularDistribution to TH2D*" << ENDM;
@@ -200,9 +200,9 @@ std::string ITSTrackCheck::getAcceptedType() { return "TH1D"; }
 
 void ITSTrackCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
-  std::vector<string> vPlotWithTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "plotWithTextMessage", ""));
-  std::vector<string> vTextMessage = convertToArray<string>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "textMessage", ""));
-  std::map<string, string> ShifterInfoText;
+  std::vector<std::string> vPlotWithTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "plotWithTextMessage", ""));
+  std::vector<std::string> vTextMessage = convertToArray<std::string>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "textMessage", ""));
+  std::map<std::string, std::string> ShifterInfoText;
 
   if ((int)vTextMessage.size() == (int)vPlotWithTextMessage.size()) {
     for (int i = 0; i < (int)vTextMessage.size(); i++) {
@@ -220,7 +220,7 @@ void ITSTrackCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
   TString status;
   int textColor;
 
-  if (((string)mo->getName()).find("NClusters") != std::string::npos) {
+  if (((std::string)mo->getName()).find("NClusters") != std::string::npos) {
     auto* h = dynamic_cast<TH1D*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast NClusters to TH1D*" << ENDM;
@@ -300,7 +300,7 @@ void ITSTrackCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRes
       h->GetListOfFunctions()->Add(tShifterInfo->Clone());
   }
 
-  if (((string)mo->getName()).find("AngularDistribution") != std::string::npos) {
+  if (((std::string)mo->getName()).find("AngularDistribution") != std::string::npos) {
     auto* h = dynamic_cast<TH2D*>(mo->getObject());
     if (h == nullptr) {
       ILOG(Error, Support) << "could not cast AngularDistribution to TH2D*" << ENDM;

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -71,10 +71,10 @@ void ITSTrackTask::initialize(o2::framework::InitContext& /*ctx*/)
   mAlignmentMonitor = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "doAlignmentMonitor", mAlignmentMonitor);
   mDefaultMomResPar = o2::quality_control_modules::common::getFromConfig<int>(mCustomParameters, "UseDefaultMomResPar", mDefaultMomResPar);
   if (mAlignmentMonitor == 1 && mDefaultMomResPar == 0) {
-    std::vector<int> vMomResParMEAS1 = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "MomResParMEAS1", ""));
-    std::vector<int> vMomResParMEAS2 = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "MomResParMEAS2", ""));
-    std::vector<int> vMomResParMSC1 = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "MomResParMSC1", ""));
-    std::vector<int> vMomResParMSC2 = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "MomResParMSC2", ""));
+    std::vector<int> vMomResParMEAS1 = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "MomResParMEAS1", ""));
+    std::vector<int> vMomResParMEAS2 = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "MomResParMEAS2", ""));
+    std::vector<int> vMomResParMSC1 = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "MomResParMSC1", ""));
+    std::vector<int> vMomResParMSC2 = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "MomResParMSC2", ""));
 
     for (int l = 0; l < NLayer; l++) {
       mSigmaMeas[0][l] = (double)vMomResParMEAS1[l];
@@ -114,7 +114,7 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
   ILOG(Debug, Devel) << "START DOING QC General" << ENDM;
 
   if (mTimestamp == -1) { // get dict from ccdb
-    mTimestamp = std::stol(o2::quality_control_modules::common::getFromConfig<string>(mCustomParameters, "dicttimestamp", "0"));
+    mTimestamp = std::stol(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "dicttimestamp", "0"));
     long int ts = mTimestamp ? mTimestamp : ctx.services().get<o2::framework::TimingInfo>().creation;
     ILOG(Debug, Devel) << "Getting dictionary from ccdb - timestamp: " << ts << ENDM;
 

--- a/Modules/MFT/include/MFT/QcMFTClusterCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterCheck.h
@@ -53,7 +53,7 @@ class QcMFTClusterCheck : public o2::quality_control::checker::CheckInterface
   // masked chips part
   bool mFirstCall;
   std::vector<int> mMaskedChips;
-  std::vector<string> mChipMapName;
+  std::vector<std::string> mChipMapName;
 
   void readMaskedChips(std::shared_ptr<MonitorObject> mo);
   void createMaskedChipsNames();

--- a/Modules/MFT/include/MFT/QcMFTDigitCheck.h
+++ b/Modules/MFT/include/MFT/QcMFTDigitCheck.h
@@ -52,7 +52,7 @@ class QcMFTDigitCheck : public o2::quality_control::checker::CheckInterface
   // masked chips part
   bool mFirstCall;
   std::vector<int> mMaskedChips;
-  std::vector<string> mChipMapName;
+  std::vector<std::string> mChipMapName;
 
   void readMaskedChips(std::shared_ptr<MonitorObject> mo);
   void createMaskedChipsNames();

--- a/Modules/MFT/include/MFT/QcMFTUtilTables.h
+++ b/Modules/MFT/include/MFT/QcMFTUtilTables.h
@@ -353,7 +353,7 @@ class QcMFTUtilTables
   };
 
   // names for occupancy maps (for outside acceptance and ladder checker)
-  string mDigitChipMapNames[20] = {
+  std::string mDigitChipMapNames[20] = {
     "ChipOccupancyMaps/Half_0/Disk_0/Face_0/mDigitChipOccupancyMap",
     "ChipOccupancyMaps/Half_0/Disk_0/Face_1/mDigitChipOccupancyMap",
     "ChipOccupancyMaps/Half_0/Disk_1/Face_0/mDigitChipOccupancyMap",
@@ -376,7 +376,7 @@ class QcMFTUtilTables
     "ChipOccupancyMaps/Half_1/Disk_4/Face_1/mDigitChipOccupancyMap"
   };
 
-  string mClusterChipMapNames[20] = {
+  std::string mClusterChipMapNames[20] = {
     "ChipOccupancyMaps/Half_0/Disk_0/Face_0/mClusterChipOccupancyMap",
     "ChipOccupancyMaps/Half_0/Disk_0/Face_1/mClusterChipOccupancyMap",
     "ChipOccupancyMaps/Half_0/Disk_1/Face_0/mClusterChipOccupancyMap",

--- a/Modules/MUON/MID/src/CalibMQcTask.cxx
+++ b/Modules/MUON/MID/src/CalibMQcTask.cxx
@@ -36,7 +36,7 @@ void CalibMQcTask::initialize(o2::framework::InitContext& /*ctx*/)
 {
   gStyle->SetPalette(kRainBow);
 
-  std::array<string, 4> chId{ "11", "12", "21", "22" };
+  std::array<std::string, 4> chId{ "11", "12", "21", "22" };
 
   mNbBadChannelTF = std::make_unique<TH1F>("NbBadChannelTF", "Anaylyzed timeframes", 1, 0, 1.);
   getObjectsManager()->startPublishing(mNbBadChannelTF.get());

--- a/Modules/MUON/MID/src/CalibQcTask.cxx
+++ b/Modules/MUON/MID/src/CalibQcTask.cxx
@@ -45,7 +45,7 @@ void CalibQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mNbDeadROF = std::make_unique<TH1F>("NbDeadROF", "NbDeadROF", 1, 0, 1.);
   getObjectsManager()->startPublishing(mNbDeadROF.get());
 
-  std::array<string, 4> chId{ "11", "12", "21", "22" };
+  std::array<std::string, 4> chId{ "11", "12", "21", "22" };
 
   // Noise strips Histograms ::
   for (int ich = 0; ich < 4; ++ich) {

--- a/Modules/MUON/MID/src/DigitsQcTask.cxx
+++ b/Modules/MUON/MID/src/DigitsQcTask.cxx
@@ -66,7 +66,7 @@ void DigitsQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mEPRate = std::make_unique<TH1F>("EPRate", "EPRate", 4, 0, 4.);
   getObjectsManager()->startPublishing(mEPRate.get());
 
-  std::array<string, 4> chId{ "11", "12", "21", "22" };
+  std::array<std::string, 4> chId{ "11", "12", "21", "22" };
 
   for (size_t ich = 0; ich < 5; ++ich) {
     std::string chName = "";

--- a/Modules/TPC/src/CheckOfSlices.cxx
+++ b/Modules/TPC/src/CheckOfSlices.cxx
@@ -101,7 +101,7 @@ void CheckOfSlices::configure()
     mExpectedPhysicsValue = common::getFromConfig<double>(mCustomParameters, "expectedPhysicsValue", 1);
   }
 
-  std::string maskingValues = common::getFromConfig<string>(mCustomParameters, "maskedPoints", "");
+  std::string maskingValues = common::getFromConfig<std::string>(mCustomParameters, "maskedPoints", "");
   mMaskedPoints.clear();
   if (maskingValues != "") {
     mMaskedPoints = RangeTokenizer::tokenize<int>(maskingValues);

--- a/Modules/TRD/src/DigitsTask.cxx
+++ b/Modules/TRD/src/DigitsTask.cxx
@@ -51,7 +51,7 @@ void DigitsTask::initialize(o2::framework::InitContext& /*ctx*/)
   mPulseHeightPeakRegion.first = getFromConfig<float>(mCustomParameters, "peakRegionStart", 0.f);
   mPulseHeightPeakRegion.second = getFromConfig<float>(mCustomParameters, "peakRegionEnd", 5.f);
   mPulseHeightThreshold = getFromConfig<unsigned int>(mCustomParameters, "phThreshold", 400u);
-  mChambersToIgnore = getFromConfig<string>(mCustomParameters, "ignoreChambers", "16_3_0");
+  mChambersToIgnore = getFromConfig<std::string>(mCustomParameters, "ignoreChambers", "16_3_0");
   mClsCutoff = getFromConfig<int>(mCustomParameters, "clsCutoff", 1000);
   mAdcBaseline = getFromConfig<int>(mCustomParameters, "adcBaseline", 10);
 

--- a/Modules/TRD/src/TrackingTask.cxx
+++ b/Modules/TRD/src/TrackingTask.cxx
@@ -40,7 +40,7 @@ void TrackingTask::initialize(o2::framework::InitContext& /*ctx*/)
 
   mPtMin = getFromConfig<float>(mCustomParameters, "pTminvalue", 0.f);
   mDetailedTrackQC = getFromConfig<bool>(mCustomParameters, "detailedQC");
-  std::string trackSources = getFromConfig<string>(mCustomParameters, "trackSources", "all");
+  std::string trackSources = getFromConfig<std::string>(mCustomParameters, "trackSources", "all");
   GID::mask_t allowedSources = GID::getSourcesMask("ITS-TPC,TPC-TRD,ITS-TPC-TRD");
   mSrcSelected = allowedSources & GID::getSourcesMask(trackSources);
   mDataRequest = std::make_shared<o2::globaltracking::DataRequest>();


### PR DESCRIPTION
The header TJAlienCredentials.h polluted the global namespace, included usually with CCDB or something related.

See AliceO2Group/AliceO2#14524 for more background. 
This PR prepares for the removal of the polluted namespace. 