### PR TITLE
Use MeanVertex to apply DCA veto for ITS V0s check

### DIFF
--- a/Modules/ITS/include/ITS/ITSTrackTask.h
+++ b/Modules/ITS/include/ITS/ITSTrackTask.h
@@ -19,6 +19,7 @@
 
 #include "QualityControl/TaskInterface.h"
 #include <DataFormatsITSMFT/TopologyDictionary.h>
+#include <DataFormatsCalibration/MeanVertexObject.h>
 #include <ITSBase/GeometryTGeo.h>
 #include <Framework/TimingInfo.h>
 #include <TLine.h>
@@ -125,7 +126,8 @@ class ITSTrackTask : public TaskInterface
   double mCoslBins[25];   // y bins for cos(lambda) plot
   double ptBins[141];     // pt bins
 
-  o2::itsmft::TopologyDictionary* mDict;
+  o2::itsmft::TopologyDictionary* mDict = nullptr;
+  o2::dataformats::MeanVertexObject* mMeanVertex = nullptr;
 
  private:
   // analysis for its-only residual

--- a/Modules/ITS/src/ITSTrackTask.cxx
+++ b/Modules/ITS/src/ITSTrackTask.cxx
@@ -112,13 +112,12 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
 
   ILOG(Debug, Devel) << "START DOING QC General" << ENDM;
-
+  static std::map<std::string, std::string> metadata;
   if (mTimestamp == -1) { // get dict from ccdb
     mTimestamp = std::stol(o2::quality_control_modules::common::getFromConfig<std::string>(mCustomParameters, "dicttimestamp", "0"));
     long int ts = mTimestamp ? mTimestamp : ctx.services().get<o2::framework::TimingInfo>().creation;
     ILOG(Debug, Devel) << "Getting dictionary from ccdb - timestamp: " << ts << ENDM;
 
-    std::map<std::string, std::string> metadata;
     mDict = TaskInterface::retrieveConditionAny<o2::itsmft::TopologyDictionary>("ITS/Calib/ClusterDictionary", metadata, ts);
     ILOG(Debug, Devel) << "Dictionary size: " << mDict->getSize() << ENDM;
 
@@ -131,6 +130,10 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
       }
       ILOG(Debug, Devel) << "Loaded new instance of mGeom (for ITS alignment monitoring)" << ENDM;
     }
+  }
+  if (mInvMasses) {
+    long ts = mTimestamp > 0 ? mTimestamp : ctx.services().get<o2::framework::TimingInfo>().creation;
+    mMeanVertex = TaskInterface::retrieveConditionAny<o2::dataformats::MeanVertexObject>("GLO/Calib/MeanVertex", metadata, ts);
   }
 
   auto trackArr = ctx.inputs().get<gsl::span<o2::its::TrackITS>>("tracks");
@@ -214,7 +217,6 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
   ft.setMinRelChi2Change(0.9);
   ft.setMaxChi2(10);
   // prepare variables for v0
-  float vx = 0, vy = 0, vz = 0;
   float dca[2]{ 0., 0. };
   float bz = 5.0;
   // loop on tracks per ROF
@@ -371,7 +373,7 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
       if (mInvMasses == 1) {
         if (track.getSign() < 0) // choose only positive tracks
           continue;
-        track.getImpactParams(vx, vy, vz, bz, dca);
+        track.getImpactParams(mMeanVertex->getX(), mMeanVertex->getY(), mMeanVertex->getZ(), bz, dca);
         if ((track.getNumberOfClusters() < 6) || (abs(track.getTgl()) > 1.5) || (abs(dca[0]) < 0.06)) // conditions for the track acceptance
           continue;
 
@@ -379,7 +381,7 @@ void ITSTrackTask::monitorData(o2::framework::ProcessingContext& ctx)
           auto& ntrack = trackArr[intrack];
           if (ntrack.getSign() > 0) // choose only negative tracks
             continue;
-          ntrack.getImpactParams(vx, vy, vz, bz, dca);
+          ntrack.getImpactParams(mMeanVertex->getX(), mMeanVertex->getY(), mMeanVertex->getZ(), bz, dca);
           if ((ntrack.getNumberOfClusters() < 6) || (abs(ntrack.getTgl()) > 1.5) || (abs(dca[0]) < 0.06)) // conditions for the track acceptance
             continue;
 


### PR DESCRIPTION
Task timing per TF (for 5 pbpb25 TFs) with and w/o fix for the v10n geometry:
```
qc-task-ITS-Tracks         0.380176 # with fix
qc-task-ITS-Tracks         16.200281 # before fix
```
