### PR TITLE
MUON: process only best matching candidates

### DIFF
--- a/Modules/MUON/Common/src/TrackPlotter.cxx
+++ b/Modules/MUON/Common/src/TrackPlotter.cxx
@@ -494,9 +494,9 @@ void TrackPlotter::fillHistograms(const o2::globaltracking::RecoContainer& recoC
 
       // sort the vector of matching candidates in ascending order of the matching chi2
       std::sort(matchingCandidatesVector.begin(), matchingCandidatesVector.end(),
-          [](const std::pair<int64_t, double>& t1, const std::pair<int64_t, double>& t2) -> bool {
-        return (t1.second < t2.second);
-      });
+                [](const std::pair<int64_t, double>& t1, const std::pair<int64_t, double>& t2) -> bool {
+                  return (t1.second < t2.second);
+                });
 
       // store the leading candidate
       auto& t = tracksFwd[matchingCandidatesVector[0].first];


### PR DESCRIPTION
The MFT-MCH matching task now stores by default multiple matching candidates for each MCH standalone track.
In order to properly assess the tracking quality and avoid a large combinatorial background, only the best matching candidate for each MCH track must be processed by the QC tracks task.