### PR TITLE
Use PP task name instead of PP task ID when requesting their outputs 

### DIFF
--- a/Framework/src/InfrastructureSpecReader.cxx
+++ b/Framework/src/InfrastructureSpecReader.cxx
@@ -268,7 +268,7 @@ DataSourceSpec InfrastructureSpecReader::readSpecEntry<DataSourceSpec>(const std
       // this allows us to have tasks with the same name for different detectors
       dss.name = wholeTree.get<std::string>("qc.postprocessing." + dss.id + ".taskName", dss.id);
       auto detectorName = wholeTree.get<std::string>("qc.postprocessing." + dss.id + ".detectorName");
-      dss.inputs = { createUserInputSpec(DataSourceType::PostProcessingTask, detectorName, dss.id, 0, dss.name) };
+      dss.inputs = { createUserInputSpec(DataSourceType::PostProcessingTask, detectorName, dss.name, 0, dss.name) };
       if (dataSourceTree.count("MOs") > 0) {
         for (const auto& moName : dataSourceTree.get_child("MOs")) {
           dss.subInputs.push_back(moName.second.get_value<std::string>());


### PR DESCRIPTION
When requesting PP task output as a data source, it's ID was used for DataDescription. Meanwhile, PostProcessingDevice::getOutputSpecs uses the task name, which is the general convention in QC. The commit fixes the data source to use task name.

I tested the change with the big TPC remote workflow, it works. It seems nothing was relying on the wrong behaviour.

Fixes QC-1336.