### PR TITLE
Fix: draw lines and markers in multigraph

### DIFF
--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -402,7 +402,8 @@ void SliceTrendingTask::drawCanvasMO(TCanvas* thisCanvas, const std::string& var
     } // for (int p = 0; p < nuPa; p++)
 
     thisCanvas->cd(1);
-    multigraph->Draw("A pmc plc");
+    std::string drawOpt = opt.empty() ? "APL" : opt;
+    multigraph->Draw(drawOpt.c_str());
 
     auto legend = new TLegend(0., 0.1, 0.95, 0.9);
     legend->SetName("MultiGraphLegend");

--- a/Modules/FIT/FV0/include/FV0/DigitQcTask.h
+++ b/Modules/FIT/FV0/include/FV0/DigitQcTask.h
@@ -157,6 +157,8 @@ class DigitQcTask final : public TaskInterface
 
   // Objects which will be published
   std::unique_ptr<TH2F> mHistAmp2Ch;
+  std::unique_ptr<TH1F> mHistAmpAll;
+  std::array<std::unique_ptr<TH1F>, sNCHANNELS_FV0_PLUSREF> mHistAmpPerCh;
   std::unique_ptr<TH2F> mHistTime2Ch;
   std::unique_ptr<TH2F> mHistEventDensity2Ch;
   std::unique_ptr<TH2F> mHistChDataBits;


### PR DESCRIPTION
With the options set as default and hardcoded for multigraph, the graphs appear empty, like:

<img width="785" height="624" alt="image" src="https://github.com/user-attachments/assets/78edfb1d-331e-4131-b046-9fd307404741" />

After allowing for changing this option and setting a different default this is resolved:

<img width="785" height="624" alt="image" src="https://github.com/user-attachments/assets/d934a211-1087-4638-8b6b-3418f0e25b7f" />

The graph here was define using the same workflow, with the only change being the one introduced in this PR. Also, unfortunately a small change in FV0 from my local master was included here. Please disregard this, from perspective of FV0 this will be merged into master anyways within next few weeks. The only change to the framework is the one in `SliceTrendingTask.cxx`