### PR TITLE
Fix: change multigraph drawing options

### DIFF
--- a/Framework/src/SliceTrendingTask.cxx
+++ b/Framework/src/SliceTrendingTask.cxx
@@ -402,7 +402,7 @@ void SliceTrendingTask::drawCanvasMO(TCanvas* thisCanvas, const std::string& var
     } // for (int p = 0; p < nuPa; p++)
 
     thisCanvas->cd(1);
-    std::string drawOpt = opt.empty() ? "APL" : opt;
+    std::string drawOpt = opt.empty() ? "A*L PMC PLC" : opt;
     multigraph->Draw(drawOpt.c_str());
 
     auto legend = new TLegend(0., 0.1, 0.95, 0.9);


### PR DESCRIPTION
With the options set as default and hardcoded for multigraph, the graphs appear empty, like:

<img width="785" height="624" alt="image" src="https://github.com/user-attachments/assets/78edfb1d-331e-4131-b046-9fd307404741" />

After allowing for changing this option and setting a different default this is resolved:

<img width="785" height="624" alt="image" src="https://github.com/user-attachments/assets/d934a211-1087-4638-8b6b-3418f0e25b7f" />

The graph here was defined using the same workflow, with the only change being the one introduced in this PR.