### PR TITLE
FIT: Include FT0/FV0 total charge histograms for Pb-Pb Galuber fits

### DIFF
--- a/Modules/FIT/FT0/include/FT0/DigitQcTask.h
+++ b/Modules/FIT/FT0/include/FT0/DigitQcTask.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <array>
 #include <boost/algorithm/string.hpp>
+#include <bitset>
 
 #include "TH1.h"
 #include "TH2.h"
@@ -32,10 +33,11 @@
 #include "Rtypes.h"
 
 #include "CommonConstants/LHCConstants.h"
-
+#include "CommonDataFormat/BunchFilling.h"
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/QcInfoLogger.h"
 
+#include "DataFormatsFIT/DeadChannelMap.h"
 #include "FT0Base/Constants.h"
 #include "FT0Base/Geometry.h"
 #include "DataFormatsFT0/Digit.h"
@@ -88,6 +90,15 @@ class DigitQcTask final : public TaskInterface
   void rebinFromConfig();
   bool chIsVertexEvent(const o2::ft0::ChannelData);
 
+  o2::BunchFilling mBcPattern;
+  std::bitset<sBCperOrbit> mCollBC;
+  bool mBcPatternLoaded = false;
+  void loadBcPatternIfNeeded();
+
+  o2::fit::DeadChannelMap* mDeadChannelMap = nullptr;
+  bool mDeadChannelMapLoaded = false;
+  void loadDeadChannelMapIfNeeded();
+
   TList* mListHistGarbage;
   std::set<unsigned int> mSetAllowedChIDs;
   std::set<unsigned int> mSetAllowedChIDsAmpVsTime;
@@ -116,10 +127,17 @@ class DigitQcTask final : public TaskInterface
   std::unique_ptr<TH2F> mHistChDataBits;
   std::unique_ptr<TH2F> mHistOrbit2BC;
   std::unique_ptr<TH1F> mHistBC;
+  std::unique_ptr<TH1F> mHistBCBeamBeam;
   std::unique_ptr<TH1F> mHistNchA;
   std::unique_ptr<TH1F> mHistNchC;
   std::unique_ptr<TH1F> mHistSumAmpA;
   std::unique_ptr<TH1F> mHistSumAmpC;
+  std::unique_ptr<TH1F> mHistSumAmpAVTXBeamBeam;
+  std::unique_ptr<TH1F> mHistSumAmpCVTXBeamBeam;
+  std::unique_ptr<TH1F> mHistSumAmpACVTXBeamBeam;
+  std::unique_ptr<TH1F> mHistSumAmpAVTXBeamBeam_by8;
+  std::unique_ptr<TH1F> mHistSumAmpCVTXBeamBeam_by8;
+  std::unique_ptr<TH1F> mHistSumAmpACVTXBeamBeam_by8;
   std::unique_ptr<TH1F> mHistAverageTimeA;
   std::unique_ptr<TH1F> mHistAverageTimeC;
   std::unique_ptr<TH1F> mHistChannelID;

--- a/Modules/FIT/FT0/src/DigitQcTask.cxx
+++ b/Modules/FIT/FT0/src/DigitQcTask.cxx
@@ -25,6 +25,9 @@
 #include "DataFormatsFT0/LookUpTable.h"
 #include "Common/Utils.h"
 
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "CCDB/BasicCCDBManager.h"
+
 #include "FITCommon/HelperHist.h"
 #include "FITCommon/HelperCommon.h"
 
@@ -106,6 +109,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mHistTime2Ch = helper::registerHist<TH2F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "TimePerChannel", "Time vs Channel;Channel;Time", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4100, -2050, 2050);
   mHistAmp2Ch = helper::registerHist<TH2F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_PM, 0, sNCHANNELS_PM, 4200, -100, 4100);
   mHistBC = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
+  mHistBCBeamBeam = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "BC_BeamBeam", "Colliding BCs;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
   mHistChDataBits = helper::registerHist<TH2F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_PM, 0, sNCHANNELS_PM, mMapPMbits);
 
   // Trg plots
@@ -170,6 +174,13 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mHistNchC = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_PM, 0, sNCHANNELS_PM);
   mHistSumAmpA = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "SumAmpA", "Sum of amplitudes(TCM), side A;", 1e4, 0, 1e4);
   mHistSumAmpC = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "SumAmpC", "Sum of amplitudes(TCM), side C;", 1e4, 0, 1e4);
+  mHistSumAmpAVTXBeamBeam = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "SumAmpAVTXBeamBeam", "Sum of amplitudes(VTX+BeamBeam), FT0 A;ADC units;", 4e5, 0, 4e5);
+  mHistSumAmpCVTXBeamBeam = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "SumAmpCVTXBeamBeam", "Sum of amplitudes(VTX+BeamBeam), FT0 C;ADC units;", 4e5, 0, 4e5);
+  mHistSumAmpACVTXBeamBeam = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "SumAmpACVTXBeamBeam", "Sum of amplitudes(VTX+BeamBeam), FT0 A+C;ADC units;", 9e5, 0, 9e5);
+  mHistSumAmpAVTXBeamBeam_by8 = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "SumAmpAVTXBeamBeam_by8", "Sum of amplitudes(VTX+BeamBeam), FT0 A;ADC/8 units;", 42000, 0, 42000);
+  mHistSumAmpCVTXBeamBeam_by8 = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "SumAmpCVTXBeamBeam_by8", "Sum of amplitudes(VTX+BeamBeam), FT0 C;ADC/8 units;", 42000, 0, 42000);
+  mHistSumAmpACVTXBeamBeam_by8 = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "SumAmpACVTXBeamBeam_by8", "Sum of amplitudes(VTX+BeamBeam), FT0 A+C;ADC/8 units;", 1e5, 0, 1e5);
+
   mHistAverageTimeA = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "AverageTimeA", "Average time(TCM), side A", 4100, -2050, 2050);
   mHistAverageTimeC = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "AverageTimeC", "Average time(TCM), side C", 4100, -2050, 2050);
   mHistChannelID = helper::registerHist<TH1F>(getObjectsManager(), PublicationPolicy::Forever, "COLZ", "StatChannelID", "ChannelID statistics;ChannelID", sNCHANNELS_PM, 0, sNCHANNELS_PM);
@@ -249,6 +260,7 @@ void DigitQcTask::startOfActivity(const Activity& activity)
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
   mHistBC->Reset();
+  mHistBCBeamBeam->Reset();
   mHistChDataBits->Reset();
   mHistTimeSum2Diff->Reset();
   mHistBCvsFEEmodules->Reset();
@@ -264,6 +276,12 @@ void DigitQcTask::startOfActivity(const Activity& activity)
   mHistNchC->Reset();
   mHistSumAmpA->Reset();
   mHistSumAmpC->Reset();
+  mHistSumAmpAVTXBeamBeam->Reset();
+  mHistSumAmpCVTXBeamBeam->Reset();
+  mHistSumAmpACVTXBeamBeam->Reset();
+  mHistSumAmpAVTXBeamBeam_by8->Reset();
+  mHistSumAmpCVTXBeamBeam_by8->Reset();
+  mHistSumAmpACVTXBeamBeam_by8->Reset();
   mHistAverageTimeA->Reset();
   mHistAverageTimeC->Reset();
   mHistChannelID->Reset();
@@ -299,10 +317,54 @@ void DigitQcTask::startOfCycle()
   mTimeSum = 0.;
 }
 
+void DigitQcTask::loadBcPatternIfNeeded()
+{
+  if (mBcPatternLoaded) {
+    return;
+  }
+  auto& ccdbManager = o2::ccdb::BasicCCDBManager::instance();
+  ccdbManager.setTimestamp(mTFcreationTime);
+  ccdbManager.setCaching(true);
+  auto lhcIf = ccdbManager.get<o2::parameters::GRPLHCIFData>("GLO/Config/GRPLHCIF");
+  if (!lhcIf) {
+    ILOG(Error) << "GRPLHCIF missing → no colliding BC mask will be applied" << ENDM;
+    mCollBC.reset();
+    mBcPatternLoaded = true;
+    return;
+  }
+  const auto& pattern = lhcIf->getBunchFilling().getBCPattern();
+  mCollBC.reset();
+  for (size_t bc = 0; bc < pattern.size(); ++bc) {
+    if (pattern.test(bc)) {
+      mCollBC.set(bc);
+    }
+  }
+  mBcPatternLoaded = true;
+}
+
+void DigitQcTask::loadDeadChannelMapIfNeeded()
+{
+  if (mDeadChannelMapLoaded) {
+    return;
+  }
+  auto& ccdbManager = o2::ccdb::BasicCCDBManager::instance();
+  ccdbManager.setTimestamp(mTFcreationTime);
+  mDeadChannelMap = ccdbManager.get<o2::fit::DeadChannelMap>("FT0/Calib/DeadChannelMap");
+  if (!mDeadChannelMap) {
+    ILOG(Error) << "Failed to load FT0 dead channel map" << ENDM;
+    mDeadChannelMapLoaded = true;
+    return;
+  }
+  ILOG(Info) << "Loaded FT0 dead channel map with " << mDeadChannelMap->map.size() << " entries" << ENDM;
+  mDeadChannelMapLoaded = true;
+}
+
 void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
   mTFcreationTime = ctx.services().get<o2::framework::TimingInfo>().creation;
   mTfCounter++;
+  loadBcPatternIfNeeded();
+  loadDeadChannelMapIfNeeded();
   auto channels = ctx.inputs().get<gsl::span<o2::ft0::ChannelData>>("channels");
   auto digits = ctx.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
   if (digits.size() > 0) {
@@ -325,6 +387,12 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
     mHistBC->Fill(digit.getBC());
 
+    const bool isCollidingBC = mCollBC.test(digit.getBC());
+
+    if (isCollidingBC) {
+      mHistBCBeamBeam->Fill(digit.getBC());
+    }
+
     std::set<uint8_t> setFEEmodules{};
 
     int32_t pmSumAmplA = 0;
@@ -337,9 +405,17 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     int pmAverTimeC{ 0 };
 
     std::map<uint8_t, int> mapPMhash2sumAmpl;
+    std::map<uint8_t, int> mapPMhash2sumAmplAliveChannels;
     for (const auto& entry : mMapPMhash2isAside) {
       mapPMhash2sumAmpl.insert({ entry.first, 0 });
+      mapPMhash2sumAmplAliveChannels.insert({ entry.first, 0 });
     }
+
+    int32_t sumampAVTXBeamBeam = 0;
+    int32_t sumampCVTXBeamBeam = 0;
+    int32_t sumampAVTXBeamBeam_by8 = 0;
+    int32_t sumampCVTXBeamBeam_by8 = 0;
+
     for (const auto& chData : vecChData) {
       mHistTime2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(chData.CFDTime));
       mHistAmp2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(chData.QTCAmpl));
@@ -376,7 +452,36 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (chData.getFlag(o2::ft0::ChannelData::kIsCFDinADCgate)) {
         mapPMhash2sumAmpl[mChID2PMhash[static_cast<uint8_t>(chData.ChId)]] += static_cast<Int_t>(chData.QTCAmpl);
       }
+
+      const auto chId = static_cast<uint8_t>(chData.ChId);
+      if (mDeadChannelMap && !mDeadChannelMap->isChannelAlive(chId)) {
+        continue;
+      }
+      if (chData.getFlag(o2::ft0::ChannelData::kIsCFDinADCgate) && digit.mTriggers.getVertex() && isCollidingBC) {
+        mapPMhash2sumAmplAliveChannels[mChID2PMhash[chId]] += static_cast<Int_t>(chData.QTCAmpl);
+      }
+
+      if (digit.mTriggers.getVertex() && chData.getFlag(o2::ft0::ChannelData::kIsCFDinADCgate) && isCollidingBC) {
+        if (!mMapPMhash2isAside[mChID2PMhash[static_cast<uint8_t>(chData.ChId)]]) {
+          sumampCVTXBeamBeam += chData.QTCAmpl;
+        } else if (mMapPMhash2isAside[mChID2PMhash[static_cast<uint8_t>(chData.ChId)]]) {
+          sumampAVTXBeamBeam += chData.QTCAmpl;
+        }
+      }
     }
+    mHistSumAmpAVTXBeamBeam->Fill(sumampAVTXBeamBeam);
+    mHistSumAmpCVTXBeamBeam->Fill(sumampCVTXBeamBeam);
+    mHistSumAmpACVTXBeamBeam->Fill(sumampAVTXBeamBeam + sumampCVTXBeamBeam);
+
+    for (const auto& entry : mapPMhash2sumAmplAliveChannels) {
+      if (mMapPMhash2isAside[entry.first]) {
+        sumampAVTXBeamBeam_by8 += (entry.second >> 3);
+      } else
+        sumampCVTXBeamBeam_by8 += (entry.second >> 3);
+    }
+    mHistSumAmpAVTXBeamBeam_by8->Fill(sumampAVTXBeamBeam_by8);
+    mHistSumAmpCVTXBeamBeam_by8->Fill(sumampCVTXBeamBeam_by8);
+    mHistSumAmpACVTXBeamBeam_by8->Fill(sumampAVTXBeamBeam_by8 + sumampCVTXBeamBeam_by8);
 
     for (const auto& entry : mapPMhash2sumAmpl) {
       if (mMapPMhash2isAside[entry.first])
@@ -433,6 +538,7 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 
       mHistTimeSum2Diff->Fill((digit.mTriggers.getTimeC() - digit.mTriggers.getTimeA()) * sCFDChannel2NS / 2, (digit.mTriggers.getTimeC() + digit.mTriggers.getTimeA()) * sCFDChannel2NS / 2);
     }
+
     if (isTCM) {
       std::vector<unsigned int> vecTrgWords{};
       const uint64_t trgWordExt = digit.mTriggers.getExtendedTrgWordFT0();
@@ -490,6 +596,7 @@ void DigitQcTask::reset()
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
   mHistBC->Reset();
+  mHistBCBeamBeam->Reset();
   mHistChDataBits->Reset();
   mHistTimeSum2Diff->Reset();
   mHistOrbit2BC->Reset();
@@ -497,6 +604,12 @@ void DigitQcTask::reset()
   mHistNchC->Reset();
   mHistSumAmpA->Reset();
   mHistSumAmpC->Reset();
+  mHistSumAmpAVTXBeamBeam->Reset();
+  mHistSumAmpCVTXBeamBeam->Reset();
+  mHistSumAmpACVTXBeamBeam->Reset();
+  mHistSumAmpAVTXBeamBeam_by8->Reset();
+  mHistSumAmpCVTXBeamBeam_by8->Reset();
+  mHistSumAmpACVTXBeamBeam_by8->Reset();
   mHistAverageTimeA->Reset();
   mHistAverageTimeC->Reset();
   mHistChannelID->Reset();

--- a/Modules/FIT/FV0/include/FV0/DigitQcTask.h
+++ b/Modules/FIT/FV0/include/FV0/DigitQcTask.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <array>
 #include <boost/algorithm/string.hpp>
+#include <bitset>
 
 #include "TH1.h"
 #include "TH2.h"
@@ -32,10 +33,11 @@
 #include "Rtypes.h"
 
 #include "CommonConstants/LHCConstants.h"
-
+#include "CommonDataFormat/BunchFilling.h"
 #include "QualityControl/TaskInterface.h"
 #include "QualityControl/QcInfoLogger.h"
 
+#include "DataFormatsFIT/DeadChannelMap.h"
 #include "FV0Base/Constants.h"
 #include "DataFormatsFV0/Digit.h"
 #include "DataFormatsFV0/ChannelData.h"
@@ -83,9 +85,19 @@ class DigitQcTask final : public TaskInterface
   double mTimeSum = 0.;
 
   long mTFcreationTime = 0;
+  long mRunStartTime = 0;
 
   int mMinTimeGate = -192;
   int mMaxTimeGate = 192;
+
+  o2::BunchFilling mBcPattern;
+  std::bitset<sBCperOrbit> mCollBC;
+  bool mBcPatternLoaded = false;
+  void loadBcPatternIfNeeded();
+
+  o2::fit::DeadChannelMap* mDeadChannelMap = nullptr;
+  bool mDeadChannelMapLoaded = false;
+  void loadDeadChannelMapIfNeeded();
 
   template <typename Param_t,
             typename = typename std::enable_if<std::is_floating_point<Param_t>::value ||
@@ -162,10 +174,13 @@ class DigitQcTask final : public TaskInterface
   std::unique_ptr<TH2F> mHistChDataBits;
   std::unique_ptr<TH2F> mHistOrbit2BC;
   std::unique_ptr<TH1F> mHistBC;
+  std::unique_ptr<TH1F> mHistBCBeamBeam;
   std::unique_ptr<TH1F> mHistNchA;
   std::unique_ptr<TH1F> mHistNchC;
   std::unique_ptr<TH1F> mHistSumAmpA;
   std::unique_ptr<TH1F> mHistSumAmpC;
+  std::unique_ptr<TH1F> mHistSumAmpAOrABeamBeam;
+  std::unique_ptr<TH1F> mHistSumAmpAOrABeamBeam_by8;
   std::unique_ptr<TH1F> mHistAverageTimeA;
   std::unique_ptr<TH1F> mHistAverageTimeC;
   std::unique_ptr<TH1F> mHistChannelID;

--- a/Modules/FIT/FV0/src/DigitQcTask.cxx
+++ b/Modules/FIT/FV0/src/DigitQcTask.cxx
@@ -26,6 +26,9 @@
 #include "DataFormatsFV0/LookUpTable.h"
 #include "Common/Utils.h"
 
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "CCDB/BasicCCDBManager.h"
+
 #include "FITCommon/HelperHist.h"
 #include "FITCommon/HelperCommon.h"
 
@@ -188,6 +191,7 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mHistAmp2Ch = std::make_unique<TH2F>("AmpPerChannel", "Amplitude vs Channel;Channel;Amp", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, 4200, -100, 4100);
   mHistAmp2Ch->SetOption("colz");
   mHistBC = std::make_unique<TH1F>("BC", "BC;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
+  mHistBCBeamBeam = std::make_unique<TH1F>("BC_BeamBeam", "Colliding BCs;BC;counts;", sBCperOrbit, 0, sBCperOrbit);
   mHistChDataBits = std::make_unique<TH2F>("ChannelDataBits", "ChannelData bits per ChannelID;Channel;Bit", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF, mMapPMbits.size(), 0, mMapPMbits.size());
   mHistChDataBits->SetOption("colz");
   for (const auto& entry : mMapPMbits) {
@@ -278,6 +282,8 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   mHistNchA = std::make_unique<TH1F>("NumChannelsA", "Number of channels(TCM), side A;Nch", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
   // mHistNchC = std::make_unique<TH1F>("NumChannelsC", "Number of channels(TCM), side C;Nch", sNCHANNELS_FV0_PLUSREF, 0, sNCHANNELS_FV0_PLUSREF);
   mHistSumAmpA = std::make_unique<TH1F>("SumAmpA", "Sum of amplitudes(TCM), side A;", 1e4, 0, 1e4);
+  mHistSumAmpAOrABeamBeam = std::make_unique<TH1F>("SumAmpAOrABeamBeam", "Sum of amplitudes + OrA + Colliding BC;ADC units;", 2e5, 0, 2e5);
+  mHistSumAmpAOrABeamBeam_by8 = std::make_unique<TH1F>("SumAmpAOrABeamBeam_by8", "Sum of amplitudes + OrA + Colliding BC;ADC/8 units;", 4e4, 0, 4e4);
   // mHistSumAmpC = std::make_unique<TH1F>("SumAmpC", "Sum of amplitudes(TCM), side C;", 1e4, 0, 1e4);
   mHistAverageTimeA = std::make_unique<TH1F>("AverageTimeA", "Average time(TCM), side A", 4100, -2050, 2050);
   // mHistAverageTimeC = std::make_unique<TH1F>("AverageTimeC", "Average time(TCM), side C", 4100, -2050, 2050);
@@ -319,9 +325,12 @@ void DigitQcTask::initialize(o2::framework::InitContext& /*ctx*/)
   getObjectsManager()->startPublishing(mHistGateTimeRatio2Ch.get());
   getObjectsManager()->startPublishing(mHistCFDEff.get());
   getObjectsManager()->startPublishing(mHistBC.get());
+  getObjectsManager()->startPublishing(mHistBCBeamBeam.get());
   getObjectsManager()->startPublishing(mHistNchA.get());
   // getObjectsManager()->startPublishing(mHistNchC.get());
   getObjectsManager()->startPublishing(mHistSumAmpA.get());
+  getObjectsManager()->startPublishing(mHistSumAmpAOrABeamBeam.get());
+  getObjectsManager()->startPublishing(mHistSumAmpAOrABeamBeam_by8.get());
   // getObjectsManager()->startPublishing(mHistSumAmpC.get());
   getObjectsManager()->startPublishing(mHistAverageTimeA.get());
   // getObjectsManager()->startPublishing(mHistAverageTimeC.get());
@@ -385,6 +394,7 @@ void DigitQcTask::startOfActivity(const Activity& activity)
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
   mHistBC->Reset();
+  mHistBCBeamBeam->Reset();
   mHistChDataBits->Reset();
   mHistGateTimeRatio2Ch->Reset();
   mHistCFDEff->Reset();
@@ -409,6 +419,8 @@ void DigitQcTask::startOfActivity(const Activity& activity)
   mHistNchA->Reset();
   // mHistNchC->Reset();
   mHistSumAmpA->Reset();
+  mHistSumAmpAOrABeamBeam->Reset();
+  mHistSumAmpAOrABeamBeam_by8->Reset();
   // mHistSumAmpC->Reset();
   mHistAverageTimeA->Reset();
   // mHistAverageTimeC->Reset();
@@ -433,11 +445,54 @@ void DigitQcTask::startOfCycle()
   mTimeSum = 0.;
 }
 
+void DigitQcTask::loadBcPatternIfNeeded()
+{
+  if (mBcPatternLoaded) {
+    return;
+  }
+  auto& ccdbManager = o2::ccdb::BasicCCDBManager::instance();
+  ccdbManager.setTimestamp(mTFcreationTime);
+  ccdbManager.setCaching(true);
+  auto lhcIf = ccdbManager.get<o2::parameters::GRPLHCIFData>("GLO/Config/GRPLHCIF");
+  if (!lhcIf) {
+    ILOG(Error) << "GRPLHCIF missing → no colliding BC mask will be applied" << ENDM;
+    mCollBC.reset();
+    mBcPatternLoaded = true;
+    return;
+  }
+  const auto& pattern = lhcIf->getBunchFilling().getBCPattern();
+  mCollBC.reset();
+  for (size_t bc = 0; bc < pattern.size(); ++bc) {
+    if (pattern.test(bc)) {
+      mCollBC.set(bc);
+    }
+  }
+  mBcPatternLoaded = true;
+}
+
+void DigitQcTask::loadDeadChannelMapIfNeeded()
+{
+  if (mDeadChannelMapLoaded) {
+    return;
+  }
+  auto& ccdbManager = o2::ccdb::BasicCCDBManager::instance();
+  ccdbManager.setTimestamp(mTFcreationTime);
+  mDeadChannelMap = ccdbManager.get<o2::fit::DeadChannelMap>("FV0/Calib/DeadChannelMap");
+  if (!mDeadChannelMap) {
+    ILOG(Error) << "Failed to load FV0 dead channel map" << ENDM;
+    mDeadChannelMapLoaded = true;
+    return;
+  }
+  ILOG(Info) << "Loaded FV0 dead channel map with " << mDeadChannelMap->map.size() << " entries" << ENDM;
+  mDeadChannelMapLoaded = true;
+}
+
 void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
   mTFcreationTime = ctx.services().get<o2::framework::TimingInfo>().creation;
-
   mTfCounter++;
+  loadBcPatternIfNeeded();
+  loadDeadChannelMapIfNeeded();
   auto channels = ctx.inputs().get<gsl::span<o2::fv0::ChannelData>>("channels");
   auto digits = ctx.inputs().get<gsl::span<o2::fv0::Digit>>("digits");
   if (digits.size() > 0) {
@@ -463,6 +518,12 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     mHistOrbit2BC->Fill(digit.getIntRecord().orbit % sOrbitsPerTF, digit.getIntRecord().bc);
     mHistBC->Fill(digit.getBC());
 
+    const bool isCollidingBC = mCollBC.test(digit.getBC());
+
+    if (isCollidingBC) {
+      mHistBCBeamBeam->Fill(digit.getBC());
+    }
+
     std::set<uint8_t> setFEEmodules{};
     // reset triggers
     for (auto& entry : mMapTrgSoftware) {
@@ -476,9 +537,15 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
     Int_t pmAverTime = 0;
 
     std::map<uint8_t, int> mapPMhash2sumAmpl;
+    std::map<uint8_t, int> mapPMhash2sumAmplAliveChannels;
     for (const auto& entry : mMapPMhash2isInner) {
       mapPMhash2sumAmpl.insert({ entry.first, 0 });
+      mapPMhash2sumAmplAliveChannels.insert({ entry.first, 0 });
     }
+
+    int32_t sumampAOrABeamBeam = 0;
+    int32_t sumampAOrABeamBeam_by8_inner = 0;
+    int32_t sumampAOrABeamBeam_by8_outer = 0;
 
     for (const auto& chData : vecChData) {
       mHistTime2Ch->Fill(static_cast<Double_t>(chData.ChId), static_cast<Double_t>(chData.CFDTime));
@@ -514,7 +581,29 @@ void DigitQcTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (chData.getFlag(o2::fv0::ChannelData::kIsCFDinADCgate)) {
         mapPMhash2sumAmpl[mChID2PMhash[static_cast<uint8_t>(chData.ChId)]] += static_cast<Int_t>(chData.QTCAmpl);
       }
+
+      const auto chId = static_cast<uint8_t>(chData.ChId);
+      if (mDeadChannelMap && !mDeadChannelMap->isChannelAlive(chId)) {
+        continue;
+      }
+
+      if (chData.getFlag(o2::fv0::ChannelData::kIsCFDinADCgate) && digit.mTriggers.getOrA() && isCollidingBC) {
+        mapPMhash2sumAmplAliveChannels[mChID2PMhash[chId]] += static_cast<Int_t>(chData.QTCAmpl);
+      }
+
+      if (digit.mTriggers.getOrA() && chData.getFlag(o2::fv0::ChannelData::kIsCFDinADCgate) && isCollidingBC) {
+        sumampAOrABeamBeam += chData.QTCAmpl;
+      }
     } // channel data loop
+    mHistSumAmpAOrABeamBeam->Fill(sumampAOrABeamBeam);
+
+    for (const auto& entry : mapPMhash2sumAmplAliveChannels) {
+      if (mMapPMhash2isInner[entry.first]) {
+        sumampAOrABeamBeam_by8_inner += (entry.second >> 3);
+      } else
+        sumampAOrABeamBeam_by8_outer += (entry.second >> 3);
+    }
+    mHistSumAmpAOrABeamBeam_by8->Fill(sumampAOrABeamBeam_by8_inner + sumampAOrABeamBeam_by8_outer);
 
     for (const auto& entry : mapPMhash2sumAmpl) {
       if (mMapPMhash2isInner[entry.first])
@@ -675,6 +764,7 @@ void DigitQcTask::reset()
   mHistTime2Ch->Reset();
   mHistAmp2Ch->Reset();
   mHistBC->Reset();
+  mHistBCBeamBeam->Reset();
   mHistChDataBits->Reset();
   mHistCFDEff->Reset();
   mHistNumADC->Reset();
@@ -685,6 +775,8 @@ void DigitQcTask::reset()
   mHistNchA->Reset();
   // mHistNchC->Reset();
   mHistSumAmpA->Reset();
+  mHistSumAmpAOrABeamBeam->Reset();
+  mHistSumAmpAOrABeamBeam_by8->Reset();
   // mHistSumAmpC->Reset();
   mHistAverageTimeA->Reset();
   // mHistAverageTimeC->Reset();


### PR DESCRIPTION
This PR updates the FT0 and FV0 DigitQcTasks.
There are new histograms added that show the total integrated charge for FT0A, FT0C, FT0A+C and FV0
with selection of Colliding BCs with FT0 Vertex and FV0 OrA triggers.