### PR TITLE
Fix of a hang in ITSClusterTask

### DIFF
--- a/Modules/ITS/src/ITSClusterTask.cxx
+++ b/Modules/ITS/src/ITSClusterTask.cxx
@@ -55,12 +55,12 @@ ITSClusterTask::~ITSClusterTask()
       delete hClusterCenterMap[iLayer];
       delete hLongClustersPerChip[iLayer];
       delete hMultPerChipWhenLongClusters[iLayer];
-      delete hDcolMapOBSor[iLayer - NLayerIB];
-      delete hDcolMapOBEor[iLayer - NLayerIB];
     }
 
     else {
       delete hLongClustersPerStave[iLayer - NLayerIB];
+      delete hDcolMapOBSor[iLayer - NLayerIB];
+      delete hDcolMapOBEor[iLayer - NLayerIB];
     }
     delete hClusterSizeLayerSummary[iLayer];
     delete hClusterTopologyLayerSummary[iLayer];
@@ -131,7 +131,9 @@ void ITSClusterTask::startOfCycle()
   if (nCycle % nResetCycle == 0) {
     hDcolMapIBEor->Reset();
     for (int i = 0; i < NLayerOB; i++) {
-      hDcolMapOBEor[i]->Reset();
+      if (hDcolMapOBEor[i]) {
+        hDcolMapOBEor[i]->Reset();
+      }
     }
   }
 


### PR DESCRIPTION
This commit fixes a hang observed in the MC nightlies since 11. August 2026.

The patch corrects upon findings of a debug session which surfaced that

- ITSTracksClustersQC never returns.
- It keeps its semaphore, so the other timeframes never run.
- The QC finalisation stalls and the GRID watchdog kills the job.
- The task aborts inside free() while it is destroyed.
- The crash handler then deadlocks, so the process never exits.

The destructor deletes the dcol maps in the inner barrel branch. For layers 0 to 2 this frees hDcolMapOBSor and hDcolMapOBEor at index -3, -2 and -1. They belong in the outer barrel branch.

startOfCycle resets the same histograms without a null check. createAllHistos skips disabled layers, so they can be null.