### PR TITLE
Common: enable log scale in refernce comparator plots

### DIFF
--- a/Modules/Common/include/Common/ReferenceComparatorPlot.h
+++ b/Modules/Common/include/Common/ReferenceComparatorPlot.h
@@ -43,6 +43,7 @@ class ReferenceComparatorPlot
                           bool scaleReference,
                           bool drawRatioOnly,
                           double legendHeight,
+                          bool logScale,
                           const std::string& drawOption1D,
                           const std::string& drawOption2D);
   virtual ~ReferenceComparatorPlot() = default;

--- a/Modules/Common/include/Common/ReferenceComparatorTaskConfig.h
+++ b/Modules/Common/include/Common/ReferenceComparatorTaskConfig.h
@@ -50,6 +50,8 @@ struct ReferenceComparatorTaskConfig : quality_control::postprocessing::PostProc
     std::string drawOption1D{ "HIST" };
     // ROOT option to be used for drawing 2-D plots ("COLZ" by default)
     std::string drawOption2D{ "COLZ" };
+    // wether to draw the values axis in log scale (Y axis for 1-D plots and Z axis for 2-D plots)
+    bool logScale{ false };
     // list of QCDB objects in this group
     std::vector<std::string> objects;
   };

--- a/Modules/Common/src/ReferenceComparatorPlot.cxx
+++ b/Modules/Common/src/ReferenceComparatorPlot.cxx
@@ -200,8 +200,9 @@ class ReferenceComparatorPlotImpl1D : public ReferenceComparatorPlotImpl
                                 bool scaleReference,
                                 bool drawRatioOnly,
                                 double legendHeight,
+                                bool logScale,
                                 const std::string& drawOption)
-    : ReferenceComparatorPlotImpl(referenceHistogram, scaleReference), mLegendHeight(legendHeight)
+    : ReferenceComparatorPlotImpl(referenceHistogram, scaleReference), mLegendHeight(legendHeight), mLogScale(logScale)
   {
     float labelSize = 0.04;
 
@@ -357,6 +358,9 @@ class ReferenceComparatorPlotImpl1D : public ReferenceComparatorPlotImpl
     double histMax = (mLegendHeight > 0) ? (1.0 + mLegendHeight) * max : 1.05 * max;
     mPlot->SetMaximum(histMax);
     mReferencePlot->SetMaximum(histMax);
+    if (mPadHist) {
+      mPadHist->SetLogy(mLogScale ? kTRUE : kFALSE);
+    }
 
     mRatioPlot->Reset();
     mRatioPlot->Add(mPlot.get());
@@ -379,6 +383,7 @@ class ReferenceComparatorPlotImpl1D : public ReferenceComparatorPlotImpl
   std::shared_ptr<TPaveText> mHistogramTitle;
   std::shared_ptr<TLegend> mHistogramLegend;
   double mLegendHeight;
+  bool mLogScale;
 };
 
 template <class HIST>
@@ -390,8 +395,9 @@ class ReferenceComparatorPlotImpl2D : public ReferenceComparatorPlotImpl
                                 const std::string& outputPath,
                                 bool scaleReference,
                                 bool drawRatioOnly,
+                                bool logScale,
                                 const std::string& drawOption)
-    : ReferenceComparatorPlotImpl(referenceHistogram, scaleReference)
+    : ReferenceComparatorPlotImpl(referenceHistogram, scaleReference), mLogScale(logScale)
   {
     if (!referenceHistogram) {
       return;
@@ -509,6 +515,13 @@ class ReferenceComparatorPlotImpl2D : public ReferenceComparatorPlotImpl
 
     copyAndScaleHistograms(histogram, referenceHistogram, mPlot.get(), mReferencePlot.get(), getScaleReference());
 
+    if (mPadHist) {
+      mPadHist->SetLogz(mLogScale ? kTRUE : kFALSE);
+    }
+    if (mPadHistRef) {
+      mPadHistRef->SetLogz(mLogScale ? kTRUE : kFALSE);
+    }
+
     mRatioPlot->Reset();
     mRatioPlot->Add(mPlot.get());
     mRatioPlot->Divide(mReferencePlot.get());
@@ -525,6 +538,7 @@ class ReferenceComparatorPlotImpl2D : public ReferenceComparatorPlotImpl
   std::shared_ptr<HIST> mReferencePlot;
   std::shared_ptr<HIST> mRatioPlot;
   std::shared_ptr<TPaveText> mQualityLabel;
+  bool mLogScale;
 };
 
 ReferenceComparatorPlot::ReferenceComparatorPlot(TH1* referenceHistogram,
@@ -533,6 +547,7 @@ ReferenceComparatorPlot::ReferenceComparatorPlot(TH1* referenceHistogram,
                                                  bool scaleReference,
                                                  bool drawRatioOnly,
                                                  double legendHeight,
+                                                 bool logScale,
                                                  const std::string& drawOption1D,
                                                  const std::string& drawOption2D)
 {
@@ -540,20 +555,20 @@ ReferenceComparatorPlot::ReferenceComparatorPlot(TH1* referenceHistogram,
 
   // 1-D histograms
   if (referenceHistogram->InheritsFrom("TH1C") || referenceHistogram->InheritsFrom("TH1S") || referenceHistogram->InheritsFrom("TH1F")) {
-    mImplementation = std::make_shared<ReferenceComparatorPlotImpl1D<TH1F>>(referenceHistogram, referenceRun, outputPath, scaleReference, drawRatioOnly, legendHeight, drawOption1D);
+    mImplementation = std::make_shared<ReferenceComparatorPlotImpl1D<TH1F>>(referenceHistogram, referenceRun, outputPath, scaleReference, drawRatioOnly, legendHeight, logScale, drawOption1D);
   }
 
   if (referenceHistogram->InheritsFrom("TH1I") || referenceHistogram->InheritsFrom("TH1D")) {
-    mImplementation = std::make_shared<ReferenceComparatorPlotImpl1D<TH1D>>(referenceHistogram, referenceRun, outputPath, scaleReference, drawRatioOnly, legendHeight, drawOption1D);
+    mImplementation = std::make_shared<ReferenceComparatorPlotImpl1D<TH1D>>(referenceHistogram, referenceRun, outputPath, scaleReference, drawRatioOnly, legendHeight, logScale, drawOption1D);
   }
 
   // 2-D histograms
   if (referenceHistogram->InheritsFrom("TH2C") || referenceHistogram->InheritsFrom("TH2S") || referenceHistogram->InheritsFrom("TH2F")) {
-    mImplementation = std::make_shared<ReferenceComparatorPlotImpl2D<TH2F>>(referenceHistogram, referenceRun, outputPath, scaleReference, drawRatioOnly, drawOption2D);
+    mImplementation = std::make_shared<ReferenceComparatorPlotImpl2D<TH2F>>(referenceHistogram, referenceRun, outputPath, scaleReference, drawRatioOnly, logScale, drawOption2D);
   }
 
   if (referenceHistogram->InheritsFrom("TH2I") || referenceHistogram->InheritsFrom("TH2D")) {
-    mImplementation = std::make_shared<ReferenceComparatorPlotImpl2D<TH2D>>(referenceHistogram, referenceRun, outputPath, scaleReference, drawRatioOnly, drawOption2D);
+    mImplementation = std::make_shared<ReferenceComparatorPlotImpl2D<TH2D>>(referenceHistogram, referenceRun, outputPath, scaleReference, drawRatioOnly, logScale, drawOption2D);
   }
 }
 

--- a/Modules/Common/src/ReferenceComparatorTask.cxx
+++ b/Modules/Common/src/ReferenceComparatorTask.cxx
@@ -154,6 +154,7 @@ void ReferenceComparatorTask::initialize(quality_control::postprocessing::Trigge
                                                                         group.normalizeReference,
                                                                         group.drawRatioOnly,
                                                                         group.legendHeight,
+                                                                        group.logScale,
                                                                         group.drawOption1D,
                                                                         group.drawOption2D);
       auto* outObject = mHistograms[fullPath]->getMainCanvas();

--- a/Modules/Common/src/ReferenceComparatorTaskConfig.cxx
+++ b/Modules/Common/src/ReferenceComparatorTaskConfig.cxx
@@ -36,7 +36,8 @@ ReferenceComparatorTaskConfig::ReferenceComparatorTaskConfig(std::string name, c
       dataGroupConfig.second.get<bool>("drawRatioOnly", false),
       dataGroupConfig.second.get<double>("legendHeight", 0.2),
       dataGroupConfig.second.get<std::string>("drawOption1D", "HIST"),
-      dataGroupConfig.second.get<std::string>("drawOption2D", "COLZ")
+      dataGroupConfig.second.get<std::string>("drawOption2D", "COLZ"),
+      dataGroupConfig.second.get<bool>("logScale", false)
     };
     if (const auto& inputObjects = dataGroupConfig.second.get_child_optional("inputObjects"); inputObjects.has_value()) {
       for (const auto& inputObject : inputObjects.value()) {

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -604,6 +604,7 @@ The input MonitorObjects to be processed are logically divided in **dataGroups**
 * `legendHeight`: space reserved for the legend above the histograms, in fractions of the pad height; if the height is set to zero, the legend is not shown
 * `drawOption1D`: the ROOT draw option to be used for the 1-D histograms
 * `drawOption2D`: the ROOT draw option to be used for the 2-D histograms
+* `logScale`: boolean parameter specifying wether to draw the value axis in log or linear scale (default is `false`)
 
  The input objects are searched within the `inputPath`, and the output plots are stored inside the `outputPath`.
 It is also possible to optionally specify a different path for the reference objects, via the `referencePath` parameter. If not given, the `referencePath` will coincide with the `inputPath`.
@@ -694,6 +695,7 @@ In the example configuration below, the relationship between the input and outpu
             "legendHeight": "0.2",  
             "drawOption1D": "E",
             "drawOption2D": "COL",
+            "logScale": "false",
             "inputObjects": [
               "TrackEta",
               "TrackEtaPhi"


### PR DESCRIPTION
A new boolean configuration parameter for the ReferenceComparatorTask allows to display the histogram values (Y axis for 1-D histograms and Z axis for 2-D histograms) in log scale. This does not affect the ratio plot, which is always displayed in linear scale.