### PR TITLE
Do not hardcode location of test CCDB

### DIFF
--- a/Framework/test/testCcdbDatabase.cxx
+++ b/Framework/test/testCcdbDatabase.cxx
@@ -34,6 +34,7 @@
 #include <DataFormatsQualityControl/FlagTypeFactory.h>
 #include <TROOT.h>
 #include <CCDB/CcdbApi.h>
+#include <cstdlib>
 
 namespace utf = boost::unit_test;
 
@@ -48,7 +49,13 @@ using namespace o2::quality_control::core;
 using namespace o2::quality_control::repository;
 using namespace std;
 
-const std::string CCDB_ENDPOINT = "ccdb-test.cern.ch:8080";
+// These tests upload, so this has to be a WRITABLE instance -- ccdb-test by
+// default. ALICEO2_CCDB_HOST lets a network-isolated build container reach one
+// through a broker instead; unset, behaviour is unchanged.
+const std::string CCDB_ENDPOINT = [] {
+  const char* host = std::getenv("ALICEO2_CCDB_HOST");
+  return std::string((host && *host) ? host : "ccdb-test.cern.ch:8080");
+}();
 
 /**
  * Fixture for the tests, i.e. code is ran in every test that uses it, i.e. it is like a setup and teardown for tests.

--- a/Framework/test/testCcdbDatabaseExtra.cxx
+++ b/Framework/test/testCcdbDatabaseExtra.cxx
@@ -26,6 +26,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <TH1F.h>
+#include <cstdlib>
 
 namespace utf = boost::unit_test;
 
@@ -39,7 +40,13 @@ using namespace o2::quality_control::core;
 using namespace o2::quality_control::repository;
 using namespace std;
 
-const std::string CCDB_ENDPOINT = "ccdb-test.cern.ch:8080";
+// These tests upload, so this has to be a WRITABLE instance -- ccdb-test by
+// default. ALICEO2_CCDB_HOST lets a network-isolated build container reach one
+// through a broker instead; unset, behaviour is unchanged.
+const std::string CCDB_ENDPOINT = [] {
+  const char* host = std::getenv("ALICEO2_CCDB_HOST");
+  return std::string((host && *host) ? host : "ccdb-test.cern.ch:8080");
+}();
 std::unordered_map<std::string, std::string> Objects;
 
 /**

--- a/Framework/test/testReductor.cxx
+++ b/Framework/test/testReductor.cxx
@@ -30,8 +30,15 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
+#include <cstdlib>
 
-const std::string CCDB_ENDPOINT = "ccdb-test.cern.ch:8080";
+// These tests upload, so this has to be a WRITABLE instance -- ccdb-test by
+// default. ALICEO2_CCDB_HOST lets a network-isolated build container reach one
+// through a broker instead; unset, behaviour is unchanged.
+const std::string CCDB_ENDPOINT = [] {
+  const char* host = std::getenv("ALICEO2_CCDB_HOST");
+  return std::string((host && *host) ? host : "ccdb-test.cern.ch:8080");
+}();
 
 using namespace o2::quality_control;
 using namespace o2::quality_control::core;

--- a/Framework/test/testTriggers.cxx
+++ b/Framework/test/testTriggers.cxx
@@ -37,7 +37,13 @@ using namespace o2::quality_control::postprocessing;
 using namespace o2::quality_control::core;
 using namespace o2::quality_control::repository;
 
-const std::string CCDB_ENDPOINT = "ccdb-test.cern.ch:8080";
+// These tests upload, so this has to be a WRITABLE instance -- ccdb-test by
+// default. ALICEO2_CCDB_HOST lets a network-isolated build container reach one
+// through a broker instead; unset, behaviour is unchanged.
+const std::string CCDB_ENDPOINT = [] {
+  const char* host = std::getenv("ALICEO2_CCDB_HOST");
+  return std::string((host && *host) ? host : "ccdb-test.cern.ch:8080");
+}();
 
 BOOST_AUTO_TEST_CASE(test_casting_triggers)
 {


### PR DESCRIPTION

The new CI setup has a test instance bound to a local port of the
worker's container.
