### PR TITLE
MCH: added plots per cru link

### DIFF
--- a/Modules/MUON/MCH/CMakeLists.txt
+++ b/Modules/MUON/MCH/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRCS
   src/DecodingPostProcessing.cxx
   src/DigitsPostProcessing.cxx
   src/PreclustersPostProcessing.cxx
+  src/QualityAggregatorTask.cxx
   src/PostProcessingConfigMCH.cxx
   src/TrendingTracks.cxx
   src/ClustersTask.cxx
@@ -76,6 +77,7 @@ set(HEADERS
   include/MCH/DedodingPostProcessing.h
   include/MCH/DigitsPostProcessing.h
   include/MCH/PreclustersPostProcessing.h
+  include/MCH/QualityAggregatorTask.h
   include/MCH/PostProcessingConfigMCH.h
   include/MCH/TrendingTracks.h
   include/MCH/ClustersTask.h
@@ -161,6 +163,7 @@ add_root_dictionary(${MODULE_NAME}
                             include/MCH/DecodingPostProcessing.h
                             include/MCH/DigitsPostProcessing.h
                             include/MCH/PreclustersPostProcessing.h
+                            include/MCH/QualityAggregatorTask.h
                             include/MCH/PostProcessingConfigMCH.h
                             include/MCH/TrendingTracks.h
                             include/MCH/ClustersTask.h

--- a/Modules/MUON/MCH/include/MCH/DecodingCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingCheck.h
@@ -77,7 +77,6 @@ class DecodingCheck : public o2::quality_control::checker::CheckInterface
   double mSyncFracRatioPlotRange{ 0.2 };
   double mSyncFracRatioPerSolarPlotRange{ 0.2 };
 
-
   QualityChecker mQualityChecker;
   std::array<Quality, getNumSolar()> mSolarQuality;
 

--- a/Modules/MUON/MCH/include/MCH/DecodingCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingCheck.h
@@ -47,20 +47,41 @@ class DecodingCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
-  std::string mGoodFracHistName{ "DecodingErrors/LastCycle/GoodBoardsFractionPerDE" };
-  std::string mSyncFracHistName{ "SyncErrors/LastCycle/SyncedBoardsFractionPerDE" };
+  std::string mGoodFracHistName{ "DecodingErrors/GoodBoardsFractionPerDE" };
+  std::string mGoodFracPerSolarHistName{ "DecodingErrors/GoodBoardsFractionPerSolar" };
+  std::string mSyncFracHistName{ "SyncErrors/SyncedBoardsFractionPerDE" };
+  std::string mSyncFracPerSolarHistName{ "SyncErrors/SyncedBoardsFractionPerSolar" };
+  std::string mGoodFracRefCompHistName{ "DecodingErrors/RefComp/GoodBoardsFractionPerDE" };
+  std::string mGoodFracPerSolarRefCompHistName{ "DecodingErrors/RefComp/GoodBoardsFractionPerSolar" };
+  std::string mSyncFracRefCompHistName{ "SyncErrors/RefComp/SyncedBoardsFractionPerDE" };
+  std::string mSyncFracPerSolarRefCompHistName{ "SyncErrors/RefComp/SyncedBoardsFractionPerSolar" };
   int mMaxBadST12{ 2 };
   int mMaxBadST345{ 3 };
   double mMinGoodErrorFrac{ 0.9 };
   std::array<std::optional<double>, 5> mMinGoodErrorFracPerStation;
+  double mMinGoodErrorFracPerSolar{ 0.5 };
+  double mMinGoodErrorFracRatio{ 0.9 };
+  double mMinGoodErrorFracRatioPerSolar{ 0.9 };
+
   double mMinGoodSyncFrac{ 0.9 };
   std::array<std::optional<double>, 5> mMinGoodSyncFracPerStation;
+  double mMinGoodSyncFracPerSolar{ 0.5 };
+  double mMinGoodSyncFracRatio{ 0.9 };
+  double mMinGoodSyncFracRatioPerSolar{ 0.9 };
+
   double mMinHeartBeatRate{ 0 };
   double mMaxHeartBeatRate{ 2 };
 
-  QualityChecker mQualityChecker;
+  double mGoodFracRatioPlotRange{ 0.2 };
+  double mGoodFracRatioPerSolarPlotRange{ 0.2 };
+  double mSyncFracRatioPlotRange{ 0.2 };
+  double mSyncFracRatioPerSolarPlotRange{ 0.2 };
 
-  ClassDefOverride(DecodingCheck, 1);
+
+  QualityChecker mQualityChecker;
+  std::array<Quality, getNumSolar()> mSolarQuality;
+
+  ClassDefOverride(DecodingCheck, 2);
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/DecodingErrorsPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingErrorsPlotter.h
@@ -53,10 +53,12 @@ class DecodingErrorsPlotter : public HistPlotter
 
   std::string mPath;
 
-  std::unique_ptr<TH1F> mHistogramGoodBoardsPerDE;  ///< fraction of boards with errors per DE
   std::unique_ptr<TH2F> mHistogramErrorsPerDE;      ///< error codes per DE
   std::unique_ptr<TH2F> mHistogramErrorsPerChamber; ///< error codes per chamber
   std::unique_ptr<TH2F> mHistogramErrorsPerFeeId;   ///< error codes per FEE ID
+
+  std::unique_ptr<TH1F> mHistogramGoodBoardsPerDE;    ///< fraction of boards without errors per DE
+  std::unique_ptr<TH1F> mHistogramGoodBoardsPerSolar; ///< fraction of boards with errors per DE
 };
 
 } // namespace muonchambers

--- a/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
@@ -21,12 +21,12 @@
 
 #include "MCH/PostProcessingConfigMCH.h"
 #include "MCH/Helpers.h"
-#include "Common/TH2Ratio.h"
 #include "MCH/HistoOnCycle.h"
 #include "MCH/DecodingErrorsPlotter.h"
 #include "MCH/HeartBeatPacketsPlotter.h"
 #include "MCH/FECSyncStatusPlotter.h"
-#include "QualityControl/PostProcessingInterface.h"
+#include "Common/ReferenceComparatorTask.h"
+#include "Common/TH2Ratio.h"
 
 #include <memory>
 
@@ -43,7 +43,7 @@ namespace o2::quality_control_modules::muonchambers
 {
 
 /// \brief  A post-processing task which trends MCH hits and stores them in a TTree and produces plots.
-class DecodingPostProcessing : public PostProcessingInterface
+class DecodingPostProcessing : public ReferenceComparatorTask
 {
  public:
   DecodingPostProcessing() = default;
@@ -73,6 +73,8 @@ class DecodingPostProcessing : public PostProcessingInterface
   static std::string hbPacketsSourceName() { return "hbpackets"; }
   static std::string syncStatusSourceName() { return "syncstatus"; }
 
+  TH1* getHistogram(std::string plotName);
+
   bool mFullHistos{ false };
   bool mEnableLastCycleHistos{ false };
   bool mEnableTrending{ false };
@@ -96,7 +98,10 @@ class DecodingPostProcessing : public PostProcessingInterface
   std::unique_ptr<FECSyncStatusPlotter> mSyncStatusPlotter;
   std::unique_ptr<FECSyncStatusPlotter> mSyncStatusPlotterOnCycle;
 
-  std::unique_ptr<TH2F> mHistogramQualityPerDE; ///< quality flags for each DE, to be filled by checker task
+  std::unique_ptr<TH2F> mHistogramQualityPerDE;    ///< quality flags for each DE, to be filled by checker task
+  std::unique_ptr<TH2F> mHistogramQualityPerSolar; ///< quality flags for each SOLAR, to be filled by checker task
+
+  std::vector<TH1*> mHistogramsAll;
 };
 
 template <typename T>

--- a/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DecodingPostProcessing.h
@@ -73,7 +73,7 @@ class DecodingPostProcessing : public ReferenceComparatorTask
   static std::string hbPacketsSourceName() { return "hbpackets"; }
   static std::string syncStatusSourceName() { return "syncstatus"; }
 
-  TH1* getHistogram(std::string plotName);
+  TH1* getHistogram(std::string_view plotName);
 
   bool mFullHistos{ false };
   bool mEnableLastCycleHistos{ false };

--- a/Modules/MUON/MCH/include/MCH/DigitsCheck.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsCheck.h
@@ -50,27 +50,58 @@ class DigitsCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
-  std::array<Quality, getNumDE()> checkMeanRates(TH1F* h);
-  std::array<Quality, getNumDE()> checkMeanRatesRatio(TH1F* h);
-  std::array<Quality, getNumDE()> checkBadChannels(TH1F* h);
-  std::array<Quality, getNumDE()> checkBadChannelsRatio(TH1F* h);
+  std::array<Quality, getNumDE()> checkMeanRates(TH1* h);
+  std::array<Quality, getNumDE()> checkBadChannels(TH1* h);
+  std::array<Quality, getNumDE()> checkMeanRateRatios(TH1* h);
+  std::array<Quality, getNumDE()> checkBadChannelRatios(TH1* h);
+  void checkSolarMeanRates(TH1* h);
+  void checkSolarBadChannels(TH1* h);
+  void checkSolarMeanRateRatios(TH1* h);
+  void checkSolarBadChannelRatios(TH1* h);
 
-  std::string mMeanRateHistName{ "RatesSignal/LastCycle/MeanRate" };
-  std::string mGoodChanFracHistName{ "RatesSignal/LastCycle/GoodChannelsFraction" };
+  std::string mMeanRateHistName{ "RatesSignal/MeanRate" };
+  std::string mGoodChanFracHistName{ "RatesSignal/GoodChannelsFraction" };
+  std::string mMeanRatePerSolarHistName{ "RatesSignal/MeanRatePerSolar" };
+  std::string mGoodChanFracPerSolarHistName{ "RatesSignal/GoodChannelsFractionPerSolar" };
+  std::string mMeanRateRefCompHistName{ "RatesSignal/RefComp/MeanRate" };
+  std::string mGoodChanFracRefCompHistName{ "RatesSignal/RefComp/GoodChannelsFraction" };
+  std::string mMeanRatePerSolarRefCompHistName{ "RatesSignal/RefComp/MeanRatePerSolar" };
+  std::string mGoodChanFracPerSolarRefCompHistName{ "RatesSignal/RefComp/GoodChannelsFractionPerSolar" };
   int mMaxBadST12{ 2 };
   int mMaxBadST345{ 3 };
+
+  // Rate lower threshold
   double mMinRate{ 0.001 };
   std::array<std::optional<double>, 5> mMinRatePerStation;
+  double mMinRatePerSolar{ 0.001 };
+  // Rate upper threshold
   double mMaxRate{ 10 };
   std::array<std::optional<double>, 5> mMaxRatePerStation;
+  double mMaxRatePerSolar{ 10 };
+  // Rate ratio threshold
+  double mMinRateRatio{ 0.9 };
+  double mMinRateRatioPerSolar{ 0.9 };
+
+  // Good channels fraction threshold
   double mMinGoodFraction{ 0.9 };
   std::array<std::optional<double>, 5> mMinGoodFractionPerStation;
+  double mMinGoodFractionPerSolar{ 0.5 };
+  // Good channels ratio threshold
+  double mMinGoodFractionRatio{ 0.9 };
+  double mMinGoodFractionRatioPerSolar{ 0.9 };
+
+  // Vertical plot ranges
   double mRatePlotScaleMin{ 0 };
   double mRatePlotScaleMax{ 10 };
+  double mRateRatioPlotScaleRange{ 0.2 };
+  double mRateRatioPerSolarPlotScaleRange{ 0.2 };
+  double mGoodFractionRatioPlotScaleRange{ 0.2 };
+  double mGoodFractionRatioPerSolarPlotScaleRange{ 0.2 };
 
   QualityChecker mQualityChecker;
+  std::array<Quality, getNumSolar()> mSolarQuality;
 
-  ClassDefOverride(DigitsCheck, 2);
+  ClassDefOverride(DigitsCheck, 3);
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
@@ -24,6 +24,7 @@
 #include "MCH/RatesPlotter.h"
 #include "MCH/RatesTrendsPlotter.h"
 #include "MCH/OrbitsPlotter.h"
+#include "Common/ReferenceComparatorTask.h"
 #include "Common/TH2Ratio.h"
 #include "QualityControl/PostProcessingInterface.h"
 
@@ -40,7 +41,7 @@ namespace o2::quality_control_modules::muonchambers
 {
 
 /// \brief  A post-processing task which processes and trends MCH digits and produces plots.
-class DigitsPostProcessing : public PostProcessingInterface
+class DigitsPostProcessing : public ReferenceComparatorTask
 {
  public:
   DigitsPostProcessing() = default;
@@ -61,6 +62,8 @@ class DigitsPostProcessing : public PostProcessingInterface
   static std::string rateSignalSourceName() { return "rate_signal"; }
   static std::string orbitsSourceName() { return "orbits"; }
   static std::string orbitsSignalSourceName() { return "orbits_signal"; }
+
+  TH1* getHistogram(std::string plotName);
 
   bool mFullHistos{ false };
   bool mEnableLastCycleHistos{ false };
@@ -99,7 +102,10 @@ class DigitsPostProcessing : public PostProcessingInterface
   std::unique_ptr<OrbitsPlotter> mOrbitsPlotterSignal;
   std::unique_ptr<OrbitsPlotter> mOrbitsPlotterSignalOnCycle;
 
-  std::unique_ptr<TH2F> mHistogramQualityPerDE; ///< quality flags for each DE, to be filled by checker task
+  std::unique_ptr<TH2F> mHistogramQualityPerDE;    ///< quality flags for each DE, to be filled by checker task
+  std::unique_ptr<TH2F> mHistogramQualityPerSolar; ///< quality flags for each SOLAR, to be filled by checker task
+
+  std::vector<TH1*> mHistogramsAll;
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/DigitsPostProcessing.h
@@ -63,7 +63,7 @@ class DigitsPostProcessing : public ReferenceComparatorTask
   static std::string orbitsSourceName() { return "orbits"; }
   static std::string orbitsSignalSourceName() { return "orbits_signal"; }
 
-  TH1* getHistogram(std::string plotName);
+  TH1* getHistogram(std::string_view plotName);
 
   bool mFullHistos{ false };
   bool mEnableLastCycleHistos{ false };

--- a/Modules/MUON/MCH/include/MCH/EfficiencyPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/EfficiencyPlotter.h
@@ -69,6 +69,7 @@ class EfficiencyPlotter : public HistPlotter
   std::unique_ptr<TH2ElecMapReductor> mElecMapReductor;
 
   std::array<std::unique_ptr<TH1F>, 2> mHistogramMeanEfficiencyPerDE;
+  std::unique_ptr<TH1F> mHistogramMeanEfficiencyPerSolar;
 
   std::array<std::map<int, std::shared_ptr<DetectorHistogram>>, 2> mHistogramEfficiencyDE; // 2D hit rate map for each DE
   std::array<std::unique_ptr<GlobalHistogram>, 2> mHistogramEfficiencyGlobal;              // Efficiency histogram (global XY view)

--- a/Modules/MUON/MCH/include/MCH/FECSyncStatusPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/FECSyncStatusPlotter.h
@@ -49,11 +49,11 @@ class FECSyncStatusPlotter : public HistPlotter
     histograms().emplace_back(HistInfo{ h, drawOptions, displayHints });
   }
 
-  o2::mch::raw::Elec2DetMapper mElec2DetMapper;
-  o2::mch::raw::FeeLink2SolarMapper mFeeLink2SolarMapper;
+  o2::mch::raw::Det2ElecMapper mDet2ElecMapper;
 
   std::unique_ptr<TH1F> mGoodBoardsFractionPerDE; ///< fraction of out-of-sync DS boards per detection element
-  std::unique_ptr<TH1F> mGoodTFFractionPerDE;     ///< fraction of out-of-sync DS boards per chamber
+  std::unique_ptr<TH1F> mGoodTFFractionPerDE;     ///< fraction of in-sync TFs per DS boards, averaged on detection elements
+  std::unique_ptr<TH1F> mGoodTFFractionPerSolar;  ///< fraction of in-sync TFs per DS boards, averaged on SOLAR boards
 };
 
 } // namespace muonchambers

--- a/Modules/MUON/MCH/include/MCH/Helpers.h
+++ b/Modules/MUON/MCH/include/MCH/Helpers.h
@@ -53,6 +53,12 @@ int getDEindex(int de);
 constexpr int getNumDE() { return (4 * 4 + 18 * 2 + 26 * 4); }
 int getNumDEinChamber(int chIndex);
 std::pair<int, int> getDEindexInChamber(int deId);
+int getDEFromIndex(int index);
+
+int getSolarIndex(int solarId);
+int getSolarIdFromIndex(int index);
+constexpr int getNumSolar() { return 624; }
+int getNumSolarPerChamber(int chamberId);
 
 void getThresholdsPerStation(o2::quality_control::core::CustomParameters customParameters,
                              const o2::quality_control::core::Activity& activity,
@@ -62,10 +68,16 @@ void getThresholdsPerStation(o2::quality_control::core::CustomParameters customP
 
 o2::quality_control::core::Quality checkDetectorQuality(gsl::span<o2::quality_control::core::Quality>& deQuality);
 
-void addChamberDelimiters(TH1F* h, float xmin = 0, float xmax = 0);
-void addChamberDelimiters(TH2F* h);
+void addChamberLabelsForDE(TH1* h);
+void addChamberDelimiters(TH1* h, float xmin = 0, float xmax = 0);
+void addChamberDelimiters(TH2* h);
+void addChamberLabelsForSolar(TH1* h);
+void addChamberDelimitersToSolarHistogram(TH1* h, float xmin = 0, float xmax = 0);
+void addChamberDelimitersToSolarHistogram(TH2* h);
+void drawThreshold(TH1* histogram, double threshold);
 void drawThresholdsPerStation(TH1* histogram, const std::array<std::optional<double>, 5>& thresholdsPerStation, double defaultThreshold);
 void addDEBinLabels(TH1* histogram);
+void addSolarBinLabels(TH1* histogram);
 
 std::string getHistoPath(int deId);
 bool matchHistName(std::string hist, std::string name);

--- a/Modules/MUON/MCH/include/MCH/LinkDef.h
+++ b/Modules/MUON/MCH/include/MCH/LinkDef.h
@@ -17,6 +17,7 @@
 #pragma link C++ class o2::quality_control_modules::muonchambers::DecodingPostProcessing + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::DigitsPostProcessing + ;
 #pragma link C++ class o2::quality_control_modules::muonchambers::PreclustersPostProcessing + ;
+#pragma link C++ class o2::quality_control_modules::muonchambers::QualityAggregatorTask + ;
 // Trending
 #pragma link C++ class o2::quality_control_modules::muonchambers::TrendingTracks + ;
 // Checks

--- a/Modules/MUON/MCH/include/MCH/PreclustersCheck.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersCheck.h
@@ -48,21 +48,33 @@ class PreclustersCheck : public o2::quality_control::checker::CheckInterface
   std::string getAcceptedType() override;
 
  private:
-  std::array<Quality, getNumDE()> checkMeanEfficiencies(TH1F* h);
-  std::array<Quality, getNumDE()> checkMeanEfficienciesRatio(TH1F* h);
+  std::array<Quality, getNumDE()> checkMeanEfficiencies(TH1* h);
+  std::array<Quality, getNumDE()> checkMeanEfficiencyRatios(TH1* h);
+  void checkSolarMeanEfficiencies(TH1* h);
+  void checkSolarMeanEfficiencyRatios(TH1* h);
 
-  std::string mMeanEffHistNameB{ "Efficiency/LastCycle/MeanEfficiencyB" };
-  std::string mMeanEffHistNameNB{ "Efficiency/LastCycle/MeanEfficiencyNB" };
+  std::string mMeanEffHistNameB{ "Efficiency/MeanEfficiencyB" };
+  std::string mMeanEffHistNameNB{ "Efficiency/MeanEfficiencyNB" };
+  std::string mMeanEffPerSolarHistName{ "Efficiency/MeanEfficiencyPerSolar" };
+  std::string mMeanEffRefCompHistNameB{ "Efficiency/RefComp/MeanEfficiencyB" };
+  std::string mMeanEffRefCompHistNameNB{ "Efficiency/RefComp/MeanEfficiencyNB" };
+  std::string mMeanEffPerSolarRefCompHistName{ "Efficiency/RefComp/MeanEfficiencyPerSolar" };
   int mMaxBadST12{ 2 };
   int mMaxBadST345{ 3 };
   double mMinEfficiency{ 0.8 };
   std::array<std::optional<double>, 5> mMinEfficiencyPerStation;
+  double mMinEfficiencyPerSolar{ 0.5 };
+  double mMinEfficiencyRatio{ 0.9 };
+  double mMinEfficiencyRatioPerSolar{ 0.9 };
   double mPseudoeffPlotScaleMin{ 0.0 };
-  double mPseudoeffPlotScaleMax{ 1.0 };
+  double mPseudoeffPlotScaleMax{ 1.05 };
+  double mEfficiencyRatioScaleRange{ 0.2 };
+  double mEfficiencyRatioPerSolarScaleRange{ 0.2 };
 
   QualityChecker mQualityChecker;
+  std::array<Quality, getNumSolar()> mSolarQuality;
 
-  ClassDefOverride(PreclustersCheck, 2);
+  ClassDefOverride(PreclustersCheck, 3);
 };
 
 } // namespace o2::quality_control_modules::muonchambers

--- a/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
@@ -72,7 +72,7 @@ class PreclustersPostProcessing : public ReferenceComparatorTask
   static std::string clusterChargeSourceName() { return "clcharge"; }
   static std::string clusterSizeSourceName() { return "clsize"; }
 
-  TH1* getHistogram(std::string plotName);
+  TH1* getHistogram(std::string_view plotName);
 
   bool mFullHistos{ false };
   bool mEnableLastCycleHistos{ false };

--- a/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
+++ b/Modules/MUON/MCH/include/MCH/PreclustersPostProcessing.h
@@ -19,11 +19,8 @@
 #ifndef QC_MODULE_MCH_PP_PRECLUSTERS_H
 #define QC_MODULE_MCH_PP_PRECLUSTERS_H
 
-#include "QualityControl/PostProcessingInterface.h"
-
 #include "MCH/PostProcessingConfigMCH.h"
 #include "MCH/Helpers.h"
-#include "Common/TH2Ratio.h"
 #include "MCH/HistoOnCycle.h"
 #include "MCH/EfficiencyPlotter.h"
 #include "MCH/EfficiencyTrendsPlotter.h"
@@ -31,6 +28,8 @@
 #include "MCH/ClusterSizeTrendsPlotter.h"
 #include "MCH/ClusterChargePlotter.h"
 #include "MCH/ClusterChargeTrendsPlotter.h"
+#include "Common/ReferenceComparatorTask.h"
+#include "Common/TH2Ratio.h"
 
 namespace o2::quality_control::repository
 {
@@ -45,7 +44,7 @@ namespace o2::quality_control_modules::muonchambers
 {
 
 /// \brief  A post-processing task which processes and trends MCH pre-clusters and produces plots.
-class PreclustersPostProcessing : public PostProcessingInterface
+class PreclustersPostProcessing : public ReferenceComparatorTask
 {
  public:
   PreclustersPostProcessing() = default;
@@ -72,6 +71,8 @@ class PreclustersPostProcessing : public PostProcessingInterface
   static std::string effSourceName() { return "eff"; }
   static std::string clusterChargeSourceName() { return "clcharge"; }
   static std::string clusterSizeSourceName() { return "clsize"; }
+
+  TH1* getHistogram(std::string plotName);
 
   bool mFullHistos{ false };
   bool mEnableLastCycleHistos{ false };
@@ -102,7 +103,10 @@ class PreclustersPostProcessing : public PostProcessingInterface
   std::unique_ptr<ClusterChargeTrendsPlotter> mClusterChargeTrendsPlotter;
   std::unique_ptr<ClusterSizeTrendsPlotter> mClusterSizeTrendsPlotter;
 
-  std::unique_ptr<TH2F> mHistogramQualityPerDE; ///< quality flags for each DE, to be filled by checker task
+  std::unique_ptr<TH2F> mHistogramQualityPerDE;    ///< quality flags for each DE, to be filled by checker task
+  std::unique_ptr<TH2F> mHistogramQualityPerSolar; ///< quality flags for each SOLAR, to be filled by checker task
+
+  std::vector<TH1*> mHistogramsAll;
 };
 
 template <typename T>

--- a/Modules/MUON/MCH/include/MCH/QualityAggregatorTask.h
+++ b/Modules/MUON/MCH/include/MCH/QualityAggregatorTask.h
@@ -12,7 +12,7 @@
 ///
 /// \file    QualityAggregatorTask.h
 /// \author  Andrea Ferrero andrea.ferrero@cern.ch
-/// \brief   Post-processing of the MCH pre-clusters
+/// \brief   Post-processing of the MCH summary qualities
 /// \since   21/06/2022
 ///
 

--- a/Modules/MUON/MCH/include/MCH/QualityAggregatorTask.h
+++ b/Modules/MUON/MCH/include/MCH/QualityAggregatorTask.h
@@ -1,0 +1,70 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    QualityAggregatorTask.h
+/// \author  Andrea Ferrero andrea.ferrero@cern.ch
+/// \brief   Post-processing of the MCH pre-clusters
+/// \since   21/06/2022
+///
+
+#ifndef QC_MODULE_MCH_PP_QUALITY_H
+#define QC_MODULE_MCH_PP_QUALITY_H
+
+#include "QualityControl/PostProcessingInterface.h"
+#include "CCDB/CcdbApi.h"
+
+#include <set>
+
+using namespace o2::framework;
+
+using namespace o2::quality_control;
+using namespace o2::quality_control::postprocessing;
+
+class TH2F;
+
+namespace o2::quality_control_modules::muonchambers
+{
+
+/// \brief  A post-processing task which processes and trends MCH pre-clusters and produces plots.
+class QualityAggregatorTask : public PostProcessingInterface
+{
+ public:
+  using CcdbApi = o2::ccdb::CcdbApi;
+
+  QualityAggregatorTask() = default;
+  ~QualityAggregatorTask() override = default;
+
+  void configure(const boost::property_tree::ptree& config) override;
+  void initialize(Trigger, framework::ServiceRegistryRef) override;
+  void update(Trigger, framework::ServiceRegistryRef) override;
+  void finalize(Trigger, framework::ServiceRegistryRef) override;
+
+ private:
+  CcdbApi mAPI;
+  std::string mCCDBpath{ "http://ccdb-test.cern.ch:8080" }; // CCDB path
+
+  std::string mObjectPathBadDE{ "MCH/Calib/BadDE" };
+  std::string mObjectPathBadSOLAR{ "MCH/Calib/BadSOLAR" };
+
+  std::vector<std::string> mDEPlotPaths;
+  std::optional<std::set<int>> mPreviousBadDEs;
+
+  std::vector<std::string> mSOLARPlotPaths;
+  std::optional<std::set<int>> mPreviousBadSolarBoards;
+
+  std::unique_ptr<TH2F> mHistogramQualityPerDE;    ///< quality flags for each DE, to be filled by checker task
+  std::unique_ptr<TH2F> mHistogramQualityPerSolar; ///< quality flags for each SOLAR, to be filled by checker task
+};
+
+} // namespace o2::quality_control_modules::muonchambers
+
+#endif // QC_MODULE_MCH_PP_QUALITY_H

--- a/Modules/MUON/MCH/include/MCH/RatesPlotter.h
+++ b/Modules/MUON/MCH/include/MCH/RatesPlotter.h
@@ -69,8 +69,10 @@ class RatesPlotter : public HistPlotter
   std::unique_ptr<TH2F> mHistogramRatePerStation;
 
   std::unique_ptr<TH1F> mHistogramMeanRatePerDE;
+  std::unique_ptr<TH1F> mHistogramMeanRatePerSolar;
 
   std::unique_ptr<TH1F> mHistogramGoodChannelsFractionPerDE;
+  std::unique_ptr<TH1F> mHistogramGoodChannelsFractionPerSolar;
 
   std::map<int, std::shared_ptr<DetectorHistogram>> mHistogramRateDE[2]; // 2D hit rate map for each DE
   std::shared_ptr<GlobalHistogram> mHistogramRateGlobal[2];              // Rate histogram (global XY view)

--- a/Modules/MUON/MCH/include/MCH/TH2ElecMapReductor.h
+++ b/Modules/MUON/MCH/include/MCH/TH2ElecMapReductor.h
@@ -41,6 +41,14 @@ class TH2ElecMapReductor : public quality_control::postprocessing::ReductorTObje
   float getChamberValue(int chid);
   float getDeValue(int deid, int cathode = 2);
   float getOrbits() { return meanOrbits; }
+
+  // SOLAR related accessors
+  float getSolarValue(int solarId);
+  int getSolarNumPads(int solarId);
+  int getSolarNumPadsBad(int solarId);
+  int getSolarNumPadsNoStat(int solarId);
+
+  // DE related accessors
   int getNumPads(int deid, int cathode);
   int getNumPads(int deid)
   {
@@ -57,8 +65,10 @@ class TH2ElecMapReductor : public quality_control::postprocessing::ReductorTObje
     return getNumPadsNoStat(deid, 0) + getNumPadsNoStat(deid, 1);
   }
 
+
  private:
   static constexpr int sDeNum{ 156 };
+  static constexpr uint32_t sSolarIndexMax{ 32 * 24 };
 
   int checkPadMapping(uint16_t feeId, uint8_t linkId, uint8_t eLinkId, o2::mch::raw::DualSampaChannelId channel, int& cid);
 
@@ -70,10 +80,19 @@ class TH2ElecMapReductor : public quality_control::postprocessing::ReductorTObje
   float mMin;
   float mMax;
 
+  // SOLAR related values
+  int solarNumPads[sSolarIndexMax];
+  int solarNumPadsBad[sSolarIndexMax];
+  int solarNumPadsNoStat[sSolarIndexMax];
+  float solarValues[sSolarIndexMax];
+
+  // DE related values
   int deNumPads[2][sDeNum];
   int deNumPadsBad[2][sDeNum];
   int deNumPadsNoStat[2][sDeNum];
   float deValues[3][sDeNum];
+
+  // chamber related values
   float chValues[10];
   float meanOrbits;
   float entries;

--- a/Modules/MUON/MCH/include/MCH/TH2ElecMapReductor.h
+++ b/Modules/MUON/MCH/include/MCH/TH2ElecMapReductor.h
@@ -65,7 +65,6 @@ class TH2ElecMapReductor : public quality_control::postprocessing::ReductorTObje
     return getNumPadsNoStat(deid, 0) + getNumPadsNoStat(deid, 1);
   }
 
-
  private:
   static constexpr int sDeNum{ 156 };
   static constexpr uint32_t sSolarIndexMax{ 32 * 24 };

--- a/Modules/MUON/MCH/src/DecodingPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DecodingPostProcessing.cxx
@@ -286,7 +286,7 @@ void DecodingPostProcessing::updateSyncStatusHistos(Trigger t, repository::Datab
 
 //_________________________________________________________________________________________
 
-TH1* DecodingPostProcessing::getHistogram(std::string plotName)
+TH1* DecodingPostProcessing::getHistogram(std::string_view plotName)
 {
   TH1* result{ nullptr };
   for (auto hist : mHistogramsAll) {

--- a/Modules/MUON/MCH/src/DigitsCheck.cxx
+++ b/Modules/MUON/MCH/src/DigitsCheck.cxx
@@ -16,6 +16,7 @@
 
 #include "MCH/DigitsCheck.h"
 #include "MUONCommon/Helpers.h"
+#include "QualityControl/ReferenceUtils.h"
 #include "QualityControl/MonitorObject.h"
 #include "QualityControl/QcInfoLogger.h"
 
@@ -25,6 +26,7 @@
 #include <TCanvas.h>
 #include <TList.h>
 #include <TLine.h>
+#include <TPaveLabel.h>
 #include <fstream>
 #include <string>
 
@@ -40,25 +42,50 @@ void DigitsCheck::configure()
 
 void DigitsCheck::startOfActivity(const Activity& activity)
 {
+  // input histogram names customization
   mMeanRateHistName = getConfigurationParameter<std::string>(mCustomParameters, "MeanRateHistName", mMeanRateHistName, activity);
   mGoodChanFracHistName = getConfigurationParameter<std::string>(mCustomParameters, "GoodChanFracHistName", mGoodChanFracHistName, activity);
 
+  mMeanRatePerSolarHistName = getConfigurationParameter<std::string>(mCustomParameters, "MeanRatePerSolarHistName", mMeanRatePerSolarHistName, activity);
+  mGoodChanFracPerSolarHistName = getConfigurationParameter<std::string>(mCustomParameters, "GoodChanFracPerSolarHistName", mGoodChanFracPerSolarHistName, activity);
+
+  mMeanRateRefCompHistName = getConfigurationParameter<std::string>(mCustomParameters, "MeanRateRefCompHistName", mMeanRateRefCompHistName, activity);
+  mGoodChanFracRefCompHistName = getConfigurationParameter<std::string>(mCustomParameters, "GoodChanFracRefCompHistName", mGoodChanFracRefCompHistName, activity);
+
+  mMeanRatePerSolarRefCompHistName = getConfigurationParameter<std::string>(mCustomParameters, "MeanRatePerSolarRefCompHistName", mMeanRatePerSolarRefCompHistName, activity);
+  mGoodChanFracPerSolarRefCompHistName = getConfigurationParameter<std::string>(mCustomParameters, "GoodChanFracPerSolarRefCompHistName", mGoodChanFracPerSolarRefCompHistName, activity);
+
+  // threshold customization
   getThresholdsPerStation(mCustomParameters, activity, "MinRate", mMinRatePerStation, mMinRate);
   getThresholdsPerStation(mCustomParameters, activity, "MaxRate", mMaxRatePerStation, mMaxRate);
+  mMinRateRatio = getConfigurationParameter<double>(mCustomParameters, "MinRateRatio", mMinRateRatio, activity);
+
+  mMinRatePerSolar = getConfigurationParameter<double>(mCustomParameters, "MinRatePerSolar", mMinRatePerSolar, activity);
+  mMaxRatePerSolar = getConfigurationParameter<double>(mCustomParameters, "MaxRatePerSolar", mMaxRatePerSolar, activity);
+  mMinRateRatioPerSolar = getConfigurationParameter<double>(mCustomParameters, "MinRateRatioPerSolar", mMinRateRatioPerSolar, activity);
+
   getThresholdsPerStation(mCustomParameters, activity, "MinGoodFraction", mMinGoodFractionPerStation, mMinGoodFraction);
+  mMinGoodFractionRatio = getConfigurationParameter<double>(mCustomParameters, "MinGoodFractionRatio", mMinGoodFractionRatio, activity);
+
+  mMinGoodFractionPerSolar = getConfigurationParameter<double>(mCustomParameters, "MinGoodFractionPerSolar", mMinGoodFractionPerSolar, activity);
+  mMinGoodFractionRatioPerSolar = getConfigurationParameter<double>(mCustomParameters, "MinGoodFractionRatioPerSolar", mMinGoodFractionRatioPerSolar, activity);
 
   mMaxBadST12 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST12", mMaxBadST12, activity);
   mMaxBadST345 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST345", mMaxBadST345, activity);
 
   mRatePlotScaleMin = getConfigurationParameter<double>(mCustomParameters, "RatePlotScaleMin", mRatePlotScaleMin, activity);
   mRatePlotScaleMax = getConfigurationParameter<double>(mCustomParameters, "RatePlotScaleMax", mRatePlotScaleMax, activity);
+  mRateRatioPlotScaleRange = getConfigurationParameter<double>(mCustomParameters, "RateRatioPlotScaleRange", mRateRatioPlotScaleRange, activity);
+  mRateRatioPerSolarPlotScaleRange = getConfigurationParameter<double>(mCustomParameters, "RateRatioPerSolarPlotScaleRange", mRateRatioPerSolarPlotScaleRange, activity);
+  mGoodFractionRatioPlotScaleRange = getConfigurationParameter<double>(mCustomParameters, "GoodFractionRatioPlotScaleRange", mGoodFractionRatioPlotScaleRange, activity);
+  mGoodFractionRatioPerSolarPlotScaleRange = getConfigurationParameter<double>(mCustomParameters, "GoodFractionRatioPerSolarPlotScaleRange", mGoodFractionRatioPerSolarPlotScaleRange, activity);
 
   mQualityChecker.mMaxBadST12 = mMaxBadST12;
   mQualityChecker.mMaxBadST345 = mMaxBadST345;
 }
 
 template <typename Lambda>
-std::array<Quality, getNumDE()> checkPlot(TH1F* h, Lambda check)
+std::array<Quality, getNumDE()> checkPlot(TH1* h, Lambda check)
 {
   std::array<Quality, getNumDE()> result;
   std::fill(result.begin(), result.end(), Quality::Null);
@@ -84,7 +111,7 @@ std::array<Quality, getNumDE()> checkPlot(TH1F* h, Lambda check)
   return result;
 }
 
-std::array<Quality, getNumDE()> DigitsCheck::checkMeanRates(TH1F* h)
+std::array<Quality, getNumDE()> DigitsCheck::checkMeanRates(TH1* h)
 {
   auto checkFunction = [&](double val, int station) -> bool {
     auto minRate = mMinRate;
@@ -102,7 +129,16 @@ std::array<Quality, getNumDE()> DigitsCheck::checkMeanRates(TH1F* h)
   return checkPlot(h, checkFunction);
 }
 
-std::array<Quality, getNumDE()> DigitsCheck::checkBadChannels(TH1F* h)
+std::array<Quality, getNumDE()> DigitsCheck::checkMeanRateRatios(TH1* h)
+{
+  auto checkFunction = [&](double val, int /*station*/) -> bool {
+    auto minRateRatio = mMinRateRatio;
+    return (val >= minRateRatio);
+  };
+  return checkPlot(h, checkFunction);
+}
+
+std::array<Quality, getNumDE()> DigitsCheck::checkBadChannels(TH1* h)
 {
   auto checkFunction = [&](double val, int station) -> bool {
     auto minGoodFraction = mMinGoodFraction;
@@ -114,6 +150,63 @@ std::array<Quality, getNumDE()> DigitsCheck::checkBadChannels(TH1F* h)
     return (val >= minGoodFraction);
   };
   return checkPlot(h, checkFunction);
+}
+
+std::array<Quality, getNumDE()> DigitsCheck::checkBadChannelRatios(TH1* h)
+{
+  auto checkFunction = [&](double val, int /*station*/) -> bool {
+    auto minGoodFractionRatio = mMinGoodFractionRatio;
+    return (val >= minGoodFractionRatio);
+  };
+  return checkPlot(h, checkFunction);
+}
+
+void DigitsCheck::checkSolarMeanRates(TH1* h)
+{
+  for (int solar = 0; solar < h->GetXaxis()->GetNbins(); solar++) {
+    int bin = solar + 1;
+    double value = h->GetBinContent(bin);
+    if (value >= mMinRatePerSolar && value <= mMaxRatePerSolar) {
+      continue;
+    }
+    mSolarQuality[solar] = Quality::Bad;
+  }
+}
+
+void DigitsCheck::checkSolarMeanRateRatios(TH1* h)
+{
+  for (int solar = 0; solar < h->GetXaxis()->GetNbins(); solar++) {
+    int bin = solar + 1;
+    double value = h->GetBinContent(bin);
+    if (value >= mMinRateRatioPerSolar) {
+      continue;
+    }
+    mSolarQuality[solar] = Quality::Bad;
+  }
+}
+
+void DigitsCheck::checkSolarBadChannels(TH1* h)
+{
+  for (int solar = 0; solar < h->GetXaxis()->GetNbins(); solar++) {
+    int bin = solar + 1;
+    double value = h->GetBinContent(bin);
+    if (value >= mMinGoodFractionPerSolar) {
+      continue;
+    }
+    mSolarQuality[solar] = Quality::Bad;
+  }
+}
+
+void DigitsCheck::checkSolarBadChannelRatios(TH1* h)
+{
+  for (int solar = 0; solar < h->GetXaxis()->GetNbins(); solar++) {
+    int bin = solar + 1;
+    double value = h->GetBinContent(bin);
+    if (value >= mMinGoodFractionRatioPerSolar) {
+      continue;
+    }
+    mSolarQuality[solar] = Quality::Bad;
+  }
 }
 
 template <typename T>
@@ -151,9 +244,11 @@ static T* getHisto(std::shared_ptr<MonitorObject> mo)
 Quality DigitsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
   mQualityChecker.reset();
+  std::fill(mSolarQuality.begin(), mSolarQuality.end(), Quality::Good);
 
   for (auto& [moName, mo] : *moMap) {
 
+    // DE histograms
     if (matchHistName(mo->getName(), mMeanRateHistName)) {
       TH1F* h = getHisto<TH1F>(mo);
       if (h) {
@@ -161,12 +256,65 @@ Quality DigitsCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
         mQualityChecker.addCheckResult(q);
       }
     }
-
     if (matchHistName(mo->getName(), mGoodChanFracHistName)) {
       TH1F* h = getHisto<TH1F>(mo);
       if (h) {
         auto q = checkBadChannels(h);
         mQualityChecker.addCheckResult(q);
+      }
+    }
+    // comparisons with reference
+    if (matchHistName(mo->getName(), mMeanRateRefCompHistName)) {
+      TCanvas* canvas = dynamic_cast<TCanvas*>(mo->getObject());
+      if (canvas) {
+        auto ratioPlot = o2::quality_control::checker::getRatioPlotFromCanvas(canvas);
+        if (ratioPlot) {
+          auto q = checkMeanRateRatios(ratioPlot);
+          mQualityChecker.addCheckResult(q);
+        }
+      }
+    }
+    if (matchHistName(mo->getName(), mGoodChanFracRefCompHistName)) {
+      TCanvas* canvas = dynamic_cast<TCanvas*>(mo->getObject());
+      if (canvas) {
+        auto ratioPlot = o2::quality_control::checker::getRatioPlotFromCanvas(canvas);
+        if (ratioPlot) {
+          auto q = checkBadChannelRatios(ratioPlot);
+          mQualityChecker.addCheckResult(q);
+        }
+      }
+    }
+
+    // SOLAR histograms
+    if (matchHistName(mo->getName(), mMeanRatePerSolarHistName)) {
+      TH1F* h = getHisto<TH1F>(mo);
+      if (h) {
+        checkSolarMeanRates(h);
+      }
+    }
+    if (matchHistName(mo->getName(), mGoodChanFracPerSolarHistName)) {
+      TH1F* h = getHisto<TH1F>(mo);
+      if (h) {
+        checkSolarBadChannels(h);
+      }
+    }
+    // comparisons with reference
+    if (matchHistName(mo->getName(), mMeanRatePerSolarRefCompHistName)) {
+      TCanvas* canvas = dynamic_cast<TCanvas*>(mo->getObject());
+      if (canvas) {
+        auto ratioPlot = o2::quality_control::checker::getRatioPlotFromCanvas(canvas);
+        if (ratioPlot) {
+          checkSolarMeanRateRatios(ratioPlot);
+        }
+      }
+    }
+    if (matchHistName(mo->getName(), mGoodChanFracPerSolarRefCompHistName)) {
+      TCanvas* canvas = dynamic_cast<TCanvas*>(mo->getObject());
+      if (canvas) {
+        auto ratioPlot = o2::quality_control::checker::getRatioPlotFromCanvas(canvas);
+        if (ratioPlot) {
+          checkSolarBadChannelRatios(ratioPlot);
+        }
       }
     }
   }
@@ -189,6 +337,103 @@ static void updateTitle(TH1* hist, std::string suffix)
 
 void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
+  if ((mo->getName().find("RefComp/") != std::string::npos)) {
+    TCanvas* canvas = dynamic_cast<TCanvas*>(mo->getObject());
+    if (!canvas) {
+      return;
+    }
+
+    auto ratioPlot = o2::quality_control::checker::getRatioPlotFromCanvas(canvas);
+    if (!ratioPlot) {
+      return;
+    }
+
+    std::string messages;
+    auto refCompPlots = o2::quality_control::checker::getPlotsFromCanvas(canvas, messages);
+
+    double ratioPlotRange{ -1 };
+    double ratioThreshold{ -1 };
+    double plotScaleMin{ -1 };
+    double plotScaleMax{ -1 };
+    bool isSolar{ false };
+
+    if (matchHistName(mo->getName(), mMeanRateRefCompHistName)) {
+      ratioPlotRange = mRateRatioPlotScaleRange;
+      ratioThreshold = mMinRateRatio;
+      plotScaleMin = mRatePlotScaleMin;
+      plotScaleMax = mRatePlotScaleMax;
+      isSolar = false;
+    } else if (matchHistName(mo->getName(), mMeanRatePerSolarRefCompHistName)) {
+      ratioPlotRange = mRateRatioPerSolarPlotScaleRange;
+      ratioThreshold = mMinRateRatioPerSolar;
+      plotScaleMin = mRatePlotScaleMin;
+      plotScaleMax = mRatePlotScaleMax;
+      isSolar = true;
+    } else if (matchHistName(mo->getName(), mGoodChanFracRefCompHistName)) {
+      ratioPlotRange = mGoodFractionRatioPlotScaleRange;
+      ratioThreshold = mMinGoodFractionRatio;
+      plotScaleMin = 0;
+      plotScaleMax = 1.05;
+      isSolar = false;
+    } else if (matchHistName(mo->getName(), mGoodChanFracPerSolarRefCompHistName)) {
+      ratioPlotRange = mGoodFractionRatioPerSolarPlotScaleRange;
+      ratioThreshold = mMinGoodFractionRatioPerSolar;
+      plotScaleMin = 0;
+      plotScaleMax = 1.05;
+      isSolar = true;
+    }
+
+    if (ratioPlotRange < 0) {
+      return;
+    }
+
+    ratioPlot->SetMinimum(1.0 - ratioPlotRange);
+    ratioPlot->SetMaximum(1.0 + ratioPlotRange);
+    ratioPlot->GetXaxis()->SetTickLength(0);
+
+    if (isSolar) {
+      addChamberDelimitersToSolarHistogram(ratioPlot);
+      addSolarBinLabels(ratioPlot);
+    } else {
+      addChamberDelimiters(ratioPlot);
+      addDEBinLabels(ratioPlot);
+    }
+    drawThreshold(ratioPlot, ratioThreshold);
+
+    if (refCompPlots.first) {
+      refCompPlots.first->SetMinimum(plotScaleMin);
+      refCompPlots.first->SetMaximum(plotScaleMax);
+      if (isSolar) {
+        addChamberDelimitersToSolarHistogram(refCompPlots.first);
+        addChamberLabelsForSolar(refCompPlots.first);
+        addSolarBinLabels(refCompPlots.first);
+        if (refCompPlots.second) {
+          addSolarBinLabels(refCompPlots.second);
+        }
+      } else {
+        addChamberDelimiters(refCompPlots.first);
+        addChamberLabelsForDE(refCompPlots.first);
+        addDEBinLabels(refCompPlots.first);
+        if (refCompPlots.second) {
+          addDEBinLabels(refCompPlots.second);
+        }
+      }
+    }
+
+    if (refCompPlots.second) {
+      if (checkResult == Quality::Good) {
+        refCompPlots.second->SetLineColor(kGreen + 2);
+      } else if (checkResult == Quality::Bad) {
+        refCompPlots.second->SetLineColor(kRed);
+      } else if (checkResult == Quality::Medium) {
+        refCompPlots.second->SetLineColor(kOrange - 3);
+      } else if (checkResult == Quality::Null) {
+        refCompPlots.second->SetLineColor(kViolet - 6);
+      }
+    }
+    return;
+  }
+
   if (mo->getName().find("Occupancy_Elec") != std::string::npos ||
       mo->getName().find("OccupancySignal_Elec") != std::string::npos) {
     auto* h = dynamic_cast<TH2F*>(mo->getObject());
@@ -232,8 +477,13 @@ void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
     h->SetMaximum(scaleMax);
     h->GetYaxis()->SetTitle("rate (kHz)");
 
-    addChamberDelimiters(h, scaleMin, scaleMax);
-    addDEBinLabels(h);
+    if (mo->getName().find("MeanRatePerSolar") != std::string::npos) {
+      addChamberDelimitersToSolarHistogram(h, scaleMin, scaleMax);
+      addChamberLabelsForSolar(h);
+    } else {
+      addChamberDelimiters(h, scaleMin, scaleMax);
+      addChamberLabelsForDE(h);
+    }
 
     // only the plot used for the check is beautified by changing the color
     // and adding the horizontal lines corresponding to the thresholds
@@ -250,6 +500,21 @@ void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
       drawThresholdsPerStation(h, mMinRatePerStation, mMinRate);
       drawThresholdsPerStation(h, mMaxRatePerStation, mMaxRate);
     }
+
+    // also beautify the SOLAR plot
+    if (matchHistName(mo->getName(), mMeanRatePerSolarHistName)) {
+      if (checkResult == Quality::Good) {
+        h->SetFillColor(kGreen);
+      } else if (checkResult == Quality::Bad) {
+        h->SetFillColor(kRed);
+      } else if (checkResult == Quality::Medium) {
+        h->SetFillColor(kOrange);
+      }
+      h->SetLineColor(kBlack);
+
+      drawThreshold(h, mMinRatePerSolar);
+      drawThreshold(h, mMaxRatePerSolar);
+    }
   }
 
   if (mo->getName().find("GoodChannelsFraction") != std::string::npos) {
@@ -264,8 +529,13 @@ void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
     h->SetMaximum(scaleMax);
     h->GetYaxis()->SetTitle("fraction");
 
-    addChamberDelimiters(h, scaleMin, scaleMax);
-    addDEBinLabels(h);
+    if (mo->getName().find("GoodChannelsFractionPerSolar") != std::string::npos) {
+      addChamberDelimitersToSolarHistogram(h, scaleMin, scaleMax);
+      addChamberLabelsForSolar(h);
+    } else {
+      addChamberDelimiters(h, scaleMin, scaleMax);
+      addChamberLabelsForDE(h);
+    }
 
     // only the plot used for the check is beautified by changing the color
     // and adding the horizontal lines corresponding to the thresholds
@@ -281,6 +551,20 @@ void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
 
       drawThresholdsPerStation(h, mMinGoodFractionPerStation, mMinGoodFraction);
     }
+
+    // also beautify the SOLAR plot
+    if (matchHistName(mo->getName(), mGoodChanFracPerSolarHistName)) {
+      if (checkResult == Quality::Good) {
+        h->SetFillColor(kGreen);
+      } else if (checkResult == Quality::Bad) {
+        h->SetFillColor(kRed);
+      } else if (checkResult == Quality::Medium) {
+        h->SetFillColor(kOrange);
+      }
+      h->SetLineColor(kBlack);
+
+      drawThreshold(h, mMinGoodFractionPerSolar);
+    }
   }
 
   // update quality flags for each DE
@@ -290,22 +574,74 @@ void DigitsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
       return;
     }
 
-    addChamberDelimiters(h);
-    addDEBinLabels(h);
-
-    for (int deId = 0; deId < mQualityChecker.mQuality.size(); deId++) {
+    std::string badDEs;
+    for (int deIndex = 0; deIndex < mQualityChecker.mQuality.size(); deIndex++) {
       float ybin = 0;
-      if (mQualityChecker.mQuality[deId] == Quality::Good) {
+      if (mQualityChecker.mQuality[deIndex] == Quality::Good) {
         ybin = 3;
       }
-      if (mQualityChecker.mQuality[deId] == Quality::Medium) {
+      if (mQualityChecker.mQuality[deIndex] == Quality::Medium) {
         ybin = 2;
       }
-      if (mQualityChecker.mQuality[deId] == Quality::Bad) {
+      if (mQualityChecker.mQuality[deIndex] == Quality::Bad) {
         ybin = 1;
+        std::string deIdStr = std::to_string(getDEFromIndex(deIndex));
+        if (badDEs.empty()) {
+          badDEs = deIdStr;
+        } else {
+          badDEs += std::string(" ") + deIdStr;
+        }
       }
 
-      h->SetBinContent(deId + 1, ybin, 1);
+      h->SetBinContent(deIndex + 1, ybin, 1);
+    }
+
+    if (!badDEs.empty()) {
+      std::string text = std::string("Bad DEs: ") + badDEs;
+      TPaveLabel* label = new TPaveLabel(0.2, 0.8, 0.8, 0.88, text.c_str(), "blNDC");
+      label->SetBorderSize(1);
+      h->GetListOfFunctions()->Add(label);
+
+      ILOG(Warning, Support) << "[DecodingCheck] " << text << ENDM;
+    }
+  }
+
+  // update quality flags for each SOLAR
+  if (mo->getName().find("QualityFlagPerSolar") != std::string::npos) {
+    TH2F* h = getHisto<TH2F>(mo);
+    if (!h) {
+      return;
+    }
+
+    std::string badSolarBoards;
+    for (int solar = 0; solar < mSolarQuality.size(); solar++) {
+      float ybin = 0;
+      if (mSolarQuality[solar] == Quality::Good) {
+        ybin = 3;
+      }
+      if (mSolarQuality[solar] == Quality::Medium) {
+        ybin = 2;
+      }
+      if (mSolarQuality[solar] == Quality::Bad) {
+        ybin = 1;
+        std::string solarId = std::to_string(getSolarIdFromIndex(solar));
+        if (badSolarBoards.empty()) {
+          badSolarBoards = solarId;
+        } else {
+          badSolarBoards += std::string(" ") + solarId;
+        }
+      }
+
+      h->SetBinContent(solar + 1, ybin, 1);
+    }
+
+    if (!badSolarBoards.empty()) {
+      std::string badSolarList = std::string("Bad SOLAR boards: ") + badSolarBoards;
+      TPaveLabel* label = new TPaveLabel(0.2, 0.8, 0.8, 0.88, badSolarList.c_str(), "blNDC");
+      label->SetBorderSize(1);
+      h->GetListOfFunctions()->Add(label);
+
+      ILOG(Warning, Support) << "[DigitsCheck] " << badSolarList << ENDM;
     }
   }
 }

--- a/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
@@ -348,7 +348,7 @@ void DigitsPostProcessing::updateOrbitHistos(Trigger t, repository::DatabaseInte
 
 //_________________________________________________________________________________________
 
-TH1* DigitsPostProcessing::getHistogram(std::string plotName)
+TH1* DigitsPostProcessing::getHistogram(std::string_view plotName)
 {
   TH1* result{ nullptr };
   for (auto hist : mHistogramsAll) {

--- a/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/DigitsPostProcessing.cxx
@@ -18,6 +18,8 @@
 
 #include "MCH/DigitsPostProcessing.h"
 #include "MUONCommon/Helpers.h"
+#include "Common/ReferenceComparatorPlot.h"
+#include "QualityControl/ReferenceUtils.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/DatabaseInterface.h"
 #include <TDatime.h>
@@ -27,6 +29,8 @@ using namespace o2::quality_control_modules::muon;
 
 void DigitsPostProcessing::configure(const boost::property_tree::ptree& config)
 {
+  ReferenceComparatorTask::configure(config);
+
   mConfig = PostProcessingConfigMCH(getID(), config);
 }
 
@@ -42,9 +46,23 @@ void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInte
   mRatesPlotter = std::make_unique<RatesPlotter>("Rates/", mChannelRateMin, mChannelRateMax, true, mFullHistos);
   mRatesPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
+  for (auto& hinfo : mRatesPlotter->histograms()) {
+    TH1* hist = dynamic_cast<TH1*>(hinfo.object);
+    if (hist) {
+      mHistogramsAll.push_back(hist);
+    }
+  }
+
   mRatesPlotterSignal.reset();
   mRatesPlotterSignal = std::make_unique<RatesPlotter>("RatesSignal/", mChannelRateMin, mChannelRateMax, true, mFullHistos);
   mRatesPlotterSignal->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+
+  for (auto& hinfo : mRatesPlotterSignal->histograms()) {
+    TH1* hist = dynamic_cast<TH1*>(hinfo.object);
+    if (hist) {
+      mHistogramsAll.push_back(hist);
+    }
+  }
 
   //----------------------------------
   // Rate plotters for last cycle
@@ -68,9 +86,23 @@ void DigitsPostProcessing::createRatesHistos(Trigger t, repository::DatabaseInte
     mRatesPlotterOnCycle = std::make_unique<RatesPlotter>("Rates/LastCycle/", mChannelRateMin, mChannelRateMax, false, mFullHistos);
     mRatesPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
+    for (auto& hinfo : mRatesPlotterOnCycle->histograms()) {
+      TH1* hist = dynamic_cast<TH1*>(hinfo.object);
+      if (hist) {
+        mHistogramsAll.push_back(hist);
+      }
+    }
+
     mRatesPlotterSignalOnCycle.reset();
     mRatesPlotterSignalOnCycle = std::make_unique<RatesPlotter>("RatesSignal/LastCycle/", mChannelRateMin, mChannelRateMax, false, mFullHistos);
     mRatesPlotterSignalOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+
+    for (auto& hinfo : mRatesPlotterSignalOnCycle->histograms()) {
+      TH1* hist = dynamic_cast<TH1*>(hinfo.object);
+      if (hist) {
+        mHistogramsAll.push_back(hist);
+      }
+    }
   }
 
   //----------------------------------
@@ -100,9 +132,23 @@ void DigitsPostProcessing::createOrbitHistos(Trigger t, repository::DatabaseInte
   mOrbitsPlotter = std::make_unique<OrbitsPlotter>("Orbits/");
   mOrbitsPlotter->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
+  for (auto& hinfo : mOrbitsPlotter->histograms()) {
+    TH1* hist = dynamic_cast<TH1*>(hinfo.object);
+    if (hist) {
+      mHistogramsAll.push_back(hist);
+    }
+  }
+
   mOrbitsPlotterSignal.reset();
   mOrbitsPlotterSignal = std::make_unique<OrbitsPlotter>("OrbitsSignal/");
   mOrbitsPlotterSignal->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+
+  for (auto& hinfo : mOrbitsPlotterSignal->histograms()) {
+    TH1* hist = dynamic_cast<TH1*>(hinfo.object);
+    if (hist) {
+      mHistogramsAll.push_back(hist);
+    }
+  }
 
   //----------------------------------
   // Orbit plotters for last cycle
@@ -126,9 +172,23 @@ void DigitsPostProcessing::createOrbitHistos(Trigger t, repository::DatabaseInte
     mOrbitsPlotterOnCycle = std::make_unique<OrbitsPlotter>("Orbits/LastCycle/");
     mOrbitsPlotterOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
 
+    for (auto& hinfo : mOrbitsPlotterOnCycle->histograms()) {
+      TH1* hist = dynamic_cast<TH1*>(hinfo.object);
+      if (hist) {
+        mHistogramsAll.push_back(hist);
+      }
+    }
+
     mOrbitsPlotterSignalOnCycle.reset();
     mOrbitsPlotterSignalOnCycle = std::make_unique<OrbitsPlotter>("OrbitsSignal/LastCycle/");
     mOrbitsPlotterSignalOnCycle->publish(getObjectsManager(), core::PublicationPolicy::ThroughStop);
+
+    for (auto& hinfo : mOrbitsPlotterSignalOnCycle->histograms()) {
+      TH1* hist = dynamic_cast<TH1*>(hinfo.object);
+      if (hist) {
+        mHistogramsAll.push_back(hist);
+      }
+    }
   }
 }
 
@@ -136,6 +196,8 @@ void DigitsPostProcessing::createOrbitHistos(Trigger t, repository::DatabaseInte
 
 void DigitsPostProcessing::initialize(Trigger t, framework::ServiceRegistryRef services)
 {
+  ReferenceComparatorTask::initialize(t, services);
+
   auto& qcdb = services.get<repository::DatabaseInterface>();
   const auto& activity = t.activity;
 
@@ -177,14 +239,31 @@ void DigitsPostProcessing::initialize(Trigger t, framework::ServiceRegistryRef s
 
   mHistogramQualityPerDE.reset();
   mHistogramQualityPerDE = std::make_unique<TH2F>("QualityFlagPerDE", "Quality Flag vs DE", getNumDE(), 0, getNumDE(), 3, 0, 3);
+  addDEBinLabels(mHistogramQualityPerDE.get());
+  addChamberDelimiters(mHistogramQualityPerDE.get());
+  addChamberLabelsForDE(mHistogramQualityPerDE.get());
   mHistogramQualityPerDE->GetYaxis()->SetBinLabel(1, "Bad");
   mHistogramQualityPerDE->GetYaxis()->SetBinLabel(2, "Medium");
   mHistogramQualityPerDE->GetYaxis()->SetBinLabel(3, "Good");
-  mHistogramQualityPerDE->SetOption("colz");
+  mHistogramQualityPerDE->SetOption("col");
   mHistogramQualityPerDE->SetStats(0);
   getObjectsManager()->startPublishing(mHistogramQualityPerDE.get(), core::PublicationPolicy::ThroughStop);
-  getObjectsManager()->setDefaultDrawOptions(mHistogramQualityPerDE.get(), "colz");
+  getObjectsManager()->setDefaultDrawOptions(mHistogramQualityPerDE.get(), "col");
   getObjectsManager()->setDisplayHint(mHistogramQualityPerDE.get(), "gridy");
+
+  mHistogramQualityPerSolar.reset();
+  mHistogramQualityPerSolar = std::make_unique<TH2F>("QualityFlagPerSolar", "Quality Flag vs Solar", getNumSolar(), 0, getNumSolar(), 3, 0, 3);
+  addSolarBinLabels(mHistogramQualityPerSolar.get());
+  addChamberDelimitersToSolarHistogram(mHistogramQualityPerSolar.get());
+  addChamberLabelsForSolar(mHistogramQualityPerSolar.get());
+  mHistogramQualityPerSolar->GetYaxis()->SetBinLabel(1, "Bad");
+  mHistogramQualityPerSolar->GetYaxis()->SetBinLabel(2, "Medium");
+  mHistogramQualityPerSolar->GetYaxis()->SetBinLabel(3, "Good");
+  mHistogramQualityPerSolar->SetOption("col");
+  mHistogramQualityPerSolar->SetStats(0);
+  getObjectsManager()->startPublishing(mHistogramQualityPerSolar.get(), core::PublicationPolicy::ThroughStop);
+  getObjectsManager()->setDefaultDrawOptions(mHistogramQualityPerSolar.get(), "col");
+  getObjectsManager()->setDisplayHint(mHistogramQualityPerSolar.get(), "gridy");
 }
 
 //_________________________________________________________________________________________
@@ -269,12 +348,34 @@ void DigitsPostProcessing::updateOrbitHistos(Trigger t, repository::DatabaseInte
 
 //_________________________________________________________________________________________
 
+TH1* DigitsPostProcessing::getHistogram(std::string plotName)
+{
+  TH1* result{ nullptr };
+  for (auto hist : mHistogramsAll) {
+    if (plotName == hist->GetName()) {
+      result = hist;
+      break;
+    }
+  }
+  return result;
+}
+
 void DigitsPostProcessing::update(Trigger t, framework::ServiceRegistryRef services)
 {
   auto& qcdb = services.get<repository::DatabaseInterface>();
 
   updateRateHistos(t, &qcdb);
   updateOrbitHistos(t, &qcdb);
+
+  auto& comparatorPlots = getComparatorPlots();
+  for (auto& [plotName, plot] : comparatorPlots) {
+    TH1* hist = getHistogram(plotName);
+    if (!hist) {
+      continue;
+    }
+
+    plot->update(hist);
+  }
 }
 
 //_________________________________________________________________________________________

--- a/Modules/MUON/MCH/src/EfficiencyPlotter.cxx
+++ b/Modules/MUON/MCH/src/EfficiencyPlotter.cxx
@@ -47,8 +47,14 @@ EfficiencyPlotter::EfficiencyPlotter(std::string path, bool fullPlots)
     mHistogramMeanEfficiencyPerDE[ci] = std::make_unique<TH1F>(TString::Format("%sMeanEfficiency%s", path.c_str(), sc[ci].c_str()),
                                                                TString::Format("Mean Efficiency vs DE (%s)", sc[ci].c_str()),
                                                                getNumDE(), 0, getNumDE());
+    addDEBinLabels(mHistogramMeanEfficiencyPerDE[ci].get());
     addHisto(mHistogramMeanEfficiencyPerDE[ci].get(), false, "histo", "histo");
   }
+
+  mHistogramMeanEfficiencyPerSolar = std::make_unique<TH1F>(TString::Format("%sMeanEfficiencyPerSolar", path.c_str()), "Mean Efficiency per SOLAR board",
+                                                            getNumSolar(), 0, getNumSolar());
+  addSolarBinLabels(mHistogramMeanEfficiencyPerSolar.get());
+  addHisto(mHistogramMeanEfficiencyPerSolar.get(), false, "histo", "histo");
 
   //--------------------------------------------------
   // Efficiency histograms in global detector coordinates
@@ -92,6 +98,11 @@ void EfficiencyPlotter::fillAverageHistograms()
       mHistogramMeanEfficiencyPerDE[ci]->SetBinContent(de + 1, mElecMapReductor->getDeValue(de, ci));
       mHistogramMeanEfficiencyPerDE[ci]->SetBinError(de + 1, 0.1);
     }
+  }
+
+  for (size_t solar = 0; solar < mHistogramMeanEfficiencyPerSolar->GetXaxis()->GetNbins(); solar++) {
+    mHistogramMeanEfficiencyPerSolar->SetBinContent(solar + 1, mElecMapReductor->getSolarValue(solar));
+    mHistogramMeanEfficiencyPerSolar->SetBinError(solar + 1, 0.1);
   }
 }
 

--- a/Modules/MUON/MCH/src/Helpers.cxx
+++ b/Modules/MUON/MCH/src/Helpers.cxx
@@ -184,15 +184,6 @@ int getDEFromIndex(int index)
       if (deId < 0) {
         deId = lMax + (nDEhc - indexInHalfChamber);
       }
-      /*if (indexInHalfChamber > nDEqc) {
-        // the DE is in the lower half of the chamber
-        std::cout << "DE on lower R side, indexInHalfChamber=" << indexInHalfChamber << " nDEqc=" << nDEqc << std::endl;
-        deId = lMax + (nDEhc - indexInHalfChamber);
-      } else {
-        // the DE is in the upper half of the chamber
-        std::cout << "DE on upper R side, indexInHalfChamber=" << indexInHalfChamber << " nDEqc=" << nDEqc << std::endl;
-        deId = lMin - indexInHalfChamber - 1;
-      }*/
     }
 
     deId += (chamber + 1) * 100;
@@ -245,7 +236,7 @@ int getSolarIndex(int solarId)
   try {
     return m.at(solarId);
   } catch (const std::exception&) {
-    ILOG(Error, Support) << "Invalid Solar Id: " << solarId;
+    ILOG(Error, Support) << "Invalid Solar Id: " << solarId << ENDM;
   }
   return -1;
 }
@@ -256,18 +247,11 @@ int getSolarIdFromIndex(int index)
   try {
     return v.at(index);
   } catch (const std::exception&) {
-    ILOG(Error, Support) << "Invalid Solar Index: " << index;
+    ILOG(Error, Support) << "Invalid Solar Index: " << index << ENDM;
   }
   return -1;
 }
-/*
-constexpr int getNumSolar()
-{
-  //static std::vector<uint32_t> v = buildSolarIndexToSolarIdMap();
-  //return v.size();
-  return 624;
-}
-*/
+
 int getNumSolarPerChamber(int chamberId)
 {
   static std::array<uint32_t, 10> v{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
@@ -566,8 +550,6 @@ void addChamberDelimitersToSolarHistogram(TH1* h, float xmin, float xmax)
     delimiter->SetLineStyle(kDashed);
     h->GetListOfFunctions()->Add(delimiter);
   }
-
-  // addChamberLabelsForSolar(h);
 
   // draw x-axis labels
   /*float xMin{ 0 };

--- a/Modules/MUON/MCH/src/Helpers.cxx
+++ b/Modules/MUON/MCH/src/Helpers.cxx
@@ -202,7 +202,6 @@ int getDEFromIndex(int index)
   return deId;
 }
 
-
 //_________________________________________________________________________________________
 
 std::map<uint32_t, uint32_t> buildSolarIdToSolarIndexMap()
@@ -225,7 +224,6 @@ std::map<uint32_t, uint32_t> buildSolarIdToSolarIndexMap()
     }
   }
   return m;
-
 }
 
 std::vector<uint32_t> buildSolarIndexToSolarIdMap()
@@ -287,7 +285,6 @@ int getNumSolarPerChamber(int chamberId)
   }
   return -1;
 }
-
 
 //_________________________________________________________________________________________
 
@@ -570,7 +567,7 @@ void addChamberDelimitersToSolarHistogram(TH1* h, float xmin, float xmax)
     h->GetListOfFunctions()->Add(delimiter);
   }
 
-  //addChamberLabelsForSolar(h);
+  // addChamberLabelsForSolar(h);
 
   // draw x-axis labels
   /*float xMin{ 0 };

--- a/Modules/MUON/MCH/src/PedestalsCheck.cxx
+++ b/Modules/MUON/MCH/src/PedestalsCheck.cxx
@@ -291,6 +291,7 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
     h->SetMaximum(1.1);
 
     addChamberDelimiters(h, 0, 1.1);
+    addChamberLabelsForDE(h);
 
     TLine* delimiter = new TLine(h->GetXaxis()->GetXmin(), mMaxEmptyFractionPerDE, h->GetXaxis()->GetXmax(), mMaxEmptyFractionPerDE);
     delimiter->SetLineColor(kBlack);
@@ -314,6 +315,7 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
     h->SetMaximum(1.1);
 
     addChamberDelimiters(h, 0, 1.1);
+    addChamberLabelsForDE(h);
 
     TLine* delimiter = new TLine(h->GetXaxis()->GetXmin(), mMaxBadFractionPerDE, h->GetXaxis()->GetXmax(), mMaxBadFractionPerDE);
     delimiter->SetLineColor(kBlack);
@@ -343,6 +345,7 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
     h->SetMaximum(max);
 
     addChamberDelimiters(h, min, max);
+    addChamberLabelsForDE(h);
 
     TLine* delimiter = new TLine(h->GetXaxis()->GetXmin(), mMinStatisticsPerDE, h->GetXaxis()->GetXmax(), mMinStatisticsPerDE);
     delimiter->SetLineColor(kBlack);
@@ -369,6 +372,7 @@ void PedestalsCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkRe
     h->SetMaximum(max);
 
     addChamberDelimiters(h, min, max);
+    addChamberLabelsForDE(h);
   }
 
   if (mo->getName().find("Pedestals_Elec") != std::string::npos) {

--- a/Modules/MUON/MCH/src/PreclustersCheck.cxx
+++ b/Modules/MUON/MCH/src/PreclustersCheck.cxx
@@ -16,6 +16,7 @@
 #include "MCH/PreclustersCheck.h"
 #include "MCH/Helpers.h"
 #include "MUONCommon/Helpers.h"
+#include "QualityControl/ReferenceUtils.h"
 #include "QualityControl/QcInfoLogger.h"
 #include "QualityControl/MonitorObject.h"
 
@@ -25,6 +26,7 @@
 #include <TH2F.h>
 #include <TList.h>
 #include <TLine.h>
+#include <TPaveLabel.h>
 #include <fstream>
 #include <string>
 
@@ -40,13 +42,25 @@ void PreclustersCheck::configure()
 
 void PreclustersCheck::startOfActivity(const Activity& activity)
 {
+  mMeanEffHistNameB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffHistNameB", mMeanEffHistNameB, activity);
+  mMeanEffHistNameNB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffHistNameNB", mMeanEffHistNameNB, activity);
+  mMeanEffPerSolarHistName = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffPerSolarHistName", mMeanEffPerSolarHistName, activity);
+
+  mMeanEffRefCompHistNameB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffRefCompHistNameB", mMeanEffRefCompHistNameB, activity);
+  mMeanEffRefCompHistNameNB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffRefCompHistNameNB", mMeanEffRefCompHistNameNB, activity);
+  mMeanEffPerSolarRefCompHistName = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffPerSolarRefCompHistName", mMeanEffPerSolarRefCompHistName, activity);
+
   getThresholdsPerStation(mCustomParameters, activity, "MinEfficiency", mMinEfficiencyPerStation, mMinEfficiency);
+  mMinEfficiencyPerSolar = getConfigurationParameter<double>(mCustomParameters, "MinEfficiencyPerSolar", mMinEfficiencyPerSolar, activity);
+
+  mMinEfficiencyRatio = getConfigurationParameter<double>(mCustomParameters, "MinEfficiencyRatio", mMinEfficiencyRatio, activity);
+  mMinEfficiencyRatioPerSolar = getConfigurationParameter<double>(mCustomParameters, "MinEfficiencyRatioPerSolar", mMinEfficiencyRatioPerSolar, activity);
 
   mPseudoeffPlotScaleMin = getConfigurationParameter<double>(mCustomParameters, "PseudoeffPlotScaleMin", mPseudoeffPlotScaleMin, activity);
   mPseudoeffPlotScaleMax = getConfigurationParameter<double>(mCustomParameters, "PseudoeffPlotScaleMax", mPseudoeffPlotScaleMax, activity);
 
-  mMeanEffHistNameB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffHistNameB", mMeanEffHistNameB, activity);
-  mMeanEffHistNameNB = getConfigurationParameter<std::string>(mCustomParameters, "MeanEffHistNameNB", mMeanEffHistNameNB, activity);
+  mEfficiencyRatioScaleRange = getConfigurationParameter<double>(mCustomParameters, "EfficiencyRatioScaleRange", mEfficiencyRatioScaleRange, activity);
+  mEfficiencyRatioPerSolarScaleRange = getConfigurationParameter<double>(mCustomParameters, "EfficiencyRatioPerSolarScaleRange", mEfficiencyRatioPerSolarScaleRange, activity);
 
   mMaxBadST12 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST12", mMaxBadST12, activity);
   mMaxBadST345 = getConfigurationParameter<int>(mCustomParameters, "MaxBadDE_ST345", mMaxBadST345, activity);
@@ -88,10 +102,14 @@ static T* getHisto(std::shared_ptr<MonitorObject> mo)
 }
 
 template <typename Lambda>
-std::array<Quality, getNumDE()> checkPlot(TH1F* h, Lambda check)
+std::array<Quality, getNumDE()> checkPlot(TH1* h, Lambda check)
 {
   std::array<Quality, getNumDE()> result;
   std::fill(result.begin(), result.end(), Quality::Null);
+
+  if (h->GetEntries() == 0) {
+    return result;
+  }
 
   for (auto de : o2::mch::constants::deIdsForAllMCH) {
     int chamberId = (de - 100) / 100;
@@ -114,7 +132,7 @@ std::array<Quality, getNumDE()> checkPlot(TH1F* h, Lambda check)
   return result;
 }
 
-std::array<Quality, getNumDE()> PreclustersCheck::checkMeanEfficiencies(TH1F* h)
+std::array<Quality, getNumDE()> PreclustersCheck::checkMeanEfficiencies(TH1* h)
 {
   auto checkFunction = [&](double val, int station) -> bool {
     auto minEfficiency = mMinEfficiency;
@@ -128,23 +146,87 @@ std::array<Quality, getNumDE()> PreclustersCheck::checkMeanEfficiencies(TH1F* h)
   return checkPlot(h, checkFunction);
 }
 
+std::array<Quality, getNumDE()> PreclustersCheck::checkMeanEfficiencyRatios(TH1* h)
+{
+  auto checkFunction = [&](double val, int /*station*/) -> bool {
+    auto minEfficiency = mMinEfficiencyRatio;
+    return (val >= minEfficiency);
+  };
+  return checkPlot(h, checkFunction);
+}
+
+void PreclustersCheck::checkSolarMeanEfficiencies(TH1* h)
+{
+  for (int solar = 0; solar < h->GetXaxis()->GetNbins(); solar++) {
+    int bin = solar + 1;
+    double value = h->GetBinContent(bin);
+    if (value >= mMinEfficiencyPerSolar) {
+      continue;
+    }
+    mSolarQuality[solar] = Quality::Bad;
+  }
+}
+
+void PreclustersCheck::checkSolarMeanEfficiencyRatios(TH1* h)
+{
+  for (int solar = 0; solar < h->GetXaxis()->GetNbins(); solar++) {
+    int bin = solar + 1;
+    double value = h->GetBinContent(bin);
+    if (value >= mMinEfficiencyRatio) {
+      continue;
+    }
+    mSolarQuality[solar] = Quality::Bad;
+  }
+}
+
 Quality PreclustersCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
   ILOG(Debug, Devel) << "Entered PreclustersCheck::check" << ENDM;
   ILOG(Debug, Devel) << "   received a list of size : " << moMap->size() << ENDM;
-  for (const auto& item : *moMap) {
-    ILOG(Debug, Devel) << "Object: " << item.second->getName() << ENDM;
+  for (auto& [moName, mo] : *moMap) {
+    ILOG(Debug, Devel) << "Object: " << moName << " | " << mo->getName() << ENDM;
   }
 
   mQualityChecker.reset();
+  std::fill(mSolarQuality.begin(), mSolarQuality.end(), Quality::Good);
 
   for (auto& [moName, mo] : *moMap) {
 
-    if (matchHistName(mo->getName(), mMeanEffHistNameB) || matchHistName(mo->getName(), mMeanEffHistNameNB)) {
+    if (matchHistName(moName, mMeanEffHistNameB) || matchHistName(moName, mMeanEffHistNameNB)) {
       TH1F* h = getHisto<TH1F>(mo);
       if (h) {
         auto q = checkMeanEfficiencies(h);
         mQualityChecker.addCheckResult(q);
+      }
+    }
+
+    if (matchHistName(moName, mMeanEffPerSolarHistName)) {
+      TH1F* h = getHisto<TH1F>(mo);
+      if (h) {
+        checkSolarMeanEfficiencies(h);
+      }
+    }
+
+    // Ratios with reference
+    if (matchHistName(moName, mMeanEffRefCompHistNameB) || matchHistName(moName, mMeanEffRefCompHistNameNB)) {
+      TCanvas* canvas = dynamic_cast<TCanvas*>(mo->getObject());
+      if (canvas) {
+        auto ratioPlot = o2::quality_control::checker::getRatioPlotFromCanvas(canvas);
+        if (ratioPlot) {
+          auto q = checkMeanEfficiencyRatios(ratioPlot);
+          mQualityChecker.addCheckResult(q);
+        }
+      }
+    }
+
+    if (matchHistName(moName, mMeanEffPerSolarRefCompHistName)) {
+      TCanvas* canvas = dynamic_cast<TCanvas*>(mo->getObject());
+      if (canvas) {
+        auto ratioPlot = o2::quality_control::checker::getRatioPlotFromCanvas(canvas);
+        if (ratioPlot) {
+          ILOG(Debug, Devel) << "Checking eff ratio for SOLAR:" << ENDM;
+          checkSolarMeanEfficiencyRatios(ratioPlot);
+        }
       }
     }
   }
@@ -156,6 +238,92 @@ std::string PreclustersCheck::getAcceptedType() { return "TH1"; }
 
 void PreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResult)
 {
+  if ((mo->getName().find("RefComp/") != std::string::npos)) {
+    TCanvas* canvas = dynamic_cast<TCanvas*>(mo->getObject());
+    if (!canvas) {
+      return;
+    }
+
+    auto ratioPlot = o2::quality_control::checker::getRatioPlotFromCanvas(canvas);
+    if (!ratioPlot) {
+      return;
+    }
+
+    std::string messages;
+    auto refCompPlots = o2::quality_control::checker::getPlotsFromCanvas(canvas, messages);
+
+    double ratioPlotRange{ -1 };
+    double ratioThreshold{ -1 };
+    double plotScaleMin{ -1 };
+    double plotScaleMax{ -1 };
+    bool isSolar{ false };
+
+    if (matchHistName(mo->getName(), mMeanEffRefCompHistNameB) ||
+        matchHistName(mo->getName(), mMeanEffRefCompHistNameNB)) {
+      ratioPlotRange = mEfficiencyRatioScaleRange;
+      ratioThreshold = mMinEfficiencyRatio;
+      plotScaleMin = mPseudoeffPlotScaleMin;
+      plotScaleMax = mPseudoeffPlotScaleMax;
+      isSolar = false;
+    } else if (matchHistName(mo->getName(), mMeanEffPerSolarRefCompHistName)) {
+      ratioPlotRange = mEfficiencyRatioPerSolarScaleRange;
+      ratioThreshold = mMinEfficiencyRatioPerSolar;
+      plotScaleMin = mPseudoeffPlotScaleMin;
+      plotScaleMax = mPseudoeffPlotScaleMax;
+      isSolar = true;
+    }
+
+    if (ratioPlotRange < 0) {
+      return;
+    }
+
+    ratioPlot->SetMinimum(1.0 - ratioPlotRange);
+    ratioPlot->SetMaximum(1.0 + ratioPlotRange);
+    ratioPlot->GetXaxis()->SetTickLength(0);
+
+    if (isSolar) {
+      addChamberDelimitersToSolarHistogram(ratioPlot);
+      addSolarBinLabels(ratioPlot);
+    } else {
+      addChamberDelimiters(ratioPlot);
+      addDEBinLabels(ratioPlot);
+    }
+    drawThreshold(ratioPlot, ratioThreshold);
+
+    if (refCompPlots.first) {
+      refCompPlots.first->SetMinimum(plotScaleMin);
+      refCompPlots.first->SetMaximum(plotScaleMax);
+      if (isSolar) {
+        addChamberDelimitersToSolarHistogram(refCompPlots.first);
+        addChamberLabelsForSolar(refCompPlots.first);
+        addSolarBinLabels(refCompPlots.first);
+        if (refCompPlots.second) {
+          addSolarBinLabels(refCompPlots.second);
+        }
+      } else {
+        addChamberDelimiters(refCompPlots.first);
+        addChamberLabelsForDE(refCompPlots.first);
+        addDEBinLabels(refCompPlots.first);
+        if (refCompPlots.second) {
+          addDEBinLabels(refCompPlots.second);
+        }
+      }
+    }
+
+    if (refCompPlots.second) {
+      if (checkResult == Quality::Good) {
+        refCompPlots.second->SetLineColor(kGreen + 2);
+      } else if (checkResult == Quality::Bad) {
+        refCompPlots.second->SetLineColor(kRed);
+      } else if (checkResult == Quality::Medium) {
+        refCompPlots.second->SetLineColor(kOrange - 3);
+      } else if (checkResult == Quality::Null) {
+        refCompPlots.second->SetLineColor(kViolet - 6);
+      }
+    }
+    return;
+  }
+
   if ((mo->getName().find("ChargeMPV") != std::string::npos)) {
     TH1F* h = getHisto<TH1F>(mo);
     if (!h) {
@@ -197,12 +365,19 @@ void PreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality check
       h->SetMaximum(1.05 * h->GetMaximum());
     }
 
-    addChamberDelimiters(h, h->GetMinimum(), h->GetMaximum());
-    addDEBinLabels(h);
+    if (mo->getName().find("MeanEfficiencyPerSolar") != std::string::npos) {
+      addChamberDelimitersToSolarHistogram(h, h->GetMinimum(), h->GetMaximum());
+      addChamberLabelsForSolar(h);
+    } else {
+      addChamberDelimiters(h, h->GetMinimum(), h->GetMaximum());
+      addChamberLabelsForDE(h);
+    }
 
     // only the plot used for the check is beautified by changing the color
     // and adding the horizontal lines corresponding to the thresholds
-    if (matchHistName(mo->getName(), mMeanEffHistNameB) || matchHistName(mo->getName(), mMeanEffHistNameNB)) {
+    if (matchHistName(mo->getName(), mMeanEffHistNameB) ||
+        matchHistName(mo->getName(), mMeanEffHistNameNB) ||
+        matchHistName(mo->getName(), mMeanEffPerSolarHistName)) {
       if (checkResult == Quality::Good) {
         h->SetFillColor(kGreen);
       } else if (checkResult == Quality::Bad) {
@@ -212,7 +387,11 @@ void PreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality check
       }
       h->SetLineColor(kBlack);
 
-      drawThresholdsPerStation(h, mMinEfficiencyPerStation, mMinEfficiency);
+      if (matchHistName(mo->getName(), mMeanEffPerSolarHistName)) {
+        drawThreshold(h, mMinEfficiencyPerSolar);
+      } else {
+        drawThresholdsPerStation(h, mMinEfficiencyPerStation, mMinEfficiency);
+      }
     }
   }
 
@@ -236,19 +415,74 @@ void PreclustersCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality check
       return;
     }
 
-    for (int deId = 0; deId < mQualityChecker.mQuality.size(); deId++) {
+    std::string badDEs;
+    for (int deIndex = 0; deIndex < mQualityChecker.mQuality.size(); deIndex++) {
       float ybin = 0;
-      if (mQualityChecker.mQuality[deId] == Quality::Good) {
+      if (mQualityChecker.mQuality[deIndex] == Quality::Good) {
         ybin = 3;
       }
-      if (mQualityChecker.mQuality[deId] == Quality::Medium) {
+      if (mQualityChecker.mQuality[deIndex] == Quality::Medium) {
         ybin = 2;
       }
-      if (mQualityChecker.mQuality[deId] == Quality::Bad) {
+      if (mQualityChecker.mQuality[deIndex] == Quality::Bad) {
         ybin = 1;
+        std::string deIdStr = std::to_string(getDEFromIndex(deIndex));
+        if (badDEs.empty()) {
+          badDEs = deIdStr;
+        } else {
+          badDEs += std::string(" ") + deIdStr;
+        }
       }
 
-      h->SetBinContent(deId + 1, ybin, 1);
+      h->SetBinContent(deIndex + 1, ybin, 1);
+    }
+
+    if (!badDEs.empty()) {
+      std::string text = std::string("Bad DEs: ") + badDEs;
+      TPaveLabel* label = new TPaveLabel(0.2, 0.85, 0.8, 0.92, text.c_str(), "blNDC");
+      label->SetBorderSize(1);
+      h->GetListOfFunctions()->Add(label);
+
+      ILOG(Warning, Support) << "[PreclustersCheck] " << text << ENDM;
+    }
+  }
+
+  // update quality flags for each SOLAR
+  if (mo->getName().find("QualityFlagPerSolar") != std::string::npos) {
+    TH2F* h = getHisto<TH2F>(mo);
+    if (!h) {
+      return;
+    }
+
+    std::string badSolarBoards;
+    for (int solar = 0; solar < mSolarQuality.size(); solar++) {
+      float ybin = 0;
+      if (mSolarQuality[solar] == Quality::Good) {
+        ybin = 3;
+      }
+      if (mSolarQuality[solar] == Quality::Medium) {
+        ybin = 2;
+      }
+      if (mSolarQuality[solar] == Quality::Bad) {
+        ybin = 1;
+        std::string solarId = std::to_string(getSolarIdFromIndex(solar));
+        if (badSolarBoards.empty()) {
+          badSolarBoards = solarId;
+        } else {
+          badSolarBoards += std::string(" ") + solarId;
+        }
+      }
+
+      h->SetBinContent(solar + 1, ybin, 1);
+    }
+
+    if (!badSolarBoards.empty()) {
+      std::string badSolarList = std::string("Bad SOLAR boards: ") + badSolarBoards;
+      TPaveLabel* label = new TPaveLabel(0.2, 0.85, 0.8, 0.92, badSolarList.c_str(), "blNDC");
+      label->SetBorderSize(1);
+      h->GetListOfFunctions()->Add(label);
+
+      ILOG(Warning, Support) << "[PreclustersCheck] " << badSolarList << ENDM;
     }
   }
 }

--- a/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
+++ b/Modules/MUON/MCH/src/PreclustersPostProcessing.cxx
@@ -307,7 +307,7 @@ void PreclustersPostProcessing::updateClusterSizeHistos(Trigger t, repository::D
 
 //_________________________________________________________________________________________
 
-TH1* PreclustersPostProcessing::getHistogram(std::string plotName)
+TH1* PreclustersPostProcessing::getHistogram(std::string_view plotName)
 {
   TH1* result{ nullptr };
   for (auto hist : mHistogramsAll) {

--- a/Modules/MUON/MCH/src/PreclustersTask.cxx
+++ b/Modules/MUON/MCH/src/PreclustersTask.cxx
@@ -344,7 +344,7 @@ void PreclustersTask::plotPrecluster(const o2::mch::PreCluster& preCluster, gsl:
     getFecChannel(deId, padIdNB, fecIdNB, channelNB);
   } else {
     ILOG(Info, Devel) << "[PreclustersTask::plotPrecluster()] could not find pad in DE" << deId
-        << " for pre-cluster at (" << Xcog << "," << Ycog << ")" << AliceO2::InfoLogger::InfoLogger::endm;
+                      << " for pre-cluster at (" << Xcog << "," << Ycog << ")" << AliceO2::InfoLogger::InfoLogger::endm;
     return;
   }
 

--- a/Modules/MUON/MCH/src/PreclustersTask.cxx
+++ b/Modules/MUON/MCH/src/PreclustersTask.cxx
@@ -91,17 +91,17 @@ void PreclustersTask::initialize(o2::framework::InitContext& /*ctx*/)
   publishObject(mHistogramClusterCharge.get(), "colz", false);
 
   mHistogramClusterChargePerStation[0] = std::make_unique<TH2F>("ClusterCharge/ClusterChargeDistributionB",
-                                                                "Cluster charge distribution (B)",
+                                                                "Pre-cluster charge distribution (B)",
                                                                 256, 0, 256 * 50, 5, 1, 6);
   publishObject(mHistogramClusterChargePerStation[0].get(), "colz", false);
 
   mHistogramClusterChargePerStation[1] = std::make_unique<TH2F>("ClusterCharge/ClusterChargeDistributionNB",
-                                                                "Cluster charge distribution (NB)",
+                                                                "Pre-cluster charge distribution (NB)",
                                                                 256, 0, 256 * 50, 5, 1, 6);
   publishObject(mHistogramClusterChargePerStation[1].get(), "colz", false);
 
   mHistogramClusterChargePerStation[2] = std::make_unique<TH2F>("ClusterCharge/ClusterChargeDistribution",
-                                                                "Cluster charge distribution",
+                                                                "Pre-cluster charge distribution",
                                                                 256, 0, 256 * 50, 5, 1, 6);
   publishObject(mHistogramClusterChargePerStation[2].get(), "colz", false);
 
@@ -115,17 +115,17 @@ void PreclustersTask::initialize(o2::framework::InitContext& /*ctx*/)
   publishObject(mHistogramClusterSize.get(), "colz", false);
 
   mHistogramClusterSizePerStation[0] = std::make_unique<TH2F>("ClusterSize/ClusterSizeDistributionB",
-                                                              "Cluster size distribution (B)",
+                                                              "Pre-cluster size distribution (B)",
                                                               50, 0, 50, 5, 1, 6);
   publishObject(mHistogramClusterSizePerStation[0].get(), "colz", false);
 
   mHistogramClusterSizePerStation[1] = std::make_unique<TH2F>("ClusterSize/ClusterSizeDistributionNB",
-                                                              "Cluster size distribution (NB)",
+                                                              "Pre-cluster size distribution (NB)",
                                                               50, 0, 50, 5, 1, 6);
   publishObject(mHistogramClusterSizePerStation[1].get(), "colz", false);
 
   mHistogramClusterSizePerStation[2] = std::make_unique<TH2F>("ClusterSize/ClusterSizeDistribution",
-                                                              "Cluster size distribution",
+                                                              "Pre-cluster size distribution",
                                                               50, 0, 50, 5, 1, 6);
   publishObject(mHistogramClusterSizePerStation[2].get(), "colz", false);
 
@@ -299,6 +299,7 @@ void PreclustersTask::plotPrecluster(const o2::mch::PreCluster& preCluster, gsl:
   auto stationId = ((chamberId - 1) / 2) + 1;
 
   if (stationId < 1 || stationId > 5) {
+    ILOG(Info, Devel) << "[PreclustersTask::plotPrecluster()] wrong station ID for DE" << deId << AliceO2::InfoLogger::InfoLogger::endm;
     return;
   }
   const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(deId);
@@ -341,6 +342,10 @@ void PreclustersTask::plotPrecluster(const o2::mch::PreCluster& preCluster, gsl:
   if (segment.findPadPairByPosition(Xcog, Ycog, padIdB, padIdNB)) {
     getFecChannel(deId, padIdB, fecIdB, channelB);
     getFecChannel(deId, padIdNB, fecIdNB, channelNB);
+  } else {
+    ILOG(Info, Devel) << "[PreclustersTask::plotPrecluster()] could not find pad in DE" << deId
+        << " for pre-cluster at (" << Xcog << "," << Ycog << ")" << AliceO2::InfoLogger::InfoLogger::endm;
+    return;
   }
 
   // criteria to define a "good" charge cluster in one cathode:

--- a/Modules/MUON/MCH/src/QualityAggregatorTask.cxx
+++ b/Modules/MUON/MCH/src/QualityAggregatorTask.cxx
@@ -12,7 +12,7 @@
 ///
 /// \file    QualityAggregatorTask.cxx
 /// \author  Andrea Ferrero andrea.ferrero@cern.ch
-/// \brief   Post-processing of the MCH pre-clusters
+/// \brief   Post-processing of the MCH summary qualities
 /// \since   21/06/2022
 ///
 

--- a/Modules/MUON/MCH/src/QualityAggregatorTask.cxx
+++ b/Modules/MUON/MCH/src/QualityAggregatorTask.cxx
@@ -268,7 +268,6 @@ void QualityAggregatorTask::update(Trigger trigger, framework::ServiceRegistryRe
 
     int res = mAPI.storeAsBinaryFile(image->data(), image->size(), info.getFileName(), info.getObjectType(), info.getPath(), info.getMetaData(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
     if (res) {
-      //LOGP(error, "uploading to {} / {} failed for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
       ILOG(Error, Ops) << fmt::format("uploading to {} / {} failed for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp()) << ENDM;
     } else {
       ILOG(Info, Devel) << fmt::format("uploading to {} / {} succeeded for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp()) << ENDM;
@@ -381,7 +380,6 @@ void QualityAggregatorTask::update(Trigger trigger, framework::ServiceRegistryRe
 
     int res = mAPI.storeAsBinaryFile(image->data(), image->size(), info.getFileName(), info.getObjectType(), info.getPath(), info.getMetaData(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
     if (res) {
-      //LOGP(error, "uploading to {} / {} failed for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
       ILOG(Error, Ops) << fmt::format("uploading to {} / {} failed for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp()) << ENDM;
     } else {
       ILOG(Info, Devel) << fmt::format("uploading to {} / {} succeeded for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp()) << ENDM;

--- a/Modules/MUON/MCH/src/QualityAggregatorTask.cxx
+++ b/Modules/MUON/MCH/src/QualityAggregatorTask.cxx
@@ -1,0 +1,397 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    QualityAggregatorTask.cxx
+/// \author  Andrea Ferrero andrea.ferrero@cern.ch
+/// \brief   Post-processing of the MCH pre-clusters
+/// \since   21/06/2022
+///
+
+#include "MCH/QualityAggregatorTask.h"
+#include "MCH/Helpers.h"
+#include "QualityControl/QcInfoLogger.h"
+#include "QualityControl/DatabaseInterface.h"
+#include "QualityControl/ActivityHelpers.h"
+#include "QualityControl/ReferenceUtils.h"
+#include "Common/Utils.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CommonUtils/MemFileHelper.h"
+#include <TObjString.h>
+
+#include <TPaveLabel.h>
+
+#include <boost/property_tree/ptree.hpp>
+#include <gsl/span>
+
+using namespace o2::quality_control::core;
+using namespace o2::quality_control::repository;
+using namespace o2::quality_control_modules::common;
+using namespace o2::quality_control_modules::muonchambers;
+
+template <typename T>
+o2::ccdb::CcdbObjectInfo createCcdbInfo(const T& object, uint64_t timeStamp, std::string_view reason)
+{
+  auto clName = o2::utils::MemFileHelper::getClassName(object);
+  auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+  std::map<std::string, std::string> md;
+  md["upload-reason"] = reason;
+  constexpr auto fiveDays = 5 * o2::ccdb::CcdbObjectInfo::DAY;
+  return o2::ccdb::CcdbObjectInfo("MCH/Calib/BadDE", clName, flName, md, timeStamp, timeStamp + fiveDays);
+}
+
+/*
+std::string toCSV(const std::set<int>& deIds)
+{
+  std::stringstream csv;
+  csv << fmt::format("deid\n");
+
+  for (auto deId : deIds) {
+    csv << fmt::format("{}\n", deId);
+  }
+
+  return csv.str();
+}
+*/
+//_________________________________________________________________________________________
+// Helper function for retrieving a MonitorObject from the QCDB, in the form of a std::pair<std::shared_ptr<MonitorObject>, bool>
+// A non-null MO is returned in the first element of the pair if the MO is found in the QCDB
+// The second element of the pair is set to true if the MO has a time stamp more recent than a user-supplied threshold
+
+static std::pair<std::shared_ptr<MonitorObject>, bool> getMO(DatabaseInterface& qcdb, const std::string& fullPath, Trigger trigger, long notOlderThan)
+{
+  // find the time-stamp of the most recent object matching the current activity
+  // if ignoreActivity is true the activity matching criteria are not applied
+  auto objectTimestamp = trigger.timestamp;
+  const auto filterMetadata = activity_helpers::asDatabaseMetadata(trigger.activity, false);
+  const auto objectValidity = qcdb.getLatestObjectValidity(trigger.activity.mProvenance + "/" + fullPath, filterMetadata);
+  if (objectValidity.isValid()) {
+    objectTimestamp = objectValidity.getMax() - 1;
+  } else {
+    ILOG(Warning, Devel) << "Could not find the object '" << fullPath << "' for activity " << trigger.activity << ENDM;
+    return { nullptr, false };
+  }
+
+  auto [success, path, name] = o2::quality_control::core::RepoPathUtils::splitObjectPath(fullPath);
+  if (!success) {
+    return { nullptr, false };
+  }
+  // retrieve QO from CCDB
+  auto qo = qcdb.retrieveMO(path, name, objectTimestamp, trigger.activity);
+  if (!qo) {
+    return { nullptr, false };
+  }
+
+  long elapsed = static_cast<long>(trigger.timestamp) - objectTimestamp;
+  // check if the object is not older than a given number of milliseconds
+  if (elapsed > notOlderThan) {
+    ILOG(Warning, Devel) << "Object '" << fullPath << "' for activity " << trigger.activity << " is too old: " << elapsed << " > " << notOlderThan << ENDM;
+    return { qo, false };
+  }
+
+  return { qo, true };
+}
+
+void QualityAggregatorTask::configure(const boost::property_tree::ptree& config)
+{
+  // input plots
+  if (const auto& inputs = config.get_child_optional("qc.postprocessing." + getID() + ".inputsDE"); inputs.has_value()) {
+    for (const auto& input : inputs.value()) {
+      mDEPlotPaths.push_back(input.second.get_value<std::string>());
+    }
+  }
+  if (const auto& inputs = config.get_child_optional("qc.postprocessing." + getID() + ".inputsSOLAR"); inputs.has_value()) {
+    for (const auto& input : inputs.value()) {
+      mSOLARPlotPaths.push_back(input.second.get_value<std::string>());
+    }
+  }
+}
+
+//_________________________________________________________________________________________
+
+void QualityAggregatorTask::initialize(Trigger t, framework::ServiceRegistryRef services)
+{
+  mCCDBpath = getFromExtendedConfig<std::string>(t.activity, mCustomParameters, "CCDBpath", mCCDBpath);
+  mAPI.init(mCCDBpath);
+
+  mObjectPathBadDE = getFromExtendedConfig<std::string>(t.activity, mCustomParameters, "objectPathBadDE", mObjectPathBadDE);
+  mObjectPathBadSOLAR = getFromExtendedConfig<std::string>(t.activity, mCustomParameters, "objectPathBadSOLAR", mObjectPathBadSOLAR);
+
+  //--------------------------------------------------
+  // Quality histogram
+  //--------------------------------------------------
+
+  mHistogramQualityPerDE.reset();
+  mHistogramQualityPerDE = std::make_unique<TH2F>("QualityFlagPerDE", "Quality Flag vs DE", getNumDE(), 0, getNumDE(), 3, 0, 3);
+  addDEBinLabels(mHistogramQualityPerDE.get());
+  addChamberDelimiters(mHistogramQualityPerDE.get());
+  addChamberLabelsForDE(mHistogramQualityPerDE.get());
+  mHistogramQualityPerDE->GetYaxis()->SetBinLabel(1, "Bad");
+  mHistogramQualityPerDE->GetYaxis()->SetBinLabel(2, "Medium");
+  mHistogramQualityPerDE->GetYaxis()->SetBinLabel(3, "Good");
+  mHistogramQualityPerDE->SetOption("colz");
+  mHistogramQualityPerDE->SetStats(0);
+  getObjectsManager()->startPublishing(mHistogramQualityPerDE.get(), core::PublicationPolicy::ThroughStop);
+  getObjectsManager()->setDefaultDrawOptions(mHistogramQualityPerDE.get(), "colz");
+  getObjectsManager()->setDisplayHint(mHistogramQualityPerDE.get(), "gridy");
+
+  mHistogramQualityPerSolar.reset();
+  mHistogramQualityPerSolar = std::make_unique<TH2F>("QualityFlagPerSolar", "Quality Flag vs Solar", getNumSolar(), 0, getNumSolar(), 3, 0, 3);
+  addSolarBinLabels(mHistogramQualityPerSolar.get());
+  addChamberDelimitersToSolarHistogram(mHistogramQualityPerSolar.get());
+  addChamberLabelsForSolar(mHistogramQualityPerSolar.get());
+  mHistogramQualityPerSolar->GetYaxis()->SetBinLabel(1, "Bad");
+  mHistogramQualityPerSolar->GetYaxis()->SetBinLabel(2, "Medium");
+  mHistogramQualityPerSolar->GetYaxis()->SetBinLabel(3, "Good");
+  mHistogramQualityPerSolar->SetOption("col");
+  mHistogramQualityPerSolar->SetStats(0);
+  getObjectsManager()->startPublishing(mHistogramQualityPerSolar.get(), core::PublicationPolicy::ThroughStop);
+  getObjectsManager()->setDefaultDrawOptions(mHistogramQualityPerSolar.get(), "col");
+  getObjectsManager()->setDisplayHint(mHistogramQualityPerSolar.get(), "gridy");
+}
+
+//_________________________________________________________________________________________
+
+void QualityAggregatorTask::update(Trigger trigger, framework::ServiceRegistryRef services)
+{
+  ILOG(Info, Devel) << "QualityAggregatorTask::update() called" << ENDM;
+  auto& qcdb = services.get<repository::DatabaseInterface>();
+
+  // ===================
+  // Detection elements
+  // ===================
+
+  std::set<int> badDEs;
+  std::array<int, getNumDE()> deQuality;
+  std::fill(deQuality.begin(), deQuality.end(), 3);
+  // fill vector of bad DEs
+  for (auto plotPath : mDEPlotPaths) {
+    auto [mo, success] = getMO(qcdb, plotPath, trigger, 600000);
+    if (!success || !mo) {
+      ILOG(Warning, Devel) << "Could not retrieve object " << plotPath << ENDM;
+      continue;
+    }
+
+    TH2F* hist = dynamic_cast<TH2F*>(mo->getObject());
+    if (!hist) {
+      ILOG(Warning, Devel) << "Could not cast the object '" << plotPath << "' to TH2F" << ENDM;
+      continue;
+    }
+
+    if (hist->GetXaxis()->GetNbins() != getNumDE()) {
+      ILOG(Warning, Devel) << "Wrong number of bins for object '" << plotPath << "': "
+                           << hist->GetXaxis()->GetNbins() << " while " << getNumDE() << " were expected" << ENDM;
+      continue;
+    }
+
+    for (int index = 0; index < hist->GetXaxis()->GetNbins(); index++) {
+      int q = 0;
+      for (int qindex = 1; qindex <= hist->GetYaxis()->GetNbins(); qindex++) {
+        if (hist->GetBinContent(index + 1, qindex) != 0) {
+          q = qindex;
+          break;
+        }
+      }
+      if (q < deQuality[index]) {
+        deQuality[index] = q;
+      }
+
+      bool isBad = (q == 1);
+      if (!isBad) {
+        continue;
+      }
+
+      int deId = getDEFromIndex(index);
+      badDEs.insert(deId);
+
+      ILOG(Debug, Devel) << "Bad detection element DE" << deId << " found in \'" << plotPath << "\'" << ENDM;
+    }
+  }
+  mHistogramQualityPerDE->Reset();
+  for (int index = 0; index < mHistogramQualityPerDE->GetXaxis()->GetNbins(); index++) {
+    mHistogramQualityPerDE->SetBinContent(index + 1, deQuality[index], 1);
+  }
+
+  std::string badDEsStr;
+  for (auto deId : badDEs) {
+    if (badDEsStr.empty()) {
+      badDEsStr = std::to_string(deId);
+    } else {
+      badDEsStr += std::string(" ") + std::to_string(deId);
+    }
+  }
+  if (!badDEsStr.empty()) {
+    std::string badDEList = std::string("Bad DEs: ") + badDEsStr;
+    TPaveLabel* label = new TPaveLabel(0.2, 0.8, 0.8, 0.88, badDEList.c_str(), "blNDC");
+    label->SetBorderSize(1);
+    mHistogramQualityPerDE->GetListOfFunctions()->Add(label);
+
+    ILOG(Warning, Support) << "[QualityAggregator] " << badDEList << ENDM;
+  }
+
+  // check if the list of bad DEs has changed
+  bool changedDEs = (!mPreviousBadDEs.has_value() || mPreviousBadDEs.value() != badDEs);
+
+  if (changedDEs) {
+    std::string sBadDEs = "deid\n";
+    for (auto deId : badDEs) {
+      sBadDEs += fmt::format("{}\n", deId);
+    }
+    TObjString badDEsObject(sBadDEs.c_str());
+
+    // time stamp
+    auto uploadTS = o2::ccdb::getCurrentTimestamp();
+
+    // CCDB object info
+    auto clName = o2::utils::MemFileHelper::getClassName(badDEsObject);
+    auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+    constexpr auto fiveDays = 5 * o2::ccdb::CcdbObjectInfo::DAY;
+    auto info = o2::ccdb::CcdbObjectInfo(mObjectPathBadDE, clName, flName, std::map<std::string, std::string>(), uploadTS, uploadTS + fiveDays);
+
+    // CCDB object image
+    auto image = o2::ccdb::CcdbApi::createObjectImage(&badDEsObject, &info);
+
+    ILOG(Info, Devel) << "Storing object " << info.getPath()
+                      << " of type " << info.getObjectType()
+                      << " / " << info.getFileName()
+                      << " and size " << image->size()
+                      << " bytes, valid for " << info.getStartValidityTimestamp()
+                      << " : " << info.getEndValidityTimestamp() << ENDM;
+
+    int res = mAPI.storeAsBinaryFile(image->data(), image->size(), info.getFileName(), info.getObjectType(), info.getPath(), info.getMetaData(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
+    if (res) {
+      //LOGP(error, "uploading to {} / {} failed for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
+      ILOG(Error, Ops) << fmt::format("uploading to {} / {} failed for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp()) << ENDM;
+    } else {
+      ILOG(Info, Devel) << fmt::format("uploading to {} / {} succeeded for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp()) << ENDM;
+      mPreviousBadDEs = badDEs;
+    }
+  }
+
+  // =============
+  // SOLAR boards
+  // =============
+
+  std::set<int> badSolarBoards;
+  std::array<int, getNumSolar()> solarQuality;
+  std::fill(solarQuality.begin(), solarQuality.end(), 3);
+  // fill vector of bad Solars
+  for (auto plotPath : mSOLARPlotPaths) {
+    auto [mo, success] = getMO(qcdb, plotPath, trigger, 600000);
+    if (!success || !mo) {
+      ILOG(Warning, Devel) << "Could not retrieve object " << plotPath << ENDM;
+      continue;
+    }
+
+    TH2F* hist = dynamic_cast<TH2F*>(mo->getObject());
+    if (!hist) {
+      ILOG(Warning, Devel) << "Could not cast the object '" << plotPath << "' to TH2F" << ENDM;
+      continue;
+    }
+
+    if (hist->GetXaxis()->GetNbins() != getNumSolar()) {
+      ILOG(Warning, Devel) << "Wrong number of bins for object '" << plotPath << "': "
+                           << hist->GetXaxis()->GetNbins() << " while " << getNumSolar() << " were expected" << ENDM;
+      continue;
+    }
+
+    for (int index = 0; index < hist->GetXaxis()->GetNbins(); index++) {
+      int q = 0;
+      for (int qindex = 1; qindex <= hist->GetYaxis()->GetNbins(); qindex++) {
+        if (hist->GetBinContent(index + 1, qindex) != 0) {
+          q = qindex;
+          break;
+        }
+      }
+      if (q < solarQuality[index]) {
+        solarQuality[index] = q;
+      }
+
+      bool isBad = (q == 1);
+      if (!isBad) {
+        continue;
+      }
+
+      int solarId = getSolarIdFromIndex(index);
+      badSolarBoards.insert(solarId);
+
+      ILOG(Debug, Devel) << "Bad SOLAR " << solarId << " found in \'" << plotPath << "\'" << ENDM;
+    }
+  }
+
+  mHistogramQualityPerSolar->Reset();
+  for (int index = 0; index < mHistogramQualityPerSolar->GetXaxis()->GetNbins(); index++) {
+    mHistogramQualityPerSolar->SetBinContent(index + 1, solarQuality[index], 1);
+  }
+
+  std::string badSolarBoardsStr;
+  for (auto solarId : badSolarBoards) {
+    if (badSolarBoardsStr.empty()) {
+      badSolarBoardsStr = std::to_string(solarId);
+    } else {
+      badSolarBoardsStr += std::string(" ") + std::to_string(solarId);
+    }
+  }
+  if (!badSolarBoardsStr.empty()) {
+    std::string badSolarList = std::string("Bad SOLAR boards: ") + badSolarBoardsStr;
+    TPaveLabel* label = new TPaveLabel(0.2, 0.8, 0.8, 0.88, badSolarList.c_str(), "blNDC");
+    label->SetBorderSize(1);
+    mHistogramQualityPerSolar->GetListOfFunctions()->Add(label);
+
+    ILOG(Warning, Support) << "[QualityAggregator] " << badSolarList << ENDM;
+  }
+
+  // check if the list of bad Solars has changed
+  bool changedSolarBoards = (!mPreviousBadSolarBoards.has_value() || mPreviousBadSolarBoards.value() != badSolarBoards);
+
+  if (changedSolarBoards) {
+    std::string sBadSolars = "solarid\n";
+    for (auto solarId : badSolarBoards) {
+      sBadSolars += fmt::format("{}\n", solarId);
+    }
+    TObjString badSolarBoardsObject(sBadSolars.c_str());
+
+    // time stamp
+    auto uploadTS = o2::ccdb::getCurrentTimestamp();
+
+    // CCDB object info
+    auto clName = o2::utils::MemFileHelper::getClassName(badSolarBoardsObject);
+    auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+    constexpr auto fiveDays = 5 * o2::ccdb::CcdbObjectInfo::DAY;
+    auto info = o2::ccdb::CcdbObjectInfo(mObjectPathBadSOLAR, clName, flName, std::map<std::string, std::string>(), uploadTS, uploadTS + fiveDays);
+
+    // CCDB object image
+    auto image = o2::ccdb::CcdbApi::createObjectImage(&badSolarBoardsObject, &info);
+
+    ILOG(Info, Devel) << "Storing object " << info.getPath()
+                      << " of type " << info.getObjectType()
+                      << " / " << info.getFileName()
+                      << " and size " << image->size()
+                      << " bytes, valid for " << info.getStartValidityTimestamp()
+                      << " : " << info.getEndValidityTimestamp() << ENDM;
+    ILOG(Info, Devel) << badSolarBoardsObject.String().Data() << ENDM;
+
+    int res = mAPI.storeAsBinaryFile(image->data(), image->size(), info.getFileName(), info.getObjectType(), info.getPath(), info.getMetaData(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
+    if (res) {
+      //LOGP(error, "uploading to {} / {} failed for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
+      ILOG(Error, Ops) << fmt::format("uploading to {} / {} failed for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp()) << ENDM;
+    } else {
+      ILOG(Info, Devel) << fmt::format("uploading to {} / {} succeeded for [{}:{}]", mAPI.getURL(), info.getPath(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp()) << ENDM;
+      mPreviousBadSolarBoards = badSolarBoards;
+    }
+  }
+}
+
+//_________________________________________________________________________________________
+
+void QualityAggregatorTask::finalize(Trigger t, framework::ServiceRegistryRef)
+{
+}


### PR DESCRIPTION
The PR introduces the code needed to plot relevant quantities (rates, efficiencies, fractions of good channels, etc...) averaged over each SOLAR board (i.e. CRU link). The final goal is to detect links that are bad in either of the monitored quantities, and store a list of bad links in the CCDB to allow automated re-configuration during the data taking.

The new code adds the following plots:
* qc/MCH/MO/Decoding/QualityFlagPerSolar
* qc/MCH/MO/Decoding/DecodingErrors/GoodBoardsFractionPerSolar
* qc/MCH/MO/Decoding/DecodingErrors/LastCycle/GoodBoardsFractionPerSolar
* qc/MCH/MO/Decoding/SyncErrors/SyncedBoardsFractionPerSolar
* qc/MCH/MO/Decoding/SyncErrors/LastCycle/SyncedBoardsFractionPerSolar
* qc/MCH/MO/Digits/QualityFlagPerSolar
* qc/MCH/MO/Digits/Rates/GoodChannelsFractionPerSolar
* qc/MCH/MO/Digits/Rates/LastCycle/GoodChannelsFractionPerSolar
* qc/MCH/MO/Digits/Rates/MeanRatePerSolar
* qc/MCH/MO/Digits/Rates/LastCycle/MeanRatePerSolar
* qc/MCH/MO/Digits/RatesSignal/GoodChannelsFractionPerSolar
* qc/MCH/MO/Digits/RatesSignal/LastCycle/GoodChannelsFractionPerSolar
* qc/MCH/MO/Digits/RatesSignal/MeanRatePerSolar
* qc/MCH/MO/Digits/RatesSignal/LastCycle/MeanRatePerSolar
* qc/MCH/MO/Preclusters/QualityFlagPerSolar
* qc/MCH/MO/Preclusters/Efficiency/MeanEfficiencyPerSolar
* qc/MCH/MO/Preclusters/Efficiency/LastCycle/MeanEfficiencyPerSolar

It also adds some comparisons with reference plots (using the feature introduced in https://github.com/AliceO2Group/QualityControl/pull/2578):
* qc/MCH/MO/Decoding/RefComp/DecodingErrors/GoodBoardsFractionPerSolar
* qc/MCH/MO/Decoding/RefComp/DecodingErrors/GoodBoardsFractionPerDE
* qc/MCH/MO/Digits/RefComp/RatesSignal/GoodChannelsFraction
* qc/MCH/MO/Digits/RefComp/RatesSignal/GoodChannelsFractionPerSolar
* qc/MCH/MO/Digits/RefComp/RatesSignal/MeanRate
* qc/MCH/MO/Digits/RefComp/RatesSignal/MeanRatePerSolar
* qc/MCH/MO/Preclusters/RefComp/Efficiency/MeanEfficiencyB
* qc/MCH/MO/Preclusters/RefComp/Efficiency/MeanEfficiencyNB
* qc/MCH/MO/Preclusters/RefComp/Efficiency/MeanEfficiencyPerSolar

See the description of the individual commits for details.

There is some code duplication in the tasks, but I prefer to address it in a future PR, because some refactoring of the MCH code will be anyhow needed at this point.