### PR TITLE
ITS - masking staves in chipstatus checker

### DIFF
--- a/Modules/ITS/itsChipStatus.json
+++ b/Modules/ITS/itsChipStatus.json
@@ -49,6 +49,7 @@
                 "policy": "OnEachSeparately",
                 "detectorName": "ITS",
 		"checkParameters": {
+		    "skipbinsStaveOverview": "",
 		    "feeidlimitsIB": "1,1",
 		    "feeidlimitsML": "1,0.87",
 		    "feeidlimitsOL": "1,0.92",
@@ -57,7 +58,7 @@
                 "dataSource": [{
                     "type": "Task",
                     "name": "ITSChipStatus",
-                    "MOs": ["StaveStatusOverview"]
+                    "MOs": ["StaveStatusOverview","FEEIDOverview"]
                 }]
             }
        }

--- a/Modules/ITS/src/ITSChipStatusCheck.cxx
+++ b/Modules/ITS/src/ITSChipStatusCheck.cxx
@@ -33,7 +33,7 @@ Quality ITSChipStatusCheck::check(std::map<std::string, std::shared_ptr<MonitorO
   // "bin1,bin2,bin3,..." not to be checked on the TH2Poly stave overview
   std::vector<int> skipbinsStaveOverview = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "skipbinsStaveOverview", ""));
 
-  // limits to be used as "X,Y" --> BAD if at least X FFEIDs have at least Y chips each into error
+  // limits to be used as "X,Y" --> BAD if at least X FFEIDs have at least a fraction Y of chips each into error
   std::vector<float> feeidlimitsIB = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "feeidlimitsIB", ""));
   std::vector<float> feeidlimitsML = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "feeidlimitsML", ""));
   std::vector<float> feeidlimitsOL = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "feeidlimitsOL", ""));

--- a/Modules/ITS/src/ITSChipStatusCheck.cxx
+++ b/Modules/ITS/src/ITSChipStatusCheck.cxx
@@ -30,6 +30,9 @@ namespace o2::quality_control_modules::its
 Quality ITSChipStatusCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>* moMap)
 {
 
+  // "bin1,bin2,bin3,..." not to be checked on the TH2Poly stave overview
+  std::vector<int> skipbinsStaveOverview = convertToArray<int>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "skipbinsStaveOverview", ""));
+
   // limits to be used as "X,Y" --> BAD if at least X FFEIDs have at least Y chips each into error
   std::vector<float> feeidlimitsIB = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "feeidlimitsIB", ""));
   std::vector<float> feeidlimitsML = convertToArray<float>(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "feeidlimitsML", ""));
@@ -64,6 +67,9 @@ Quality ITSChipStatusCheck::check(std::map<std::string, std::shared_ptr<MonitorO
       }
       for (int ilayer = 0; ilayer < NLayer; ilayer++) {
         for (int ibin = StaveBoundary[ilayer] + 1; ibin <= StaveBoundary[ilayer + 1]; ++ibin) {
+          if (std::find(skipbinsStaveOverview.begin(), skipbinsStaveOverview.end(), ibin) != skipbinsStaveOverview.end()) {
+            continue;
+          }
           if (abs(h->GetBinContent(ibin) - 1) < 0.01) {
             result = Quality::Bad;
             TString text = Form("BAD: At least one stave is without data");

--- a/Modules/ITS/src/ITSFeeCheck.cxx
+++ b/Modules/ITS/src/ITSFeeCheck.cxx
@@ -174,12 +174,12 @@ Quality ITSFeeCheck::check(std::map<std::string, std::shared_ptr<MonitorObject>>
 
         TString trgname = (TString)(h->GetYaxis()->GetBinLabel(itrg + 1));
 
-        for (int ifee = 1; ifee <= h->GetNbinsX(); ifee++) {
+        for (int ifeebin = 1; ifeebin <= h->GetNbinsX(); ifeebin++) {
 
-          if (std::find(skipfeeid.begin(), skipfeeid.end(), ifee) != skipfeeid.end())
+          if (std::find(skipfeeid.begin(), skipfeeid.end(), ifeebin - 1) != skipfeeid.end())
             continue;
 
-          int bincontent = (int)(h->GetBinContent(ifee, itrg + 1));
+          int bincontent = (int)(h->GetBinContent(ifeebin, itrg + 1));
 
           // checking trigger flags supposed to have at least one entry
           if (TrgAtLeastOne.Contains(trgname)) {
@@ -379,7 +379,7 @@ void ITSFeeCheck::beautify(std::shared_ptr<MonitorObject> mo, Quality checkResul
             tInfoLayers[ilayer]->SetNDC();
             hp->GetListOfFunctions()->Add(tInfoLayers[ilayer]->Clone());
           } // end check result over layer
-        }   // end of loop over layers
+        } // end of loop over layers
       }
       tInfo = std::make_shared<TLatex>(0.05, 0.95, Form("#bf{%s}", status.Data()));
       tInfo->SetTextColor(textColor);


### PR DESCRIPTION
Introduce the possibility to mask the checks on `StaveStatusOverview` of the ChipStatus task (+ small correction on bin ordering in the FEE checker, to enhance clarity)