### PR TITLE
Documentation inconsistency fixes

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -19,7 +19,7 @@
       * [My objects are not stored due to their size. What can I do ?](#my-objects-are-not-stored-due-to-their-size-what-can-i-do-)
 <!--te-->
 
-[← Go back to Advanced Topics](Advanced.md) | [↑ Go to the Table of Content ↑](../README.md) 
+[↑ Go to the Table of Content ↑](../README.md) 
 
 ## Git
 

--- a/doc/FLPsuite.md
+++ b/doc/FLPsuite.md
@@ -3,7 +3,7 @@ FLP Suite
 ---
 
 <!--TOC generated with https://github.com/ekalinin/github-markdown-toc-->
-<!--./gh-md-toc --insert --no-backup --hide-footer --indent 3 QualityControl/doc/Advanced.md -->
+<!--./gh-md-toc --insert --no-backup --hide-footer --indent 3 QualityControl/doc/FLPsuite.md -->
 <!--ts-->
    * [Developing QC modules on a machine with FLP suite](#developing-qc-modules-on-a-machine-with-flp-suite)
    * [Switch detector in the workflow <em>readout-dataflow</em>](#switch-detector-in-the-workflow-readout-dataflow)

--- a/doc/Framework.md
+++ b/doc/Framework.md
@@ -3,7 +3,7 @@ Framework
 ---
 
 <!--TOC generated with https://github.com/ekalinin/github-markdown-toc-->
-<!--./gh-md-toc --insert --no-backup --hide-footer --indent 3 QualityControl/doc/Advanced.md -->
+<!--./gh-md-toc --insert --no-backup --hide-footer --indent 3 QualityControl/doc/Framework.md -->
 <!--ts-->
    * [Plugging the QC to an existing DPL workflow](#plugging-the-qc-to-an-existing-dpl-workflow)
    * [Production of QC objects outside this framework](#production-of-qc-objects-outside-this-framework)

--- a/doc/Miscellaneous.md
+++ b/doc/Miscellaneous.md
@@ -3,7 +3,7 @@ Miscellaneous
 ---
 
 <!--TOC generated with https://github.com/ekalinin/github-markdown-toc-->
-<!--./gh-md-toc --insert --no-backup --hide-footer --indent 3 QualityControl/doc/Advanced.md -->
+<!--./gh-md-toc --insert --no-backup --hide-footer --indent 3 QualityControl/doc/Miscellaneous.md -->
 <!--ts-->
 * [Asynchronous Data and Monte Carlo QC operations](#asynchronous-data-and-monte-carlo-qc-operations)
 * [QCG](#qcg)

--- a/doc/ModulesDevelopment.md
+++ b/doc/ModulesDevelopment.md
@@ -200,7 +200,7 @@ cd QualityControl/Modules
 ./o2-qc-module-configurator.sh -m TST -t RawDataQcTask # create the module and a task
 ```
 
-IMPORTANT: Make sure that your detector code is listed in TaskRunner::validateDetectorName. If it is not, feel free to add it. 
+IMPORTANT: Make sure that your detector code is listed in `InfrastructureSpecReader::validateDetectorName()` (in `Framework/src/InfrastructureSpecReader.cxx`). If it is not, feel free to add it. 
 
 We will refer in the following section to the module as `Tst` and the task as `RawDataQcTask`. Make sure to use your own code and names. 
 
@@ -345,7 +345,7 @@ For each MO or group of MOs, `beautify()` is invoked after `check()` if
 Checks return Qualities with associated Flags.
 The framework wraps them with a QualityObject, then makes it available to Aggregators (see the next section) and stores them in the repository.
 It is also possible to propagate Check results to the Run Condition Table (RCT) in Bookkeeping.
-Details are explained at [Propagating Check results to RCT in Bookkeeping](Advanced.md#propagating-check-results-to-rct-in-bookkeeping)
+Details are explained at [Propagating Check results to RCT in Bookkeeping](Framework.md#propagating-check-results-to-rct-in-bookkeeping)
 
 ## Quality Aggregation
 

--- a/doc/PostProcessing.md
+++ b/doc/PostProcessing.md
@@ -146,7 +146,7 @@ Checks can be applied to the results of Post-processing Tasks just as for normal
 
 A postprocessing task can access custom parameters declared in the configuration file at `qc.postprocessing.<task_id>.extendedTaskParameters`. They are stored inside an object of type `CustomParameters` named `mCustomParameters`, which is a protected member of `TaskInterface`.
 
-[More details](Advanced.md#definition-and-access-of-user-specific-configuration) can be found about this feature in the Tasks (same behaviour).
+[More details](Configuration.md#definition-and-access-of-user-defined-configuration-extendedtaskparameters) can be found about this feature in the Tasks (same behaviour).
 
 #### Triggers configuration
 
@@ -1094,7 +1094,7 @@ up a long-running workflow in Nomad.
 ### I want to run trend a moving window in a synchronous QC
 
 In your QC task, enable the moving window feature on the selected plot.
-More details can be found in [Advanced/Moving window](Advanced.md#moving-window).
+More details can be found in [Moving window](Framework.md#moving-window).
 
 Use the NewObject trigger on the moving window to update the task:
 

--- a/doc/QCDB.md
+++ b/doc/QCDB.md
@@ -3,7 +3,7 @@ QCDB
 ---
 
 <!--TOC generated with https://github.com/ekalinin/github-markdown-toc-->
-<!--./gh-md-toc --insert --no-backup --hide-footer --indent 3 QualityControl/doc/Advanced.md -->
+<!--./gh-md-toc --insert --no-backup --hide-footer --indent 3 QualityControl/doc/QCDB.md -->
 <!--ts-->
    * [QCDB vs CCDB](#qcdb-vs-ccdb)
    * [Details on the data storage format in the QCDB](#details-on-the-data-storage-format-in-the-qcdb)

--- a/doc/QuickStart.md
+++ b/doc/QuickStart.md
@@ -51,7 +51,7 @@ To load multiple independent packages, list them one after the other, space-sepa
 
 To make sure that your system is correctly setup, we are going to run a basic QC workflow attached to a simple data producer. 
 
-The QC repository and the GUI are central services, thus they don't have to be installed on your machine. If you want to set them up on your computer or in your lab, please have a look [here](Advanced.md#local-ccdb-setup) and [here](Advanced.md#local-qcg-qc-gui-setup).
+The QC repository and the GUI are central services, thus they don't have to be installed on your machine. If you want to set them up on your computer or in your lab, please have a look at the [Local CCDB setup](QCDB.md#local-ccdb-setup) section.
 
 ### Basic workflow
 


### PR DESCRIPTION
Out of curiosity, I asked an LLM agent to review the documentation against the code and point out inconsistencies.

It also rightfully complained about lack of clarity when to use "dataSource" and "dataSources", but I created a separate ticket for it, since it's a bigger effort to sanitize this. There were some very minor issues which I wouldn't bother, which I skipped.