### PR TITLE
Common: customize ratio plot draw option in ReferenceComparator

### DIFF
--- a/Modules/Common/src/ReferenceComparatorPlot.cxx
+++ b/Modules/Common/src/ReferenceComparatorPlot.cxx
@@ -306,8 +306,8 @@ class ReferenceComparatorPlotImpl1D : public ReferenceComparatorPlotImpl
     }
     mRatioPlot->SetLineColor(kBlack);
     mRatioPlot->SetStats(0);
-    mRatioPlot->SetOption("E");
-    mRatioPlot->Draw("E");
+    mRatioPlot->SetOption(drawOption.c_str());
+    mRatioPlot->Draw(drawOption.c_str());
     if (drawRatioOnly) {
       mRatioPlot->SetMinimum(0);
       mRatioPlot->SetMaximum(2);


### PR DESCRIPTION
By default the histograms are drawn with error bars ("E" option), however there are cases where the user might want to hide the errors and draw the histograms with the "H" option, for example because the error bars are unreliable or unphysical.

This can already be done by passing a custom draw option via the task configuration interface.
However, the customized draw option is only passed to the current and reference histograms, but not to the ratio plot, which is always drawn with the "E" option.
The commit extends the custom draw option also to the ratio histogram.

Here is a practical example:
- ratio plot with default "E" option
<img width="1194" height="589" alt="image" src="https://github.com/user-attachments/assets/8cc8bfb1-a997-4ee1-a239-58a9c5cb3ade" />

- ratio plot with "H" option
<img width="1194" height="591" alt="image" src="https://github.com/user-attachments/assets/c3881f69-4aea-4f2a-835f-8b0ad16e67d9" />
