### PR TITLE
[MFT] rework functionality of non-mergable THStack

### DIFF
--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -95,8 +95,8 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   int mOnlineQC;
 
   const TString mColors[10] = { "#1F77B4", "#FF7F0E", "#2CA02C", "#D62728", "#8C564B", "#E377C2", "#9467BD", "#BCBD22", "#7F7F7F", "#17BECF" };
-  TH1F* clonedHistos[10] = { nullptr };
-  bool firstRun = true;
+  TH1F* mClonedHistos[10] = { nullptr };
+  bool mFirstRun = true;
 
   // needed to construct the name and path of some histograms
   int mHalf[936] = { 0 };

--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -26,7 +26,6 @@
 #include <TH2F.h>
 #include <TCanvas.h>
 #include <TString.h>
-#include <THStack.h>
 #include <DataFormatsITSMFT/TopologyDictionary.h>
 #include "ReconstructionDataFormats/BaseCluster.h"
 #include "MFTBase/GeometryTGeo.h"
@@ -84,7 +83,6 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   std::vector<std::unique_ptr<TH2FRatio>> mClusterXYinLayer;
   std::vector<std::unique_ptr<TH1FRatio>> mClusterRinLayer;
   std::unique_ptr<TCanvas> mClusterRinAllLayers = nullptr;
-  std::unique_ptr<THStack> mClusterRinAllLayersStack = nullptr;
 
   std::unique_ptr<TH1FRatio> mClustersROFSize = nullptr;
   std::unique_ptr<TH1FRatio> mClustersBC = nullptr;

--- a/Modules/MFT/include/MFT/QcMFTClusterTask.h
+++ b/Modules/MFT/include/MFT/QcMFTClusterTask.h
@@ -26,6 +26,7 @@
 #include <TH2F.h>
 #include <TCanvas.h>
 #include <TString.h>
+#include <TLegend.h>
 #include <DataFormatsITSMFT/TopologyDictionary.h>
 #include "ReconstructionDataFormats/BaseCluster.h"
 #include "MFTBase/GeometryTGeo.h"
@@ -83,6 +84,8 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   std::vector<std::unique_ptr<TH2FRatio>> mClusterXYinLayer;
   std::vector<std::unique_ptr<TH1FRatio>> mClusterRinLayer;
   std::unique_ptr<TCanvas> mClusterRinAllLayers = nullptr;
+  std::unique_ptr<TH1F> mFrame = nullptr; // dummy histogram to set the axes
+  std::unique_ptr<TLegend> mLegend = nullptr;
 
   std::unique_ptr<TH1FRatio> mClustersROFSize = nullptr;
   std::unique_ptr<TH1FRatio> mClustersBC = nullptr;
@@ -92,6 +95,8 @@ class QcMFTClusterTask /*final*/ : public TaskInterface // todo add back the "fi
   int mOnlineQC;
 
   const TString mColors[10] = { "#1F77B4", "#FF7F0E", "#2CA02C", "#D62728", "#8C564B", "#E377C2", "#9467BD", "#BCBD22", "#7F7F7F", "#17BECF" };
+  TH1F* clonedHistos[10] = { nullptr };
+  bool firstRun = true;
 
   // needed to construct the name and path of some histograms
   int mHalf[936] = { 0 };

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -478,15 +478,15 @@ void QcMFTClusterTask::updateCanvas()
   mClusterRinAllLayers->cd();
   
   for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
-    clonedHistos[nMFTLayer] = static_cast<TH1F*>(mClusterRinLayer[nMFTLayer]->getNum()->Clone());
-    clonedHistos[nMFTLayer]->SetDirectory(nullptr);
-    clonedHistos[nMFTLayer]->SetStats(0);
-    clonedHistos[nMFTLayer]->SetLineColor(TColor::GetColor(mColors[nMFTLayer]));
+    mClonedHistos[nMFTLayer] = static_cast<TH1F*>(mClusterRinLayer[nMFTLayer]->getNum()->Clone());
+    mClonedHistos[nMFTLayer]->SetDirectory(nullptr);
+    mClonedHistos[nMFTLayer]->SetStats(0);
+    mClonedHistos[nMFTLayer]->SetLineColor(TColor::GetColor(mColors[nMFTLayer]));
   }
   
   double maxY = 0;
   for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
-    double localMax = clonedHistos[nMFTLayer]->GetMaximum();
+    double localMax = mClonedHistos[nMFTLayer]->GetMaximum();
     if (localMax > maxY) {
       maxY = localMax;
     }
@@ -494,14 +494,14 @@ void QcMFTClusterTask::updateCanvas()
   mFrame->SetMaximum(maxY * 1.1);
   mFrame->Draw();
   for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
-    clonedHistos[nMFTLayer]->Draw("hist same");
+    mClonedHistos[nMFTLayer]->Draw("hist same");
   }
-  if (firstRun) {
+  if (mFirstRun) {
     mLegend->Clear();
     for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
-      mLegend->AddEntry(clonedHistos[nMFTLayer], Form("D%dF%d", static_cast<int>(std::floor(nMFTLayer / 2.)), nMFTLayer % 2 == 0 ? 0 : 1), "l");
+      mLegend->AddEntry(mClonedHistos[nMFTLayer], Form("D%dF%d", static_cast<int>(std::floor(nMFTLayer / 2.)), nMFTLayer % 2 == 0 ? 0 : 1), "l");
     }
-    firstRun = false;
+    mFirstRun = false;
   }
   mLegend->Draw();
   mClusterRinAllLayers->Update();

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -259,6 +259,11 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
     // canvas for for cluster R in all layers
     mClusterRinAllLayers = std::make_unique<TCanvas>("mClusterRinAllLayers", "Cluster Radial Position in All MFT Layers");
     getObjectsManager()->startPublishing(mClusterRinAllLayers.get());
+    mFrame = std::make_unique<TH1F>("frame", "Cluster Radial Position in All MFT Layers; r (cm); # entries", 400, 0, 20);
+    mFrame->SetStats(0);
+    mLegend = std::make_unique<TLegend>(0.8, 0.5, 0.9, 0.9);
+    mLegend->SetBorderSize(0);
+    mLegend->SetFillStyle(0);
   }
 }
 
@@ -443,6 +448,8 @@ void QcMFTClusterTask::reset()
       mClusterRinLayer[nMFTLayer]->Reset();
     }
     mClusterRinAllLayers->Clear();
+    mFrame->Reset();
+    mLegend->Clear();
   }
 }
 
@@ -469,6 +476,34 @@ void QcMFTClusterTask::updateCanvas()
 {
   mClusterRinAllLayers->Clear();
   mClusterRinAllLayers->cd();
+  
+  for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
+    clonedHistos[nMFTLayer] = static_cast<TH1F*>(mClusterRinLayer[nMFTLayer]->getNum()->Clone());
+    clonedHistos[nMFTLayer]->SetDirectory(nullptr);
+    clonedHistos[nMFTLayer]->SetStats(0);
+    clonedHistos[nMFTLayer]->SetLineColor(TColor::GetColor(mColors[nMFTLayer]));
+  }
+  
+  double maxY = 0;
+  for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
+    double localMax = clonedHistos[nMFTLayer]->GetMaximum();
+    if (localMax > maxY) {
+      maxY = localMax;
+    }
+  }
+  mFrame->SetMaximum(maxY * 1.1);
+  mFrame->Draw();
+  for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
+    clonedHistos[nMFTLayer]->Draw("hist same");
+  }
+  if (firstRun) {
+    mLegend->Clear();
+    for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
+      mLegend->AddEntry(clonedHistos[nMFTLayer], Form("D%dF%d", static_cast<int>(std::floor(nMFTLayer / 2.)), nMFTLayer % 2 == 0 ? 0 : 1), "l");
+    }
+    firstRun = false;
+  }
+  mLegend->Draw();
   mClusterRinAllLayers->Update();
 }
 

--- a/Modules/MFT/src/QcMFTClusterTask.cxx
+++ b/Modules/MFT/src/QcMFTClusterTask.cxx
@@ -259,12 +259,6 @@ void QcMFTClusterTask::initialize(o2::framework::InitContext& /*ctx*/)
     // canvas for for cluster R in all layers
     mClusterRinAllLayers = std::make_unique<TCanvas>("mClusterRinAllLayers", "Cluster Radial Position in All MFT Layers");
     getObjectsManager()->startPublishing(mClusterRinAllLayers.get());
-    mClusterRinAllLayersStack = std::make_unique<THStack>("mClusterRinAllLayersStack", "Cluster Radial Position in All MFT Layers; r (cm); # entries");
-    for (auto nMFTLayer = 0; nMFTLayer < 10; nMFTLayer++) {
-      mClusterRinLayer[nMFTLayer]->getNum()->SetLineColor(TColor::GetColor(mColors[nMFTLayer]));
-      mClusterRinLayer[nMFTLayer]->getNum()->SetTitle(Form("D%dF%d", static_cast<int>(std::floor(nMFTLayer / 2.)), nMFTLayer % 2 == 0 ? 0 : 1));
-      mClusterRinAllLayersStack->Add(mClusterRinLayer[nMFTLayer]->getNum());
-    }
   }
 }
 
@@ -473,11 +467,9 @@ void QcMFTClusterTask::getChipMapData()
 
 void QcMFTClusterTask::updateCanvas()
 {
-  mClusterRinAllLayers->cd();
   mClusterRinAllLayers->Clear();
-  mClusterRinAllLayersStack->Draw("nostack hist");
+  mClusterRinAllLayers->cd();
   mClusterRinAllLayers->Update();
-  gPad->BuildLegend(0.83, 0.50, 0.90, 0.90, "", "l");
 }
 
 } // namespace o2::quality_control_modules::mft


### PR DESCRIPTION
This PR partially reverts #2645 and reworks the functionality of the non-mergeable THStack object with manual printing of histograms onto a TCanvas.